### PR TITLE
Coordinated team initial implementation

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -20,11 +20,11 @@ class Api::V1::BaseController < ApplicationController
   def update
     render_404
   end
-  
+
   def destroy
     render_404
   end
-  
+
   private
 
   def render_404
@@ -64,7 +64,7 @@ class Api::V1::BaseController < ApplicationController
   end
 
   def current_resource
-    return @current_resource if defined?(@current_resource)  
+    return @current_resource if defined?(@current_resource)
     @current_resource = if current_resource_model == Decision
       current_decision
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,6 +62,34 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def current_commitment
+    return @current_commitment if defined?(@current_commitment)
+    if current_resource_model == Commitment
+      commitment_id = params[:id] || params[:commitment_id]
+    else
+      commitment_id = params[:commitment_id]
+    end
+    column_name = commitment_id.to_s.length == 8 ? :truncated_id : :id
+    @current_commitment = Commitment.find_by(column_name => commitment_id)
+  end
+
+  def duration_param
+    duration = params[:duration].to_i
+    duration_unit = params[:duration_unit] || 'hour(s)'
+    case duration_unit
+    when 'minute(s)'
+      duration.minutes
+    when 'hour(s)'
+      duration.hours
+    when 'day(s)'
+      duration.days
+    when 'week(s)'
+      duration.weeks
+    else
+      raise "Unknown duration_unit: #{duration_unit}"
+    end
+  end
+
   def reset_session
     clear_participant_uid_cookie
     super

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,8 +74,8 @@ class ApplicationController < ActionController::Base
   end
 
   def duration_param
-    duration = params[:duration].to_i
-    duration_unit = params[:duration_unit] || 'hour(s)'
+    duration = model_params[:duration].to_i
+    duration_unit = model_params[:duration_unit] || 'hour(s)'
     case duration_unit
     when 'minute(s)'
       duration.minutes
@@ -88,6 +88,10 @@ class ApplicationController < ActionController::Base
     else
       raise "Unknown duration_unit: #{duration_unit}"
     end
+  end
+
+  def model_params
+    params[current_resource_model.name.underscore.to_sym]
   end
 
   def reset_session

--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -52,7 +52,7 @@ class Auth0Controller < ApplicationController
       # Forget anonymous participant_uid
       clear_participant_uid_cookie
     end
-    
+
     redirect_to decision_path || '/'
   end
 
@@ -88,7 +88,7 @@ class Auth0Controller < ApplicationController
   def auth0_callback_url
     request.protocol + request.host_with_port + '/auth/auth0/callback'
   end
-   
+
   def logout_url
     request_params = {
       returnTo: root_url,

--- a/app/controllers/commitments_controller.rb
+++ b/app/controllers/commitments_controller.rb
@@ -30,6 +30,7 @@ class CommitmentsController < ApplicationController
   def show
     @commitment = current_commitment
     @commitment_participant = current_commitment_participant
+    @participants_list_limit = 10
     return render '404', status: 404 unless @commitment
     @page_title = @commitment.title
     @page_description = "Coordinate with your team"
@@ -46,7 +47,16 @@ class CommitmentsController < ApplicationController
     @commitment_participant = current_commitment_participant
     return render '404', status: 404 unless @commitment && @commitment_participant
     @commitment_participant.committed = true if params[:committed].to_s == 'true'
+    @commitment_participant.name = params[:name]
     @commitment_participant.save!
     render partial: 'status'
+  end
+
+  def participants_list_items_partial
+    @commitment = current_commitment
+    return render '404', status: 404 unless @commitment
+    @participants_list_limit = params[:limit].to_i if params[:limit].present?
+    @participants_list_limit = 20 if @participants_list_limit < 1
+    render partial: 'participants_list_items'
   end
 end

--- a/app/controllers/commitments_controller.rb
+++ b/app/controllers/commitments_controller.rb
@@ -1,0 +1,35 @@
+class CommitmentsController < ApplicationController
+
+  def new
+    @page_title = "Coordinate"
+    @page_description = "Coordinate with your team"
+    @commitment = Commitment.new(
+      title: params[:title],
+    )
+  end
+
+  def create
+    @commitment = Commitment.new(
+      title: params[:title],
+      description: params[:description],
+      deadline: Time.now + duration_param,
+    )
+    begin
+      ActiveRecord::Base.transaction do
+        @commitment.save!
+        @current_commitment = @commitment
+      end
+      redirect_to @commitment.path
+    rescue ActiveRecord::RecordInvalid => e
+      flash.now[:alert] = 'There was an error creating the commitment. Please try again.'
+      render :new
+    end
+  end
+
+  def show
+    @commitment = current_commitment
+    return render '404', status: 404 unless @commitment
+    @page_title = @commitment.title
+    @page_description = "Coordinate with your team"
+  end
+end

--- a/app/controllers/commitments_controller.rb
+++ b/app/controllers/commitments_controller.rb
@@ -29,6 +29,7 @@ class CommitmentsController < ApplicationController
 
   def show
     @commitment = current_commitment
+    @commitment_participant = current_commitment_participant
     return render '404', status: 404 unless @commitment
     @page_title = @commitment.title
     @page_description = "Coordinate with your team"
@@ -40,10 +41,12 @@ class CommitmentsController < ApplicationController
     render partial: 'status'
   end
 
-  def create_option_and_return_status_partial
+  def join_and_return_status_partial
     @commitment = current_commitment
-    return render '404', status: 404 unless @commitment
-    # TODO: Implement this
+    @commitment_participant = current_commitment_participant
+    return render '404', status: 404 unless @commitment && @commitment_participant
+    @commitment_participant.committed = true if params[:committed].to_s == 'true'
+    @commitment_participant.save!
     render partial: 'status'
   end
 end

--- a/app/controllers/commitments_controller.rb
+++ b/app/controllers/commitments_controller.rb
@@ -10,8 +10,8 @@ class CommitmentsController < ApplicationController
 
   def create
     @commitment = Commitment.new(
-      title: params[:title],
-      description: params[:description],
+      title: model_params[:title],
+      description: model_params[:description],
       deadline: Time.now + duration_param,
     )
     begin

--- a/app/controllers/commitments_controller.rb
+++ b/app/controllers/commitments_controller.rb
@@ -33,4 +33,17 @@ class CommitmentsController < ApplicationController
     @page_title = @commitment.title
     @page_description = "Coordinate with your team"
   end
+
+  def status_partial
+    @commitment = current_commitment
+    return render '404', status: 404 unless @commitment
+    render partial: 'status'
+  end
+
+  def create_option_and_return_status_partial
+    @commitment = current_commitment
+    return render '404', status: 404 unless @commitment
+    # TODO: Implement this
+    render partial: 'status'
+  end
 end

--- a/app/controllers/commitments_controller.rb
+++ b/app/controllers/commitments_controller.rb
@@ -12,6 +12,7 @@ class CommitmentsController < ApplicationController
     @commitment = Commitment.new(
       title: model_params[:title],
       description: model_params[:description],
+      critical_mass: model_params[:critical_mass],
       deadline: Time.now + duration_param,
     )
     begin

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -68,23 +68,6 @@ class DecisionsController < ApplicationController
 
   private
 
-  def duration_param
-    duration = decision_params[:duration].to_i
-    duration_unit = decision_params[:duration_unit] || 'hour(s)'
-    case duration_unit
-    when 'minute(s)'
-      duration.minutes
-    when 'hour(s)'
-      duration.hours
-    when 'day(s)'
-      duration.days
-    when 'week(s)'
-      duration.weeks
-    else
-      raise "Unknown duration_unit: #{duration_unit}"
-    end
-  end
-
   def decision_params
     params.require(:decision).permit(:question, :description, :options_open, :duration, :duration_unit, :auth_required)
   end

--- a/app/javascript/controllers/commitment_controller.js
+++ b/app/javascript/controllers/commitment_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["joinButton", "statusSection"]
+  static targets = ["joinButton", "joinSection", "statusSection", "nameInput", "participantsList"];
 
   initialize() {
     document.addEventListener('poll', this.refreshDisplay.bind(this))
@@ -16,6 +16,7 @@ export default class extends Controller {
     console.log("Joining commitment... " + this.joinButtonTarget.dataset.url);
     this.joinButtonTarget.innerHTML = "Joining...";
     const url = this.joinButtonTarget.dataset.url;
+    const name = this.nameInputTarget.value.trim();
     fetch(url, {
       method: "POST",
       headers: {
@@ -24,16 +25,36 @@ export default class extends Controller {
       },
       body: JSON.stringify({
         committed: true,
+        name: name,
       }),
     })
       .then(response => response.text())
       .then((html) => {
         this.statusSectionTarget.innerHTML = html;
-        this.joinButtonTarget.innerHTML = "You are committed to participating if critical mass is reached.";
+        this.joinButtonTarget.remove();
+        this.nameInputTarget.remove();
+        this.joinSectionTarget.innerHTML = "You are committed to participating if critical mass is achieved.";
       })
       .catch((error) => {
         console.error("Error joining commitment:", error);
-        this.joinButtonTarget.innerHTML = "Something went wrong. Please refresh the page and try again.";
+        this.joinSectionTarget.innerHTML = "Something went wrong. Please refresh the page and try again.";
+      });
+  }
+
+  showMoreParticipants(event) {
+    event.preventDefault();
+    if (!this.currentParticipantsListLimit) {
+      this.currentParticipantsListLimit = +this.participantsListTarget.dataset.limit;
+    }
+    const limit = (this.currentParticipantsListLimit += 10);
+    const url = `${this.participantsListTarget.dataset.url}?limit=${limit}`;
+    fetch(url)
+      .then(response => response.text())
+      .then((html) => {
+        this.participantsListTarget.innerHTML = html;
+      })
+      .catch((error) => {
+        console.error("Error showing more participants:", error);
       });
   }
 

--- a/app/javascript/controllers/commitment_controller.js
+++ b/app/javascript/controllers/commitment_controller.js
@@ -1,0 +1,44 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["joinButton", "statusSection"]
+
+  initialize() {
+    document.addEventListener('poll', this.refreshDisplay.bind(this))
+  }
+
+  get csrfToken() {
+    return document.querySelector("meta[name='csrf-token']").content;
+  }
+
+  join(event) {
+    event.preventDefault();
+    console.log("Joining commitment... " + this.joinButtonTarget.dataset.url);
+    this.joinButtonTarget.innerHTML = "Joining...";
+    const url = this.joinButtonTarget.dataset.url;
+    fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": this.csrfToken,
+      },
+    })
+      .then(response => response.text())
+      .then((html) => {
+        this.statusSectionTarget.innerHTML = html;
+        this.joinButtonTarget.innerHTML = "You are committed to participating if critical mass is reached.";
+      })
+      .catch((error) => {
+        console.error("Error joining commitment:", error);
+        this.joinButtonTarget.innerHTML = "Something went wrong. Please refresh the page and try again.";
+      });
+  }
+
+  async refreshDisplay(event) {
+    event.preventDefault()
+    if (this.refreshing) return;
+    this.refreshing = true;
+    this.refreshing = false;
+  }
+
+}

--- a/app/javascript/controllers/commitment_controller.js
+++ b/app/javascript/controllers/commitment_controller.js
@@ -22,6 +22,9 @@ export default class extends Controller {
         "Content-Type": "application/json",
         "X-CSRF-Token": this.csrfToken,
       },
+      body: JSON.stringify({
+        committed: true,
+      }),
     })
       .then(response => response.text())
       .then((html) => {

--- a/app/javascript/controllers/commitment_controller.js
+++ b/app/javascript/controllers/commitment_controller.js
@@ -4,58 +4,74 @@ export default class extends Controller {
   static targets = ["joinButton", "joinSection", "statusSection", "nameInput", "participantsList"];
 
   initialize() {
-    document.addEventListener('poll', this.refreshDisplay.bind(this))
+    // document.addEventListener('poll', this.refreshDisplay.bind(this))
   }
 
   get csrfToken() {
     return document.querySelector("meta[name='csrf-token']").content;
   }
 
-  join(event) {
+  async join(event) {
     event.preventDefault();
     console.log("Joining commitment... " + this.joinButtonTarget.dataset.url);
     this.joinButtonTarget.innerHTML = "Joining...";
     const url = this.joinButtonTarget.dataset.url;
-    const name = this.nameInputTarget.value.trim();
-    fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-CSRF-Token": this.csrfToken,
-      },
-      body: JSON.stringify({
-        committed: true,
-        name: name,
-      }),
-    })
-      .then(response => response.text())
-      .then((html) => {
-        this.statusSectionTarget.innerHTML = html;
-        this.joinButtonTarget.remove();
-        this.nameInputTarget.remove();
-        this.joinSectionTarget.innerHTML = "You are committed to participating if critical mass is achieved.";
-      })
-      .catch((error) => {
-        console.error("Error joining commitment:", error);
-        this.joinSectionTarget.innerHTML = "Something went wrong. Please refresh the page and try again.";
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": this.csrfToken,
+        },
+        body: JSON.stringify({
+          committed: true,
+        }),
       });
+      const html = await response.text();
+      this.joinButtonTarget.remove();
+      this.joinSectionTarget.innerHTML = html;
+      this.refreshStatusSection(event);
+      this.refreshParticipantsList(event);
+    } catch (error) {
+      console.error("Error joining commitment:", error);
+      this.joinSectionTarget.innerHTML = "Something went wrong. Please refresh the page and try again.";
+    }
   }
 
-  showMoreParticipants(event) {
+  async refreshStatusSection(event) {
+    event.preventDefault();
+    const url = this.statusSectionTarget.dataset.url;
+    try {
+      const response = await fetch(url);
+      const html = await response.text();
+      this.statusSectionTarget.innerHTML = html;
+    } catch (error) {
+      console.error("Error refreshing status:", error);
+    }
+  }
+
+  async refreshParticipantsList(event) {
     event.preventDefault();
     if (!this.currentParticipantsListLimit) {
       this.currentParticipantsListLimit = +this.participantsListTarget.dataset.limit;
     }
-    const limit = (this.currentParticipantsListLimit += 10);
+    const limit = this.currentParticipantsListLimit;
     const url = `${this.participantsListTarget.dataset.url}?limit=${limit}`;
-    fetch(url)
-      .then(response => response.text())
-      .then((html) => {
-        this.participantsListTarget.innerHTML = html;
-      })
-      .catch((error) => {
-        console.error("Error showing more participants:", error);
-      });
+    try {
+      const response = await fetch(url);
+      const html = await response.text();
+      this.participantsListTarget.innerHTML = html;
+    } catch (error) {
+      console.error("Error showing more participants:", error);
+    }
+  }
+
+  async showMoreParticipants(event) {
+    if (!this.currentParticipantsListLimit) {
+      this.currentParticipantsListLimit = +this.participantsListTarget.dataset.limit;
+    }
+    this.currentParticipantsListLimit += 10
+    return this.refreshParticipantsList(event);
   }
 
   async refreshDisplay(event) {

--- a/app/javascript/controllers/decision_controller.js
+++ b/app/javascript/controllers/decision_controller.js
@@ -85,7 +85,7 @@ export default class extends Controller {
       checkbox.checked = approved;
       starButton.checked = stars;
     }
-  
+
     this.updatingApprovals = true;
     await fetch(`/api/v1/decisions/${decisionId}/options/${optionId}/approvals`, {
       method: "POST",
@@ -141,5 +141,5 @@ export default class extends Controller {
   hideOptions() {
     this.optionsSectionTarget.style.display = 'none';
   }
-  
+
 }

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,4 +8,24 @@ class ApplicationRecord < ActiveRecord::Base
   def is_tracked?
     self.class.is_tracked?
   end
+
+  def deadline_iso8601
+    if deadline
+      deadline.iso8601
+    else
+      ""
+    end
+  end
+
+  def closed?
+    deadline && deadline < Time.now
+  end
+
+  def path
+    "/#{path_prefix}/#{self.truncated_id}"
+  end
+
+  def shareable_link
+    "https://#{ENV['HOSTNAME']}#{path}"
+  end
 end

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -1,0 +1,13 @@
+class Commitment < ApplicationRecord
+  include Tracked
+  self.implicit_order_column = "created_at"
+
+  def truncated_id
+    # TODO Fix the bug that causes this to be nil on first save
+    super || self.id.to_s[0..7]
+  end
+
+  def path_prefix
+    'c'
+  end
+end

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -17,7 +17,7 @@ class Commitment < ApplicationRecord
     # critical mass not achieved
     return 'Failed to reach critical mass.' if closed?
     # critical mass not achieved yet
-    return "Pending. #{remaining_needed_for_critical_mass} more participant#{'s' if remaining_needed_for_critical_mass != 1} needed to reach critical mass."
+    return "Pending"
   end
 
 
@@ -32,7 +32,7 @@ class Commitment < ApplicationRecord
   end
 
   def remaining_needed_for_critical_mass
-    critical_mass - participant_count
+    [critical_mass - participant_count, 0].max
   end
 
   def critical_mass_achieved?

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -10,4 +10,32 @@ class Commitment < ApplicationRecord
   def path_prefix
     'c'
   end
+
+  def status_message
+    # critical mass achieved
+    return 'Critical mass achieved.' if critical_mass_achieved?
+    # critical mass not achieved
+    return 'Failed to reach critical mass.' if closed?
+    # critical mass not achieved yet
+    return "Pending. #{remaining_needed_for_critical_mass} more participant#{'s' if remaining_needed_for_critical_mass != 1} needed to reach critical mass."
+  end
+
+
+  # def critical_mass
+  #   # temp debug
+  #   20
+  # end
+
+  def participant_count
+    #participants.count
+    2
+  end
+
+  def remaining_needed_for_critical_mass
+    critical_mass - participant_count
+  end
+
+  def critical_mass_achieved?
+    participant_count >= critical_mass
+  end
 end

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -1,6 +1,7 @@
 class Commitment < ApplicationRecord
   include Tracked
   self.implicit_order_column = "created_at"
+  has_many :participants, class_name: 'CommitmentParticipant'
 
   def truncated_id
     # TODO Fix the bug that causes this to be nil on first save
@@ -20,15 +21,8 @@ class Commitment < ApplicationRecord
     return "Pending"
   end
 
-
-  # def critical_mass
-  #   # temp debug
-  #   20
-  # end
-
   def participant_count
-    #participants.count
-    2
+    participants.where(committed: true).count
   end
 
   def remaining_needed_for_critical_mass

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -21,8 +21,12 @@ class Commitment < ApplicationRecord
     return "Pending"
   end
 
+  def committed_participants
+    participants.where.not(committed_at: nil)
+  end
+
   def participant_count
-    participants.where(committed: true).count
+    committed_participants.count
   end
 
   def remaining_needed_for_critical_mass

--- a/app/models/commitment_participant.rb
+++ b/app/models/commitment_participant.rb
@@ -9,4 +9,22 @@ class CommitmentParticipant < ApplicationRecord
     # If there is a user association, then we know the participant is authenticated
     user.present?
   end
+
+  def committed?
+    committed_at.present?
+  end
+
+  def committed
+    committed?
+  end
+
+  def committed=(value)
+    if value == '1' || value == 'true' || value == true
+      self.committed_at = Time.current unless committed?
+    elsif value == '0' || value == 'false' || value == false
+      self.committed_at = nil
+    else
+      raise 'Invalid value for committed'
+    end
+  end
 end

--- a/app/models/commitment_participant.rb
+++ b/app/models/commitment_participant.rb
@@ -1,0 +1,12 @@
+class CommitmentParticipant < ApplicationRecord
+  self.implicit_order_column = "created_at"
+  belongs_to :commitment
+  belongs_to :user, optional: true
+  # TODO
+  # has_one :created_decision, class_name: 'Commitment', foreign_key: 'created_by_id'
+
+  def authenticated?
+    # If there is a user association, then we know the participant is authenticated
+    user.present?
+  end
+end

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -13,14 +13,6 @@ class Decision < ApplicationRecord
     super || self.id.to_s[0..7]
   end
 
-  def deadline_iso8601
-    if deadline
-      deadline.iso8601
-    else
-      ""
-    end
-  end
-
   def participants
     decision_participants
   end
@@ -39,10 +31,6 @@ class Decision < ApplicationRecord
 
   def can_delete_options?(participant)
     can_add_options?(participant)
-  end
-
-  def closed?
-    deadline && deadline < Time.now
   end
 
   def public?
@@ -66,11 +54,8 @@ class Decision < ApplicationRecord
     approvals.distinct.count(:decision_participant_id)
   end
 
-  def path
-    "/d/#{self.truncated_id}"
+  def path_prefix
+    'd'
   end
 
-  def shareable_link
-    "https://#{ENV['HOSTNAME']}#{path}"
-  end
 end

--- a/app/services/commitment_participant_manager.rb
+++ b/app/services/commitment_participant_manager.rb
@@ -1,0 +1,84 @@
+# This class is responsible for managing the business logic around
+# creating commitment participants and inviting users to participate.
+class CommitmentParticipantManager
+  def initialize(commitment:, user: nil, participant_uid: nil, name: nil)
+    @commitment = commitment
+    @user = user
+    @participant_uid = participant_uid
+    @name = name
+    # TODO - add validations
+  end
+
+  def find_or_create_participant
+    unless @commitment
+      raise 'commitment must be present to find or create participant'
+    end
+    if @user
+      # User takes precedence over participant_uid.
+      # TODO - maybe provide users the option to claim participant_uid after logging in.
+      @participant_uid = nil
+      participant = find_or_create_by_user
+    elsif @participant_uid
+      participant = find_or_create_by_participant_uid
+    else
+      @participant_uid = generate_participant_uid
+      participant = find_or_create_by_participant_uid
+    end
+    participant
+  end
+
+  private
+
+  def generate_participant_uid
+    SecureRandom.uuid
+  end
+
+  def find_or_create_by_participant_uid
+    if @participant_uid.nil?
+      raise 'participant_uid must be present to find or create by participant_uid'
+    elsif @user
+      raise 'user cannot be present when finding or creating by participant_uid'
+    end
+    participant = CommitmentParticipant.find_by(
+      commitment: @commitment,
+      participant_uid: @participant_uid,
+    )
+    if participant && participant.user
+      # If the participant is associated with a user,
+      # but the user is not logged in, then we cannot use this participant record
+      participant = nil
+      @participant_uid = generate_participant_uid
+    end
+    if participant.nil?
+      participant = CommitmentParticipant.create!(
+        commitment: @commitment,
+        user: @user,
+        participant_uid: @participant_uid,
+        name: @name,
+      )
+    end
+    participant
+  end
+
+  def find_or_create_by_user
+    if @user.nil?
+      raise 'user must be present to find or create by user'
+    elsif @participant_uid
+      raise 'participant_uid cannot be present when finding or creating by user'
+    end
+    participant = CommitmentParticipant.find_by(
+      commitment: @commitment,
+      user: @user,
+    )
+    if participant.nil?
+      @participant_uid = generate_participant_uid
+      participant = CommitmentParticipant.create!(
+        commitment: @commitment,
+        user: @user,
+        participant_uid: @participant_uid,
+        name: @name,
+      )
+    end
+    participant
+  end
+end

--- a/app/views/commitments/_join.html.erb
+++ b/app/views/commitments/_join.html.erb
@@ -1,0 +1,33 @@
+<% if @commitment.closed? %>
+  <p>
+    This commitment is closed.
+  </p>
+<% elsif @current_user %>
+  <p>
+    Logged in as <strong><%= @commitment_participant_name %></strong>.
+  </p>
+  <% if @commitment_participant.committed? %>
+    <p>
+      <button style="background:#dfdfdf;color:#9f9f9f;cursor:default;">
+        Committed
+      </button>
+      <span style="font-style:italic;">Your commitment has been recorded.</span>
+    </p>
+  <% else %>
+    <p>
+      <button
+      data-action="click->commitment#join"
+      data-commitment-target="joinButton"
+      data-url="<%= @commitment.path + '/join.html' %>"
+        >
+        Commit to participating
+      </button>
+      <span style="font-style:italic;">Your name and commitment will be displayed publicly.</span>
+    </p>
+  <% end %>
+  <p>Commitments only take effect if critical mass is achieved.</p>
+<% else %>
+  <div class="auth-required-message">
+    <%= button_to 'Log in', '/auth/auth0', method: :post, data: {turbo: false} %> to join this commitment.
+  </div>
+<% end %>

--- a/app/views/commitments/_participants.html.erb
+++ b/app/views/commitments/_participants.html.erb
@@ -1,0 +1,7 @@
+<ul
+  data-commitment-target="participantsList"
+  data-url="<%= @commitment.path + '/participants.html' %>"
+  data-limit="<%= @participants_list_limit %>"
+  >
+  <%= render 'participants_list_items' %>
+</ul>

--- a/app/views/commitments/_participants_list_items.html.erb
+++ b/app/views/commitments/_participants_list_items.html.erb
@@ -1,0 +1,12 @@
+<% @commitment.committed_participants.order(committed_at: :desc).limit(@participants_list_limit).each do |participant| %>
+  <li><strong><%= participant.name || 'Anonymous' %></strong> committed <%= timeago(participant.committed_at) %></li>
+<% end %>
+<% if @commitment.participant_count > @participants_list_limit %>
+  <li
+    data-action="click->commitment#showMoreParticipants"
+    data-commitment-target="moreParticipants"
+    style="cursor:pointer;"
+    >
+    <span style="color:blue;">+ <%= @commitment.participant_count - @participants_list_limit %> more</span>
+  </li>
+<% end %>

--- a/app/views/commitments/_status.html.erb
+++ b/app/views/commitments/_status.html.erb
@@ -1,0 +1,31 @@
+<% if @commitment.critical_mass > 0 %>
+  <% progress_bar_width = [(@commitment.participant_count.to_f / @commitment.critical_mass.to_f) * 100, 100].min %>
+  <div class="progress-bar-container" style="width:100%;height:16px;background-color:rgba(100,100,100,0.2);">
+    <div class="progress-bar" style="width:<%= progress_bar_width %>%;height:16px;background-color:#5ACE5E;"></div>
+  </div>
+  <br/>
+  <p>
+    <% s_or_no_s = @commitment.critical_mass == 1 ? '' : 's' %>
+    <% person_or_people = @commitment.participant_count == 1 ? 'person' : 'people' %>
+    <% is_or_are = @commitment.participant_count == 1 ? 'is' : 'are' %>
+    <strong><%= @commitment.critical_mass %></strong> participant<%= s_or_no_s %> needed to reach critical mass.
+    <br/>
+    <strong><%= @commitment.participant_count %></strong> <%= person_or_people %> <%= is_or_are %> committed to participating<%= @commitment.critical_mass_achieved? ? '' : ' if critical mass is achieved' %>.
+    <% unless @commitment.critical_mass_achieved? %>
+      <br/>
+      <% s_or_no_s = @commitment.remaining_needed_for_critical_mass == 1 ? '' : 's' %>
+      <strong><%= @commitment.remaining_needed_for_critical_mass %></strong> more participant<%= s_or_no_s %> needed to reach critical mass.
+    <% end %>
+  </p>
+  <% if @commitment.critical_mass_achieved? %>
+    <p>
+      Critical mass achieved! 🎉
+    </p>
+  <% end %>
+<% else %>
+  <p>
+    <% person_or_people = @commitment.participant_count == 1 ? 'person' : 'people' %>
+    <% is_or_are = @commitment.participant_count == 1 ? 'is' : 'are' %>
+    <strong><%= @commitment.participant_count %></strong> <%= person_or_people %> <%= is_or_are %> committed to participating.
+  </p>
+<% end %>

--- a/app/views/commitments/new.html.erb
+++ b/app/views/commitments/new.html.erb
@@ -1,0 +1,20 @@
+<h1>Coordinate</h1>
+<p>Coordinate with your team by starting a reciprocal commitment.</p>
+<%= form_with(model: [@commitment]) do |form| %>
+  <p style="margin-bottom:2px;">Give this commitment a title.</p>
+  <div>
+    <%= form.text_field :title, placeholder: 'Title' %>
+  </div>
+  <p style="margin-bottom:2px;margin-top:16px;">Add a description to provide context. (optional)</p>
+  <div>
+    <%= form.text_area :description, placeholder: 'Description (markdown supported)' %>
+  </div>
+  <p>
+    <%= form.number_field :duration, value: 24, style: 'width:48px;' %>
+    <%= form.select :duration_unit, options_for_select(['minute(s)','hour(s)', 'day(s)', 'week(s)'], selected: 'hour(s)') %>
+    will be given to reach critical mass.
+  </p>
+  <hr style="height:1px;" />
+  <p>Go to the commitment page and share the link with your team.</p>
+  <%= form.submit 'Go to commitment page' %>
+<% end %>

--- a/app/views/commitments/new.html.erb
+++ b/app/views/commitments/new.html.erb
@@ -9,6 +9,11 @@
   <div>
     <%= form.text_area :description, placeholder: 'Description (markdown supported)' %>
   </div>
+  <p style="margin-bottom:2px;margin-top:16px;">Set the minimum number of participants required for this commitment to take effect. What indicates critical mass?</p>
+  <div>
+    <%= form.number_field :critical_mass, value: 0, style: 'width:48px;' %>
+  </div>
+  <p style="margin-bottom:2px;margin-top:16px;">Set the deadline.</p>
   <p>
     <%= form.number_field :duration, value: 24, style: 'width:48px;' %>
     <%= form.select :duration_unit, options_for_select(['minute(s)','hour(s)', 'day(s)', 'week(s)'], selected: 'hour(s)') %>

--- a/app/views/commitments/new.html.erb
+++ b/app/views/commitments/new.html.erb
@@ -1,5 +1,5 @@
 <h1>Coordinate</h1>
-<p>Coordinate with your team by starting a reciprocal commitment.</p>
+<p>Coordinate with others by starting a reciprocal commitment.</p>
 <%= form_with(model: [@commitment]) do |form| %>
   <p style="margin-bottom:2px;">Give this commitment a title.</p>
   <div>
@@ -9,10 +9,12 @@
   <div>
     <%= form.text_area :description, placeholder: 'Description (markdown supported)' %>
   </div>
-  <p style="margin-bottom:2px;margin-top:16px;">Set the minimum number of participants required for this commitment to take effect. What indicates critical mass?</p>
+  <h2>Critical Mass</h2>
+  <p style="margin-bottom:2px;margin-top:16px;">Set the minimum number of participants required for this commitment to take effect.</p>
   <div>
     <%= form.number_field :critical_mass, value: 0, style: 'width:48px;' %>
   </div>
+  <h2>Deadline</h2>
   <p style="margin-bottom:2px;margin-top:16px;">Set the deadline.</p>
   <p>
     <%= form.number_field :duration, value: 24, style: 'width:48px;' %>
@@ -20,6 +22,6 @@
     will be given to reach critical mass.
   </p>
   <hr style="height:1px;" />
-  <p>Go to the commitment page and share the link with your team.</p>
+  <p>Go to the commitment page and share the link with others.</p>
   <%= form.submit 'Go to commitment page' %>
 <% end %>

--- a/app/views/commitments/show.html.erb
+++ b/app/views/commitments/show.html.erb
@@ -13,25 +13,9 @@
     <span class="clipboard-button" data-action="click->clipboard#copy" data-clipboard-target="button">Copy link to clipboard</span>
   </span><br/>
 </p>
-<% if @commitment.critical_mass > 0 %>
-  <% progress_bar_width = [(@commitment.participant_count.to_f / @commitment.critical_mass.to_f) * 100, 100].min %>
-  <div class="progress-bar-container" style="width:100%;height:16px;background-color:rgba(100,100,100,0.5);">
-    <div class="progress-bar" style="width:<%= progress_bar_width %>%;height:16px;background-color:#4CAF50;"></div>
-  </div>
-  <br/>
-  <p>
-    <% s_or_no_s = @commitment.critical_mass == 1 ? '' : 's' %>
-    <% person_or_people = @commitment.participant_count == 1 ? 'person' : 'people' %>
-    <% has_or_have = @commitment.participant_count == 1 ? 'has' : 'have' %>
-    <%= @commitment.participant_count %> <%= person_or_people %> <%= has_or_have %> committed to participate<% @commitment.critical_mass_achieved? ? '' : ' if critical mass is achieved' %>.
-    Critical mass = <%= @commitment.critical_mass %> participant<%= s_or_no_s %>.
-  </p>
-  <% if @commitment.critical_mass_achieved? %>
-    <p>
-      Critical mass achieved! 🎉
-    </p>
-  <% end %>
-<% end %>
+<span data-commitment-target="statusSection">
+<%= render 'status' %>
+</span>
 <% if @commitment.description && @commitment.description.length > 0 %>
   <h2>Description</h2>
   <p><%= markdown(@commitment.description) %></p>
@@ -47,7 +31,11 @@
   </p>
 <% else %>
   <p>
-    <span data-action="click->commitment#join" data-commitment-id="<%= @commitment.id %>">Join this commitment</span>.
+    <span
+      data-action="click->commitment#join"
+      data-commitment-target="joinButton"
+      data-url="<%= @commitment.path + '/join.html' %>"
+    >Commit to participating<%= @commitment.critical_mass_achieved? ? '' : ' if critical mass is achieved' %>.</span>
   </p>
 <% end %>
 

--- a/app/views/commitments/show.html.erb
+++ b/app/views/commitments/show.html.erb
@@ -1,20 +1,54 @@
 <span data-controller="commitment" data-commitment-id="<%= @commitment.id %>">
+<h4 style="margin-top:0px;">Commitment</h4>
 <h1 style="margin-top:0;"><%= @commitment.title %></h1>
 <p style="font-size:0.8em;">
-  Created <strong><%= timeago(@commitment.created_at) %></strong><br/>
   <% if @commitment.deadline && !@commitment.closed? %>
     Closing in <strong><%= countdown(@commitment.deadline) %></strong><br/>
   <% elsif @commitment.deadline && @commitment.closed? %>
     Closed <strong><%= timeago(@commitment.deadline) %></strong><br/>
   <% end %>
+  Status: <%= @commitment.status_message %><br/>
   Share this commitment: <span data-controller="clipboard" data-clipboard-success-content="Copied!">
     <input type="text" value="<%= @commitment.shareable_link %>" data-clipboard-target="source" style="display:none;"/>
     <span class="clipboard-button" data-action="click->clipboard#copy" data-clipboard-target="button">Copy link to clipboard</span>
   </span><br/>
 </p>
+<% if @commitment.critical_mass > 0 %>
+  <% progress_bar_width = [(@commitment.participant_count.to_f / @commitment.critical_mass.to_f) * 100, 100].min %>
+  <div class="progress-bar-container" style="width:100%;height:16px;background-color:rgba(100,100,100,0.5);">
+    <div class="progress-bar" style="width:<%= progress_bar_width %>%;height:16px;background-color:#4CAF50;"></div>
+  </div>
+  <br/>
+  <p>
+    <% s_or_no_s = @commitment.critical_mass == 1 ? '' : 's' %>
+    <% person_or_people = @commitment.participant_count == 1 ? 'person' : 'people' %>
+    <% has_or_have = @commitment.participant_count == 1 ? 'has' : 'have' %>
+    <%= @commitment.participant_count %> <%= person_or_people %> <%= has_or_have %> committed to participate<% @commitment.critical_mass_achieved? ? '' : ' if critical mass is achieved' %>.
+    Critical mass = <%= @commitment.critical_mass %> participant<%= s_or_no_s %>.
+  </p>
+  <% if @commitment.critical_mass_achieved? %>
+    <p>
+      Critical mass achieved! 🎉
+    </p>
+  <% end %>
+<% end %>
 <% if @commitment.description && @commitment.description.length > 0 %>
   <h2>Description</h2>
   <p><%= markdown(@commitment.description) %></p>
+<% end %>
+<h2>Join</h2>
+<% if false #if @commitment.participants.include?(current_user) %>
+  <p>
+    You are participating in this commitment.
+  </p>
+<% elsif @commitment.closed? %>
+  <p>
+    This commitment is closed.
+  </p>
+<% else %>
+  <p>
+    <span data-action="click->commitment#join" data-commitment-id="<%= @commitment.id %>">Join this commitment</span>.
+  </p>
 <% end %>
 
 </span>

--- a/app/views/commitments/show.html.erb
+++ b/app/views/commitments/show.html.erb
@@ -30,13 +30,22 @@
     You are committed to participating<%= @commitment.critical_mass_achieved? ? '' : ' if critical mass is achieved' %>.
   </p>
 <% else %>
-  <p>
-    <span
+  <div data-commitment-target="joinSection">
+    <p>Commitments only take effect if critical mass is achieved.</p>
+    <p>
+      <input type="text" data-commitment-target="nameInput" placeholder="Your name" style="min-width: 10px; width:240px;"/>
+      <button
       data-action="click->commitment#join"
       data-commitment-target="joinButton"
       data-url="<%= @commitment.path + '/join.html' %>"
-    >Commit to participating<%= @commitment.critical_mass_achieved? ? '' : ' if critical mass is achieved' %>.</span>
-  </p>
+        >
+        Commit to participating
+      </button>
+      <br/>(Your name will be displayed publicly. Leave blank to remain anonymous.)
+    </p>
+  </div>
 <% end %>
+<h2>Participants</h2>
+<%= render 'participants' %>
 
 </span>

--- a/app/views/commitments/show.html.erb
+++ b/app/views/commitments/show.html.erb
@@ -1,0 +1,20 @@
+<span data-controller="commitment" data-commitment-id="<%= @commitment.id %>">
+<h1 style="margin-top:0;"><%= @commitment.title %></h1>
+<p style="font-size:0.8em;">
+  Created <strong><%= timeago(@commitment.created_at) %></strong><br/>
+  <% if @commitment.deadline && !@commitment.closed? %>
+    Closing in <strong><%= countdown(@commitment.deadline) %></strong><br/>
+  <% elsif @commitment.deadline && @commitment.closed? %>
+    Closed <strong><%= timeago(@commitment.deadline) %></strong><br/>
+  <% end %>
+  Share this commitment: <span data-controller="clipboard" data-clipboard-success-content="Copied!">
+    <input type="text" value="<%= @commitment.shareable_link %>" data-clipboard-target="source" style="display:none;"/>
+    <span class="clipboard-button" data-action="click->clipboard#copy" data-clipboard-target="button">Copy link to clipboard</span>
+  </span><br/>
+</p>
+<% if @commitment.description && @commitment.description.length > 0 %>
+  <h2>Description</h2>
+  <p><%= markdown(@commitment.description) %></p>
+<% end %>
+
+</span>

--- a/app/views/commitments/show.html.erb
+++ b/app/views/commitments/show.html.erb
@@ -21,13 +21,13 @@
   <p><%= markdown(@commitment.description) %></p>
 <% end %>
 <h2>Join</h2>
-<% if false #if @commitment.participants.include?(current_user) %>
-  <p>
-    You are participating in this commitment.
-  </p>
-<% elsif @commitment.closed? %>
+<% if @commitment.closed? %>
   <p>
     This commitment is closed.
+  </p>
+<% elsif @commitment_participant.committed? %>
+  <p>
+    You are committed to participating<%= @commitment.critical_mass_achieved? ? '' : ' if critical mass is achieved' %>.
   </p>
 <% else %>
   <p>

--- a/app/views/commitments/show.html.erb
+++ b/app/views/commitments/show.html.erb
@@ -13,38 +13,17 @@
     <span class="clipboard-button" data-action="click->clipboard#copy" data-clipboard-target="button">Copy link to clipboard</span>
   </span><br/>
 </p>
-<span data-commitment-target="statusSection">
-<%= render 'status' %>
+<span data-commitment-target="statusSection" data-url="<%= @commitment.path + '/status.html' %>">
+  <%= render 'status' %>
 </span>
 <% if @commitment.description && @commitment.description.length > 0 %>
   <h2>Description</h2>
   <p><%= markdown(@commitment.description) %></p>
 <% end %>
 <h2>Join</h2>
-<% if @commitment.closed? %>
-  <p>
-    This commitment is closed.
-  </p>
-<% elsif @commitment_participant.committed? %>
-  <p>
-    You are committed to participating<%= @commitment.critical_mass_achieved? ? '' : ' if critical mass is achieved' %>.
-  </p>
-<% else %>
-  <div data-commitment-target="joinSection">
-    <p>Commitments only take effect if critical mass is achieved.</p>
-    <p>
-      <input type="text" data-commitment-target="nameInput" placeholder="Your name" style="min-width: 10px; width:240px;"/>
-      <button
-      data-action="click->commitment#join"
-      data-commitment-target="joinButton"
-      data-url="<%= @commitment.path + '/join.html' %>"
-        >
-        Commit to participating
-      </button>
-      <br/>(Your name will be displayed publicly. Leave blank to remain anonymous.)
-    </p>
-  </div>
-<% end %>
+<div data-commitment-target="joinSection">
+  <%= render 'join' %>
+</div>
 <h2>Participants</h2>
 <%= render 'participants' %>
 

--- a/app/views/decisions/_options_list_items.html.erb
+++ b/app/views/decisions/_options_list_items.html.erb
@@ -1,4 +1,4 @@
-<% @decision.options.each do |option| %>
+<% @decision.options.order(:created_at).each do |option| %>
   <% approval = @approvals.where(option: option).first || Approval.new(value: 0) %>
   <li class="option-item" data-option-id="<%= option.id %>">
     <input type="checkbox" class="approval-button" id="option<%= option.id %>" data-action="click->decision#toggleApprovalValues" <%= approval.value == 1 ? 'checked' : '' %>/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,11 +33,11 @@ Rails.application.routes.draw do
   end
 
   get 'coordinate' => 'commitments#new'
-  ['commitments', 'c'].each do |path_prefix|
+  ['c'].each do |path_prefix|
     resources :commitments, only: [:create, :show], path: path_prefix do
       get '/status.html' => 'commitments#status_partial'
       get '/participants.html' => 'commitments#participants_list_items_partial'
-      post '/join.html' => 'commitments#join_and_return_status_partial'
+      post '/join.html' => 'commitments#join_and_return_partial'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,5 +30,10 @@ Rails.application.routes.draw do
       get '/options.html' => 'decisions#options_partial'
       post '/options.html' => 'decisions#create_option_and_return_options_partial'
     end
-  end  
+  end
+
+  get 'coordinate' => 'commitments#new'
+  ['commitments', 'c'].each do |path_prefix|
+    resources :commitments, only: [:create, :show], path: path_prefix
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
   ['commitments', 'c'].each do |path_prefix|
     resources :commitments, only: [:create, :show], path: path_prefix do
       get '/status.html' => 'commitments#status_partial'
+      get '/participants.html' => 'commitments#participants_list_items_partial'
       post '/join.html' => 'commitments#join_and_return_status_partial'
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,9 @@ Rails.application.routes.draw do
 
   get 'coordinate' => 'commitments#new'
   ['commitments', 'c'].each do |path_prefix|
-    resources :commitments, only: [:create, :show], path: path_prefix
+    resources :commitments, only: [:create, :show], path: path_prefix do
+      get '/status.html' => 'commitments#status_partial'
+      post '/join.html' => 'commitments#create_option_and_return_status_partial'
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
   ['commitments', 'c'].each do |path_prefix|
     resources :commitments, only: [:create, :show], path: path_prefix do
       get '/status.html' => 'commitments#status_partial'
-      post '/join.html' => 'commitments#create_option_and_return_status_partial'
+      post '/join.html' => 'commitments#join_and_return_status_partial'
     end
   end
 end

--- a/db/migrate/20230520210703_create_decision_participants.rb
+++ b/db/migrate/20230520210703_create_decision_participants.rb
@@ -5,7 +5,7 @@ class CreateDecisionParticipants < ActiveRecord::Migration[7.0]
       t.references :entity, polymorphic: true, null: true
       t.string :name
       t.references :invite, null: true, foreign_key: { to_table: :decision_invites }
-      
+
       t.timestamps
     end
   end

--- a/db/migrate/20241003023146_create_commitments.rb
+++ b/db/migrate/20241003023146_create_commitments.rb
@@ -1,0 +1,12 @@
+class CreateCommitments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :commitments, id: :uuid do |t|
+      t.text :title
+      t.text :description
+      t.datetime :deadline
+      t.string :truncated_id, null: false, as: 'LEFT(id::text, 8)', stored: true
+      t.timestamps
+    end
+    add_index :commitments, :truncated_id, unique: true
+  end
+end

--- a/db/migrate/20241003023146_create_commitments.rb
+++ b/db/migrate/20241003023146_create_commitments.rb
@@ -3,6 +3,7 @@ class CreateCommitments < ActiveRecord::Migration[7.0]
     create_table :commitments, id: :uuid do |t|
       t.text :title
       t.text :description
+      t.integer :critical_mass
       t.datetime :deadline
       t.string :truncated_id, null: false, as: 'LEFT(id::text, 8)', stored: true
       t.timestamps

--- a/db/migrate/20241012185630_create_commitment_participants.rb
+++ b/db/migrate/20241012185630_create_commitment_participants.rb
@@ -5,7 +5,7 @@ class CreateCommitmentParticipants < ActiveRecord::Migration[7.0]
       t.references :user, null: true, type: :uuid, foreign_key: true
       t.string :participant_uid, null: false, default: "", index: true
       t.string :name
-      t.boolean :committed, null: false, default: false
+      t.datetime :committed_at, null: true
 
       t.timestamps
     end

--- a/db/migrate/20241012185630_create_commitment_participants.rb
+++ b/db/migrate/20241012185630_create_commitment_participants.rb
@@ -1,0 +1,14 @@
+class CreateCommitmentParticipants < ActiveRecord::Migration[7.0]
+  def change
+    create_table :commitment_participants, id: :uuid do |t|
+      t.references :commitment, null: false, type: :uuid, foreign_key: true
+      t.references :user, null: true, type: :uuid, foreign_key: true
+      t.string :participant_uid, null: false, default: "", index: true
+      t.string :name
+      t.boolean :committed, null: false, default: false
+
+      t.timestamps
+    end
+    add_index :commitment_participants, [:commitment_id, :participant_uid], unique: true, name: 'index_commitment_participants_on_commitment_and_uid'
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -56,6 +56,22 @@ CREATE TABLE public.ar_internal_metadata (
 
 
 --
+-- Name: commitment_participants; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.commitment_participants (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    commitment_id uuid NOT NULL,
+    user_id uuid,
+    participant_uid character varying DEFAULT ''::character varying NOT NULL,
+    name character varying,
+    committed boolean DEFAULT false NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: commitments; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -180,6 +196,14 @@ ALTER TABLE ONLY public.ar_internal_metadata
 
 
 --
+-- Name: commitment_participants commitment_participants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.commitment_participants
+    ADD CONSTRAINT commitment_participants_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: commitments commitments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -253,6 +277,34 @@ CREATE INDEX index_approvals_on_option_id ON public.approvals USING btree (optio
 --
 
 CREATE UNIQUE INDEX index_approvals_on_option_id_and_decision_participant_id ON public.approvals USING btree (option_id, decision_participant_id);
+
+
+--
+-- Name: index_commitment_participants_on_commitment_and_uid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_commitment_participants_on_commitment_and_uid ON public.commitment_participants USING btree (commitment_id, participant_uid);
+
+
+--
+-- Name: index_commitment_participants_on_commitment_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_commitment_participants_on_commitment_id ON public.commitment_participants USING btree (commitment_id);
+
+
+--
+-- Name: index_commitment_participants_on_participant_uid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_commitment_participants_on_participant_uid ON public.commitment_participants USING btree (participant_uid);
+
+
+--
+-- Name: index_commitment_participants_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_commitment_participants_on_user_id ON public.commitment_participants USING btree (user_id);
 
 
 --
@@ -386,6 +438,14 @@ ALTER TABLE ONLY public.approvals
 
 
 --
+-- Name: commitment_participants fk_rails_ca2dcc834c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.commitment_participants
+    ADD CONSTRAINT fk_rails_ca2dcc834c FOREIGN KEY (commitment_id) REFERENCES public.commitments(id);
+
+
+--
 -- Name: decisions fk_rails_db126ea214; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -399,6 +459,14 @@ ALTER TABLE ONLY public.decisions
 
 ALTER TABLE ONLY public.options
     ADD CONSTRAINT fk_rails_df3bc80da2 FOREIGN KEY (decision_id) REFERENCES public.decisions(id);
+
+
+--
+-- Name: commitment_participants fk_rails_f0bea833a7; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.commitment_participants
+    ADD CONSTRAINT fk_rails_f0bea833a7 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -453,6 +521,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230908024626'),
 ('20230913025720'),
 ('20231005010534'),
-('20241003023146');
+('20241003023146'),
+('20241012185630');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -63,6 +63,7 @@ CREATE TABLE public.commitments (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     title text,
     description text,
+    critical_mass integer,
     deadline timestamp(6) without time zone,
     truncated_id character varying GENERATED ALWAYS AS ("left"((id)::text, 8)) STORED NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -65,7 +65,7 @@ CREATE TABLE public.commitment_participants (
     user_id uuid,
     participant_uid character varying DEFAULT ''::character varying NOT NULL,
     name character varying,
-    committed boolean DEFAULT false NOT NULL,
+    committed_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -56,6 +56,21 @@ CREATE TABLE public.ar_internal_metadata (
 
 
 --
+-- Name: commitments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.commitments (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    title text,
+    description text,
+    deadline timestamp(6) without time zone,
+    truncated_id character varying GENERATED ALWAYS AS ("left"((id)::text, 8)) STORED NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: decision_participants; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -164,6 +179,14 @@ ALTER TABLE ONLY public.ar_internal_metadata
 
 
 --
+-- Name: commitments commitments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.commitments
+    ADD CONSTRAINT commitments_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: decision_participants decision_participants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -229,6 +252,13 @@ CREATE INDEX index_approvals_on_option_id ON public.approvals USING btree (optio
 --
 
 CREATE UNIQUE INDEX index_approvals_on_option_id_and_decision_participant_id ON public.approvals USING btree (option_id, decision_participant_id);
+
+
+--
+-- Name: index_commitments_on_truncated_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_commitments_on_truncated_id ON public.commitments USING btree (truncated_id);
 
 
 --
@@ -421,6 +451,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230827190826'),
 ('20230908024626'),
 ('20230913025720'),
-('20231005010534');
+('20231005010534'),
+('20241003023146');
 
 


### PR DESCRIPTION
Adding [coordinated.team](https://coordinated.team) functionality. Testing on the [app.decisive.team](https://app.decisive.team) domain temporarily. Eventually the commitment routes will only be accessible through the app.coordinated.team domain, and will be run as a separate app instance with separate login.