### PR TITLE
Agent runner improvements

### DIFF
--- a/.claude/plans/agent-search-and-help-tools.md
+++ b/.claude/plans/agent-search-and-help-tools.md
@@ -1,0 +1,201 @@
+# Plan: Add `search` and `get_help` agent tools
+
+## Context
+
+Agents currently interact with Harmonic using only `navigate` and `execute_action`. Common patterns like searching and reading documentation require agents to know the right URL to navigate to. Adding dedicated `search` and `get_help` tools makes these actions more discoverable (the tool definitions themselves serve as documentation) and saves agents a step.
+
+Both tools are thin wrappers — they construct a path and delegate to the same navigate logic. They must be added in two places:
+
+1. **agent-runner** — internal agents that run tasks and chat turns via the agent-runner service
+2. **mcp-server** — external agents (e.g., Claude Code) that connect via MCP
+
+The two systems have different architectures:
+- **agent-runner**: Effect-based, tools defined in `AgentContext.ts` as OpenAI-compatible function defs, parsed in `ActionParser.ts`, dispatched in `AgentLoop.ts`
+- **mcp-server**: MCP SDK, tools registered via `server.registerTool()` in `index.ts`, handlers in `handlers.ts`
+
+Both delegate to the same Rails markdown API endpoints:
+- Search: `GET /search?q={query}` (also available as `POST /search/actions/search` with `{query}` param)
+- Help: `GET /help/{topic}` where topic is one of: `privacy`, `collectives`, `notes`, `reminder-notes`, `table-notes`, `decisions`, `commitments`, `cycles`, `search`, `links`, `agents`, `api`
+
+## Implementation
+
+### agent-runner
+
+#### 1. Tool definitions — `agent-runner/src/core/AgentContext.ts`
+
+Add two entries to `AGENT_TOOLS`:
+
+```typescript
+{
+  type: "function",
+  function: {
+    name: "search",
+    description: "Search Harmonic for notes, decisions, commitments, and people.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search query. Supports filters: type:note, type:decision, type:commitment, status:open, cycle:current, creator:@handle, collective:handle",
+        },
+      },
+      required: ["query"],
+    },
+  },
+},
+{
+  type: "function",
+  function: {
+    name: "get_help",
+    description: "Read Harmonic documentation for a topic.",
+    parameters: {
+      type: "object",
+      properties: {
+        topic: {
+          type: "string",
+          description: "Topic name. Available: collectives, notes, reminder-notes, table-notes, decisions, commitments, cycles, search, links, agents, api, privacy",
+        },
+      },
+      required: ["topic"],
+    },
+  },
+},
+```
+
+Update `TASK_TOOLS` and `CHAT_TOOLS` prompt strings to mention the new tools (e.g., "You have four tools: `navigate`, `execute_action`, `search`, and `get_help`." for task mode, five for chat mode).
+
+#### 2. Action type + parse logic — `agent-runner/src/core/ActionParser.ts`
+
+Add two variants to the `AgentAction` union:
+
+```typescript
+| { readonly type: "search"; readonly query: string }
+| { readonly type: "get_help"; readonly topic: string }
+```
+
+Add two cases to the `parseToolCall` switch:
+- `"search"`: validate `query` is a non-empty string
+- `"get_help"`: validate `topic` is a non-empty string
+
+#### 3. Dispatch — `agent-runner/src/services/AgentLoop.ts`
+
+Add two cases to the action dispatch switch. Both delegate to `navigateTo` (same as navigate), so the agent sees page content + available actions:
+
+```typescript
+case "search": {
+  yield* navigateTo(`/search?q=${encodeURIComponent(action.query)}`);
+  toolResults.push(truncateContent(currentContent ?? ""));
+  break;
+}
+case "get_help": {
+  yield* navigateTo(`/help/${encodeURIComponent(action.topic)}`);
+  toolResults.push(truncateContent(currentContent ?? ""));
+  break;
+}
+```
+
+#### 4. agent-runner tests
+
+**`agent-runner/test/core/ActionParser.test.ts`**:
+- Parsing `search` tool call with query
+- Parsing `get_help` tool call with topic
+- Error on empty query / empty topic
+
+**`agent-runner/test/core/AgentContext.test.ts`**:
+- Tool count assertion (2 → 4)
+- Tool names assertion includes `search` and `get_help`
+
+### mcp-server
+
+#### 5. Handlers — `mcp-server/src/handlers.ts`
+
+Add two handler functions that delegate to `handleNavigate`:
+
+```typescript
+export async function handleSearch(
+  query: string,
+  config: Config,
+  state: State,
+  fetchFn: typeof fetch = fetch
+): Promise<ToolResult> {
+  return handleNavigate(`/search?q=${encodeURIComponent(query)}`, config, state, fetchFn);
+}
+
+export async function handleGetHelp(
+  topic: string,
+  config: Config,
+  state: State,
+  fetchFn: typeof fetch = fetch
+): Promise<ToolResult> {
+  return handleNavigate(`/help/${encodeURIComponent(topic)}`, config, state, fetchFn);
+}
+```
+
+#### 6. Tool registration — `mcp-server/src/index.ts`
+
+Register both tools using `server.registerTool()` with the same descriptions/schemas as agent-runner:
+
+```typescript
+server.registerTool(
+  "search",
+  {
+    description: "Search Harmonic for notes, decisions, commitments, and people.",
+    inputSchema: {
+      query: z.string().describe(
+        "Search query. Supports filters: type:note, type:decision, type:commitment, status:open, cycle:current, creator:@handle, collective:handle"
+      ),
+    },
+  },
+  async ({ query }) => handleSearch(query, config, state)
+);
+
+server.registerTool(
+  "get_help",
+  {
+    description: "Read Harmonic documentation for a topic.",
+    inputSchema: {
+      topic: z.string().describe(
+        "Topic name. Available: collectives, notes, reminder-notes, table-notes, decisions, commitments, cycles, search, links, agents, api, privacy"
+      ),
+    },
+  },
+  async ({ topic }) => handleGetHelp(topic, config, state)
+);
+```
+
+#### 7. mcp-server tests — `mcp-server/src/handlers.test.ts`
+
+Add tests for both handlers:
+
+**`handleSearch`**:
+- Delegates to navigate with correct search URL
+- Encodes query parameter
+- Passes through errors from navigate
+
+**`handleGetHelp`**:
+- Delegates to navigate with correct help URL
+- Encodes topic parameter
+- Passes through errors from navigate
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `agent-runner/src/core/AgentContext.ts` | Tool definitions + prompt text |
+| `agent-runner/src/core/ActionParser.ts` | Type + parse logic |
+| `agent-runner/src/services/AgentLoop.ts` | Dispatch |
+| `agent-runner/test/core/ActionParser.test.ts` | Parse tests |
+| `agent-runner/test/core/AgentContext.test.ts` | Tool definition tests |
+| `mcp-server/src/handlers.ts` | Handler functions |
+| `mcp-server/src/index.ts` | Tool registration |
+| `mcp-server/src/handlers.test.ts` | Handler tests |
+
+## Verification
+
+```bash
+# agent-runner
+cd agent-runner && npm test && npm run typecheck && npm run build
+
+# mcp-server
+cd mcp-server && npm test && npm run typecheck && npm run build
+```

--- a/agent-runner/src/core/ActionParser.ts
+++ b/agent-runner/src/core/ActionParser.ts
@@ -7,6 +7,8 @@ import type { ToolCall } from "./PromptBuilder.js";
 export type AgentAction =
   | { readonly type: "navigate"; readonly path: string }
   | { readonly type: "execute_action"; readonly action: string; readonly params: Record<string, unknown> | undefined }
+  | { readonly type: "search"; readonly query: string }
+  | { readonly type: "get_help"; readonly topic: string }
   | { readonly type: "respond_to_human"; readonly message: string }
   | { readonly type: "done"; readonly content: string }
   | { readonly type: "error"; readonly message: string };
@@ -53,6 +55,20 @@ function parseToolCall(toolCall: ToolCall): AgentAction {
         ? args["params"] as Record<string, unknown>
         : undefined;
       return { type: "execute_action", action, params };
+    }
+    case "search": {
+      const query = args["query"];
+      if (typeof query !== "string" || query === "") {
+        return { type: "error", message: "search requires a non-empty 'query' string" };
+      }
+      return { type: "search", query };
+    }
+    case "get_help": {
+      const topic = args["topic"];
+      if (typeof topic !== "string" || topic === "") {
+        return { type: "error", message: "get_help requires a non-empty 'topic' string" };
+      }
+      return { type: "get_help", topic };
     }
     case "respond_to_human": {
       const message = args["message"];

--- a/agent-runner/src/core/AgentContext.ts
+++ b/agent-runner/src/core/AgentContext.ts
@@ -60,6 +60,44 @@ export const AGENT_TOOLS: readonly ToolDefinition[] = [
       },
     },
   },
+  {
+    type: "function",
+    function: {
+      name: "search",
+      description:
+        "Search Harmonic for notes, decisions, commitments, and people.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "Search query. Supports filters: type:note, type:decision, type:commitment, status:open, cycle:current, creator:@handle, collective:handle",
+          },
+        },
+        required: ["query"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "get_help",
+      description:
+        "Read Harmonic documentation for a topic.",
+      parameters: {
+        type: "object",
+        properties: {
+          topic: {
+            type: "string",
+            description:
+              "Topic name. Available: collectives, notes, reminder-notes, table-notes, decisions, commitments, cycles, search, links, agents, api, privacy",
+          },
+        },
+        required: ["topic"],
+      },
+    },
+  },
 ] as const;
 
 /**
@@ -123,19 +161,23 @@ const NAVIGATION = `## Navigation
 
 const TASK_TOOLS = `## Tools
 
-You have two tools: \`navigate\` and \`execute_action\`.
+You have four tools: \`navigate\`, \`execute_action\`, \`search\`, and \`get_help\`.
 
 Use \`navigate\` to view any page. The response includes markdown content and a list of available actions.
 Use \`execute_action\` to perform an action on the current page. Only actions listed for the current page will work.
+Use \`search\` to find notes, decisions, commitments, and people across your collectives.
+Use \`get_help\` to read documentation about any Harmonic concept before acting.
 
 Always navigate before executing actions. After each action, check the result. If your task is complete, stop calling tools.`;
 
 const CHAT_TOOLS = `## Tools
 
-You have three tools: \`navigate\`, \`execute_action\`, and \`respond_to_human\`.
+You have five tools: \`navigate\`, \`execute_action\`, \`search\`, \`get_help\`, and \`respond_to_human\`.
 
 Use \`navigate\` to view any page. The response includes markdown content and a list of available actions.
 Use \`execute_action\` to perform an action on the current page. Only actions listed for the current page will work.
+Use \`search\` to find notes, decisions, commitments, and people across your collectives.
+Use \`get_help\` to read documentation about any Harmonic concept before acting.
 Use \`respond_to_human\` to send a message to the human. This ends your turn — the human will see your message and can reply.
 
 Always navigate before executing actions. You can chain multiple navigations and actions before responding. When you're done or need input, call \`respond_to_human\`.`;

--- a/agent-runner/src/services/AgentLoop.ts
+++ b/agent-runner/src/services/AgentLoop.ts
@@ -403,6 +403,16 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
               toolResults.push(lastActionResult ?? "");
               break;
             }
+            case "search": {
+              yield* navigateTo(`/search?q=${encodeURIComponent(action.query)}`);
+              toolResults.push(truncateContent(currentContent ?? ""));
+              break;
+            }
+            case "get_help": {
+              yield* navigateTo(`/help/${encodeURIComponent(action.topic)}`);
+              toolResults.push(truncateContent(currentContent ?? ""));
+              break;
+            }
             case "error": {
               yield* addStep(errorStep({ message: action.message }, new Date()));
               finalMessage = action.message;

--- a/agent-runner/src/services/AgentLoop.ts
+++ b/agent-runner/src/services/AgentLoop.ts
@@ -134,21 +134,24 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
             Effect.succeed({
               content: "",
               availableActions: [] as readonly string[],
+              resolvedPath: path,
               _error: err.message,
             }),
           ),
         );
 
-        currentPath = path;
-        currentContent = result.content;
+        currentPath = result.resolvedPath;
         currentActions = result.availableActions;
         lastActionResult = null; // Cleared on navigate, matching Ruby
 
         const navError = "_error" in result ? (result as { _error: string })._error : null;
+        currentContent = navError
+          ? `Error navigating to ${path}: ${navError}`
+          : result.content;
 
         yield* addStep(navigateStep({
           path,
-          resolvedPath: path,
+          resolvedPath: result.resolvedPath,
           contentPreview: result.content,
           availableActions: [...result.availableActions],
           error: navError,

--- a/agent-runner/src/services/HarmonicClient.ts
+++ b/agent-runner/src/services/HarmonicClient.ts
@@ -25,6 +25,7 @@ import { RailsHttp } from "./RailsHttp.js";
 export interface NavigateResult {
   readonly content: string;
   readonly availableActions: readonly string[];
+  readonly resolvedPath: string;
 }
 
 export interface ActionResult {
@@ -117,25 +118,46 @@ export const HarmonicClientLive = Layer.effect(
     const navigate: HarmonicClientService["navigate"] = (path, token, subdomain) =>
       Effect.tryPromise({
         try: async () => {
-          const response = await railsHttp.request({
-            method: "GET",
-            subdomain,
-            path,
-            headers: {
-              "X-Forwarded-Proto": "https",
-              "Accept": "text/markdown",
-              "Authorization": `Bearer ${token}`,
-            },
-            timeoutMs: 30_000,
-          });
+          let currentPath = path;
+          const maxRedirects = 5;
 
-          const content = await response.text();
-          if (response.statusCode < 200 || response.statusCode >= 300) {
-            throw new Error(`Navigate to ${path} failed: HTTP ${response.statusCode} - ${content.slice(0, 500)}`);
+          for (let i = 0; i <= maxRedirects; i++) {
+            const response = await railsHttp.request({
+              method: "GET",
+              subdomain,
+              path: currentPath,
+              headers: {
+                "X-Forwarded-Proto": "https",
+                "Accept": "text/markdown",
+                "Authorization": `Bearer ${token}`,
+              },
+              timeoutMs: 30_000,
+            });
+
+            // Follow redirects (3xx with Location header)
+            if (response.statusCode >= 300 && response.statusCode < 400) {
+              const location = response.headers["location"];
+              if (typeof location === "string") {
+                // Drain the redirect response body to release the socket
+                await response.text();
+                currentPath = location.startsWith("http")
+                  ? new URL(location).pathname
+                  : location;
+                continue;
+              }
+              // 3xx without Location — fall through to error handling
+            }
+
+            const content = await response.text();
+            if (response.statusCode < 200 || response.statusCode >= 300) {
+              throw new Error(`Navigate to ${currentPath} failed: HTTP ${response.statusCode} - ${content.slice(0, 500)}`);
+            }
+
+            const availableActions = parseAvailableActions(content);
+            return { content, availableActions, resolvedPath: currentPath };
           }
-          const availableActions = parseAvailableActions(content);
 
-          return { content, availableActions };
+          throw new Error(`Navigate to ${path} failed: too many redirects`);
         },
         catch: (error) =>
           new HarmonicApiError({

--- a/agent-runner/src/services/RailsHttp.ts
+++ b/agent-runner/src/services/RailsHttp.ts
@@ -39,6 +39,7 @@ import { Config } from "../config/Config.js";
 
 export interface RailsResponse {
   readonly statusCode: number;
+  readonly headers: Record<string, string | string[] | undefined>;
   readonly text: () => Promise<string>;
 }
 
@@ -89,6 +90,7 @@ export const RailsHttpLive = Layer.effect(
       const res: Dispatcher.ResponseData = await railsClient.request(requestOpts);
       return {
         statusCode: res.statusCode,
+        headers: res.headers as Record<string, string | string[] | undefined>,
         text: () => res.body.text(),
       };
     };

--- a/agent-runner/test/core/ActionParser.test.ts
+++ b/agent-runner/test/core/ActionParser.test.ts
@@ -103,6 +103,92 @@ describe("parseToolCalls", () => {
     );
     expect(result[0]?.type).toBe("error");
   });
+
+  it("parses search tool call", () => {
+    const result = parseToolCalls(
+      [{
+        id: "call_7",
+        type: "function",
+        function: {
+          name: "search",
+          arguments: '{"query": "type:note status:open"}',
+        },
+      }],
+      undefined,
+    );
+    expect(result).toEqual([{ type: "search", query: "type:note status:open" }]);
+  });
+
+  it("returns error for search without query", () => {
+    const result = parseToolCalls(
+      [{
+        id: "call_8",
+        type: "function",
+        function: { name: "search", arguments: "{}" },
+      }],
+      undefined,
+    );
+    expect(result[0]?.type).toBe("error");
+    if (result[0]?.type === "error") {
+      expect(result[0].message).toContain("search");
+      expect(result[0].message).toContain("query");
+    }
+  });
+
+  it("returns error for search with empty query", () => {
+    const result = parseToolCalls(
+      [{
+        id: "call_9",
+        type: "function",
+        function: { name: "search", arguments: '{"query": ""}' },
+      }],
+      undefined,
+    );
+    expect(result[0]?.type).toBe("error");
+  });
+
+  it("parses get_help tool call", () => {
+    const result = parseToolCalls(
+      [{
+        id: "call_10",
+        type: "function",
+        function: {
+          name: "get_help",
+          arguments: '{"topic": "decisions"}',
+        },
+      }],
+      undefined,
+    );
+    expect(result).toEqual([{ type: "get_help", topic: "decisions" }]);
+  });
+
+  it("returns error for get_help without topic", () => {
+    const result = parseToolCalls(
+      [{
+        id: "call_11",
+        type: "function",
+        function: { name: "get_help", arguments: "{}" },
+      }],
+      undefined,
+    );
+    expect(result[0]?.type).toBe("error");
+    if (result[0]?.type === "error") {
+      expect(result[0].message).toContain("get_help");
+      expect(result[0].message).toContain("topic");
+    }
+  });
+
+  it("returns error for get_help with empty topic", () => {
+    const result = parseToolCalls(
+      [{
+        id: "call_12",
+        type: "function",
+        function: { name: "get_help", arguments: '{"topic": ""}' },
+      }],
+      undefined,
+    );
+    expect(result[0]?.type).toBe("error");
+  });
 });
 
 describe("validateAction", () => {

--- a/agent-runner/test/core/AgentContext.test.ts
+++ b/agent-runner/test/core/AgentContext.test.ts
@@ -53,6 +53,9 @@ describe("buildSystemPrompt", () => {
     const prompt = buildSystemPrompt("", undefined);
     expect(prompt).toContain("navigate");
     expect(prompt).toContain("execute_action");
+    expect(prompt).toContain("search");
+    expect(prompt).toContain("get_help");
+    expect(prompt).toContain("four tools");
   });
 
   it("includes boundaries with hierarchy", () => {
@@ -105,7 +108,7 @@ describe("buildChatSystemPrompt", () => {
   it("includes chat tools with respond_to_human", () => {
     const prompt = buildChatSystemPrompt("", undefined, undefined);
     expect(prompt).toContain("respond_to_human");
-    expect(prompt).toContain("three tools");
+    expect(prompt).toContain("five tools");
   });
 
   it("includes time context when provided", () => {
@@ -121,9 +124,11 @@ describe("buildChatSystemPrompt", () => {
 });
 
 describe("AGENT_TOOLS", () => {
-  it("has navigate and execute_action tools", () => {
-    expect(AGENT_TOOLS.length).toBe(2);
-    expect(AGENT_TOOLS.map((t) => t.function.name)).toEqual(["navigate", "execute_action"]);
+  it("has all four tools", () => {
+    expect(AGENT_TOOLS.length).toBe(4);
+    expect(AGENT_TOOLS.map((t) => t.function.name)).toEqual([
+      "navigate", "execute_action", "search", "get_help",
+    ]);
   });
 
   it("navigate has path parameter", () => {
@@ -139,5 +144,19 @@ describe("AGENT_TOOLS", () => {
     const properties = props["properties"] as Record<string, unknown>;
     expect(properties["action"]).toBeDefined();
     expect(properties["params"]).toBeDefined();
+  });
+
+  it("search has query parameter", () => {
+    const search = AGENT_TOOLS[2];
+    const props = search?.function.parameters as Record<string, unknown>;
+    const properties = props["properties"] as Record<string, unknown>;
+    expect(properties["query"]).toBeDefined();
+  });
+
+  it("get_help has topic parameter", () => {
+    const help = AGENT_TOOLS[3];
+    const props = help?.function.parameters as Record<string, unknown>;
+    const properties = props["properties"] as Record<string, unknown>;
+    expect(properties["topic"]).toBeDefined();
   });
 });

--- a/agent-runner/test/services/AgentLoop.test.ts
+++ b/agent-runner/test/services/AgentLoop.test.ts
@@ -7,7 +7,7 @@ import { HarmonicClient } from "../../src/services/HarmonicClient.js";
 import { TaskReporter } from "../../src/services/TaskReporter.js";
 import { Config } from "../../src/config/Config.js";
 import { LLMError, HarmonicApiError } from "../../src/errors/Errors.js";
-import type { TaskPayload } from "../../src/core/PromptBuilder.js";
+import type { Message, TaskPayload } from "../../src/core/PromptBuilder.js";
 import type { StepRecord } from "../../src/core/StepBuilder.js";
 import { createCipheriv, hkdfSync } from "node:crypto";
 
@@ -15,14 +15,14 @@ import { createCipheriv, hkdfSync } from "node:crypto";
 
 const TEST_SECRET = "test-secret";
 const HKDF_INFO = "agent-runner-token-encryption";
-const PLAINTEXT_TOKEN = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+const TEST_BEARER_VALUE = "test-value-not-a-real-token-abc123";
 
 function encryptTestToken(): string {
   const key = Buffer.from(hkdfSync("sha256", TEST_SECRET, "", HKDF_INFO, 32));
   const iv = Buffer.alloc(12, 1);
   const cipher = createCipheriv("aes-256-gcm", key, iv);
   cipher.setAAD(Buffer.alloc(0));
-  const encrypted = Buffer.concat([cipher.update(PLAINTEXT_TOKEN, "utf8"), cipher.final()]);
+  const encrypted = Buffer.concat([cipher.update(TEST_BEARER_VALUE, "utf8"), cipher.final()]);
   const authTag = cipher.getAuthTag();
   return Buffer.concat([iv, authTag, encrypted]).toString("base64");
 }
@@ -83,8 +83,10 @@ interface MockState {
   scratchpadContent: string | null;
   navigatePaths: string[];
   executeActions: string[];
+  executeActionPaths: string[];
   llmCallCount: number;
   cancellationStatus: string;
+  llmMessages: Message[][];
 }
 
 function createMockState(): MockState {
@@ -99,13 +101,15 @@ function createMockState(): MockState {
     scratchpadContent: null,
     navigatePaths: [],
     executeActions: [],
+    executeActionPaths: [],
     llmCallCount: 0,
     cancellationStatus: "running",
+    llmMessages: [],
   };
 }
 
 interface MockOptions {
-  readonly navigateResults?: Record<string, { content: string; availableActions: readonly string[] }>;
+  readonly navigateResults?: Record<string, { content: string; availableActions: readonly string[]; resolvedPath?: string }>;
   readonly executeResults?: Record<string, { content: string; success: boolean }>;
   readonly navigateErrors?: Record<string, string>;  // path → error message
   readonly llmErrorOnCall?: number;  // fail on the Nth LLM call (0-indexed)
@@ -133,7 +137,8 @@ function buildTestLayers(
 
   let llmCallIndex = 0;
   const LLMClientTest = Layer.succeed(LLMClient, {
-    chat: () => {
+    chat: (messages: readonly Message[]) => {
+      state.llmMessages.push([...messages]);
       const callIndex = llmCallIndex;
       state.llmCallCount++;
       llmCallIndex++;
@@ -154,10 +159,12 @@ function buildTestLayers(
         return Effect.fail(new HarmonicApiError({ message: navErrors[path], path }));
       }
       const result = (options?.navigateResults ?? navigateResults)?.[path] ?? defaultNavigate;
-      return Effect.succeed(result);
+      const resolvedPath: string = (result as { resolvedPath?: string }).resolvedPath ?? path;
+      return Effect.succeed({ content: result.content, availableActions: result.availableActions, resolvedPath });
     },
-    executeAction: (_path: string, action: string, _params: Record<string, unknown> | undefined) => {
+    executeAction: (path: string, action: string, _params: Record<string, unknown> | undefined) => {
       state.executeActions.push(action);
+      state.executeActionPaths.push(path);
       const result = (options?.executeResults ?? executeResults)?.[action] ?? { content: "Action completed", success: true };
       return Effect.succeed(result);
     },
@@ -769,6 +776,92 @@ describe("AgentLoop", () => {
     const brokenNav = navSteps.find((s) => s.detail["path"] === "/broken-page");
     expect(brokenNav).toBeDefined();
     expect(brokenNav?.detail["error"]).toContain("Connection refused");
+  });
+
+  it("Bug 1b: navigation error message is visible to the LLM in tool results", async () => {
+    const state = createMockState();
+    await runWithMocks(
+      makeTask(),
+      state,
+      [
+        // LLM says navigate to a path that will fail
+        makeLLMResponse({
+          content: null,
+          toolCalls: [makeNavigateToolCall("/broken-page")],
+          finishReason: "tool_calls",
+        }),
+        // LLM sees error and decides to stop
+        makeLLMResponse({ content: "Could not reach the page", toolCalls: [], finishReason: "stop" }),
+        // Scratchpad
+        makeLLMResponse({ content: '{"scratchpad": null}', toolCalls: [], finishReason: "stop" }),
+      ],
+      undefined,
+      undefined,
+      { navigateErrors: { "/broken-page": "Connection refused" } },
+    );
+
+    // The LLM's second call should include a tool result with the error message
+    // (call 0 = whoami, call 1 = after navigate error, call 2 = after done, call 3 = scratchpad)
+    expect(state.llmMessages.length).toBeGreaterThanOrEqual(2);
+    const messagesAfterNav = state.llmMessages[1]!;
+    const toolResultMsg = messagesAfterNav.find(
+      (m) => m.role === "tool" && typeof m.content === "string" && m.content.includes("Error"),
+    );
+    expect(toolResultMsg).toBeDefined();
+    expect(toolResultMsg!.content).toContain("Connection refused");
+    expect(toolResultMsg!.content).toContain("/broken-page");
+  });
+
+  it("Bug 1c: executeAction uses resolved path after redirect", async () => {
+    const state = createMockState();
+    const WORKSPACE_CONTENT = "---\nactions:\n  - name: create_note\n---\n# Workspace";
+
+    await runWithMocks(
+      makeTask(),
+      state,
+      [
+        // LLM navigates to /workspace (which "redirects" to /workspace/abc123)
+        makeLLMResponse({
+          content: null,
+          toolCalls: [makeNavigateToolCall("/workspace")],
+          finishReason: "tool_calls",
+        }),
+        // LLM executes create_note (should POST to /workspace/abc123, not /workspace)
+        makeLLMResponse({
+          content: null,
+          toolCalls: [makeExecuteToolCall("create_note", { text: "hello" })],
+          finishReason: "tool_calls",
+        }),
+        // LLM done
+        makeLLMResponse({ content: "Created note", toolCalls: [], finishReason: "stop" }),
+        // Scratchpad
+        makeLLMResponse({ content: '{"scratchpad": null}', toolCalls: [], finishReason: "stop" }),
+      ],
+      undefined,
+      undefined,
+      {
+        navigateResults: {
+          "/workspace": {
+            content: WORKSPACE_CONTENT,
+            availableActions: ["create_note"],
+            resolvedPath: "/workspace/abc123",
+          },
+        },
+      },
+    );
+
+    expect(state.completeCalled).toBe(true);
+    expect(state.executeActions).toContain("create_note");
+
+    // executeAction should have been called with the resolved path, not the original
+    expect(state.executeActionPaths).toContain("/workspace/abc123");
+    expect(state.executeActionPaths).not.toContain("/workspace");
+
+    // The navigate step should record the resolved path
+    const navSteps = state.stepsCalled.filter((s) => s.type === "navigate");
+    const workspaceNav = navSteps.find((s) => s.detail["path"] === "/workspace");
+    expect(workspaceNav).toBeDefined();
+    expect(workspaceNav!.detail["resolved_path"]).toBe("/workspace/abc123");
   });
 
   it("Bug 2: LLM error records think step with llm_error and fails gracefully", async () => {

--- a/agent-runner/test/services/HarmonicClient.test.ts
+++ b/agent-runner/test/services/HarmonicClient.test.ts
@@ -1,5 +1,162 @@
 import { describe, it, expect } from "vitest";
-import { parseAvailableActions } from "../../src/services/HarmonicClient.js";
+import { Effect, Layer, Exit } from "effect";
+import { HarmonicClient, HarmonicClientLive, parseAvailableActions, type NavigateResult } from "../../src/services/HarmonicClient.js";
+import { RailsHttp } from "../../src/services/RailsHttp.js";
+import type { RailsRequestOptions, RailsResponse } from "../../src/services/RailsHttp.js";
+import { Config } from "../../src/config/Config.js";
+import type { HarmonicApiError } from "../../src/errors/Errors.js";
+
+// --- Test helpers for navigate ---
+
+function makeResponse(statusCode: number, body: string, headers: Record<string, string> = {}): RailsResponse {
+  return {
+    statusCode,
+    headers,
+    text: async () => body,
+  };
+}
+
+const TEST_CONFIG = {
+  harmonicInternalUrl: "http://web:3000",
+  harmonicHostname: "harmonic.local",
+  agentRunnerSecret: "test-secret",
+  redisUrl: "redis://localhost:6379",
+  llmBaseUrl: "http://localhost:4000",
+  llmGatewayMode: "litellm" as const,
+  stripeGatewayKey: undefined,
+  streamName: "agent_tasks",
+  consumerGroup: "agent_runners",
+  consumerName: "test",
+  maxConcurrentTasks: 1,
+  streamMaxLen: 1000,
+};
+
+function buildTestLayer(requestHandler: (opts: RailsRequestOptions) => RailsResponse) {
+  const RailsHttpTest = Layer.succeed(RailsHttp, {
+    request: async (opts: RailsRequestOptions) => requestHandler(opts),
+  });
+  const ConfigTest = Layer.succeed(Config, TEST_CONFIG);
+  return HarmonicClientLive.pipe(Layer.provide(Layer.merge(RailsHttpTest, ConfigTest)));
+}
+
+function runNavigate(
+  requestHandler: (opts: RailsRequestOptions) => RailsResponse,
+  path: string,
+): Promise<Exit.Exit<NavigateResult, HarmonicApiError>> {
+  const layer = buildTestLayer(requestHandler);
+  const program = Effect.gen(function* () {
+    const client = yield* HarmonicClient;
+    return yield* client.navigate(path, "test-token", "app");
+  });
+  return Effect.runPromiseExit(program.pipe(Effect.provide(layer)));
+}
+
+describe("navigate redirect following", () => {
+  it("follows a single redirect", async () => {
+    const requests: string[] = [];
+    const result = await runNavigate((opts) => {
+      requests.push(opts.path);
+      if (opts.path === "/workspace") {
+        return makeResponse(302, "", { location: "/workspace/abc123" });
+      }
+      return makeResponse(200, "# Workspace\n\nContent here.");
+    }, "/workspace");
+
+    expect(Exit.isSuccess(result)).toBe(true);
+    if (Exit.isSuccess(result)) {
+      expect(result.value.content).toContain("# Workspace");
+      expect(result.value.resolvedPath).toBe("/workspace/abc123");
+    }
+    expect(requests).toEqual(["/workspace", "/workspace/abc123"]);
+  });
+
+  it("follows multiple redirects", async () => {
+    const requests: string[] = [];
+    const result = await runNavigate((opts) => {
+      requests.push(opts.path);
+      if (opts.path === "/a") return makeResponse(301, "", { location: "/b" });
+      if (opts.path === "/b") return makeResponse(302, "", { location: "/c" });
+      return makeResponse(200, "# Final page");
+    }, "/a");
+
+    expect(Exit.isSuccess(result)).toBe(true);
+    if (Exit.isSuccess(result)) {
+      expect(result.value.content).toContain("# Final page");
+      expect(result.value.resolvedPath).toBe("/c");
+    }
+    expect(requests).toEqual(["/a", "/b", "/c"]);
+  });
+
+  it("handles absolute URL in Location header", async () => {
+    const requests: string[] = [];
+    const result = await runNavigate((opts) => {
+      requests.push(opts.path);
+      if (opts.path === "/workspace") {
+        return makeResponse(302, "", { location: "https://app.harmonic.local/workspace/abc123" });
+      }
+      return makeResponse(200, "# Workspace");
+    }, "/workspace");
+
+    expect(Exit.isSuccess(result)).toBe(true);
+    expect(requests).toEqual(["/workspace", "/workspace/abc123"]);
+  });
+
+  it("fails after too many redirects", async () => {
+    const result = await runNavigate((opts) => {
+      const n = parseInt(opts.path.slice(1)) || 0;
+      return makeResponse(302, "", { location: `/${n + 1}` });
+    }, "/0");
+
+    expect(Exit.isFailure(result)).toBe(true);
+    if (Exit.isFailure(result)) {
+      const error = result.cause;
+      expect(String(error)).toContain("too many redirects");
+    }
+  });
+
+  it("returns success directly when no redirect", async () => {
+    const result = await runNavigate(() => {
+      return makeResponse(200, "---\nactions:\n  - name: create_note\n---\n# Page");
+    }, "/collectives/team");
+
+    expect(Exit.isSuccess(result)).toBe(true);
+    if (Exit.isSuccess(result)) {
+      expect(result.value.content).toContain("# Page");
+      expect(result.value.availableActions).toEqual(["create_note"]);
+      expect(result.value.resolvedPath).toBe("/collectives/team");
+    }
+  });
+
+  it("fails on non-redirect error status", async () => {
+    const result = await runNavigate(() => {
+      return makeResponse(404, "Not Found");
+    }, "/nonexistent");
+
+    expect(Exit.isFailure(result)).toBe(true);
+  });
+
+  it("fails on 3xx without Location header", async () => {
+    const result = await runNavigate(() => {
+      return makeResponse(302, "Redirecting...");
+    }, "/bad-redirect");
+
+    expect(Exit.isFailure(result)).toBe(true);
+    if (Exit.isFailure(result)) {
+      expect(String(result.cause)).toContain("302");
+    }
+  });
+
+  it("resolvedPath equals original path when no redirect", async () => {
+    const result = await runNavigate(() => {
+      return makeResponse(200, "# Direct page");
+    }, "/direct");
+
+    expect(Exit.isSuccess(result)).toBe(true);
+    if (Exit.isSuccess(result)) {
+      expect(result.value.resolvedPath).toBe("/direct");
+    }
+  });
+});
 
 describe("parseAvailableActions", () => {
   it("parses action names from YAML frontmatter", () => {

--- a/mcp-server/src/handlers.test.ts
+++ b/mcp-server/src/handlers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { handleNavigate, handleExecuteAction, createState, type Config, type State } from "./handlers.js";
+import { handleNavigate, handleExecuteAction, handleSearch, handleGetHelp, createState, type Config, type State } from "./handlers.js";
 
 // Helper to create a mock fetch response
 function mockFetch(status: number, body: string): typeof fetch {
@@ -191,6 +191,90 @@ describe("handleExecuteAction", () => {
       "http://localhost:3000/notifications/actions/mark_read",
       expect.anything()
     );
+  });
+});
+
+describe("handleSearch", () => {
+  let config: Config;
+  let state: State;
+
+  beforeEach(() => {
+    config = { baseUrl: "http://localhost:3000", apiToken: "test-token" };
+    state = createState();
+  });
+
+  it("delegates to navigate with search URL", async () => {
+    const mockFn = mockFetch(200, "# Search Results\n\n- Note: Test note");
+    const result = await handleSearch("type:note status:open", config, state, mockFn);
+
+    expect(mockFn).toHaveBeenCalledWith(
+      "http://localhost:3000/search?q=type%3Anote%20status%3Aopen",
+      expect.objectContaining({ method: "GET" })
+    );
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("Search Results");
+  });
+
+  it("updates currentPath to search URL", async () => {
+    const mockFn = mockFetch(200, "results");
+    await handleSearch("test query", config, state, mockFn);
+
+    expect(state.currentPath).toBe("/search?q=test%20query");
+  });
+
+  it("passes through errors from navigate", async () => {
+    config.apiToken = undefined;
+    const result = await handleSearch("test", config, state);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("HARMONIC_API_TOKEN");
+  });
+});
+
+describe("handleGetHelp", () => {
+  let config: Config;
+  let state: State;
+
+  beforeEach(() => {
+    config = { baseUrl: "http://localhost:3000", apiToken: "test-token" };
+    state = createState();
+  });
+
+  it("delegates to navigate with help URL", async () => {
+    const mockFn = mockFetch(200, "# Decisions\n\nAcceptance voting...");
+    const result = await handleGetHelp("decisions", config, state, mockFn);
+
+    expect(mockFn).toHaveBeenCalledWith(
+      "http://localhost:3000/help/decisions",
+      expect.objectContaining({ method: "GET" })
+    );
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("Decisions");
+  });
+
+  it("encodes topic with special characters", async () => {
+    const mockFn = mockFetch(200, "# Help");
+    await handleGetHelp("reminder-notes", config, state, mockFn);
+
+    expect(mockFn).toHaveBeenCalledWith(
+      "http://localhost:3000/help/reminder-notes",
+      expect.anything()
+    );
+  });
+
+  it("updates currentPath to help URL", async () => {
+    const mockFn = mockFetch(200, "help content");
+    await handleGetHelp("agents", config, state, mockFn);
+
+    expect(state.currentPath).toBe("/help/agents");
+  });
+
+  it("passes through errors from navigate", async () => {
+    const mockFn = mockFetch(404, "Not found");
+    const result = await handleGetHelp("nonexistent", config, state, mockFn);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("HTTP 404");
   });
 });
 

--- a/mcp-server/src/handlers.ts
+++ b/mcp-server/src/handlers.ts
@@ -68,6 +68,26 @@ export async function handleNavigate(
   }
 }
 
+// Search handler — delegates to navigate with a search URL
+export async function handleSearch(
+  query: string,
+  config: Config,
+  state: State,
+  fetchFn: typeof fetch = fetch
+): Promise<ToolResult> {
+  return handleNavigate(`/search?q=${encodeURIComponent(query)}`, config, state, fetchFn);
+}
+
+// Get help handler — delegates to navigate with a help URL
+export async function handleGetHelp(
+  topic: string,
+  config: Config,
+  state: State,
+  fetchFn: typeof fetch = fetch
+): Promise<ToolResult> {
+  return handleNavigate(`/help/${encodeURIComponent(topic)}`, config, state, fetchFn);
+}
+
 // Execute action handler
 export async function handleExecuteAction(
   action: string,

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -3,7 +3,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { handleNavigate, handleExecuteAction, createState, type Config } from "./handlers.js";
+import { handleNavigate, handleExecuteAction, handleSearch, handleGetHelp, createState, type Config } from "./handlers.js";
 import { CONTEXT_MARKDOWN } from "./context.js";
 
 // Configuration from environment
@@ -54,6 +54,36 @@ server.registerTool(
     },
   },
   async ({ action, params }) => handleExecuteAction(action, params as Record<string, unknown> | undefined, config, state)
+);
+
+// Register search tool
+server.registerTool(
+  "search",
+  {
+    description:
+      "Search Harmonic for notes, decisions, commitments, and people.",
+    inputSchema: {
+      query: z.string().describe(
+        "Search query. Supports filters: type:note, type:decision, type:commitment, status:open, cycle:current, creator:@handle, collective:handle"
+      ),
+    },
+  },
+  async ({ query }) => handleSearch(query, config, state)
+);
+
+// Register get_help tool
+server.registerTool(
+  "get_help",
+  {
+    description:
+      "Read Harmonic documentation for a topic.",
+    inputSchema: {
+      topic: z.string().describe(
+        "Topic name. Available: collectives, notes, reminder-notes, table-notes, decisions, commitments, cycles, search, links, agents, api, privacy"
+      ),
+    },
+  },
+  async ({ topic }) => handleGetHelp(topic, config, state)
 );
 
 // Register context resource

--- a/test/integration/private_workspace_test.rb
+++ b/test/integration/private_workspace_test.rb
@@ -334,6 +334,59 @@ class PrivateWorkspaceTest < ActionDispatch::IntegrationTest
   end
 
   # =========================================================================
+  # Multi-tenant workspace creation
+  # =========================================================================
+
+  test "user has separate private workspaces on each tenant" do
+    # Create a second tenant
+    tenant2 = create_tenant(subdomain: "pw-test2-#{SecureRandom.hex(4)}")
+    tenant2.create_main_collective!(created_by: @alice)
+    tenant2.add_user!(@alice)
+
+    # Alice should have a workspace on each tenant
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    workspace1 = @alice.private_workspace
+    assert workspace1, "Alice should have a workspace on tenant 1"
+    assert_equal @tenant.id, workspace1.tenant_id
+
+    @alice.reload
+    Tenant.scope_thread_to_tenant(subdomain: tenant2.subdomain)
+    workspace2 = @alice.private_workspace
+    assert workspace2, "Alice should have a workspace on tenant 2"
+    assert_equal tenant2.id, workspace2.tenant_id
+
+    refute_equal workspace1.id, workspace2.id, "Workspaces should be different collectives"
+  end
+
+  test "navigating to /workspace/ on second tenant loads that tenant's workspace" do
+    tenant2 = create_tenant(subdomain: "pw-test2-#{SecureRandom.hex(4)}")
+    tenant2.create_main_collective!(created_by: @alice)
+    tenant2.add_user!(@alice)
+    tenant2.enable_api!
+
+    @alice.reload
+    Tenant.scope_thread_to_tenant(subdomain: tenant2.subdomain)
+    workspace2 = @alice.private_workspace
+    assert workspace2, "Alice should have a workspace on tenant 2"
+    workspace2.enable_api!
+
+    api_token = ApiToken.create!(
+      user: @alice,
+      tenant: tenant2,
+      name: "Tenant2 Token",
+      scopes: ApiToken.valid_scopes,
+    )
+
+    host! "#{tenant2.subdomain}.#{ENV.fetch("HOSTNAME", nil)}"
+    get workspace2.path, headers: {
+      "Accept" => "text/markdown",
+      "Authorization" => "Bearer #{api_token.plaintext_token}",
+    }
+    assert_response :success
+    assert_includes response.body, workspace2.name
+  end
+
+  # =========================================================================
   # Commitment critical mass enforcement
   # =========================================================================
 


### PR DESCRIPTION
## Summary

- **Fix agent-runner navigate**: follow HTTP redirects, surface error messages to agents, and track the resolved path after redirects. Previously, navigating to `/workspace` (which returns a 302) gave agents empty content with no error — now redirects are followed automatically and errors are visible.
- **Add `search` and `get_help` tools** to both agent-runner and mcp-server, giving agents direct access to search and documentation without needing to know the exact URL to navigate to.

## Details

### Navigate fixes (agent-runner)

The agent-runner uses undici's low-level `Client.request` which does not follow HTTP redirects. Three issues fixed:

1. **Follow redirects**: `navigate` now follows 3xx responses by reading the `Location` header (up to 5 hops). `RailsResponse` exposes headers for this.
2. **Surface errors**: When navigate fails, the tool result sent to the LLM now contains the error message instead of an empty string. Previously the error was only recorded in step metadata (invisible to the agent).
3. **Track resolved path**: `NavigateResult` includes `resolvedPath` so that `currentPath` and step records reflect the final URL after redirects. Without this, `executeAction` would POST to the pre-redirect path.

### New tools (agent-runner + mcp-server)

Both `search` and `get_help` are thin wrappers that construct a URL and delegate to the existing navigate infrastructure:

- `search(query)` → navigates to `/search?q={query}`
- `get_help(topic)` → navigates to `/help/{topic}`

Added to both agent-runner (internal agents) and mcp-server (external MCP clients like Claude Code), with matching descriptions and schemas.

### Multi-tenant workspace tests (Rails)

Added integration tests verifying private workspaces are created and accessible when a user belongs to multiple tenants.

## Test plan

- [x] agent-runner: 167 tests pass, typecheck clean
- [x] mcp-server: 23 tests pass, build clean
- [x] Rails integration tests pass for multi-tenant workspaces
- [x] Manually tested MCP server `search` and `get_help` tools via Claude Code
- [x] Deployed agent-runner with rebuilt Docker image, verified agent can use new tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
