### PR TITLE
Add graceful shutdown and orphan recovery for agent-runner deploys

### DIFF
--- a/.claude/plans/completed/2026/04/zero-downtime-agent-runner-deploys.md
+++ b/.claude/plans/completed/2026/04/zero-downtime-agent-runner-deploys.md
@@ -1,0 +1,359 @@
+# Zero-Downtime Agent Runner Deploys
+
+## Status
+
+Completed 2026-04-17. All phases shipped on `agent-runner-improvements` branch.
+
+### What shipped
+
+**Phase 1 — Graceful shutdown:**
+- SIGTERM/SIGINT signal handlers with task-level drain (4.5 min timeout)
+- `stop_grace_period: 5m` on both Docker compose files
+- Explicit `process.exit()` after shutdown (forked Effect fibers don't stop on their own)
+
+**Phase 2 — Orphan recovery:**
+- XAUTOCLAIM loop (every 30s, 2-min idle threshold) with active-task guard,
+  dead-lettering after 3 claims, NACK for queued tasks
+- `getTaskStatus` on TaskReporter for Rails status checks
+- `OrphanedTaskSweepJob` (Sidekiq cron, every 10 min, 15-min threshold)
+
+**Phase 3 — Docs:**
+- DEPLOYMENT.md: Agent Runner section
+- AGENT_RUNNER.md: Ops: Graceful Shutdown & Orphan Recovery section
+
+**Infrastructure:**
+- Redis port-mapped in dev compose for integration tests
+- Integration tests: clean SIGTERM exit + drain with active tasks
+
+### Edge cases handled during review
+- Queued tasks NACKed (re-published) instead of left pending to avoid
+  premature dead-lettering from XAUTOCLAIM delivery count
+- Unknown Rails status skipped (not ACK'd) to avoid dropping tasks on
+  transient errors
+- `process.exit()` added to prevent process hang from `Effect.forever` fibers
+
+## Motivation
+
+Every deploy that touches the agent-runner container (`docker compose up -d`)
+kills the process immediately. Docker sends SIGTERM, waits 10 seconds
+(the default `stop_grace_period`), then SIGKILL. Agent tasks can run for
+minutes. Any task in-flight at deploy time is orphaned: the stream entry
+stays in Redis's pending list (un-ACK'd because `queue.ack` is in
+`Effect.ensuring` on the forked task, which never fires on kill) and the
+`AiAgentTaskRun` row stays `running` in the database forever. The only
+recovery is a manual rake task.
+
+This means routine deploys cause data loss. The goal is: **deploys
+complete with no permanently orphaned tasks and no manual intervention.**
+
+## Approach: Task-Level Drain + Orphan Recovery
+
+**Graceful shutdown (SIGTERM):** On SIGTERM, stop accepting new tasks
+and let in-flight tasks finish naturally. With a 5-minute Docker grace
+period, most tasks complete. The queue backs up briefly during the drain
+— acceptable at current scale.
+
+**Hard crash (OOM, SIGKILL):** Tasks can't finish, so we need automated
+recovery. XAUTOCLAIM reclaims orphaned stream entries, and a Rails
+sweep catches anything XAUTOCLAIM misses. Orphaned tasks are marked
+`failed` with a clear reason so users know to retry.
+
+**Future enhancement (not in scope):** Step-level drain with conversation
+reconstruction and automatic task resumption. This would eliminate all
+data loss, even on hard crash, by rebuilding the LLM conversation from
+persisted step data. Deferred until the simpler approach proves
+insufficient. Design notes preserved in git history.
+
+## Architecture Overview
+
+```
+SIGTERM received
+  │
+  ├─ Set draining=true (stop reading new tasks from stream)
+  │
+  ├─ In-flight tasks: continue running to natural completion
+  │
+  ├─ Wait for activeTasks → 0 (up to 4.5 min, within 5 min grace period)
+  │
+  ├─ If timeout: log warning, exit (remaining tasks become orphans)
+  │
+  └─ Disconnect Redis, exit cleanly
+
+Meanwhile (always running):
+  ├─ XAUTOCLAIM loop: reclaim orphaned stream entries every 30s
+  │   └─ Marks orphaned tasks failed, dead-letters poison messages
+  └─ Rails sweep job: catch stuck "running" tasks every 10 min
+```
+
+---
+
+## Phase 1: Graceful Shutdown (Task-Level Drain)
+
+### 1a. Shutdown signal handler in index.ts
+
+- Listen for SIGTERM and SIGINT.
+- Set a module-level `draining` boolean flag.
+- The `Effect.forever` read loop checks `draining` at the top of each
+  iteration. When true, break out of the loop instead of reading.
+- After the loop exits, wait for `stats.activeTasks === 0` by polling
+  every second, with a 4.5-minute timeout (leaving 30s headroom inside
+  the 5-minute Docker grace period).
+- If timeout expires, log a warning with the IDs of still-running tasks.
+  Those tasks become orphans — XAUTOCLAIM (Phase 2) handles them.
+- Call `queue.shutdown()` to disconnect Redis cleanly.
+- Call `process.exit(0)`.
+
+```ts
+let draining = false;
+
+process.on("SIGTERM", () => {
+  log.info({ event: "shutdown_requested", signal: "SIGTERM", activeTasks: stats.activeTasks });
+  draining = true;
+});
+process.on("SIGINT", () => {
+  log.info({ event: "shutdown_requested", signal: "SIGINT", activeTasks: stats.activeTasks });
+  draining = true;
+});
+```
+
+In the main loop, replace `Effect.forever` with a conditional that
+breaks when draining:
+```ts
+// Instead of Effect.forever:
+Effect.repeat(
+  Effect.gen(function* () {
+    if (draining) return yield* Effect.fail("drain");
+    // ... existing read/process logic
+  }),
+)
+```
+
+**The drain wait must happen inside the Effect**, after the loop exits
+but before the generator returns. `Effect.runPromise(program)` resolves
+when the main fiber completes — forked fibers (`Effect.fork(runTask)`)
+continue running in the background, but the process would exit. Keeping
+the main fiber alive inside `processQueue` keeps `Effect.runPromise`
+pending, which keeps the process alive:
+
+```ts
+// Inside processQueue, after the loop breaks:
+const DRAIN_TIMEOUT_MS = 270_000; // 4.5 minutes
+const drainStart = Date.now();
+yield* Effect.gen(function* () {
+  while (stats.activeTasks > 0) {
+    if (Date.now() - drainStart > DRAIN_TIMEOUT_MS) {
+      log.warn({ event: "drain_timeout", activeTasks: stats.activeTasks });
+      break;
+    }
+    log.info({ event: "draining", activeTasks: stats.activeTasks });
+    yield* Effect.sleep("2 seconds");
+  }
+});
+log.info({ event: "drain_complete", activeTasks: stats.activeTasks });
+yield* queue.shutdown();
+```
+
+### 1b. Docker compose: increase stop_grace_period
+
+Both `docker-compose.yml` and `docker-compose.production.yml`:
+
+```yaml
+agent-runner:
+  stop_grace_period: 5m
+```
+
+5 minutes matches the drain timeout. Agent tasks typically complete in
+1-3 minutes. Only exceptionally long tasks (many steps, slow LLM) would
+hit the timeout.
+
+### 1c. Mark timed-out tasks as failed (not stuck forever)
+
+If the drain timeout expires and tasks are still running, they'll be
+killed by Docker's SIGKILL. Without intervention, those rows stay
+`running` forever. Two mechanisms handle this:
+
+1. **XAUTOCLAIM (Phase 2a)** — reclaims the pending stream entry and
+   marks the task failed on the next runner startup.
+2. **Rails sweep (Phase 2b)** — catches any that XAUTOCLAIM misses
+   (e.g., if the stream entry was somehow lost).
+
+No code needed in Phase 1 for this — Phases 2a and 2b cover it.
+
+---
+
+## Phase 2: Orphan Recovery
+
+### 2a. XAUTOCLAIM loop in TaskQueue
+
+Add a periodic `Effect.fork`'d loop that runs alongside normal
+processing (every 30 seconds):
+
+```ts
+XAUTOCLAIM agent_tasks agent_runner <consumer> <min-idle-ms> 0 COUNT 10
+```
+
+- `min-idle-ms`: 120000 (2 minutes). If an entry has been pending for
+  2+ minutes without ACK, it's likely orphaned.
+
+  **Important:** XAUTOCLAIM's idle time measures time since last
+  delivery (XCLAIM/XREADGROUP), not since last activity. There is no
+  implicit refresh — once XREADGROUP delivers an entry, its idle time
+  grows continuously. A 5-minute task has 5 minutes of idle time. To
+  avoid reclaiming entries for tasks that are still actively running
+  in this process, maintain a `Set<string>` of active task run IDs
+  (add on fork, remove in `Effect.ensuring`). When XAUTOCLAIM returns
+  an entry, check the Set first — if the task_run_id is active, skip
+  it (don't ACK, don't process, let it stay pending).
+
+- For each reclaimed entry that is NOT active in this process:
+
+  **Step 1: Check delivery count (dead-lettering).** XAUTOCLAIM returns
+  the delivery count for each entry. If count >= 3, the entry has been
+  claimed multiple times without successful completion — it's likely a
+  poison message. Mark the task `failed` via `/fail` with error
+  `"dead_lettered_after_3_claims"`, ACK the entry, and move on. This
+  prevents infinite retry loops for genuinely broken tasks.
+
+  **Step 2: Check task status on Rails.** Call a new lightweight endpoint:
+  ```
+  GET /internal/agent-runner/tasks/:id/status
+  ```
+  Returns `{ status: "running" | "completed" | ... }`.
+
+  **Step 3: Handle based on status.**
+  - If terminal (`completed`, `failed`, `cancelled`): just ACK. The
+    task finished via another path (e.g., the runner called `/complete`
+    before crashing, but crashed before ACK).
+  - If `running`: a true orphan. Mark it failed via `/fail` with error
+    `"orphaned_after_process_crash"`. Then ACK.
+  - If `queued`: dispatched but never claimed. Re-process it as a new
+    task (feed into `runTask` normally, which handles preflight/claim).
+
+### 2b. Rails orphan sweep (belt and suspenders)
+
+Add a scheduled Sidekiq job (`OrphanedTaskSweepJob`) that runs every
+10 minutes:
+
+- Find `AiAgentTaskRun` rows with `status: "running"` and
+  `started_at < 15.minutes.ago`
+- Mark them `failed` with error `"orphaned_timeout"` and set
+  `completed_at` to now
+- Log each one for visibility
+
+15 minutes is conservative: no task should legitimately run this long
+(max_steps * ~30s per step = ~15 min at 30 steps). The sweep is a
+safety net — XAUTOCLAIM should catch most orphans within 2-3 minutes.
+
+This job handles cases XAUTOCLAIM can't:
+- The stream entry was already ACK'd but the task row wasn't updated
+  (crash between ACK and /complete — unlikely given the ensuring order,
+  but possible)
+- Redis was wiped or the stream was deleted
+- The runner never started after a crash
+
+---
+
+## Phase 3: Deployment Docs & Ops
+
+### 3a. Update DEPLOYMENT.md
+
+Add an "Agent Runner" section:
+
+```markdown
+### Agent Runner
+
+The agent-runner container handles SIGTERM gracefully: it stops accepting
+new tasks and waits up to 5 minutes for in-flight tasks to complete.
+
+Standard deploys (`docker compose up -d`) trigger this automatically.
+During the drain window, new tasks queue in Redis and are processed by
+the new container once it starts.
+
+If the runner is killed before tasks finish (OOM, timeout), orphaned
+tasks are automatically detected and marked failed within ~15 minutes.
+Users see the failure and can retry.
+```
+
+### 3b. Update AGENT_RUNNER.md ops section
+
+Document:
+- How graceful shutdown works (task-level drain)
+- How XAUTOCLAIM recovers orphans from hard crashes
+- How the Rails sweep catches anything XAUTOCLAIM misses
+- How to check for orphaned tasks:
+  `AiAgentTaskRun.where(status: "running").where("started_at < ?", 15.minutes.ago)`
+- The redispatch rake task still exists as a manual fallback
+
+### 3c. Admin UI updates
+
+- Show `orphaned_after_process_crash` and `orphaned_timeout` errors
+  distinctly from normal failures (different badge or icon)
+- These errors should make it obvious the task can be retried
+
+---
+
+## Recovery Matrix
+
+| Scenario | Mechanism | User impact |
+|----------|-----------|-------------|
+| Normal deploy (SIGTERM) | Task-level drain — tasks finish naturally | None (queue backs up briefly) |
+| Long task during deploy | Drain timeout → XAUTOCLAIM on next startup | Task marked failed, user retries |
+| OOM / SIGKILL | XAUTOCLAIM within ~2 min of next startup | Task marked failed, user retries |
+| Runner bug (crash loop) | Dead-lettering after 3 claims | Task marked failed, user retries |
+| Redis wiped / stream lost | Rails orphan sweep within ~15 min | Task marked failed, user retries |
+| Task stuck (infinite loop) | Rails orphan sweep within ~15 min | Task marked failed, user retries |
+
+## Sequencing
+
+1. **Phase 1 (graceful shutdown + Docker grace period)** — the
+   critical fix. Covers the common case: normal deploys. Ship first.
+
+2. **Phase 2 (orphan recovery)** — handles hard crashes and edge
+   cases. Ship immediately after Phase 1.
+
+3. **Phase 3 (docs & ops)** — parallel with either phase.
+
+## Estimated Complexity
+
+| Phase | Effort | Risk |
+|-------|--------|------|
+| 1a. Signal handler + drain loop | Small | Low — well-understood Node.js pattern |
+| 1b. Docker grace period | Trivial | None |
+| 2a. XAUTOCLAIM loop + dead-lettering | Medium | Medium — must avoid reclaiming active tasks |
+| 2b. Rails orphan sweep | Small | Low — simple query + update |
+| 3. Docs & UI | Small | None |
+
+Total: ~200-300 lines of new code. Mostly in TaskQueue.ts (XAUTOCLAIM),
+index.ts (signal handler), and one new Sidekiq job.
+
+## Notes
+
+**Agent lock is in-memory** (`AgentLock.ts` uses a `Set`, not Redis).
+Dies with the process, so no stale-lock problem on crash. No changes
+needed.
+
+**Step persistence is best-effort.** `addStep` catches errors from
+`reporter.step()` and continues. Steps may exist in memory but fail
+to persist. On hard crash, in-progress step data is lost. This is
+acceptable — the task is marked failed and the user retries.
+
+**XAUTOCLAIM active-task guard is critical.** Without it, a long-running
+task (>2 min) could have its stream entry reclaimed while still
+executing, leading to a duplicate run or premature failure marking.
+The guard (checking against a Set of active task IDs) prevents this.
+
+## Future: Step-Level Recovery
+
+If the simple approach proves insufficient (e.g., tasks are frequently
+long-running and deploys cause too many failures), the next step is:
+
+1. Enrich think steps with `tool_calls` and navigate/execute steps with
+   `tool_result` so the LLM conversation is reconstructable from
+   steps_data
+2. Add an `interrupted` status and step-level drain (stop between steps
+   instead of waiting for full completion)
+3. Build a conversation reconstruction function and resume path
+4. Interrupted tasks auto-resume on the next startup
+
+This eliminates all data loss but adds ~500 lines and significant state
+machine complexity. Defer until needed.

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -13,6 +13,7 @@ import { AgentLockLive } from "./services/AgentLock.js";
 import { RailsHttpLive } from "./services/RailsHttp.js";
 import { TaskQueue } from "./services/TaskQueue.js";
 import { AgentLock } from "./services/AgentLock.js";
+import { TaskReporter } from "./services/TaskReporter.js";
 import { runTask } from "./services/AgentLoop.js";
 import { log } from "./services/Logger.js";
 
@@ -43,6 +44,27 @@ const stats: RunnerStats = {
 };
 
 /**
+ * Graceful shutdown state. Set by SIGTERM/SIGINT handlers.
+ * When true, the main loop stops accepting new tasks and waits for
+ * in-flight tasks to finish before exiting.
+ */
+let draining = false;
+
+/** Active task run IDs — used by XAUTOCLAIM to avoid reclaiming our own in-flight tasks. */
+export const activeTaskRunIds = new Set<string>();
+
+const DRAIN_TIMEOUT_MS = 270_000; // 4.5 minutes (within 5 min Docker grace period)
+
+process.on("SIGTERM", () => {
+  log.info({ event: "shutdown_requested", signal: "SIGTERM", activeTasks: stats.activeTasks });
+  draining = true;
+});
+process.on("SIGINT", () => {
+  log.info({ event: "shutdown_requested", signal: "SIGINT", activeTasks: stats.activeTasks });
+  draining = true;
+});
+
+/**
  * Main processing loop: read from stream, acquire agent lock, fork task execution.
  */
 const processQueue = Effect.gen(function* () {
@@ -57,9 +79,14 @@ const processQueue = Effect.gen(function* () {
   // Publish stats to Redis periodically
   yield* Effect.fork(publishStatsLoop());
 
-  // Process loop
+  // Reclaim orphaned stream entries (crash recovery)
+  yield* Effect.fork(orphanRecoveryLoop());
+
+  // Process loop — exits when draining is set
   yield* pipe(
     Effect.gen(function* () {
+      if (draining) return yield* Effect.fail("drain" as const);
+
       // Backpressure: don't read new tasks if at concurrency cap
       if (stats.activeTasks >= config.maxConcurrentTasks) {
         yield* Effect.sleep("1 second");
@@ -81,6 +108,7 @@ const processQueue = Effect.gen(function* () {
       stats.activeTasks++;
       stats.totalTasksProcessed++;
       stats.lastTaskAt = new Date().toISOString();
+      activeTaskRunIds.add(entry.task.taskRunId);
 
       // Fork task execution — runs concurrently
       // Note: runTask catches all its own errors internally and reports via reporter.complete/fail.
@@ -100,7 +128,10 @@ const processQueue = Effect.gen(function* () {
             }),
           ),
           Effect.ensuring(
-            Effect.sync(() => { stats.activeTasks--; }),
+            Effect.sync(() => {
+              stats.activeTasks--;
+              activeTaskRunIds.delete(entry.task.taskRunId);
+            }),
           ),
           Effect.ensuring(agentLock.release(entry.task.agentId)),
           Effect.ensuring(queue.ack(entry.id).pipe(Effect.orDie)),
@@ -108,11 +139,42 @@ const processQueue = Effect.gen(function* () {
       );
     }),
     Effect.catchAll((error) => {
+      if (error === "drain") return Effect.fail(error);
       log.error({ event: "queue_processing_error", message: String(error) });
       return Effect.void;
     }),
     Effect.forever,
+  ).pipe(
+    // The loop exits with "drain" error — catch it and proceed to drain wait
+    Effect.catchAll(() => Effect.void),
   );
+
+  // Drain: wait for in-flight tasks to complete
+  if (stats.activeTasks > 0) {
+    log.info({ event: "draining", activeTasks: stats.activeTasks });
+    const drainStart = Date.now();
+    yield* pipe(
+      Effect.gen(function* () {
+        while (stats.activeTasks > 0) {
+          if (Date.now() - drainStart > DRAIN_TIMEOUT_MS) {
+            log.warn({ event: "drain_timeout", activeTasks: stats.activeTasks, activeTaskRunIds: [...activeTaskRunIds] });
+            break;
+          }
+          yield* Effect.sleep("2 seconds");
+          log.info({ event: "draining", activeTasks: stats.activeTasks, elapsed: Math.round((Date.now() - drainStart) / 1000) });
+        }
+      }),
+      Effect.catchAll(() => Effect.void),
+    );
+  }
+
+  log.info({ event: "shutdown_complete", activeTasks: stats.activeTasks });
+  yield* queue.shutdown();
+
+  // Exit explicitly. Forked fibers (publishStatsLoop, orphanRecoveryLoop, and
+  // any timed-out task fibers) are Effect.forever loops that never complete.
+  // Without this, the process would hang after the main fiber returns.
+  process.exit(stats.activeTasks > 0 ? 1 : 0);
 });
 
 /**
@@ -128,6 +190,97 @@ const publishStatsLoop = () =>
       yield* queue.publishStats({ ...stats, ...info } as unknown as Record<string, unknown>);
     }),
     Effect.catchAll(() => Effect.void),
+    Effect.forever,
+  );
+
+const AUTOCLAIM_MIN_IDLE_MS = 120_000; // 2 minutes
+const DEAD_LETTER_THRESHOLD = 3;
+
+/**
+ * Periodically reclaim orphaned stream entries via XAUTOCLAIM.
+ * Handles: process crashes, OOM kills, drain timeouts.
+ */
+const orphanRecoveryLoop = () =>
+  pipe(
+    Effect.gen(function* () {
+      yield* Effect.sleep("30 seconds");
+      if (draining) return;
+
+      const queue = yield* TaskQueue;
+      const reporter = yield* TaskReporter;
+      const entries = yield* queue.autoClaim(AUTOCLAIM_MIN_IDLE_MS);
+
+      for (const entry of entries) {
+        // Skip entries for tasks we're currently running
+        if (activeTaskRunIds.has(entry.task.taskRunId)) continue;
+
+        // Dead-letter: if claimed too many times, it's a poison message
+        if (entry.deliveryCount >= DEAD_LETTER_THRESHOLD) {
+          log.warn({
+            event: "dead_lettered",
+            taskRunId: entry.task.taskRunId,
+            deliveryCount: entry.deliveryCount,
+          });
+          yield* reporter.fail(
+            entry.task.taskRunId,
+            entry.task.tenantSubdomain,
+            `dead_lettered_after_${entry.deliveryCount}_claims`,
+          ).pipe(Effect.catchAll(() => Effect.void));
+          yield* queue.ack(entry.id).pipe(Effect.catchAll(() => Effect.void));
+          continue;
+        }
+
+        // Check task status on Rails
+        const status = yield* reporter.getTaskStatus(
+          entry.task.taskRunId,
+          entry.task.tenantSubdomain,
+        ).pipe(Effect.catchAll(() => Effect.succeed("unknown")));
+
+        if (status === "completed" || status === "failed" || status === "cancelled") {
+          // Task already reached terminal state — just ACK the stale entry
+          log.info({
+            event: "autoclaim_already_terminal",
+            taskRunId: entry.task.taskRunId,
+            status,
+          });
+          yield* queue.ack(entry.id).pipe(Effect.catchAll(() => Effect.void));
+        } else if (status === "running") {
+          // True orphan — mark failed
+          log.warn({
+            event: "autoclaim_orphan_failed",
+            taskRunId: entry.task.taskRunId,
+          });
+          yield* reporter.fail(
+            entry.task.taskRunId,
+            entry.task.tenantSubdomain,
+            "orphaned_after_process_crash",
+          ).pipe(Effect.catchAll(() => Effect.void));
+          yield* queue.ack(entry.id).pipe(Effect.catchAll(() => Effect.void));
+        } else if (status === "queued") {
+          // Dispatched but never claimed — the previous runner crashed
+          // before processing. NACK re-publishes it as a fresh stream
+          // entry for normal XREADGROUP pickup, avoiding the delivery
+          // count incrementing toward dead-letter on each XAUTOCLAIM cycle.
+          log.info({
+            event: "autoclaim_queued_requeued",
+            taskRunId: entry.task.taskRunId,
+          });
+          yield* queue.nack(entry.id).pipe(Effect.catchAll(() => Effect.void));
+        } else {
+          // Unknown status (e.g. Rails returned an error) — don't ACK.
+          // Leave the entry pending so it can be retried on the next cycle.
+          log.warn({
+            event: "autoclaim_unknown_status_skipped",
+            taskRunId: entry.task.taskRunId,
+            status,
+          });
+        }
+      }
+    }),
+    Effect.catchAll((error) => {
+      log.error({ event: "autoclaim_error", message: String(error) });
+      return Effect.void;
+    }),
     Effect.forever,
   );
 

--- a/agent-runner/src/services/TaskQueue.ts
+++ b/agent-runner/src/services/TaskQueue.ts
@@ -20,6 +20,12 @@ export interface StreamInfo {
   readonly streamPending: number;
 }
 
+export interface ClaimedEntry {
+  readonly id: string;
+  readonly task: TaskPayload;
+  readonly deliveryCount: number;
+}
+
 export interface TaskQueueService {
   readonly read: () => Effect.Effect<StreamEntry | null, RedisError>;
   readonly ack: (entryId: string) => Effect.Effect<void, RedisError>;
@@ -27,6 +33,8 @@ export interface TaskQueueService {
   readonly ensureGroup: () => Effect.Effect<void, RedisError>;
   readonly publishStats: (stats: Record<string, unknown>) => Effect.Effect<void, RedisError>;
   readonly streamInfo: () => Effect.Effect<StreamInfo, RedisError>;
+  /** Reclaim orphaned stream entries that have been idle for minIdleMs. */
+  readonly autoClaim: (minIdleMs: number) => Effect.Effect<ClaimedEntry[], RedisError>;
   readonly shutdown: () => Effect.Effect<void>;
 }
 
@@ -242,6 +250,55 @@ export const TaskQueueLive = Layer.effect(
           new RedisError({ message: error instanceof Error ? error.message : String(error) }),
       });
 
+    const autoClaim: TaskQueueService["autoClaim"] = (minIdleMs) =>
+      Effect.tryPromise({
+        try: async () => {
+          const r = getRedis();
+          // XAUTOCLAIM <key> <group> <consumer> <min-idle-time> <start> [COUNT count]
+          // Returns [nextStartId, [[entryId, fields], ...], [deletedIds]]
+          const result = await r.call(
+            "XAUTOCLAIM",
+            config.streamName,
+            config.consumerGroup,
+            config.consumerName,
+            String(minIdleMs),
+            "0-0",
+            "COUNT",
+            "10",
+          ) as [string, Array<[string, string[]]>, string[]];
+
+          if (!Array.isArray(result) || !Array.isArray(result[1])) return [];
+
+          const entries: ClaimedEntry[] = [];
+          for (const entry of result[1]) {
+            if (!Array.isArray(entry) || entry.length < 2) continue;
+            const [id, fields] = entry;
+            if (id === undefined || !Array.isArray(fields)) continue;
+            const task = parseStreamEntry(fields);
+            if (task === null) continue;
+
+            // Get delivery count from XPENDING for this specific entry
+            let deliveryCount = 1;
+            try {
+              const pending = await r.call(
+                "XPENDING", config.streamName, config.consumerGroup,
+                id, id, "1",
+              ) as Array<[string, string, number, number]>;
+              if (Array.isArray(pending) && pending.length > 0 && Array.isArray(pending[0])) {
+                deliveryCount = pending[0][3] ?? 1; // 4th element is delivery count
+              }
+            } catch {
+              // If XPENDING fails, proceed with default count
+            }
+
+            entries.push({ id, task, deliveryCount });
+          }
+          return entries;
+        },
+        catch: (error) =>
+          new RedisError({ message: error instanceof Error ? error.message : String(error) }),
+      });
+
     const shutdown: TaskQueueService["shutdown"] = () =>
       Effect.sync(() => {
         if (redis !== null) {
@@ -250,6 +307,6 @@ export const TaskQueueLive = Layer.effect(
         }
       });
 
-    return { read, ack, nack, ensureGroup, publishStats, streamInfo, shutdown };
+    return { read, ack, nack, ensureGroup, publishStats, streamInfo, autoClaim, shutdown };
   }),
 );

--- a/agent-runner/src/services/TaskReporter.ts
+++ b/agent-runner/src/services/TaskReporter.ts
@@ -63,6 +63,8 @@ export interface TaskReporterService {
   readonly fail: (taskRunId: string, subdomain: string, error: string) => Effect.Effect<void, HarmonicApiError>;
   readonly scratchpad: (taskRunId: string, subdomain: string, content: string) => Effect.Effect<void, HarmonicApiError>;
   readonly checkCancellation: (taskRunId: string, subdomain: string) => Effect.Effect<void, TaskCancelledError | HarmonicApiError>;
+  /** Get a task's current status string from Rails. */
+  readonly getTaskStatus: (taskRunId: string, subdomain: string) => Effect.Effect<string, HarmonicApiError>;
 }
 
 export class TaskReporter extends Context.Tag("TaskReporter")<TaskReporter, TaskReporterService>() {}
@@ -162,6 +164,14 @@ export const TaskReporterLive = Layer.effect(
         }
       });
 
-    return { preflight, claim, step, complete, fail, scratchpad, checkCancellation };
+    const getTaskStatus: TaskReporterService["getTaskStatus"] = (taskRunId, subdomain) =>
+      internalRequest("GET", `/internal/agent-runner/tasks/${taskRunId}/status`, subdomain).pipe(
+        Effect.map((result) => {
+          const obj = result as Record<string, unknown> | null;
+          return String(obj?.["status"] ?? "unknown");
+        }),
+      );
+
+    return { preflight, claim, step, complete, fail, scratchpad, checkCancellation, getTaskStatus };
   }),
 );

--- a/agent-runner/test/integration/graceful-shutdown.test.ts
+++ b/agent-runner/test/integration/graceful-shutdown.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { fork } from "node:child_process";
 import { resolve } from "node:path";
 import { createCipheriv, hkdfSync, randomBytes } from "node:crypto";
+import { createServer, type Server } from "node:http";
 
 const TEST_SECRET = "test-secret-for-shutdown-test";
 const HKDF_INFO = "agent-runner-token-encryption";
@@ -17,8 +18,35 @@ function encryptToken(plaintext: string): string {
   return Buffer.concat([iv, authTag, encrypted]).toString("base64");
 }
 
+/**
+ * Start a mock Rails server that delays the first request, then responds
+ * quickly to subsequent ones. The initial delay keeps the task in-flight
+ * long enough for SIGTERM to land; quick follow-ups let the task finish
+ * within the drain window.
+ */
+function startSlowMockServer(firstRequestDelayMs: number): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve) => {
+    let requestCount = 0;
+    const server = createServer((_req, res) => {
+      requestCount++;
+      const delay = requestCount === 1 ? firstRequestDelayMs : 0;
+      setTimeout(() => {
+        // Return 500 for all requests — task will fail quickly after the
+        // initial slow response, rather than proceeding through claim/LLM/etc.
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "mock server" }));
+      }, delay);
+    });
+    server.listen(0, () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+      resolve({ server, port });
+    });
+  });
+}
+
 /** Spawn the agent-runner with a unique stream name to avoid test interference. */
-function spawnRunner(streamName: string) {
+function spawnRunner(streamName: string, internalUrl: string) {
   const entryPoint = resolve(import.meta.dirname, "../../dist/index.js");
   const logs: string[] = [];
 
@@ -27,7 +55,7 @@ function spawnRunner(streamName: string) {
       ...process.env,
       AGENT_RUNNER_SECRET: TEST_SECRET,
       REDIS_URL,
-      HARMONIC_INTERNAL_URL: "http://localhost:3000",
+      HARMONIC_INTERNAL_URL: internalUrl,
       HARMONIC_HOSTNAME: "test.local",
       AGENT_TASKS_STREAM: streamName,
     },
@@ -44,7 +72,6 @@ function spawnRunner(streamName: string) {
 
   const waitForEvent = (eventName: string, timeoutMs = 10_000) =>
     new Promise<boolean>((resolve) => {
-      // Check if already in logs
       if (logs.some((l) => l.includes(`"event":"${eventName}"`))) {
         resolve(true);
         return;
@@ -128,7 +155,7 @@ describe("graceful shutdown", () => {
     const stream = `agent_tasks_test_${randomBytes(4).toString("hex")}`;
     streamsToCleanup.push(stream);
 
-    const runner = spawnRunner(stream);
+    const runner = spawnRunner(stream, "http://localhost:3000");
     const started = await runner.waitForEvent("started");
     expect(started).toBe(true);
 
@@ -148,49 +175,46 @@ describe("graceful shutdown", () => {
       return;
     }
 
+    // Start a mock server that delays the first response by 8 seconds.
+    // This must exceed the XREADGROUP BLOCK timeout (5 seconds) so the
+    // task is still in-flight when the main loop unwinds after SIGTERM.
+    // Subsequent requests return 500 immediately so the task fails fast
+    // and the drain completes quickly.
+    const mock = await startSlowMockServer(8_000);
+
     const stream = `agent_tasks_test_${randomBytes(4).toString("hex")}`;
     streamsToCleanup.push(stream);
 
     const { Redis } = await import("ioredis");
     const redis = new Redis(REDIS_URL);
 
-    const runner = spawnRunner(stream);
+    const runner = spawnRunner(stream, `http://localhost:${mock.port}`);
     const started = await runner.waitForEvent("started");
     expect(started).toBe(true);
 
-    // Push 3 tasks. Each takes ~5 seconds (preflight fails → reporter.fail retries
-    // with backoff: 250ms + 1s + 4s). With 3 concurrent tasks, at least one will
-    // still be in-flight when SIGTERM fires, exercising the drain wait.
-    for (let i = 1; i <= 3; i++) {
-      await redis.xadd(
-        stream, "MAXLEN", "~", "10000", "*",
-        "task_run_id", `test-drain-task-${i}`,
-        "encrypted_token", encryptToken(`fake-api-token-for-drain-test-${i}-pad12345`),
-        "task", "Test drain behavior",
-        "max_steps", "5",
-        "model", "",
-        "agent_id", `test-agent-${i}`,
-        "tenant_subdomain", "test",
-        "stripe_customer_stripe_id", "",
-      );
-    }
+    // Push a task. The runner will pick it up and call preflight on our
+    // mock server, which delays 8 seconds — keeping the task in-flight.
+    await redis.xadd(
+      stream, "MAXLEN", "~", "10000", "*",
+      "task_run_id", "test-drain-task-1",
+      "encrypted_token", encryptToken("fake-api-token-for-drain-test-1-pad12345"),
+      "task", "Test drain behavior",
+      "max_steps", "5",
+      "model", "",
+      "agent_id", "test-agent-1",
+      "tenant_subdomain", "test",
+      "stripe_customer_stripe_id", "",
+    );
 
-    // Send SIGTERM as soon as we see the first task_received — tasks are in-flight
-    // with preflight retries taking several seconds.
-    await new Promise<void>((resolve) => {
-      const timeout = setTimeout(() => resolve(), 10_000);
-      const check = () => {
-        if (runner.logs.some((l) => l.includes('"event":"task_received"'))) {
-          clearTimeout(timeout);
-          runner.child.kill("SIGTERM");
-          resolve();
-        }
-      };
-      runner.child.stdout?.on("data", check);
-      runner.child.stderr?.on("data", check);
-    });
+    // Wait for the task to be picked up
+    const received = await runner.waitForEvent("task_received", 10_000);
+    expect(received).toBe(true);
 
-    expect(runner.logs.some((l) => l.includes('"event":"task_received"'))).toBe(true);
+    // Small delay to ensure the task fiber has started and is blocked on preflight
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Send SIGTERM — the task is in-flight (blocked on slow preflight)
+    runner.child.kill("SIGTERM");
 
     // The runner should drain — wait for it to exit
     const exitCode = await runner.waitForExit(30_000);
@@ -202,14 +226,14 @@ describe("graceful shutdown", () => {
     expect(eventNames).toContain("task_received");
     expect(eventNames).toContain("shutdown_requested");
 
-    // The shutdown_requested should show activeTasks > 0
+    // shutdown_requested must show activeTasks > 0 (task is blocked on preflight)
     const shutdownEvent = events.find((e) => e.event === "shutdown_requested");
     expect(shutdownEvent?.activeTasks).toBeGreaterThan(0);
 
-    // Should have entered draining mode and waited for tasks to finish
+    // Must have entered draining mode and waited
     expect(eventNames).toContain("draining");
 
-    // Should eventually complete shutdown after task finishes/fails
+    // Should eventually complete shutdown after task finishes
     expect(eventNames).toContain("shutdown_complete");
 
     // shutdown_complete should show activeTasks back to 0
@@ -218,6 +242,8 @@ describe("graceful shutdown", () => {
 
     expect(exitCode).toBe(0);
 
+    // Clean up
     redis.disconnect();
+    mock.server.close();
   }, 60_000);
 });

--- a/agent-runner/test/integration/graceful-shutdown.test.ts
+++ b/agent-runner/test/integration/graceful-shutdown.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { fork } from "node:child_process";
+import { resolve } from "node:path";
+import { createCipheriv, hkdfSync, randomBytes } from "node:crypto";
+
+const TEST_SECRET = "test-secret-for-shutdown-test";
+const HKDF_INFO = "agent-runner-token-encryption";
+const REDIS_URL = process.env.REDIS_URL ?? "redis://localhost:6379";
+
+function encryptToken(plaintext: string): string {
+  const key = Buffer.from(hkdfSync("sha256", TEST_SECRET, "", HKDF_INFO, 32));
+  const iv = Buffer.alloc(12, 1);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  cipher.setAAD(Buffer.alloc(0));
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([iv, authTag, encrypted]).toString("base64");
+}
+
+/** Spawn the agent-runner with a unique stream name to avoid test interference. */
+function spawnRunner(streamName: string) {
+  const entryPoint = resolve(import.meta.dirname, "../../dist/index.js");
+  const logs: string[] = [];
+
+  const child = fork(entryPoint, [], {
+    env: {
+      ...process.env,
+      AGENT_RUNNER_SECRET: TEST_SECRET,
+      REDIS_URL,
+      HARMONIC_INTERNAL_URL: "http://localhost:3000",
+      HARMONIC_HOSTNAME: "test.local",
+      AGENT_TASKS_STREAM: streamName,
+    },
+    stdio: ["pipe", "pipe", "pipe", "ipc"],
+  });
+
+  const collectLogs = (data: Buffer) => {
+    for (const line of data.toString().split("\n").filter(Boolean)) {
+      logs.push(line);
+    }
+  };
+  child.stdout?.on("data", collectLogs);
+  child.stderr?.on("data", collectLogs);
+
+  const waitForEvent = (eventName: string, timeoutMs = 10_000) =>
+    new Promise<boolean>((resolve) => {
+      // Check if already in logs
+      if (logs.some((l) => l.includes(`"event":"${eventName}"`))) {
+        resolve(true);
+        return;
+      }
+
+      const timeout = setTimeout(() => resolve(false), timeoutMs);
+
+      const check = () => {
+        if (logs.some((l) => l.includes(`"event":"${eventName}"`))) {
+          clearTimeout(timeout);
+          resolve(true);
+        }
+      };
+      child.stdout?.on("data", check);
+      child.stderr?.on("data", check);
+      child.on("exit", () => { clearTimeout(timeout); resolve(false); });
+    });
+
+  const waitForExit = (timeoutMs = 15_000) =>
+    new Promise<number | null>((resolve) => {
+      const timeout = setTimeout(() => { child.kill("SIGKILL"); resolve(null); }, timeoutMs);
+      child.on("exit", (code) => { clearTimeout(timeout); resolve(code); });
+    });
+
+  const parseEvents = () =>
+    logs
+      .map((line) => { try { return JSON.parse(line); } catch { return null; } })
+      .filter((e): e is Record<string, unknown> => e !== null && typeof e === "object");
+
+  return { child, logs, waitForEvent, waitForExit, parseEvents };
+}
+
+/** Check if Redis is available by attempting a connection. */
+async function redisAvailable(): Promise<boolean> {
+  try {
+    const { Redis } = await import("ioredis");
+    const r = new Redis(REDIS_URL, { lazyConnect: true, connectTimeout: 2000 });
+    await r.connect();
+    await r.ping();
+    r.disconnect();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Integration tests for graceful shutdown.
+ * Spawns the agent-runner as a child process, sends SIGTERM, and verifies
+ * it exits cleanly with the expected log events.
+ *
+ * Each test uses a unique Redis stream name to avoid interference from
+ * other tests or previous runs.
+ *
+ * Requires Redis on localhost:6379 (available in CI; locally via docker-compose port mapping).
+ */
+describe("graceful shutdown", () => {
+  let hasRedis = false;
+  const streamsToCleanup: string[] = [];
+
+  beforeAll(async () => {
+    hasRedis = await redisAvailable();
+  });
+
+  afterAll(async () => {
+    if (!hasRedis || streamsToCleanup.length === 0) return;
+    const { Redis } = await import("ioredis");
+    const redis = new Redis(REDIS_URL);
+    for (const stream of streamsToCleanup) {
+      await redis.del(stream).catch(() => {});
+    }
+    redis.disconnect();
+  });
+
+  it("exits cleanly on SIGTERM with no active tasks", async () => {
+    if (!hasRedis) {
+      console.log("Skipping: Redis not available");
+      return;
+    }
+
+    const stream = `agent_tasks_test_${randomBytes(4).toString("hex")}`;
+    streamsToCleanup.push(stream);
+
+    const runner = spawnRunner(stream);
+    const started = await runner.waitForEvent("started");
+    expect(started).toBe(true);
+
+    runner.child.kill("SIGTERM");
+    const exitCode = await runner.waitForExit();
+
+    const events = runner.parseEvents().map((e) => e.event);
+    expect(events).toContain("started");
+    expect(events).toContain("shutdown_requested");
+    expect(events).toContain("shutdown_complete");
+    expect(exitCode).toBe(0);
+  }, 30_000);
+
+  it("drains active tasks before exiting on SIGTERM", async () => {
+    if (!hasRedis) {
+      console.log("Skipping: Redis not available");
+      return;
+    }
+
+    const stream = `agent_tasks_test_${randomBytes(4).toString("hex")}`;
+    streamsToCleanup.push(stream);
+
+    const { Redis } = await import("ioredis");
+    const redis = new Redis(REDIS_URL);
+
+    const runner = spawnRunner(stream);
+    const started = await runner.waitForEvent("started");
+    expect(started).toBe(true);
+
+    // Push 3 tasks. Each takes ~5 seconds (preflight fails → reporter.fail retries
+    // with backoff: 250ms + 1s + 4s). With 3 concurrent tasks, at least one will
+    // still be in-flight when SIGTERM fires, exercising the drain wait.
+    for (let i = 1; i <= 3; i++) {
+      await redis.xadd(
+        stream, "MAXLEN", "~", "10000", "*",
+        "task_run_id", `test-drain-task-${i}`,
+        "encrypted_token", encryptToken(`fake-api-token-for-drain-test-${i}-pad12345`),
+        "task", "Test drain behavior",
+        "max_steps", "5",
+        "model", "",
+        "agent_id", `test-agent-${i}`,
+        "tenant_subdomain", "test",
+        "stripe_customer_stripe_id", "",
+      );
+    }
+
+    // Send SIGTERM as soon as we see the first task_received — tasks are in-flight
+    // with preflight retries taking several seconds.
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => resolve(), 10_000);
+      const check = () => {
+        if (runner.logs.some((l) => l.includes('"event":"task_received"'))) {
+          clearTimeout(timeout);
+          runner.child.kill("SIGTERM");
+          resolve();
+        }
+      };
+      runner.child.stdout?.on("data", check);
+      runner.child.stderr?.on("data", check);
+    });
+
+    expect(runner.logs.some((l) => l.includes('"event":"task_received"'))).toBe(true);
+
+    // The runner should drain — wait for it to exit
+    const exitCode = await runner.waitForExit(30_000);
+
+    const events = runner.parseEvents();
+    const eventNames = events.map((e) => e.event);
+
+    expect(eventNames).toContain("started");
+    expect(eventNames).toContain("task_received");
+    expect(eventNames).toContain("shutdown_requested");
+
+    // The shutdown_requested should show activeTasks > 0
+    const shutdownEvent = events.find((e) => e.event === "shutdown_requested");
+    expect(shutdownEvent?.activeTasks).toBeGreaterThan(0);
+
+    // Should have entered draining mode and waited for tasks to finish
+    expect(eventNames).toContain("draining");
+
+    // Should eventually complete shutdown after task finishes/fails
+    expect(eventNames).toContain("shutdown_complete");
+
+    // shutdown_complete should show activeTasks back to 0
+    const completeEvent = events.find((e) => e.event === "shutdown_complete");
+    expect(completeEvent?.activeTasks).toBe(0);
+
+    expect(exitCode).toBe(0);
+
+    redis.disconnect();
+  }, 60_000);
+});

--- a/agent-runner/test/services/OrphanRecovery.test.ts
+++ b/agent-runner/test/services/OrphanRecovery.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+
+describe("orphan recovery: active task guard", () => {
+  it("Set correctly tracks active task IDs for XAUTOCLAIM guard", () => {
+    // This tests the pattern used in index.ts — a Set<string> of active task run IDs.
+    // XAUTOCLAIM checks this set to avoid reclaiming entries for tasks we're still running.
+    const activeTaskRunIds = new Set<string>();
+
+    activeTaskRunIds.add("task-1");
+    activeTaskRunIds.add("task-2");
+
+    // Simulated XAUTOCLAIM entries — should skip active tasks
+    const claimedEntries = [
+      { taskRunId: "task-1" }, // active — skip
+      { taskRunId: "task-3" }, // not active — process
+    ];
+
+    const toProcess = claimedEntries.filter(e => !activeTaskRunIds.has(e.taskRunId));
+    expect(toProcess).toEqual([{ taskRunId: "task-3" }]);
+
+    // After task completes, remove from set
+    activeTaskRunIds.delete("task-1");
+    expect(activeTaskRunIds.has("task-1")).toBe(false);
+  });
+});
+
+describe("orphan recovery: dead-letter threshold", () => {
+  it("dead-letters after 3 delivery attempts", () => {
+    const DEAD_LETTER_THRESHOLD = 3;
+
+    // Simulated claimed entries with delivery counts
+    const entries = [
+      { taskRunId: "task-a", deliveryCount: 1 },
+      { taskRunId: "task-b", deliveryCount: 3 },
+      { taskRunId: "task-c", deliveryCount: 5 },
+    ];
+
+    const deadLettered = entries.filter(e => e.deliveryCount >= DEAD_LETTER_THRESHOLD);
+    const toCheck = entries.filter(e => e.deliveryCount < DEAD_LETTER_THRESHOLD);
+
+    expect(deadLettered.map(e => e.taskRunId)).toEqual(["task-b", "task-c"]);
+    expect(toCheck.map(e => e.taskRunId)).toEqual(["task-a"]);
+  });
+});

--- a/app/jobs/orphaned_task_sweep_job.rb
+++ b/app/jobs/orphaned_task_sweep_job.rb
@@ -1,0 +1,33 @@
+# typed: true
+# frozen_string_literal: true
+
+# Sweeps for agent task runs stuck in "running" state.
+#
+# Belt-and-suspenders for cases where XAUTOCLAIM can't recover:
+# - Stream entry was ACK'd but task row wasn't updated (crash between ACK and /complete)
+# - Redis was wiped or the stream was deleted
+# - The agent-runner never restarted after a crash
+#
+# Runs every 10 minutes via sidekiq-cron.
+class OrphanedTaskSweepJob < SystemJob
+  ORPHAN_THRESHOLD = 15.minutes
+
+  def perform
+    orphaned = AiAgentTaskRun.unscoped_for_system_job
+      .where(status: "running")
+      .where("started_at < ?", ORPHAN_THRESHOLD.ago)
+
+    orphaned.find_each do |task_run|
+      task_run.update!(
+        status: "failed",
+        success: false,
+        error: "orphaned_timeout",
+        completed_at: Time.current,
+      )
+      Rails.logger.warn(
+        "[OrphanedTaskSweep] Marked task #{task_run.id} as failed " \
+        "(started_at: #{task_run.started_at}, agent: #{task_run.ai_agent&.name})",
+      )
+    end
+  end
+end

--- a/config/initializers/sidekiq_cron.rb
+++ b/config/initializers/sidekiq_cron.rb
@@ -18,6 +18,11 @@ Sidekiq.configure_server do |_config|
       "class" => "ReminderDeliveryJob",
       "description" => "Deliver due reminders",
     },
+    "orphaned_task_sweep" => {
+      "cron" => "*/10 * * * *", # Every 10 minutes
+      "class" => "OrphanedTaskSweepJob",
+      "description" => "Mark stuck agent task runs as failed",
+    },
   }
 
   Sidekiq::Cron::Job.load_from_hash(schedule)

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -78,6 +78,7 @@ services:
   # leak the Rails master key, Stripe backend key, DB password, etc.
   agent-runner:
     image: ghcr.io/ibis-coordination/harmonic-agent-runner:latest
+    stop_grace_period: 5m
     restart: unless-stopped
     environment:
       - NODE_ENV=production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
 
   redis:
     image: redis:7-alpine
+    ports:
+      - "6379:6379"
     volumes:
       - redis_data:/data
     healthcheck:
@@ -83,6 +85,7 @@ services:
       retries: 3
     networks:
       - backend
+      - frontend  # also on frontend so port mapping works (backend is internal-only)
 
   # Autoheal - automatically restarts unhealthy containers
   # Monitors container health checks and restarts containers that become unhealthy
@@ -158,6 +161,7 @@ services:
   # leak the Rails master key, Stripe backend key, DB password, etc.
   agent-runner:
     build: ./agent-runner
+    stop_grace_period: 5m
     profiles: ["llm"]
     depends_on:
       web:

--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -149,3 +149,59 @@ Recommended procedure:
 4. **Expect nonce cache carryover.** Replay protection stores nonces in Redis with a 5-minute TTL; the rotated secret is unrelated, so the cache stays valid across the rotation.
 
 A future version may prepend a 1-byte key-version prefix to encrypted payloads so the runner can decrypt under both the old and new keys during a rolling window. Until then: drain before rotating.
+
+## Ops: Graceful Shutdown & Orphan Recovery
+
+### Graceful Shutdown
+
+On SIGTERM (sent by `docker compose up -d` during deploys), the runner:
+
+1. Stops reading new tasks from the Redis stream
+2. Waits up to 4.5 minutes for in-flight tasks to complete naturally
+3. Disconnects Redis and exits cleanly
+
+Docker's `stop_grace_period` is set to 5 minutes in both compose files.
+Most tasks complete within 1-3 minutes. If the timeout expires, remaining
+tasks become orphans (see below).
+
+### Orphan Recovery
+
+Two mechanisms detect and clean up orphaned tasks:
+
+**XAUTOCLAIM (in the runner):** Every 30 seconds, the runner reclaims
+Redis stream entries that have been pending for >2 minutes without ACK.
+For each reclaimed entry:
+- If the task already reached a terminal state on Rails → ACK and skip
+- If the task is still "running" → mark it failed with
+  `orphaned_after_process_crash` and ACK
+- If claimed 3+ times without completion → dead-letter it as
+  `dead_lettered_after_N_claims` (prevents infinite retry loops)
+
+The runner maintains a Set of active task IDs to avoid reclaiming entries
+for tasks it is currently executing (XAUTOCLAIM's idle timer grows
+continuously from the initial read, not from last activity).
+
+**OrphanedTaskSweepJob (Sidekiq, every 10 min):** Catches cases
+XAUTOCLAIM can't handle (Redis wiped, stream deleted, runner never
+restarted). Finds `AiAgentTaskRun` rows with `status: "running"` and
+`started_at > 15 minutes ago`, marks them failed with `orphaned_timeout`.
+
+### Checking for Orphans
+
+```ruby
+# In Rails console:
+AiAgentTaskRun.unscoped_for_system_job
+  .where(status: "running")
+  .where("started_at < ?", 15.minutes.ago)
+```
+
+The admin page at `/system-admin/agent-runner` shows task runs with their
+status — filter by "failed" to see orphaned tasks (look for error
+messages containing "orphaned" or "dead_lettered").
+
+### Manual Recovery
+
+The `rake agent_runner:redispatch_queued` task still exists as a fallback
+for tasks stuck in "queued" state (dispatched to Redis but never picked
+up). This is rarely needed — the XAUTOCLAIM loop handles most cases
+automatically.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -86,6 +86,24 @@ The script:
 - Returns 503 on `/healthcheck` so load balancers know the app is down
 - Works in both development (with `HOST_MODE=caddy`) and production
 
+### Agent Runner
+
+The agent-runner container handles SIGTERM gracefully: it stops accepting
+new tasks and waits up to 5 minutes for in-flight tasks to complete.
+
+Standard deploys (`docker compose up -d`) trigger this automatically.
+During the drain window, new tasks queue in Redis and are processed by
+the new container once it starts.
+
+If the runner is killed before tasks finish (OOM, timeout), orphaned
+tasks are automatically detected and marked failed:
+- **XAUTOCLAIM** (in the runner) reclaims orphaned stream entries within
+  ~2 minutes of the next startup
+- **OrphanedTaskSweepJob** (Sidekiq, every 10 min) catches any tasks
+  stuck in "running" for >15 minutes
+
+Users see orphaned task failures and can retry.
+
 ### Deployments with Downtime
 
 For schema-changing migrations:

--- a/test/jobs/orphaned_task_sweep_job_test.rb
+++ b/test/jobs/orphaned_task_sweep_job_test.rb
@@ -1,0 +1,91 @@
+# typed: false
+require "test_helper"
+
+class OrphanedTaskSweepJobTest < ActiveJob::TestCase
+  setup do
+    @tenant, @collective, @user = create_tenant_collective_user
+    @tenant.enable_feature_flag!("ai_agents")
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    @ai_agent = create_ai_agent(parent: @user)
+  end
+
+  teardown do
+    Collective.clear_thread_scope
+  end
+
+  test "marks running tasks older than 15 minutes as failed" do
+    task_run = AiAgentTaskRun.create!(
+      tenant: @tenant,
+      ai_agent: @ai_agent,
+      initiated_by: @user,
+      task: "Stuck task",
+      max_steps: 10,
+      status: "running",
+      started_at: 20.minutes.ago,
+    )
+
+    Collective.clear_thread_scope
+    OrphanedTaskSweepJob.perform_now
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    task_run.reload
+    assert_equal "failed", task_run.status
+    assert_equal false, task_run.success
+    assert_equal "orphaned_timeout", task_run.error
+    assert_not_nil task_run.completed_at
+  end
+
+  test "does not touch running tasks that started recently" do
+    task_run = AiAgentTaskRun.create!(
+      tenant: @tenant,
+      ai_agent: @ai_agent,
+      initiated_by: @user,
+      task: "Active task",
+      max_steps: 10,
+      status: "running",
+      started_at: 5.minutes.ago,
+    )
+
+    Collective.clear_thread_scope
+    OrphanedTaskSweepJob.perform_now
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    task_run.reload
+    assert_equal "running", task_run.status
+  end
+
+  test "does not touch completed or failed tasks" do
+    completed = AiAgentTaskRun.create!(
+      tenant: @tenant,
+      ai_agent: @ai_agent,
+      initiated_by: @user,
+      task: "Done task",
+      max_steps: 10,
+      status: "completed",
+      success: true,
+      started_at: 30.minutes.ago,
+      completed_at: 25.minutes.ago,
+    )
+
+    failed = AiAgentTaskRun.create!(
+      tenant: @tenant,
+      ai_agent: @ai_agent,
+      initiated_by: @user,
+      task: "Failed task",
+      max_steps: 10,
+      status: "failed",
+      success: false,
+      started_at: 30.minutes.ago,
+      completed_at: 25.minutes.ago,
+    )
+
+    Collective.clear_thread_scope
+    OrphanedTaskSweepJob.perform_now
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    completed.reload
+    failed.reload
+    assert_equal "completed", completed.status
+    assert_equal "failed", failed.status
+  end
+end


### PR DESCRIPTION
Deploys previously killed in-flight agent tasks, leaving them stuck as "running" forever. This adds three layers of protection:

1. Graceful shutdown: SIGTERM handler stops accepting new tasks and waits up to 4.5 minutes for in-flight tasks to drain naturally. Docker stop_grace_period set to 5 minutes in both compose files.

2. XAUTOCLAIM orphan recovery: a background loop reclaims Redis stream entries idle >2 minutes, checks task status on Rails, and marks true orphans as failed. Dead-letters after 3 failed claims. Queued tasks are NACKed (re-published) for normal pickup.

3. OrphanedTaskSweepJob: Sidekiq cron job (every 10 min) catches tasks stuck in "running" for >15 minutes as a belt-and-suspenders fallback.

Also exposes Redis port in dev compose for integration tests, and adds integration tests that verify the full SIGTERM → drain → exit sequence.