### PR TITLE
Add deadline event system for decisions and commitments

### DIFF
--- a/.claude/plans/deadline-events.md
+++ b/.claude/plans/deadline-events.md
@@ -1,0 +1,68 @@
+# Deadline Events
+
+## Problem
+
+When a decision or commitment deadline passes, nothing happens automatically. No event is fired, so automations, webhooks, and agent rules can't react to deadlines. The lottery draw job (`LotteryDrawJob`) works around this by being manually enqueued when someone closes a lottery, but if nobody takes action, deadlines pass silently.
+
+This also means:
+- Webhooks can't notify external systems when a deadline passes
+- Automations can't trigger actions at deadline time (e.g., post a summary, notify participants)
+- Lottery decisions with preset deadlines require manual closing before the draw happens
+
+## Design
+
+### New cron job: `DeadlineEventJob`
+
+A `SystemJob` that runs every minute via sidekiq-cron (same pattern as `ReminderDeliveryJob`). It:
+
+1. Queries for decisions and commitments whose deadlines have passed but haven't had a deadline event fired yet
+2. Fires `EventService.record!` for each, producing `decision.deadline_reached` and `commitment.deadline_reached` events
+3. These events flow through the existing `AutomationDispatcher` and `NotificationDispatcher`
+
+### Duplicate prevention
+
+Add a `deadline_event_fired_at` timestamp column to both `decisions` and `commitments`. The job sets this after firing the event. The query filters on `deadline < NOW() AND deadline_event_fired_at IS NULL`.
+
+This is simpler and more reliable than querying the events table, and survives event table cleanup.
+
+### Lottery draw as a downstream handler
+
+Instead of `LotteryDrawJob` being enqueued manually from `close_decision`, it becomes a handler for the `decision.deadline_reached` event. Options:
+
+1. **Inline in the job**: `DeadlineEventJob` fires the event, then checks `decision.is_lottery?` and enqueues `LotteryDrawJob`
+2. **Via automation dispatch**: An internal/system automation rule listens for `decision.deadline_reached` where subtype is lottery
+
+Option 1 is simpler and keeps the lottery logic explicit. The `LotteryDrawJob` already has all the right guards (checks closed?, is_lottery?, not already drawn), so enqueuing it from the deadline job is safe and idempotent.
+
+The existing `close_decision` path in `ApiHelper` should also continue to enqueue `LotteryDrawJob` — this handles the case where someone manually closes a lottery before the deadline.
+
+### Event metadata
+
+The deadline events should include useful context in metadata:
+
+```ruby
+{
+  "resource_type" => "decision",  # or "commitment"
+  "resource_id" => decision.id,
+  "question" => decision.question,
+  "subtype" => decision.subtype,
+  "deadline" => decision.deadline.iso8601,
+}
+```
+
+### Tenant/collective context
+
+`DeadlineEventJob` is a `SystemJob` (like `ReminderDeliveryJob`). It queries across all tenants unscoped, then sets tenant/collective context before firing each event via `with_tenant_and_collective_context`.
+
+### Documentation
+
+Add `decision.deadline_reached` and `commitment.deadline_reached` to the automation YAML reference so users can write automations triggered by deadlines.
+
+## Scope
+
+- Migration: add `deadline_event_fired_at` to decisions and commitments
+- New job: `DeadlineEventJob` (system job, cron every minute)
+- Update `sidekiq_cron.rb` to register the job
+- Enqueue `LotteryDrawJob` from `DeadlineEventJob` for lottery decisions
+- Update automation YAML reference with new event types
+- Tests for the job, duplicate prevention, and lottery integration

--- a/app/jobs/deadline_event_job.rb
+++ b/app/jobs/deadline_event_job.rb
@@ -1,0 +1,143 @@
+# typed: true
+# frozen_string_literal: true
+
+# DeadlineEventJob fires events when decision or commitment deadlines pass.
+# It runs every minute (via sidekiq-cron) and queries across all tenants for
+# items whose deadlines have passed but haven't had their event fired yet.
+#
+# Events fired:
+#   - decision.deadline_reached
+#   - commitment.deadline_reached
+#
+# For lottery decisions, also enqueues LotteryDrawJob.
+class DeadlineEventJob < SystemJob
+  extend T::Sig
+
+  queue_as :default
+
+  MAX_PER_RUN = 100
+
+  sig { void }
+  def perform
+    decision_count = process_decisions
+    commitment_count = process_commitments
+
+    total = decision_count + commitment_count
+    return unless total.positive?
+
+    Rails.logger.info(
+      "DeadlineEventJob: Fired #{total} deadline events " \
+      "(#{decision_count} decisions, #{commitment_count} commitments)"
+    )
+  end
+
+  private
+
+  sig { returns(Integer) }
+  def process_decisions
+    decisions = Decision.unscoped_for_system_job
+      .where(deleted_at: nil)
+      .where(deadline: ...Time.current)
+      .where(deadline_event_fired_at: nil)
+      .includes(:tenant, :collective, :created_by)
+      .limit(MAX_PER_RUN)
+      .order(:deadline)
+
+    count = 0
+    decisions.each do |decision|
+      fire_deadline_event(decision)
+      count += 1
+    rescue StandardError => e
+      Rails.logger.error("DeadlineEventJob: Failed for decision #{decision.id}: #{e.message}")
+      increment_error_counter("decision")
+    end
+    count
+  end
+
+  sig { returns(Integer) }
+  def process_commitments
+    commitments = Commitment.unscoped_for_system_job
+      .where(deleted_at: nil)
+      .where(deadline: ...Time.current)
+      .where(deadline_event_fired_at: nil)
+      .includes(:tenant, :collective, :created_by)
+      .limit(MAX_PER_RUN)
+      .order(:deadline)
+
+    count = 0
+    commitments.each do |commitment|
+      fire_deadline_event(commitment)
+      count += 1
+    rescue StandardError => e
+      Rails.logger.error("DeadlineEventJob: Failed for commitment #{commitment.id}: #{e.message}")
+      increment_error_counter("commitment")
+    end
+    count
+  end
+
+  sig { params(resource: T.any(Decision, Commitment)).void }
+  def fire_deadline_event(resource)
+    tenant = resource.tenant
+    collective = resource.collective
+    unless tenant && collective
+      Rails.logger.warn(
+        "DeadlineEventJob: Skipping #{resource.class.name} #{resource.id} — missing tenant or collective"
+      )
+      resource.update_column(:deadline_event_fired_at, Time.current)
+      return
+    end
+
+    event_type = "#{T.must(resource.class.name).underscore}.deadline_reached"
+
+    # Mark as fired BEFORE recording the event, so that if the event dispatch
+    # succeeds but a later step fails, we don't re-fire on the next run.
+    # Missing an event is better than duplicating webhooks.
+    resource.update_column(:deadline_event_fired_at, Time.current)
+
+    with_tenant_and_collective_context(tenant, collective) do
+      EventService.record!(
+        event_type: event_type,
+        actor: resource.created_by,
+        subject: resource,
+        metadata: event_metadata(resource)
+      )
+
+      LotteryDrawJob.perform_later(resource.id) if resource.is_a?(Decision) && resource.is_lottery?
+    end
+
+    increment_fired_counter(T.must(resource.class.name).underscore)
+  end
+
+  sig { params(resource_type: String).void }
+  def increment_fired_counter(resource_type)
+    return if Rails.env.test?
+
+    Yabeda.deadline_events.fired_total.increment({ resource_type: resource_type })
+  end
+
+  sig { params(resource_type: String).void }
+  def increment_error_counter(resource_type)
+    return if Rails.env.test?
+
+    Yabeda.deadline_events.errors_total.increment({ resource_type: resource_type })
+  end
+
+  sig { params(resource: T.any(Decision, Commitment)).returns(T::Hash[String, T.untyped]) }
+  def event_metadata(resource)
+    metadata = {
+      "resource_type" => T.must(resource.class.name).underscore,
+      "resource_id" => resource.id,
+      "deadline" => resource.deadline&.iso8601,
+    }
+
+    case resource
+    when Decision
+      metadata["question"] = resource.question
+      metadata["subtype"] = resource.subtype
+    when Commitment
+      metadata["title"] = resource.title
+    end
+
+    metadata
+  end
+end

--- a/app/views/shared/_automation_yaml_reference.html.erb
+++ b/app/views/shared/_automation_yaml_reference.html.erb
@@ -62,7 +62,9 @@ actions:
     <li class="pulse-list-item"><code>comment.created</code> - A comment was added</li>
     <li class="pulse-list-item"><code>reply.created</code> - A reply was added to a comment</li>
     <li class="pulse-list-item"><code>decision.created</code> - A decision was created</li>
+    <li class="pulse-list-item"><code>decision.deadline_reached</code> - A decision's deadline has passed</li>
     <li class="pulse-list-item"><code>commitment.created</code> - A commitment was created</li>
+    <li class="pulse-list-item"><code>commitment.deadline_reached</code> - A commitment's deadline has passed</li>
     <li class="pulse-list-item"><code>commitment.critical_mass</code> - A commitment reached critical mass</li>
   </ul>
 

--- a/app/views/shared/_automation_yaml_reference.md.erb
+++ b/app/views/shared/_automation_yaml_reference.md.erb
@@ -65,7 +65,9 @@ actions:
 - `comment.created` - A comment was added
 - `reply.created` - A reply was added to a comment
 - `decision.created` - A decision was created
+- `decision.deadline_reached` - A decision's deadline has passed
 - `commitment.created` - A commitment was created
+- `commitment.deadline_reached` - A commitment's deadline has passed
 - `commitment.critical_mass` - A commitment reached critical mass
 
 <% if automation_type == :agent %>

--- a/config/initializers/sidekiq_cron.rb
+++ b/config/initializers/sidekiq_cron.rb
@@ -18,6 +18,11 @@ Sidekiq.configure_server do |_config|
       "class" => "ReminderDeliveryJob",
       "description" => "Deliver due reminders",
     },
+    "deadline_event" => {
+      "cron" => "* * * * *", # Every minute
+      "class" => "DeadlineEventJob",
+      "description" => "Fire events when decision/commitment deadlines pass",
+    },
     "orphaned_task_sweep" => {
       "cron" => "*/10 * * * *", # Every 10 minutes
       "class" => "OrphanedTaskSweepJob",

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -68,6 +68,17 @@ Yabeda.configure do
           tags: [:tenant_id]
   end
 
+  # Deadline event metrics
+  group :deadline_events do
+    counter :fired_total,
+            comment: "Total deadline events fired",
+            tags: [:resource_type]
+
+    counter :errors_total,
+            comment: "Total deadline event processing errors",
+            tags: [:resource_type]
+  end
+
   # Automation metrics
   group :automations do
     counter :runs_total,

--- a/db/migrate/20260501224518_add_deadline_event_fired_at_to_decisions_and_commitments.rb
+++ b/db/migrate/20260501224518_add_deadline_event_fired_at_to_decisions_and_commitments.rb
@@ -1,0 +1,6 @@
+class AddDeadlineEventFiredAtToDecisionsAndCommitments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :decisions, :deadline_event_fired_at, :datetime, null: true
+    add_column :commitments, :deadline_event_fired_at, :datetime, null: true
+  end
+end

--- a/db/migrate/20260501230351_backfill_deadline_event_fired_at_for_existing_records.rb
+++ b/db/migrate/20260501230351_backfill_deadline_event_fired_at_for_existing_records.rb
@@ -1,0 +1,27 @@
+# Backfill deadline_event_fired_at for decisions and commitments whose
+# deadlines have already passed. Without this, the first run of
+# DeadlineEventJob would fire events for every historical record.
+class BackfillDeadlineEventFiredAtForExistingRecords < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      UPDATE decisions
+      SET deadline_event_fired_at = deadline
+      WHERE deadline < NOW()
+        AND deadline_event_fired_at IS NULL
+        AND deleted_at IS NULL
+    SQL
+
+    execute <<~SQL
+      UPDATE commitments
+      SET deadline_event_fired_at = deadline
+      WHERE deadline < NOW()
+        AND deadline_event_fired_at IS NULL
+        AND deleted_at IS NULL
+    SQL
+  end
+
+  def down
+    execute "UPDATE decisions SET deadline_event_fired_at = NULL"
+    execute "UPDATE commitments SET deadline_event_fired_at = NULL"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -378,7 +378,8 @@ CREATE TABLE public.commitments (
     "limit" integer,
     deleted_at timestamp(6) without time zone,
     deleted_by_id uuid,
-    subtype character varying DEFAULT 'action'::character varying NOT NULL
+    subtype character varying DEFAULT 'action'::character varying NOT NULL,
+    deadline_event_fired_at timestamp(6) without time zone
 );
 
 
@@ -587,7 +588,8 @@ CREATE TABLE public.decisions (
     subtype character varying DEFAULT 'vote'::character varying NOT NULL,
     decision_maker_id uuid,
     lottery_beacon_round bigint,
-    lottery_beacon_randomness character varying
+    lottery_beacon_randomness character varying,
+    deadline_event_fired_at timestamp(6) without time zone
 );
 
 
@@ -8956,6 +8958,8 @@ ALTER TABLE ONLY public.representation_session_events
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260501230351'),
+('20260501224518'),
 ('20260501200240'),
 ('20260501180221'),
 ('20260430190112'),

--- a/sorbet/rbi/dsl/commitment.rbi
+++ b/sorbet/rbi/dsl/commitment.rbi
@@ -992,6 +992,51 @@ class Commitment
     def deadline_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deadline_event_fired_at; end
+
+    sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deadline_event_fired_at=(value); end
+
+    sig { returns(T::Boolean) }
+    def deadline_event_fired_at?; end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deadline_event_fired_at_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def deadline_event_fired_at_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def deadline_event_fired_at_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def deadline_event_fired_at_change; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def deadline_event_fired_at_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def deadline_event_fired_at_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deadline_event_fired_at_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def deadline_event_fired_at_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def deadline_event_fired_at_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deadline_event_fired_at_previously_was; end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deadline_event_fired_at_was; end
+
+    sig { void }
+    def deadline_event_fired_at_will_change!; end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
     def deadline_in_database; end
 
     sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
@@ -1295,6 +1340,9 @@ class Commitment
     def restore_deadline!; end
 
     sig { void }
+    def restore_deadline_event_fired_at!; end
+
+    sig { void }
     def restore_deleted_at!; end
 
     sig { void }
@@ -1359,6 +1407,12 @@ class Commitment
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_deadline?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def saved_change_to_deadline_event_fired_at; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_deadline_event_fired_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
     def saved_change_to_deleted_at; end
@@ -1716,6 +1770,9 @@ class Commitment
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_deadline?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_deadline_event_fired_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_deleted_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/sorbet/rbi/dsl/decision.rbi
+++ b/sorbet/rbi/dsl/decision.rbi
@@ -952,6 +952,51 @@ class Decision
     def deadline_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deadline_event_fired_at; end
+
+    sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deadline_event_fired_at=(value); end
+
+    sig { returns(T::Boolean) }
+    def deadline_event_fired_at?; end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deadline_event_fired_at_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def deadline_event_fired_at_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def deadline_event_fired_at_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def deadline_event_fired_at_change; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def deadline_event_fired_at_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def deadline_event_fired_at_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deadline_event_fired_at_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def deadline_event_fired_at_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def deadline_event_fired_at_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deadline_event_fired_at_previously_was; end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deadline_event_fired_at_was; end
+
+    sig { void }
+    def deadline_event_fired_at_will_change!; end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
     def deadline_in_database; end
 
     sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
@@ -1432,6 +1477,9 @@ class Decision
     def restore_deadline!; end
 
     sig { void }
+    def restore_deadline_event_fired_at!; end
+
+    sig { void }
     def restore_decision_maker_id!; end
 
     sig { void }
@@ -1499,6 +1547,12 @@ class Decision
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_deadline?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def saved_change_to_deadline_event_fired_at; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_deadline_event_fired_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
     def saved_change_to_decision_maker_id; end
@@ -1826,6 +1880,9 @@ class Decision
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_deadline?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_deadline_event_fired_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_decision_maker_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/sorbet/rbi/shims/yabeda.rbi
+++ b/sorbet/rbi/shims/yabeda.rbi
@@ -21,5 +21,8 @@ module Yabeda
 
     sig { returns(T.untyped) }
     def users; end
+
+    sig { returns(T.untyped) }
+    def deadline_events; end
   end
 end

--- a/test/jobs/deadline_event_job_test.rb
+++ b/test/jobs/deadline_event_job_test.rb
@@ -1,0 +1,268 @@
+# typed: false
+
+require "test_helper"
+
+class DeadlineEventJobTest < ActiveJob::TestCase
+  def setup
+    @tenant, @collective, @user = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    Tenant.current_id = @tenant.id
+  end
+
+  def teardown
+    Collective.clear_thread_scope
+  end
+
+  def create_decision(deadline:, subtype: "vote")
+    Decision.create!(
+      tenant: @tenant, collective: @collective,
+      created_by: @user, updated_by: @user,
+      question: "Test?", description: "",
+      deadline: deadline,
+      subtype: subtype
+    )
+  end
+
+  def create_commitment(deadline:)
+    Commitment.create!(
+      tenant: @tenant, collective: @collective,
+      created_by: @user, updated_by: @user,
+      title: "Test commitment", description: "",
+      deadline: deadline,
+      critical_mass: 1
+    )
+  end
+
+  # === Decision deadline events ===
+
+  test "fires decision.deadline_reached for past-deadline decisions" do
+    decision = create_decision(deadline: 1.minute.ago)
+    original_updated_at = decision.updated_at
+
+    Collective.clear_thread_scope
+
+    travel 1.minute do
+      DeadlineEventJob.perform_now
+    end
+
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    event = Event.where(event_type: "decision.deadline_reached").last
+    assert_not_nil event
+    assert_equal decision.id, event.subject_id
+    assert_equal "Decision", event.subject_type
+
+    decision.reload
+    assert_not_nil decision.deadline_event_fired_at
+    assert_equal original_updated_at, decision.updated_at
+  end
+
+  test "does not fire for decisions with future deadlines" do
+    create_decision(deadline: 1.hour.from_now)
+
+    Collective.clear_thread_scope
+
+    DeadlineEventJob.perform_now
+
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    assert_equal 0, Event.where(event_type: "decision.deadline_reached").count
+  end
+
+  test "does not fire twice for the same decision" do
+    decision = create_decision(deadline: 1.minute.ago)
+    decision.update!(deadline_event_fired_at: Time.current)
+
+    Collective.clear_thread_scope
+
+    DeadlineEventJob.perform_now
+
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    assert_equal 0, Event.where(event_type: "decision.deadline_reached").count
+  end
+
+  # === Commitment deadline events ===
+
+  test "fires commitment.deadline_reached for past-deadline commitments" do
+    commitment = create_commitment(deadline: 1.minute.ago)
+
+    Collective.clear_thread_scope
+
+    DeadlineEventJob.perform_now
+
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    event = Event.where(event_type: "commitment.deadline_reached").last
+    assert_not_nil event
+    assert_equal commitment.id, event.subject_id
+    assert_equal "Commitment", event.subject_type
+
+    commitment.reload
+    assert_not_nil commitment.deadline_event_fired_at
+  end
+
+  test "does not fire for commitments with future deadlines" do
+    create_commitment(deadline: 1.hour.from_now)
+
+    Collective.clear_thread_scope
+
+    DeadlineEventJob.perform_now
+
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    assert_equal 0, Event.where(event_type: "commitment.deadline_reached").count
+  end
+
+  test "does not fire twice for the same commitment" do
+    commitment = create_commitment(deadline: 1.minute.ago)
+    commitment.update!(deadline_event_fired_at: Time.current)
+
+    Collective.clear_thread_scope
+
+    DeadlineEventJob.perform_now
+
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    assert_equal 0, Event.where(event_type: "commitment.deadline_reached").count
+  end
+
+  # === Lottery integration ===
+
+  test "enqueues LotteryDrawJob for lottery decisions" do
+    decision = create_decision(deadline: 1.minute.ago, subtype: "lottery")
+
+    Collective.clear_thread_scope
+
+    assert_enqueued_with(job: LotteryDrawJob, args: [decision.id]) do
+      DeadlineEventJob.perform_now
+    end
+  end
+
+  test "does not enqueue LotteryDrawJob for vote decisions" do
+    create_decision(deadline: 1.minute.ago, subtype: "vote")
+
+    Collective.clear_thread_scope
+
+    assert_no_enqueued_jobs(only: LotteryDrawJob) do
+      DeadlineEventJob.perform_now
+    end
+  end
+
+  # === Cross-tenant ===
+
+  test "processes decisions and commitments across multiple tenants" do
+    # Create a decision in the first tenant
+    create_decision(deadline: 1.minute.ago)
+
+    # Create a second tenant with its own decision
+    other_tenant = create_tenant(subdomain: "tenant2", name: "Tenant 2")
+    other_user = create_user(name: "User 2")
+    other_tenant.add_user!(other_user)
+    other_collective = create_collective(tenant: other_tenant, created_by: other_user, name: "Collective 2", handle: "collective2")
+    other_collective.add_user!(other_user)
+
+    Collective.scope_thread_to_collective(subdomain: other_tenant.subdomain, handle: other_collective.handle)
+    Tenant.current_id = other_tenant.id
+
+    Decision.create!(
+      tenant: other_tenant, collective: other_collective,
+      created_by: other_user, updated_by: other_user,
+      question: "Tenant 2 decision?", description: "",
+      deadline: 1.minute.ago,
+      subtype: "vote"
+    )
+
+    Collective.clear_thread_scope
+    Tenant.current_id = nil
+
+    DeadlineEventJob.perform_now
+
+    # Should fire deadline events for both tenants
+    deadline_events = Event.unscoped_for_system_job.where(event_type: "decision.deadline_reached")
+    assert_equal 2, deadline_events.count
+  end
+
+  # === Event metadata ===
+
+  test "includes resource metadata in decision event" do
+    decision = create_decision(deadline: 1.minute.ago)
+
+    Collective.clear_thread_scope
+    DeadlineEventJob.perform_now
+
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    event = Event.where(event_type: "decision.deadline_reached").last
+    assert_not_nil event
+    assert_equal "decision", event.metadata["resource_type"]
+    assert_equal decision.id, event.metadata["resource_id"]
+    assert_equal "Test?", event.metadata["question"]
+    assert_equal "vote", event.metadata["subtype"]
+    assert_not_nil event.metadata["deadline"]
+  end
+
+  test "includes resource metadata in commitment event" do
+    commitment = create_commitment(deadline: 1.minute.ago)
+
+    Collective.clear_thread_scope
+    DeadlineEventJob.perform_now
+
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    event = Event.where(event_type: "commitment.deadline_reached").last
+    assert_not_nil event
+    assert_equal "commitment", event.metadata["resource_type"]
+    assert_equal commitment.id, event.metadata["resource_id"]
+    assert_equal "Test commitment", event.metadata["title"]
+    assert_not_nil event.metadata["deadline"]
+  end
+
+  # === Soft-deleted items ===
+
+  test "does not fire for soft-deleted decisions" do
+    decision = create_decision(deadline: 1.minute.ago)
+    decision.update!(deleted_at: Time.current)
+
+    Collective.clear_thread_scope
+
+    DeadlineEventJob.perform_now
+
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    assert_equal 0, Event.where(event_type: "decision.deadline_reached").count
+  end
+
+  test "does not fire for soft-deleted commitments" do
+    commitment = create_commitment(deadline: 1.minute.ago)
+    commitment.update!(deleted_at: Time.current)
+
+    Collective.clear_thread_scope
+
+    DeadlineEventJob.perform_now
+
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    assert_equal 0, Event.where(event_type: "commitment.deadline_reached").count
+  end
+
+  # === Error isolation ===
+
+  test "continues processing after a single record fails" do
+    create_decision(deadline: 3.minutes.ago) # this one will fail
+    good_decision = create_decision(deadline: 2.minutes.ago)
+
+    Collective.clear_thread_scope
+
+    call_count = 0
+    original_record = EventService.method(:record!)
+    EventService.stub(:record!, lambda { |**kwargs|
+      call_count += 1
+      raise "simulated failure" if call_count == 1
+
+      original_record.call(**kwargs)
+    }) do
+      DeadlineEventJob.perform_now
+    end
+
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    # The good decision (processed second) should still have its event fired
+    good_decision.reload
+    assert_not_nil good_decision.deadline_event_fired_at
+  end
+end


### PR DESCRIPTION
## Summary

- **Deadline events for automations/webhooks**: When a decision or commitment deadline passes, the system now fires `decision.deadline_reached` and `commitment.deadline_reached` events automatically. These flow through the existing EventService → AutomationDispatcher + NotificationDispatcher pipeline, so webhooks and automations can react to deadlines without any user action.
- **Lottery draw on deadline**: Lottery decisions now automatically enqueue `LotteryDrawJob` when their deadline passes, instead of requiring manual close first.
- **Monitoring**: Info-level logging with per-run counts, Yabeda metrics (`deadline_events.fired_total`, `deadline_events.errors_total`), and warning logs for corrupt data.

### How it works

A new `DeadlineEventJob` (SystemJob) runs every minute via sidekiq-cron — same pattern as `ReminderDeliveryJob`. It queries across all tenants for decisions/commitments where `deadline < NOW() AND deadline_event_fired_at IS NULL AND deleted_at IS NULL`, fires events, and sets the `deadline_event_fired_at` flag. The flag is set *before* the event is dispatched to avoid duplicate webhooks on retry.

A backfill migration pre-marks all existing past-deadline records so the first deploy doesn't flood events.

### Key design decisions

- **Flag before event**: `update_column(:deadline_event_fired_at, ...)` runs before `EventService.record!` — missing an event is better than duplicating webhooks
- **`update_column` not `update!`**: Avoids touching `updated_at` and avoids triggering `Tracked` callbacks (no spurious `decision.updated` events)
- **Error isolation**: One failed record doesn't block processing of others
- **Idempotent lottery draw**: The existing `close_decision` path still enqueues `LotteryDrawJob` for manual closes; `LotteryDrawJob` guards on `lottery_beacon_round.present?` so double-enqueue is harmless

## Test plan

- [x] 14 unit tests covering: event firing, future deadline skipping, duplicate prevention, commitment events, lottery draw integration, cross-tenant processing, event metadata, soft-delete exclusion, error isolation, `updated_at` unchanged
- [x] Sorbet type check passes
- [x] RuboCop clean
- [x] Local end-to-end: created a decision with a near-future deadline, watched Sidekiq cron pick it up after deadline passed, verified event created with correct metadata, confirmed no duplicate on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
