### PR TITLE
Close vote-after-close trigger race and pin audit timestamp precision

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -132,7 +132,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   sig { returns(T::Boolean) }
   def closed?
-    T.unsafe(self).deadline && T.unsafe(self).deadline < Time.now
+    T.unsafe(self).deadline && T.unsafe(self).deadline <= Time.now
   end
 
   sig { params(user: User).returns(T::Boolean) }

--- a/app/services/decision_audit_service.rb
+++ b/app/services/decision_audit_service.rb
@@ -134,7 +134,7 @@ class DecisionAuditService
         sequence_number = (last_entry&.sequence_number || 0) + 1
         previous_hash = last_entry&.entry_hash
 
-        now = Time.current
+        now = Time.current.change(usec: 0)
 
         entry = DecisionAuditEntry.new(
           tenant_id: decision.tenant_id,

--- a/db/migrate/20260506230000_tighten_vote_after_close_trigger.rb
+++ b/db/migrate/20260506230000_tighten_vote_after_close_trigger.rb
@@ -1,0 +1,35 @@
+class TightenVoteAfterCloseTrigger < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION prevent_vote_mutation_after_close() RETURNS TRIGGER AS $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1 FROM decisions
+          WHERE id = NEW.decision_id
+          AND deadline <= NOW()
+        ) THEN
+          RAISE EXCEPTION 'Votes cannot be created or modified after the decision is closed';
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION prevent_vote_mutation_after_close() RETURNS TRIGGER AS $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1 FROM decisions
+          WHERE id = NEW.decision_id
+          AND deadline < NOW()
+        ) THEN
+          RAISE EXCEPTION 'Votes cannot be created or modified after the decision is closed';
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -68,7 +68,7 @@ BEGIN
   IF EXISTS (
     SELECT 1 FROM decisions
     WHERE id = NEW.decision_id
-    AND deadline < NOW()
+    AND deadline <= NOW()
   ) THEN
     RAISE EXCEPTION 'Votes cannot be created or modified after the decision is closed';
   END IF;
@@ -9214,6 +9214,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260507200842'),
 ('20260506234024'),
+('20260506230000'),
 ('20260505203614'),
 ('20260503232136'),
 ('20260502202229'),


### PR DESCRIPTION
Two audit chain hardening fixes:

1. The DB trigger checked `deadline < NOW()`, but close sets `deadline = Time.current`. At the exact same instant, `deadline < NOW()` is false, leaving a sub-millisecond window for a vote to slip through. Changed to `deadline <= NOW()` in the trigger and `<=` in `closed?` for consistency.

2. Audit entry hashes use `created_at.iso8601` (second precision), but Postgres stores microseconds. Truncate `Time.current` to second precision before storing, so the DB value exactly matches what was hashed. Prevents a future refactor from introducing a hash mismatch on DB round-trip.

https://claude.ai/code/session_019ZP1DbyXFyC7aW2aqMxyHq