### PR TITLE
Use verifiable randomness beacon for vote decision tiebreakers

### DIFF
--- a/.claude/plans/beacon-for-vote-decisions.md
+++ b/.claude/plans/beacon-for-vote-decisions.md
@@ -1,0 +1,136 @@
+# Verifiable Random Tiebreakers for Vote Decisions
+
+## Context
+
+Vote decisions currently use `options.random_id` (a Postgres-generated random integer) to break ties when acceptance and preference counts are equal. Lotteries already use an external randomness beacon (drand) to produce verifiably random sort keys. We want to extend the beacon to vote decisions so that tie-breaking is provably fair.
+
+**Key difference from lotteries**: Vote decisions show in-progress results before closing. Since the beacon value isn't known until after the deadline, the random column should show "???" while the decision is open, with an explanation that final tie-breaking will happen at close time. After close, the beacon is fetched and the `lottery_sort_key` replaces `random_id` — exactly as lotteries work today.
+
+The existing DB columns (`lottery_beacon_round`, `lottery_beacon_randomness`) and SQL view (`lottery_sort_key`) already work for any decision type. The main work is generalizing the guards, naming, job triggers, and UI copy.
+
+## Plan
+
+### Step 1: Generalize `lottery_drawn?` on Decision model
+
+**File**: `app/models/decision.rb`
+
+- Add a new method `beacon_drawn?` that checks `lottery_beacon_round.present?` without requiring `is_lottery?`
+- Keep `lottery_drawn?` as-is for backward compat (it's used in a few places) or update it to delegate to `beacon_drawn?`
+- Update `api_json` to include beacon data when `beacon_drawn?` (not just for lotteries)
+
+```ruby
+def beacon_drawn?
+  lottery_beacon_round.present?
+end
+
+def lottery_drawn?
+  is_lottery? && beacon_drawn?
+end
+```
+
+### Step 2: Generalize LotteryService
+
+**File**: `app/services/lottery_service.rb`
+
+- Rename `draw!` validation: allow both lottery and vote subtypes (not just lottery)
+- Or add a second method. Simplest: relax the guard from `is_lottery?` to `is_lottery? || is_vote?`
+
+### Step 3: Generalize LotteryDrawJob
+
+**File**: `app/jobs/lottery_draw_job.rb`
+
+- Change the guard from `decision.is_lottery?` to `decision.is_lottery? || decision.is_vote?`
+- The rest of the job logic (reschedule if deadline in future, call `LotteryService.new.draw!`) works as-is
+
+### Step 4: Trigger beacon fetch for vote decisions on close
+
+**File**: `app/services/api_helper.rb` (line ~936)
+
+- Change `if decision.is_lottery?` to `if decision.is_lottery? || decision.is_vote?`
+
+### Step 5: Update results partial
+
+**File**: `app/views/decisions/_results.html.erb`
+
+Three changes:
+
+**a) Random column cells (lines 34-40)**: Add a third branch for vote decisions that are closed but not yet beacon-drawn:
+```erb
+<% if @decision.beacon_drawn? %>
+  <td ...><%= result.lottery_sort_key&.slice(0, 3) %>...</td>
+<% elsif @decision.is_vote? && @decision.closed? %>
+  <td class="pulse-results-random">???</td>
+<% else %>
+  <%# existing random_id logic %>
+<% end %>
+```
+
+**b) Explanation text (lines 45-53)**: Update the vote branch to account for open vs beacon-drawn states:
+- **Vote, open**: "Results are sorted first by acceptance ✅, then by preference ⭐, then by random digits 🎲 (final tiebreakers determined at close time)."
+- **Vote, closed but not drawn**: Same as open text, or "Fetching verifiable randomness for tiebreakers..."
+- **Beacon drawn (any type)**: Include link to verify page. For votes: "Results are sorted first by acceptance ✅, then by preference ⭐, then by verifiably random tiebreakers 🎲."
+
+**c) "Drawing..." spinner (line 2)**: Extend to also show for votes that are closed but not drawn. For votes, this should probably be a subtler inline indicator rather than hiding the whole table — maybe a small note below the table.
+
+### Step 6: Update verify page
+
+**File**: `app/views/decisions/verify.html.erb`
+
+- Change breadcrumb from `['Lottery', ...]` to `[@decision.is_lottery? ? 'Lottery' : 'Decision', ...]`
+- Change heading from "Verify Lottery Results" to "Verify Results" (or conditional)
+- Change "This lottery uses..." to "This decision uses..." or conditional
+- Change "entry/entries" to "option/entry" based on subtype
+- For votes, add a note that the beacon only affects tiebreakers, not the acceptance/preference ranking
+
+### Step 7: Update verify controller action
+
+**File**: `app/controllers/decisions_controller.rb` (line 519)
+
+- Change guard from `lottery_drawn?` to `beacon_drawn?`
+- Update page title from "Verify Lottery" to "Verify Results" (or conditional)
+
+### Step 8: Update DecisionResult `get_sorting_factor`
+
+**File**: `app/models/decision_result.rb`
+
+- Currently checks `lottery_sort_key.present?` — this already works generically, no change needed
+- The `is_sorting_factor?` calls in the results partial may need updating for the "???" state
+
+### Step 9: Tests
+
+Write tests for:
+- Beacon fetch triggered when vote decision closes
+- Results show "???" in random column for open vote decisions
+- Results show beacon sort key after vote decision beacon is drawn
+- Verify page accessible for vote decisions with beacon data
+- Verify page redirects for vote decisions without beacon data
+- LotteryDrawJob processes vote decisions
+- LotteryService.draw! works for vote decisions
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `app/models/decision.rb` | Add `beacon_drawn?`, update `api_json` |
+| `app/services/lottery_service.rb` | Relax subtype guard |
+| `app/jobs/lottery_draw_job.rb` | Relax subtype guard |
+| `app/services/api_helper.rb` | Trigger job for votes too |
+| `app/views/decisions/_results.html.erb` | "???" state, updated explanation text |
+| `app/views/decisions/verify.html.erb` | Generalize lottery-specific language |
+| `app/controllers/decisions_controller.rb` | `beacon_drawn?` guard on verify action |
+| Tests for all of the above |
+
+## Optional future rename
+
+The DB columns are named `lottery_beacon_*` which is a bit awkward for vote decisions. A migration to rename them to `beacon_round` / `beacon_randomness` would be cleaner but isn't required — the existing names work fine functionally. This could be a follow-up.
+
+## Verification
+
+1. Create a vote decision with 3+ options that tie on acceptance/preference
+2. While open, confirm "???" shows in random column and explanation mentions "determined at close time"
+3. Close the decision
+4. Confirm beacon is fetched (check logs or DB)
+5. Confirm results show beacon sort keys and link to verify page
+6. Visit verify page, confirm it works for vote decisions
+7. Run existing lottery tests to confirm no regressions
+8. Run new vote beacon tests

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -516,9 +516,9 @@ class DecisionsController < ApplicationController
   def verify
     @decision = current_decision
     return render '404', status: 404 unless @decision
-    return redirect_to @decision.path unless @decision.lottery_drawn?
+    return redirect_to @decision.path unless @decision.beacon_drawn?
 
-    @page_title = "Verify Lottery | #{@decision.question}"
+    @page_title = "Verify Results | #{@decision.question}"
     @sidebar_mode = 'resource'
     lottery_service = LotteryService.new
     @verification_url = lottery_service.verification_url(@decision)
@@ -541,7 +541,13 @@ class DecisionsController < ApplicationController
 
   def set_results_view_vars
     @voter_count = @decision.voter_count
-    @results_header = @decision.closed? ? 'Final Results' : 'Current Results'
+    @results_header = if @decision.closed? && !@decision.is_executive? && !@decision.beacon_drawn?
+                        'Finalizing...'
+                      elsif @decision.closed?
+                        'Final Results'
+                      else
+                        'Current Results'
+                      end
   end
 
   def current_app

--- a/app/jobs/lottery_draw_job.rb
+++ b/app/jobs/lottery_draw_job.rb
@@ -12,9 +12,9 @@ class LotteryDrawJob < TenantScopedJob
   def perform(decision_id)
     decision = Decision.unscoped_for_system_job.find_by(id: decision_id)
     return unless decision
-    return unless decision.is_lottery?
+    return unless decision.is_lottery? || decision.is_vote?
     return unless decision.closed?
-    return if decision.lottery_beacon_round.present?
+    return if decision.beacon_drawn?
 
     set_tenant_context!(decision.tenant)
 

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -47,8 +47,13 @@ class Decision < ApplicationRecord
   end
 
   sig { returns(T::Boolean) }
+  def beacon_drawn?
+    lottery_beacon_round.present?
+  end
+
+  sig { returns(T::Boolean) }
   def lottery_drawn?
-    is_lottery? && lottery_beacon_round.present?
+    is_lottery? && beacon_drawn?
   end
 
   sig { returns(User) }
@@ -82,7 +87,7 @@ class Decision < ApplicationRecord
       # history_events: history_events.map(&:api_json),
       # backlinks: backlinks.map(&:api_json),
     }
-    if lottery_drawn?
+    if beacon_drawn?
       response.merge!({
         lottery_beacon_round: lottery_beacon_round,
         lottery_beacon_randomness: lottery_beacon_randomness,

--- a/app/services/api_helper.rb
+++ b/app/services/api_helper.rb
@@ -933,7 +933,7 @@ class ApiHelper
       end
     end
 
-    if decision.is_lottery?
+    if decision.is_lottery? || decision.is_vote?
       LotteryDrawJob.perform_later(decision.id)
     end
 

--- a/app/services/lottery_service.rb
+++ b/app/services/lottery_service.rb
@@ -11,8 +11,8 @@ class LotteryService
 
   sig { params(decision: Decision).void }
   def draw!(decision)
-    raise "Decision is not a lottery" unless decision.is_lottery?
-    raise "Lottery has already been drawn" if decision.lottery_beacon_round.present?
+    raise "Decision must be a lottery or vote" unless decision.is_lottery? || decision.is_vote?
+    raise "Beacon has already been drawn" if decision.beacon_drawn?
 
     round_number = @provider.round_for_timestamp(T.must(decision.deadline))
     result = @provider.fetch_round(round_number)

--- a/app/services/randomness_provider/drand.rb
+++ b/app/services/randomness_provider/drand.rb
@@ -99,8 +99,8 @@ module RandomnessProvider
     def round_derivation(deadline, round_number)
       deadline_unix = deadline.to_i
       {
-        description: "The beacon round is the first drand round published after the lottery deadline. " \
-                     "This ensures the randomness was not yet known when entries were added.",
+        description: "The beacon round is the first drand round published after the decision deadline. " \
+                     "This ensures the randomness was not yet known when the decision closed.",
         formula: "round = floor( (deadline_unix - genesis_time) / period ) + 2",
         steps: [
           "deadline_unix = #{deadline_unix}",

--- a/app/views/decisions/_results.html.erb
+++ b/app/views/decisions/_results.html.erb
@@ -31,8 +31,14 @@
               <td style="opacity:<%= (result.accepted_yes || 0) > 0 ? 1 : 0.2 %>;"><%= (result.accepted_yes || 0) %></td>
               <td style="opacity:<%= (result.preferred || 0) > 0 ? 1 : 0.2 %>;"><%= (result.preferred || 0) %></td>
             <% end %>
-            <% if @decision.lottery_drawn? %>
+            <% if @decision.is_lottery? && @decision.beacon_drawn? %>
               <td class="pulse-results-random" title="<%= result.lottery_sort_key %>"><%= result.lottery_sort_key&.slice(0, 3) %>...</td>
+            <% elsif @decision.is_vote? && @decision.beacon_drawn? %>
+              <% is_relevant = result.is_sorting_factor?(prev_result, 'lottery_sort_key') || result.is_sorting_factor?(next_result, 'lottery_sort_key') %>
+              <td class="pulse-results-random" title="<%= result.lottery_sort_key %>"><%= is_relevant ? (result.lottery_sort_key&.slice(0, 3) + "...") : "" %></td>
+            <% elsif @decision.is_vote? %>
+              <% is_relevant = result.is_sorting_factor?(prev_result, 'random_id') || result.is_sorting_factor?(next_result, 'random_id') %>
+              <td class="pulse-results-random"><%= is_relevant ? "???" : "" %></td>
             <% else %>
               <% random_id_is_relevant = @decision.is_lottery? || result.is_sorting_factor?(prev_result, 'random_id') || result.is_sorting_factor?(next_result, 'random_id') %>
               <% random_id = result.random_id %>
@@ -43,10 +49,14 @@
       </tbody>
     </table>
     <p class="pulse-results-explanation">
-      <% if @decision.lottery_drawn? %>
+      <% if @decision.is_lottery? && @decision.beacon_drawn? %>
         Results are sorted by <%= link_to "verifiably random", "#{@decision.path}/verify" %> values 🎲.
       <% elsif @decision.is_lottery? %>
         Entries are sorted by random digits 🎲. Final order will be determined by verifiable randomness when the lottery closes.
+      <% elsif @decision.beacon_drawn? %>
+        Results are sorted first by acceptance ✅, then by preference ⭐, then by <%= link_to "verifiably random", "#{@decision.path}/verify" %> tiebreakers 🎲.
+      <% elsif @decision.is_vote? %>
+        Results are sorted first by acceptance ✅, then by preference ⭐, then by random tiebreakers 🎲 (determined at close time).
       <% else %>
         Results are sorted first by acceptance ✅, then by preference ⭐, then by random digits 🎲.
       <% end %>

--- a/app/views/decisions/show.md.erb
+++ b/app/views/decisions/show.md.erb
@@ -120,9 +120,30 @@ Check ✅ all options that you would accept. Star ⭐️ options you prefer.
 <% end -%>
 <% end -%>
 <% if @show_results -%>
-## <%= @decision.closed? ? "Final" : "Current" %> Results
+<% if @decision.beacon_drawn? -%>
+## Final Results
 
-Results are sorted first by acceptance ✅, then by preference ⭐, then by random digits 🎲.
+Results are sorted first by acceptance ✅, then by preference ⭐, then by [verifiably random](<%= @decision.path %>/verify) tiebreakers 🎲.
+
+|   |   | ✅ | ⭐ | 🎲 |
+|---|---|---|---|---|
+<% @decision.results.each.with_index do |result, index| -%>
+| <%= index + 1 %> | <%= result.option_title %> | <%= (result.accepted_yes || 0) %> | <%= (result.preferred || 0) %> | `<%= result.lottery_sort_key&.slice(0, 3) %>...` |
+<% end -%>
+<% elsif @decision.closed? -%>
+## Finalizing...
+
+Results are sorted first by acceptance ✅, then by preference ⭐, then by random tiebreakers 🎲 (determined at close time).
+
+|   |   | ✅ | ⭐ | 🎲 |
+|---|---|---|---|---|
+<% @decision.results.each.with_index do |result, index| -%>
+| <%= index + 1 %> | <%= result.option_title %> | <%= (result.accepted_yes || 0) %> | <%= (result.preferred || 0) %> | ??? |
+<% end -%>
+<% else -%>
+## Current Results
+
+Results are sorted first by acceptance ✅, then by preference ⭐, then by random tiebreakers 🎲 (determined at close time).
 
 |   |   | ✅ | ⭐ | 🎲 |
 |---|---|---|---|---|
@@ -130,7 +151,8 @@ Results are sorted first by acceptance ✅, then by preference ⭐, then by rand
 | 0 | Add options to see results. | 0 | 0 | 0 |
 <% end -%>
 <% @decision.results.each.with_index do |result, index| -%>
-| <%= index + 1 %> | <%= result.option_title %> | <%= (result.accepted_yes || 0) %> | <%= (result.preferred || 0) %> | <%= result.random_id.slice(0, 3) + "..." %> |
+| <%= index + 1 %> | <%= result.option_title %> | <%= (result.accepted_yes || 0) %> | <%= (result.preferred || 0) %> | ??? |
+<% end -%>
 <% end -%>
 
 <% if @decision.statement.present? -%>

--- a/app/views/decisions/verify.html.erb
+++ b/app/views/decisions/verify.html.erb
@@ -1,20 +1,26 @@
 <%= render 'shared/pulse_breadcrumb', items: [
   [@current_collective.name, @current_collective.path],
-  ['Lottery', @decision.path],
+  [@decision.is_lottery? ? 'Lottery' : 'Decision', @decision.path],
   'Verify'
 ] %>
 
 <article class="pulse-resource-detail">
-  <h1 style="font-size: 1.5em; margin-bottom: 8px;">Verify Lottery Results</h1>
+  <h1 style="font-size: 1.5em; margin-bottom: 8px;">Verify Results</h1>
   <p class="pulse-body-text-muted" style="margin-bottom: 20px;">
     <%= link_to @decision.question, @decision.path %>
   </p>
 
   <div class="pulse-resource-body" style="padding: 16px;">
     <h2 style="font-size: 1.15em; margin: 0 0 12px 0;">How It Works</h2>
+    <% unless @decision.is_lottery? %>
+      <p style="line-height: 1.6; margin-bottom: 16px;">
+        Everyone's votes are visible on the <%= link_to "voters page", "#{@decision.path}/voters" %>.
+        When options are tied on acceptance and preference, ties are broken using verifiable randomness.
+      </p>
+    <% end %>
     <p style="line-height: 1.6; margin-bottom: 16px;">
-      This lottery uses <strong>verifiable randomness</strong>. The outcome is determined by combining
-      a publicly verifiable random value (from a randomness beacon) with each entry's title using a
+      This decision uses <strong>verifiable randomness</strong>. <%= @decision.is_lottery? ? 'The outcome is' : 'Tiebreakers are' %> determined by combining
+      a publicly verifiable random value (from a randomness beacon) with each <%= @decision.is_lottery? ? "entry's" : "option's" %> title using a
       SHA-256 hash. Anyone can independently reproduce the calculation to confirm the results were not tampered with.
     </p>
 
@@ -60,11 +66,11 @@
 
     <h2 style="font-size: 1.15em; margin: 0 0 12px 0;">Formula</h2>
     <p style="line-height: 1.6; margin-bottom: 8px;">
-      For each entry, the sort key is computed as:
+      For each <%= @decision.is_lottery? ? 'entry' : 'option' %>, the sort key is computed as:
     </p>
-    <pre style="background: var(--color-canvas-subtle); padding: 12px; border-radius: 6px; overflow-x: auto; margin-bottom: 16px;"><code>sort_key = SHA256( beacon_randomness + NFC(entry_title) )</code></pre>
+    <pre style="background: var(--color-canvas-subtle); padding: 12px; border-radius: 6px; overflow-x: auto; margin-bottom: 16px;"><code>sort_key = SHA256( beacon_randomness + NFC(<%= @decision.is_lottery? ? 'entry' : 'option' %>_title) )</code></pre>
     <p style="line-height: 1.6; margin-bottom: 16px;">
-      Entries are sorted by sort key in descending order.
+      <%= @decision.is_lottery? ? 'Entries' : 'Options' %> are sorted by sort key in descending order.
       Titles are <a href="https://unicode.org/reports/tr15/" target="_blank" rel="noopener">NFC-normalized</a> before hashing.
     </p>
 
@@ -73,15 +79,24 @@
       <thead>
         <tr>
           <th style="padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--color-border-default); color: var(--color-fg-muted); width: 40px;">#</th>
-          <th style="padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--color-border-default); color: var(--color-fg-muted);">Entry</th>
+          <th style="padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--color-border-default); color: var(--color-fg-muted);"><%= @decision.is_lottery? ? 'Entry' : 'Option' %></th>
+          <% unless @decision.is_lottery? %>
+            <th style="padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--color-border-default); color: var(--color-fg-muted);">✅</th>
+            <th style="padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--color-border-default); color: var(--color-fg-muted);">⭐</th>
+          <% end %>
           <th style="padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--color-border-default); color: var(--color-fg-muted);">Sort Key</th>
         </tr>
       </thead>
       <tbody>
-        <% @decision.results.each_with_index do |result, index| %>
-          <tr style="<%= index == 0 ? 'background: var(--color-attention-subtle); font-weight: 600;' : '' %>">
+        <% ([nil] + @decision.results + [nil]).each_cons(3).with_index do |(prev_result, result, next_result), index| %>
+          <% is_tiebreaker = @decision.is_lottery? || result.is_sorting_factor?(prev_result, 'lottery_sort_key') || result.is_sorting_factor?(next_result, 'lottery_sort_key') %>
+          <tr style="<%= index == 0 ? 'background: var(--color-attention-subtle); font-weight: 600;' : '' %><%= is_tiebreaker ? '' : ' opacity: 0.4;' %>">
             <td style="padding: 8px 12px; border-bottom: 1px solid var(--color-border-default); width: 40px;"><%= index + 1 %></td>
             <td style="padding: 8px 12px; border-bottom: 1px solid var(--color-border-default);"><%= markdown_inline(result.option_title) %></td>
+            <% unless @decision.is_lottery? %>
+              <td style="padding: 8px 12px; border-bottom: 1px solid var(--color-border-default);"><%= result.accepted_yes || 0 %></td>
+              <td style="padding: 8px 12px; border-bottom: 1px solid var(--color-border-default);"><%= result.preferred || 0 %></td>
+            <% end %>
             <td style="padding: 8px 12px; border-bottom: 1px solid var(--color-border-default);"><code style="font-size: 0.85em;"><%= result.lottery_sort_key %></code></td>
           </tr>
         <% end %>
@@ -99,7 +114,7 @@ title = <%= result.option_title.inspect %>
 print(hashlib.sha256((beacon + unicodedata.normalize("NFC", title)).encode()).hexdigest())
 <% end %></code></pre>
     <p class="pulse-body-text-muted" style="line-height: 1.6;">
-      Each output should match the sort key shown above for that entry.
+      Each output should match the sort key shown above for that <%= @decision.is_lottery? ? 'entry' : 'option' %>.
     </p>
   </div>
 </article>

--- a/app/views/decisions/verify.md.erb
+++ b/app/views/decisions/verify.md.erb
@@ -1,8 +1,12 @@
-# Verify Lottery: <%= @decision.question %>
+# Verify Results: <%= @decision.question %>
 
-[Back to lottery](<%= @decision.path %>)
+[Back to <%= @decision.is_lottery? ? 'lottery' : 'decision' %>](<%= @decision.path %>)
 
-This lottery uses **verifiable randomness**. The outcome is determined by combining a publicly verifiable random value (from a randomness beacon) with each entry's title using a SHA-256 hash. Anyone can independently reproduce the calculation to confirm the results were not tampered with.
+<% unless @decision.is_lottery? -%>
+Everyone's votes are visible on the [voters page](<%= @decision.path %>/voters). When options are tied on acceptance and preference, ties are broken using verifiable randomness.
+
+<% end -%>
+This decision uses **verifiable randomness**. <%= @decision.is_lottery? ? 'The outcome is' : 'Tiebreakers are' %> determined by combining a publicly verifiable random value (from a randomness beacon) with each <%= @decision.is_lottery? ? "entry's" : "option's" %> title using a SHA-256 hash. Anyone can independently reproduce the calculation to confirm the results were not tampered with.
 
 ## How the Beacon Round Is Determined
 
@@ -34,17 +38,25 @@ This lottery uses **verifiable randomness**. The outcome is determined by combin
 ## Formula
 
 ```
-sort_key = SHA256( beacon_randomness + NFC(entry_title) )
+sort_key = SHA256( beacon_randomness + NFC(<%= @decision.is_lottery? ? 'entry' : 'option' %>_title) )
 ```
 
-Entries are sorted by sort key in descending order. Titles are [NFC-normalized](https://unicode.org/reports/tr15/) before hashing.
+<%= @decision.is_lottery? ? 'Entries' : 'Options' %> are sorted by sort key in descending order. Titles are [NFC-normalized](https://unicode.org/reports/tr15/) before hashing.
 
 ## Results Breakdown
 
+<% if @decision.is_lottery? -%>
 | # | Entry | Sort Key |
 |---|-------|----------|
 <% @decision.results.each_with_index do |result, index| -%>
 | <%= index + 1 %> | <%= result.option_title %> | `<%= result.lottery_sort_key %>` |
+<% end -%>
+<% else -%>
+| # | Option | ✅ | ⭐ | Sort Key |
+|---|--------|---|---|----------|
+<% @decision.results.each_with_index do |result, index| -%>
+| <%= index + 1 %> | <%= result.option_title %> | <%= result.accepted_yes || 0 %> | <%= result.preferred || 0 %> | `<%= result.lottery_sort_key %>` |
+<% end -%>
 <% end -%>
 
 ## Verify Manually
@@ -60,4 +72,4 @@ print(hashlib.sha256((beacon + unicodedata.normalize("NFC", title)).encode()).he
 <% end -%>
 ```
 
-Each output should match the sort key shown above for that entry.
+Each output should match the sort key shown above for that <%= @decision.is_lottery? ? 'entry' : 'option' %>.

--- a/app/views/help/decisions.md.erb
+++ b/app/views/help/decisions.md.erb
@@ -15,9 +15,9 @@ Results are sorted by three factors in order:
 
 1. **Acceptances ✅** — Options with more acceptances rank higher
 2. **Preferences ⭐** — Among options with equal acceptances, more preferences rank higher
-3. **Random digits 🎲** — If still tied, a random number assigned to each option breaks the tie
+3. **Random tiebreakers 🎲** — If still tied, a verifiably random value breaks the tie
 
-The random digits ensure there is always a clear ordering, even when votes are identical. They are only displayed in the results table when they are the deciding factor.
+The random tiebreakers ensure there is always a clear ordering, even when votes are identical. They are only displayed in the results table when they are the deciding factor. The tiebreaker values come from an external randomness beacon and are not known until the decision closes — the same verifiable randomness used by [lottery decisions](/help/lottery-decisions). After a decision closes, a verification page is available where anyone can independently confirm the tiebreaker values.
 
 **Results are hidden until you vote.** You will not see the current results until after you submit your own vote. This prevents strategic voting and encourages independent evaluation. Results are always visible once the decision is closed.
 
@@ -32,7 +32,7 @@ Suppose 3 people vote on a decision with 4 options:
 | 3 | Option C | 1 | 1 | 847... |
 | 4 | Option D | 1 | 1 | 231... |
 
-Options A and B both have 3 acceptances, so preferences break the tie (A wins with 2 vs 1). Options C and D are tied on both acceptances and preferences, so random digits decide (C's 847 beats D's 231).
+Options A and B both have 3 acceptances, so preferences break the tie (A wins with 2 vs 1). Options C and D are tied on both acceptances and preferences, so the random tiebreaker decides (C's 847 beats D's 231).
 
 ## Creating a Decision
 
@@ -92,3 +92,4 @@ Each decision has a voters page (`{decision}/voters`) that shows a detailed brea
 - Create: `{collective}/decide`
 - View: `{collective}/d/{id}`
 - Voters: `{collective}/d/{id}/voters`
+- Verify: `{collective}/d/{id}/verify`

--- a/app/views/help/lottery_decisions.md.erb
+++ b/app/views/help/lottery_decisions.md.erb
@@ -10,7 +10,7 @@ A **lottery** selects randomly from a list of entries. There is no voting — th
 
 Results are hidden until the lottery closes.
 
-The randomness is **verifiable** — it comes from an external source that nobody controls, so the outcome cannot be rigged. After the lottery is drawn, a verification page is available where anyone can independently confirm the results.
+The randomness is **verifiable** — it comes from an external source that nobody controls, so the outcome cannot be rigged. After the lottery is drawn, a verification page is available where anyone can independently confirm the results. The same verifiable randomness is used to break ties in [vote decisions](/help/decisions).
 
 ## Key Differences from Vote Decisions
 

--- a/test/controllers/decisions_controller_test.rb
+++ b/test/controllers/decisions_controller_test.rb
@@ -1280,7 +1280,7 @@ class DecisionsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/verifiably random/, response.body)
   end
 
-  test "open vote decision shows finalized at close time message" do
+  test "open vote decision shows determined at close time message" do
     sign_in_as(@user, tenant: @tenant)
 
     Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
@@ -1294,6 +1294,6 @@ class DecisionsControllerTest < ActionDispatch::IntegrationTest
 
     get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}"
     assert_response :success
-    assert_match(/finalized at close time/, response.body)
+    assert_match(/determined at close time/, response.body)
   end
 end

--- a/test/controllers/decisions_controller_test.rb
+++ b/test/controllers/decisions_controller_test.rb
@@ -1199,4 +1199,101 @@ class DecisionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match(/verifiably random/, response.body)
   end
+
+  # === Vote Decision Beacon Tests ===
+
+  test "verify page renders for vote decision with beacon" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    @decision.update!(
+      subtype: "vote",
+      deadline: 1.hour.ago,
+      lottery_beacon_round: 12345,
+      lottery_beacon_randomness: "deadbeef123",
+    )
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    Option.create!(decision: @decision, decision_participant: participant, title: "Option B")
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/verify"
+    assert_response :success
+    assert_match(/Verify Results/, response.body)
+    assert_match(/Tiebreakers are/, response.body)
+    assert_match(/voters page/, response.body)
+  end
+
+  test "verify page redirects for vote decision without beacon" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    @decision.update!(subtype: "vote", deadline: 1.hour.ago)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/verify"
+    assert_response :redirect
+  end
+
+  test "closed vote decision shows question marks when beacon pending" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    @decision.update!(subtype: "vote", deadline: 1.hour.ago)
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option_a = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    option_b = Option.create!(decision: @decision, decision_participant: participant, title: "Option B")
+    Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: option_a, decision_participant: participant, accepted: 1, preferred: 0)
+    Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: option_b, decision_participant: participant, accepted: 1, preferred: 0)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}"
+    assert_response :success
+    assert_match(/\?\?\?/, response.body)
+  end
+
+  test "drawn vote decision shows verify link" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    @decision.update!(
+      subtype: "vote",
+      deadline: 1.hour.ago,
+      lottery_beacon_round: 999,
+      lottery_beacon_randomness: "abc",
+    )
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: option, decision_participant: participant, accepted: 1, preferred: 0)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}"
+    assert_response :success
+    assert_match(/verifiably random/, response.body)
+  end
+
+  test "open vote decision shows finalized at close time message" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    @decision.update!(subtype: "vote", deadline: 1.hour.from_now)
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: option, decision_participant: participant, accepted: 1, preferred: 0)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}"
+    assert_response :success
+    assert_match(/finalized at close time/, response.body)
+  end
 end

--- a/test/models/decision_test.rb
+++ b/test/models/decision_test.rb
@@ -466,7 +466,64 @@ class DecisionTest < ActiveSupport::TestCase
     assert_not decision.lottery_drawn?
   end
 
-  test "lottery results sorted by beacon-derived keys when drawn" do
+  # === beacon_drawn? tests ===
+
+  test "beacon_drawn? returns true for vote decision with beacon data" do
+    decision = Decision.create!(
+      tenant: @tenant, collective: @collective,
+      created_by: @user, updated_by: @user,
+      question: "Beacon vote test?", description: "", deadline: 1.day.from_now,
+      subtype: "vote",
+      lottery_beacon_round: 12345,
+      lottery_beacon_randomness: "abc123",
+    )
+    assert decision.beacon_drawn?
+    assert_not decision.lottery_drawn?
+  end
+
+  test "beacon_drawn? returns false when no beacon data" do
+    decision = create_decision
+    assert_not decision.beacon_drawn?
+  end
+
+  test "api_json includes beacon data for vote decision with beacon" do
+    decision = Decision.create!(
+      tenant: @tenant, collective: @collective,
+      created_by: @user, updated_by: @user,
+      question: "Vote beacon API?", description: "", deadline: 1.minute.ago,
+      subtype: "vote",
+      lottery_beacon_round: 42,
+      lottery_beacon_randomness: "vote_beacon_hex",
+    )
+    json = decision.api_json
+    assert_equal 42, json[:lottery_beacon_round]
+    assert_equal "vote_beacon_hex", json[:lottery_beacon_randomness]
+  end
+
+  test "vote decision results use beacon sort key when beacon drawn" do
+    decision = Decision.create!(
+      tenant: @tenant, collective: @collective,
+      created_by: @user, updated_by: @user,
+      question: "Vote with beacon?", description: "", deadline: 1.minute.ago,
+      subtype: "vote",
+      lottery_beacon_round: 100,
+      lottery_beacon_randomness: "deadbeef",
+    )
+    participant = DecisionParticipant.create!(decision: decision, user: @user)
+    Option.create!(decision: decision, title: "Alpha", decision_participant: participant)
+    Option.create!(decision: decision, title: "Beta", decision_participant: participant)
+
+    results = decision.results
+    sort_keys = results.map(&:lottery_sort_key)
+    assert sort_keys.all?(&:present?), "All results should have lottery_sort_key"
+
+    results.each do |result|
+      expected = Digest::SHA256.hexdigest("deadbeef" + result.option_title.unicode_normalize(:nfc))
+      assert_equal expected, result.lottery_sort_key
+    end
+  end
+
+  test "vote decision results have nil lottery_sort_key when no beacon" do
     decision = Decision.create!(
       tenant: @tenant, collective: @collective,
       created_by: @user, updated_by: @user,
@@ -493,15 +550,6 @@ class DecisionTest < ActiveSupport::TestCase
       expected = Digest::SHA256.hexdigest("deadbeef" + result.option_title.unicode_normalize(:nfc))
       assert_equal expected, result.lottery_sort_key
     end
-  end
-
-  test "vote decision results have nil lottery_sort_key" do
-    decision = create_decision
-    participant = DecisionParticipant.create!(decision: decision, user: @user)
-    Option.create!(decision: decision, title: "Option A", decision_participant: participant)
-
-    results = decision.results
-    assert_nil results.first.lottery_sort_key
   end
 
   test "api_json includes beacon data for drawn lottery" do

--- a/test/services/lottery_service_test.rb
+++ b/test/services/lottery_service_test.rb
@@ -38,8 +38,10 @@ class LotteryServiceTest < ActiveSupport::TestCase
     assert_equal "test_random_hex", decision.lottery_beacon_randomness
   end
 
-  test "draw! raises if decision is not a lottery" do
+  test "draw! works for vote decisions" do
     provider = RandomnessProvider::Test.new
+    provider.randomness = "vote_random_hex"
+    provider.round = 99
     service = LotteryService.new(provider: provider)
 
     decision = Decision.create!(
@@ -49,7 +51,25 @@ class LotteryServiceTest < ActiveSupport::TestCase
       subtype: "vote",
     )
 
-    assert_raises(RuntimeError, "Decision is not a lottery") do
+    service.draw!(decision)
+    decision.reload
+    assert_equal 99, decision.lottery_beacon_round
+    assert_equal "vote_random_hex", decision.lottery_beacon_randomness
+  end
+
+  test "draw! raises if decision is executive" do
+    provider = RandomnessProvider::Test.new
+    service = LotteryService.new(provider: provider)
+
+    decision = Decision.create!(
+      tenant: @tenant, collective: @collective,
+      created_by: @user, updated_by: @user,
+      question: "Executive?", description: "", deadline: 1.minute.ago,
+      subtype: "executive",
+      decision_maker: @user,
+    )
+
+    assert_raises(RuntimeError, "Decision must be a lottery or vote") do
       service.draw!(decision)
     end
   end
@@ -61,7 +81,7 @@ class LotteryServiceTest < ActiveSupport::TestCase
     decision = create_lottery_decision
     decision.update!(lottery_beacon_round: 1, lottery_beacon_randomness: "existing")
 
-    assert_raises(RuntimeError, "Lottery has already been drawn") do
+    assert_raises(RuntimeError, "Beacon has already been drawn") do
       service.draw!(decision)
     end
   end


### PR DESCRIPTION
Vote decisions now fetch a drand beacon value when they close, using the same mechanism as lotteries. This makes tie-breaking between options with equal acceptance and preference counts provably fair.

Key changes:
- Add beacon_drawn? to Decision (subtype-agnostic check for beacon data)
- Generalize LotteryService and LotteryDrawJob to handle vote decisions
- Trigger beacon fetch on vote close in api_helper
- Show "???" in random column while beacon is pending (only when relevant)
- Show beacon sort keys after drawn (only when they're the sorting factor)
- Header shows "Finalizing..." between close and beacon arrival
- Verify page works for both subtypes with contextual language
- Update help topics to document verifiable tiebreakers