### PR TITLE
Update net-imap, addressable, and yard to fix security vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,8 +74,8 @@ GEM
       minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.4)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     anyway_config (2.7.2)
       ruby-next-core (~> 1.0)
     ast (2.4.3)
@@ -199,7 +199,7 @@ GEM
     mutex_m (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.4.20)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -492,7 +492,7 @@ GEM
       anyway_config (>= 1.3, < 3)
       sidekiq
       yabeda (~> 0.6)
-    yard (0.9.38)
+    yard (0.9.43)
     yard-sorbet (0.9.0)
       sorbet-runtime
       yard


### PR DESCRIPTION
Addresses all 7 open Dependabot alerts (164, 167, 171-175):
- net-imap 0.4.20 → 0.6.4 (command injection, DoS, STARTTLS stripping)
- addressable 2.8.4 → 2.9.0 (ReDoS in templates)
- yard 0.9.38 → 0.9.43 (path traversal in yard server)