### PR TITLE
Add client-side and server-side audit chain verification

### DIFF
--- a/.claude/plans/audit-chain-incident-response.md
+++ b/.claude/plans/audit-chain-incident-response.md
@@ -1,0 +1,62 @@
+# Audit Chain Incident Response & Monitoring
+
+## Context
+
+The audit chain verification system can detect integrity failures — tampered hashes, mismatched vote tallies, wrong beacon data. But detecting a problem is only half the story. We need to be prepared for what happens when a problem is actually detected, whether by the in-browser verifier, the Python script, or the server-side integrity job.
+
+Most integrity failures will be bugs in our code, not actual tampering. But from the user's perspective, the system is telling them their vote results may not be trustworthy. How we respond determines whether the audit chain builds trust or destroys it.
+
+## Proactive Detection
+
+### 1. AuditChainIntegrityJob alerting
+The job already runs and detects problems, but only logs them. It should:
+- Send alerts to the ops team (email, Slack, or whatever monitoring we use) when any chain fails verification
+- Include the decision ID, collective, failure type, and error details
+- Distinguish severity: chain hash mismatch (critical) vs missing audit entry for a vote (warning)
+
+### 2. Verification failure reporting from the browser
+When the client-side verifier detects a failure, consider:
+- Should it report back to the server? (privacy tradeoff — the user may not want us to know they're verifying)
+- At minimum, the error messaging should tell users how to contact us
+
+### 3. Monitoring dashboard
+An admin view showing:
+- How many decisions have been verified (by the integrity job)
+- Any failures, grouped by type
+- Last run time, coverage percentage
+
+## Incident Response
+
+### When a user reports a verification failure
+
+**Step 1: Triage — is this a real integrity failure or a bug?**
+- Check the `AuditChainIntegrityJob` logs — does server-side verification also fail?
+- If server-side passes but client-side fails: likely a bug in the TypeScript verifier or a data serialization issue in the JSON endpoint
+- If both fail: this is a real integrity issue
+- Run the Python script independently as a third opinion
+
+**Step 2: If it's a bug in verification code**
+- Fix the bug, deploy
+- Communicate to the user: "The verification check had a bug that caused a false alarm. The underlying data is intact. Here's what we fixed."
+- Consider whether the bug affected other decisions
+
+**Step 3: If it's a real integrity issue**
+- Determine the scope: one decision or many? One collective or cross-tenant?
+- Determine the cause: database issue, code bug that wrote bad data, or unexplained?
+- Preserve evidence: snapshot the audit entries, the decision state, and any relevant logs before attempting fixes
+- Communicate transparently: tell affected users exactly what happened, what data was affected, and what we're doing about it
+- If vote results are unreliable: the decision may need to be re-run
+- Post-mortem: document root cause, timeline, and preventive measures
+
+### Communication principles
+- Never downplay an integrity failure — the whole point of the audit chain is transparency
+- Be specific about what was affected and what wasn't
+- Explain what it means for the decision's results — can they still be trusted?
+- If we don't know yet, say so — "we're investigating" is better than guessing
+
+## Open Questions
+- Should verification failures be reportable from the browser UI? (e.g. "Report this issue" button)
+- Should we proactively notify collective admins when the integrity job detects a problem?
+- What's the SLA for investigating a reported integrity failure?
+- Should we keep an audit log of who ran verification and when? (for accountability, not surveillance)
+- Do we need a way to "quarantine" a decision whose integrity is in question — hide results until investigated?

--- a/.claude/plans/audit-chain-receipts.md
+++ b/.claude/plans/audit-chain-receipts.md
@@ -1,0 +1,29 @@
+# Audit Chain Receipts
+
+Follow-up work for vote receipt features on the audit chain.
+
+## Items
+
+### 1. Receipt hashes on voters page
+Show each voter's receipt hash next to their name on the voters page. The hash should link to the per-user verification page (item 2).
+
+### 2. Receipt verification route
+New page at `/d/:decision_id/verify/:receipt_hash` that shows all audit entries for the user associated with that receipt hash. Enables anyone to verify anyone else's votes — full transparency.
+
+Together with item 1, this replaces the originally-deferred "receipt lookup UX" (paste hash to search). The voters page links directly to per-user verification via a dedicated route.
+
+### 3. Email receipt opt-in toggle
+`VoteReceiptMailer` exists and works, but `send_vote_receipt_email` in `ApiHelper` is currently a no-op. Needs:
+- A user preference / notification setting for opting in to vote receipt emails
+- UI for toggling the preference
+- Wire up `send_vote_receipt_email` to check the preference and send when enabled
+
+### 4. Vote history visibility on verify page
+Open design question: should the verify page (and the per-user receipt page) show the full vote change history (every `vote_cast` + `vote_updated` entry) or just the final state?
+
+This affects what users and verifiers can learn from the audit log. Full history gives maximum transparency but may be noisy. Final state is cleaner but hides intermediate changes.
+
+## Dependencies
+- Item 2 depends on item 1 conceptually (the voters page is the primary entry point to per-user verification)
+- Item 3 is independent
+- Item 4 is a design decision that affects items 2 and 3 (what's shown on the receipt page and in the email)

--- a/.claude/plans/audit-chain-verification-implementations.md
+++ b/.claude/plans/audit-chain-verification-implementations.md
@@ -1,0 +1,120 @@
+# Audit Chain Verification Implementations
+
+## Context
+
+The audit chain currently has one verification path: a Python script (`scripts/verify-audit-chain.py`) that users must download and run independently. This creates friction — most users won't bother. We need:
+
+1. **Client-side TypeScript verification** — runs automatically in the browser on the verify page
+2. **Server-side Ruby verification via markdown** — AI agents see results inline when reading `Accept: text/markdown`
+
+All three implementations (Python, TypeScript, Ruby) must produce identical results for the same input.
+
+## Phase 1: Extend Ruby Verifier
+
+`DecisionAuditVerifier` currently only verifies chain integrity (hash recomputation + chain links). Extend it to also verify vote tallies and beacon, matching what the Python script does.
+
+### Files
+- `app/services/decision_audit_verifier.rb` — add `verify_vote_tallies`, `verify_beacon`, `verify_all`
+- `test/services/decision_audit_verifier_test.rb` — tests for each new method
+
+### New methods
+
+**`verify_vote_tallies(decision)`**
+- Replay `vote_cast`/`vote_updated` audit entries, keep latest per (actor_id, option_title)
+- Sum accepted/preferred per option, compare against `decision.results`
+- Return `{ valid:, errors: }`
+
+**`verify_beacon(decision, fetched_randomness:)`**
+- Derive expected round from deadline via `RandomnessProvider`
+- Compare round against `decision.lottery_beacon_round`
+- Recompute sort keys: `SHA256(randomness + NFC(option_title))`
+- Accept randomness as parameter (caller fetches — keeps it testable)
+- Return `{ valid:, errors: }`
+
+**`verify_all(decision, fetched_randomness: nil)`**
+- Calls all three checks, returns `{ chain:, vote_tallies:, beacon:, valid: }`
+
+## Phase 2: Wire Ruby Verification into Markdown Response
+
+### Files
+- `app/controllers/decisions_controller.rb` — call `verify_all` for `format.md`
+- `app/views/decisions/verify.md.erb` — add verification results section
+
+The markdown verify page gets a "Verification Results" section at the top showing pass/fail for each check. AI agents reading the markdown see verification status inline without needing to run anything.
+
+## Phase 3: TypeScript Verification Library
+
+Pure-function async library with no DOM dependencies. Uses Web Crypto API (`crypto.subtle.digest`) for SHA-256.
+
+### Files
+- `app/javascript/lib/audit_chain_verifier.ts` — verification functions
+- `app/javascript/lib/audit_chain_types.ts` — TypeScript types for verify.json schema
+- `app/javascript/lib/audit_chain_verifier.test.ts` — vitest tests
+
+### Functions
+
+**`verifyChain(data: VerifyData): Promise<ChainResult>`**
+- Replay hashes using SubtleCrypto, check chain links, verify final hash
+- NFC normalization via `String.prototype.normalize("NFC")`
+
+**`verifyVoteTallies(data: VerifyData): VoteTalliesResult`**
+- Synchronous — replay votes, sum totals, compare to results
+
+**`verifyBeacon(data: VerifyData, fetchRandomness: (round: number) => Promise<string>): Promise<BeaconResult>`**
+- Derive round from deadline (hardcoded drand params, same as Python)
+- Fetch randomness via injected callback (testable)
+- Recompute sort keys via SubtleCrypto
+
+**`verifyAll(data: VerifyData, fetchRandomness?): Promise<VerificationResult>`**
+- Runs all three, returns unified result
+
+### Testing notes
+- jsdom doesn't provide `crypto.subtle` — add `globalThis.crypto = require("node:crypto").webcrypto` to `app/javascript/test/setup.ts`
+- Mock drand fetch in beacon tests
+- Test against both valid and tampered data
+
+## Phase 4: Stimulus Controller + Verify Page UI
+
+### Files
+- `app/javascript/controllers/audit_verify_controller.ts` — Stimulus controller
+- `app/javascript/controllers/audit_verify_controller.test.ts` — vitest tests
+- `app/javascript/controllers/index.ts` — register controller
+- `app/views/decisions/verify.html.erb` — add verification results section
+
+### Controller behavior
+- `url` value: points to verify.json endpoint
+- On connect: fetch JSON, run `verifyAll()`, render results into targets
+- Targets for chain, vote tallies, beacon, and overall status
+- Shows "Verifying..." while running, then pass/fail for each check
+- Handles network failures gracefully (shows error, doesn't crash)
+- `fetchRandomness` callback fetches from drand API directly (cross-origin, CORS supported)
+
+### Verify page update
+- New "Automated Verification" section before "Verify Independently"
+- Uses the Stimulus controller to show live results
+- The Python script section remains for independent verification
+
+## Phase 5: Cross-Implementation Consistency Testing
+
+### Approach
+- Generate a static JSON fixture from a seeded decision lifecycle (Rake task or test helper)
+- All three implementations verify the same fixture, all must agree
+- The existing Python integration test (`test/integration/audit_chain_verification_test.rb`) already validates Python against Ruby-generated data — extend this pattern
+
+### Files
+- `test/fixtures/files/audit_chain_fixture.json` — canonical fixture (valid)
+- `test/fixtures/files/audit_chain_fixture_tampered.json` — tampered variant
+- Extend `test/integration/audit_chain_verification_test.rb` — Python against fixture
+- `app/javascript/lib/audit_chain_verifier.test.ts` — TypeScript against same fixture
+- Extend `test/services/decision_audit_verifier_test.rb` — Ruby against same fixture (via `verify_from_json`)
+
+### Optional: `verify_from_json` on Ruby verifier
+Add a JSON-based entry point to `DecisionAuditVerifier` that accepts parsed verify.json data (same format as the endpoint). This parallels how Python and TypeScript both operate on JSON directly, and enables fixture-based testing without ActiveRecord objects.
+
+## Verification
+
+- `docker compose exec web bundle exec rails test` — all Ruby tests pass
+- `docker compose exec js npm test` — all vitest tests pass (including fixture consistency)
+- `docker compose exec js npm run typecheck` — TypeScript compiles
+- Manual: open verify page in browser, see automated verification results
+- Manual: `curl -H "Accept: text/markdown"` on verify endpoint, see verification results inline

--- a/.claude/plans/data-deletion-manager-investigation.md
+++ b/.claude/plans/data-deletion-manager-investigation.md
@@ -1,0 +1,21 @@
+# DataDeletionManager Investigation
+
+Deep investigation into pre-existing bugs surfaced during the audit chain work.
+
+## Context
+During the audit chain implementation, two bugs were discovered in `DataDeletionManager` and documented as skipped tests in `test/services/data_deletion_manager_test.rb`. These are not audit-chain-specific — they are pre-existing issues with collective and decision deletion.
+
+## Known Issues
+
+### 1. FK violation on events table during `delete_collective!`
+Deleting a collective fails due to foreign key constraints on the events table. The events table likely references records that `delete_collective!` tries to delete before cleaning up events.
+
+### 2. Options with wrong collective_id during `delete_decision!`
+Some options end up with a collective_id that doesn't match their parent decision's collective_id. This causes `delete_decision!` to miss them when scoping by collective.
+
+## Investigation Needed
+- Reproduce both bugs and understand the root cause
+- Determine if these affect production data or only test scenarios
+- Check if there are other FK ordering issues in the deletion sequence
+- Assess whether the fix is reordering deletions, adding missing cascade rules, or fixing how collective_id is assigned to options
+- Review the full deletion order in `delete_collective!` for other potential issues

--- a/.claude/plans/decision-verification-ui-polish.md
+++ b/.claude/plans/decision-verification-ui-polish.md
@@ -1,0 +1,11 @@
+# Decision & Verification UI Polish
+
+UI improvements and general polish for decision show pages and the verification page.
+
+## Items
+
+### 1. Consistent chainlink icon on show page
+The audit chain icon on the decision show page currently changes based on decision state. It should always show the chainlink icon regardless of whether the decision is open, closed, or has a beacon drawn.
+
+### 2. Don't highlight top result row before beacon is drawn
+When a decision is closed but the beacon hasn't been fetched yet, the results table highlights the top row as if it's the winner. Since random sorting could change the order when the beacon resolves, the top row shouldn't be highlighted until the beacon is drawn and results are final.

--- a/app/assets/stylesheets/pulse/_components.css
+++ b/app/assets/stylesheets/pulse/_components.css
@@ -3468,5 +3468,10 @@ dialog.pulse-dialog form {
   opacity: 1;
 }
 
+/* Audit chain verification status */
+.verification-pass { color: var(--color-success-fg); }
+.verification-fail { color: var(--color-danger-fg); }
+.verification-error { color: var(--color-fg-muted); }
+
 /* highlight.js overrides to match app theme */
 .hljs { background: transparent !important; padding: 0 !important; }

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -550,7 +550,12 @@ class DecisionsController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.md
+      format.md do
+        @verification_result = DecisionAuditVerifier.verify_all(
+          @decision,
+          fetched_randomness: @decision.lottery_beacon_randomness,
+        )
+      end
       format.json do
         json = {
           decision: {

--- a/app/javascript/controllers/audit_verify_controller.test.ts
+++ b/app/javascript/controllers/audit_verify_controller.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, beforeEach, vi, type Mock } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import AuditVerifyController from "./audit_verify_controller"
+import { waitForController } from "../test/setup"
+import { computeEntryHash } from "../lib/audit_chain_verifier"
+import type { VerifyData, AuditEntry } from "../lib/audit_chain_types"
+
+const validData: VerifyData = {
+  decision: {
+    id: "d1",
+    question: "Test?",
+    subtype: "vote",
+    deadline: "2026-05-06T12:00:00Z",
+    audit_chain_hash: null,
+    lottery_beacon_round: null,
+    lottery_beacon_randomness: null,
+  },
+  audit_chain: [],
+}
+
+function setupDOM(url: string): void {
+  document.body.innerHTML = `
+    <div data-controller="audit-verify"
+         data-audit-verify-url-value="${url}">
+      <div data-audit-verify-target="results">Verifying...</div>
+    </div>
+  `
+}
+
+function resultsText(): string {
+  return document.querySelector("[data-audit-verify-target='results']")?.textContent ?? ""
+}
+
+function resultsHtml(): string {
+  return document.querySelector("[data-audit-verify-target='results']")?.innerHTML ?? ""
+}
+
+describe("AuditVerifyController", () => {
+  let fetchMock: Mock
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  async function startController(): Promise<void> {
+    const application = Application.start()
+    application.register("audit-verify", AuditVerifyController)
+    await waitForController()
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+
+  // --- Happy path ---
+
+  it("shows detailed pass results for valid empty chain", async () => {
+    setupDOM("/verify.json")
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(validData),
+    })
+
+    await startController()
+
+    const text = resultsText()
+    expect(text).toContain("PASS")
+    expect(text).toContain("0 entries verified")
+    expect(text).toContain("All checks passed")
+  })
+
+  it("uses verification-pass CSS class for passing checks", async () => {
+    setupDOM("/verify.json")
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(validData),
+    })
+
+    await startController()
+
+    const html = resultsHtml()
+    expect(html).toContain("verification-pass")
+    expect(html).not.toContain("verification-fail")
+  })
+
+  // --- Fetch errors ---
+
+  it("explains server error with guidance", async () => {
+    setupDOM("/verify.json")
+    fetchMock.mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        json: () => Promise.reject(new Error("not ok")),
+      }),
+    )
+
+    await startController()
+
+    const text = resultsText()
+    expect(text).toContain("Could not load audit data")
+    expect(text).toContain("HTTP 500")
+    expect(text).toContain("try refreshing")
+    expect(text).toContain("verify independently")
+  })
+
+  it("explains network error with guidance", async () => {
+    setupDOM("/verify.json")
+    fetchMock.mockImplementation(() => Promise.reject(new Error("Network error")))
+
+    await startController()
+
+    const text = resultsText()
+    expect(text).toContain("Network error")
+    expect(text).toContain("internet connection")
+    expect(text).toContain("verify independently")
+  })
+
+  // --- Chain integrity failures ---
+
+  it("renders chain failure with integrity warning", async () => {
+    // Build a chain with a tampered hash
+    const entry: AuditEntry = {
+      sequence_number: 1,
+      action: "option_added",
+      actor_id: "user-1",
+      actor_handle: "alice",
+      option_title: "Option A",
+      accepted: "",
+      preferred: "",
+      metadata: "",
+      previous_hash: "",
+      entry_hash: "tampered_hash",
+      created_at: "2026-05-05T12:00:00Z",
+    }
+
+    const tamperedData: VerifyData = {
+      ...validData,
+      audit_chain: [entry],
+    }
+
+    setupDOM("/verify.json")
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(tamperedData),
+    })
+
+    await startController()
+
+    const text = resultsText()
+    expect(text).toContain("FAIL")
+    expect(text).toContain("altered or corrupted")
+    expect(text).toContain("serious integrity issue")
+    expect(text).toContain("Do not rely")
+    expect(text).toContain("hash mismatch")
+
+    const html = resultsHtml()
+    expect(html).toContain("verification-fail")
+  })
+
+  // --- Vote tally failures ---
+
+  it("renders vote tally failure with tampering warning", async () => {
+    const entry: AuditEntry = {
+      sequence_number: 1,
+      action: "vote_cast",
+      actor_id: "user-1",
+      actor_handle: "alice",
+      option_title: "Option A",
+      accepted: "1",
+      preferred: "0",
+      metadata: "",
+      previous_hash: "",
+      entry_hash: "",
+      created_at: "2026-05-05T12:00:00Z",
+    }
+    entry.entry_hash = await computeEntryHash(entry)
+
+    const mismatchData: VerifyData = {
+      decision: { ...validData.decision, audit_chain_hash: entry.entry_hash },
+      audit_chain: [entry],
+      results: [
+        { position: 1, option_title: "Option A", accepted_yes: 99, preferred: 0, lottery_sort_key: null },
+      ],
+    }
+
+    setupDOM("/verify.json")
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mismatchData),
+    })
+
+    await startController()
+
+    const text = resultsText()
+    expect(text).toContain("Chain integrity:")
+    expect(text).toMatch(/Chain integrity:.*PASS/)
+    expect(text).toMatch(/Vote tallies:.*FAIL/)
+    expect(text).toContain("do not match")
+    expect(text).toContain("added, removed, or changed")
+    expect(text).toContain("Do not rely")
+  })
+
+  // --- Beacon states ---
+
+  it("renders beacon skip when drand is unreachable", async () => {
+    const GENESIS_TIME = 1692803367
+    const PERIOD = 3
+    const deadlineUnix = GENESIS_TIME + 1000 * PERIOD
+    const expectedRound = Math.floor((deadlineUnix - GENESIS_TIME) / PERIOD) + 2
+    const deadline = new Date(deadlineUnix * 1000).toISOString()
+
+    const beaconData: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "lottery",
+        deadline,
+        audit_chain_hash: null,
+        lottery_beacon_round: expectedRound,
+        lottery_beacon_randomness: "abc123",
+      },
+      audit_chain: [],
+      beacon: { round: expectedRound, randomness: "abc123", verification_url: "" },
+    }
+
+    setupDOM("/verify.json")
+    // First call: verify.json succeeds. Second call: drand fails.
+    fetchMock.mockImplementation((url: string) => {
+      if (url === "/verify.json") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(beaconData) })
+      }
+      // drand fetch fails
+      return Promise.reject(new Error("Failed to fetch"))
+    })
+
+    await startController()
+
+    const text = resultsText()
+    expect(text).toContain("SKIPPED")
+    expect(text).toContain("drand randomness beacon")
+    expect(text).toContain("temporarily unavailable")
+    expect(text).toContain("Python script below")
+    expect(text).toContain("Chain and vote checks passed")
+  })
+
+  it("renders beacon failure when randomness doesn't match drand", async () => {
+    const GENESIS_TIME = 1692803367
+    const PERIOD = 3
+    const deadlineUnix = GENESIS_TIME + 1000 * PERIOD
+    const expectedRound = Math.floor((deadlineUnix - GENESIS_TIME) / PERIOD) + 2
+    const deadline = new Date(deadlineUnix * 1000).toISOString()
+
+    const beaconData: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "lottery",
+        deadline,
+        audit_chain_hash: null,
+        lottery_beacon_round: expectedRound,
+        lottery_beacon_randomness: "server_claims_this",
+      },
+      audit_chain: [],
+      beacon: { round: expectedRound, randomness: "server_claims_this", verification_url: "" },
+      results: [
+        { position: 1, option_title: "Option A", accepted_yes: 0, preferred: 0, lottery_sort_key: "abc" },
+      ],
+    }
+
+    setupDOM("/verify.json")
+    fetchMock.mockImplementation((url: string) => {
+      if (url === "/verify.json") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(beaconData) })
+      }
+      // drand returns different randomness
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ round: expectedRound, randomness: "drand_says_different" }),
+      })
+    })
+
+    await startController()
+
+    const text = resultsText()
+    expect(text).toMatch(/Beacon verification:.*FAIL/)
+    expect(text).toContain("random sorting could not be verified")
+    expect(text).toContain("manipulated")
+    expect(text).toContain("randomness does not match")
+  })
+
+  // --- Partial failures ---
+
+  it("shows overall failure when any check fails", async () => {
+    const entry: AuditEntry = {
+      sequence_number: 1,
+      action: "option_added",
+      actor_id: "user-1",
+      actor_handle: "alice",
+      option_title: "Option A",
+      accepted: "",
+      preferred: "",
+      metadata: "",
+      previous_hash: "",
+      entry_hash: "tampered",
+      created_at: "2026-05-05T12:00:00Z",
+    }
+
+    const partialData: VerifyData = {
+      ...validData,
+      audit_chain: [entry],
+    }
+
+    setupDOM("/verify.json")
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(partialData),
+    })
+
+    await startController()
+
+    const text = resultsText()
+    // Chain fails but vote tallies and beacon should still pass
+    expect(text).toMatch(/Chain integrity:.*FAIL/)
+    expect(text).toMatch(/Vote tallies:.*PASS/)
+    expect(text).toMatch(/Beacon verification:.*PASS/)
+    expect(text).toContain("One or more checks failed")
+  })
+
+  // --- HTML escaping ---
+
+  it("escapes HTML in error messages to prevent XSS", async () => {
+    const entry: AuditEntry = {
+      sequence_number: 1,
+      action: "vote_cast",
+      actor_id: "user-1",
+      actor_handle: "alice",
+      option_title: '<img src=x onerror=alert(1)>',
+      accepted: "1",
+      preferred: "0",
+      metadata: "",
+      previous_hash: "",
+      entry_hash: "",
+      created_at: "2026-05-05T12:00:00Z",
+    }
+    entry.entry_hash = await computeEntryHash(entry)
+
+    const xssData: VerifyData = {
+      decision: { ...validData.decision, audit_chain_hash: entry.entry_hash },
+      audit_chain: [entry],
+      results: [
+        { position: 1, option_title: '<img src=x onerror=alert(1)>', accepted_yes: 99, preferred: 0, lottery_sort_key: null },
+      ],
+    }
+
+    setupDOM("/verify.json")
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(xssData),
+    })
+
+    await startController()
+
+    const html = resultsHtml()
+    expect(html).not.toContain("<img")
+    expect(html).toContain("&lt;img")
+  })
+})

--- a/app/javascript/controllers/audit_verify_controller.ts
+++ b/app/javascript/controllers/audit_verify_controller.ts
@@ -1,0 +1,160 @@
+import { Controller } from "@hotwired/stimulus"
+import { verifyAll } from "../lib/audit_chain_verifier"
+import type { VerifyData, VerificationResult } from "../lib/audit_chain_types"
+
+// drand quicknet chain parameters
+const DRAND_CHAIN_HASH = "52db9ba70e0cc0f6eaf7803dd07447a1f5477735fd3f661792ba94600c84e971"
+const DRAND_BASE_URL = "https://api.drand.sh"
+
+export default class AuditVerifyController extends Controller {
+  static values = { url: String }
+  static targets = ["results"]
+
+  declare readonly urlValue: string
+  declare readonly resultsTarget: HTMLElement
+
+  async connect(): Promise<void> {
+    await this.verify()
+  }
+
+  async verify(): Promise<void> {
+    let data: VerifyData
+    try {
+      const response = await fetch(this.urlValue, { credentials: "same-origin" })
+      if (!response.ok) {
+        this.renderError(
+          "Could not load audit data",
+          `The server returned an error (HTTP ${response.status}) when fetching the audit chain data. ` +
+          "This could be a temporary issue — try refreshing the page. " +
+          "You can also verify independently using the Python script below.",
+        )
+        return
+      }
+      data = await response.json()
+    } catch (error) {
+      this.renderError(
+        "Network error",
+        "Could not connect to the server to fetch audit chain data. " +
+        "Check your internet connection and try refreshing the page. " +
+        "You can also verify independently using the Python script below.",
+      )
+      return
+    }
+
+    const fetchDrandRandomness = async (round: number): Promise<string> => {
+      const url = `${DRAND_BASE_URL}/${DRAND_CHAIN_HASH}/public/${round}`
+      const response = await fetch(url)
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      const result = await response.json()
+      return result.randomness
+    }
+
+    let result: VerificationResult
+    try {
+      result = await verifyAll(data, fetchDrandRandomness)
+    } catch (error) {
+      console.error("Audit verification error:", error)
+      this.renderError(
+        "Verification script error",
+        "An unexpected error occurred while running the verification checks. " +
+        "This is likely a bug in the verification code, not a problem with the decision data. " +
+        `The error was: ${error instanceof Error ? error.message : String(error)}. ` +
+        "You can verify independently using the Python script below to confirm whether the data is intact.",
+      )
+      return
+    }
+
+    this.renderResult(result)
+  }
+
+  private renderResult(result: VerificationResult): void {
+    const lines: string[] = []
+
+    // Chain integrity
+    if (result.chain.valid) {
+      lines.push(this.passLine("Chain integrity", `All ${result.chain.entryCount} entries verified — every hash is correct and links to the previous entry.`))
+    } else {
+      lines.push(this.failLine("Chain integrity", this.explainChainFailure(result.chain.errors)))
+    }
+
+    // Vote tallies
+    if (result.voteTallies.valid) {
+      lines.push(this.passLine("Vote tallies", "Replayed all votes from the audit chain — totals match the displayed results."))
+    } else {
+      lines.push(this.failLine("Vote tallies", this.explainTallyFailure(result.voteTallies.errors)))
+    }
+
+    // Beacon
+    if (result.beacon.skipped) {
+      lines.push(this.warnLine("Beacon verification", "Could not reach the drand randomness beacon to verify sort keys. " +
+        "This does not indicate a problem with the decision — the drand API may be temporarily unavailable. " +
+        "You can verify the beacon independently using the Python script below."))
+    } else if (result.beacon.valid) {
+      lines.push(this.passLine("Beacon verification", "Randomness round and sort keys verified against the drand beacon."))
+    } else {
+      lines.push(this.failLine("Beacon verification", this.explainBeaconFailure(result.beacon.errors)))
+    }
+
+    // Overall
+    if (result.valid && !result.beacon.skipped) {
+      lines.push(`<p class="verification-pass" style="font-weight: 600; margin: 12px 0 0 0;">All checks passed.</p>`)
+    } else if (result.valid && result.beacon.skipped) {
+      lines.push(`<p style="font-weight: 600; margin: 12px 0 0 0;">Chain and vote checks passed. Beacon could not be checked — see above.</p>`)
+    } else {
+      lines.push(`<p class="verification-fail" style="font-weight: 600; margin: 12px 0 0 0;">One or more checks failed — see details above.</p>`)
+    }
+
+    this.resultsTarget.innerHTML = lines.join("\n")
+  }
+
+  private passLine(label: string, detail: string): string {
+    return `<div style="margin-bottom: 8px;"><strong>${label}:</strong> <span class="verification-pass">PASS</span> — ${this.escapeHtml(detail)}</div>`
+  }
+
+  private failLine(label: string, detail: string): string {
+    return `<div style="margin-bottom: 8px;"><strong>${label}:</strong> <span class="verification-fail">FAIL</span><div style="margin: 4px 0 0 8px; color: var(--color-danger-fg);">${this.escapeHtml(detail)}</div></div>`
+  }
+
+  private warnLine(label: string, detail: string): string {
+    return `<div style="margin-bottom: 8px;"><strong>${label}:</strong> <span class="verification-error">SKIPPED</span><div style="margin: 4px 0 0 8px; color: var(--color-fg-muted);">${this.escapeHtml(detail)}</div></div>`
+  }
+
+  private explainChainFailure(errors: string[]): string {
+    const parts = ["The audit chain has been altered or corrupted. This is a serious integrity issue — " +
+      "it means the recorded history of this decision may not be trustworthy. " +
+      "Do not rely on the displayed results until this is investigated."]
+    if (errors.length > 0) {
+      parts.push("Details: " + errors.join("; ") + ".")
+    }
+    return parts.join(" ")
+  }
+
+  private explainTallyFailure(errors: string[]): string {
+    const parts = ["The vote totals shown in the results do not match what the audit chain recorded. " +
+      "This means votes may have been added, removed, or changed outside of the audited process. " +
+      "Do not rely on the displayed results until this is investigated."]
+    if (errors.length > 0) {
+      parts.push("Details: " + errors.join("; ") + ".")
+    }
+    return parts.join(" ")
+  }
+
+  private explainBeaconFailure(errors: string[]): string {
+    const parts = ["The random sorting could not be verified against the drand randomness beacon. " +
+      "This could mean the sort order was manipulated, or that the wrong beacon round was used."]
+    if (errors.length > 0) {
+      parts.push("Details: " + errors.join("; ") + ".")
+    }
+    return parts.join(" ")
+  }
+
+  private renderError(title: string, detail: string): void {
+    this.resultsTarget.innerHTML = `<div style="margin-bottom: 8px;"><strong>${this.escapeHtml(title)}</strong><div style="margin: 4px 0 0 0; color: var(--color-fg-muted);">${this.escapeHtml(detail)}</div></div>`
+  }
+
+  private escapeHtml(text: string): string {
+    const div = document.createElement("div")
+    div.textContent = text
+    return div.innerHTML
+  }
+}

--- a/app/javascript/controllers/index.ts
+++ b/app/javascript/controllers/index.ts
@@ -58,6 +58,7 @@ import TooltipController from "./tooltip_controller"
 import TopLeftMenuController from "./top_left_menu_controller"
 import TopRightMenuController from "./top_right_menu_controller"
 import TrioLogoController from "./trio_logo_controller"
+import AuditVerifyController from "./audit_verify_controller"
 import AutoSubmitController from "./auto_submit_controller"
 import CheckboxGroupController from "./checkbox_group_controller"
 import KebabMenuController from "./kebab_menu_controller"
@@ -114,6 +115,7 @@ application.register("tooltip", TooltipController)
 application.register("top-left-menu", TopLeftMenuController)
 application.register("top-right-menu", TopRightMenuController)
 application.register("trio-logo", TrioLogoController)
+application.register("audit-verify", AuditVerifyController)
 application.register("auto-submit", AutoSubmitController)
 application.register("checkbox-group", CheckboxGroupController)
 application.register("kebab-menu", KebabMenuController)

--- a/app/javascript/lib/audit_chain_types.ts
+++ b/app/javascript/lib/audit_chain_types.ts
@@ -1,0 +1,69 @@
+export interface AuditEntry {
+  sequence_number: number
+  action: string
+  actor_id: string
+  actor_handle: string
+  option_title: string
+  accepted: string
+  preferred: string
+  metadata: string
+  previous_hash: string
+  entry_hash: string
+  created_at: string
+}
+
+export interface DecisionMeta {
+  id: string
+  question: string
+  subtype: string
+  deadline: string
+  audit_chain_hash: string | null
+  lottery_beacon_round: number | null
+  lottery_beacon_randomness: string | null
+}
+
+export interface BeaconInfo {
+  round: number
+  randomness: string
+  verification_url: string
+}
+
+export interface ResultEntry {
+  position: number
+  option_title: string
+  accepted_yes: number
+  preferred: number
+  lottery_sort_key: string | null
+}
+
+export interface VerifyData {
+  decision: DecisionMeta
+  audit_chain: AuditEntry[]
+  beacon?: BeaconInfo
+  results?: ResultEntry[]
+}
+
+export interface ChainResult {
+  valid: boolean
+  entryCount: number
+  errors: string[]
+  lastHash: string | null
+}
+
+export interface VoteTalliesResult {
+  valid: boolean
+  errors: string[]
+}
+
+export interface BeaconResult {
+  valid: boolean
+  skipped: boolean
+  errors: string[]
+}
+
+export interface VerificationResult {
+  valid: boolean
+  chain: ChainResult
+  voteTallies: VoteTalliesResult
+  beacon: BeaconResult
+}

--- a/app/javascript/lib/audit_chain_verifier.test.ts
+++ b/app/javascript/lib/audit_chain_verifier.test.ts
@@ -1,0 +1,478 @@
+import { describe, it, expect, vi } from "vitest"
+import { verifyChain, verifyVoteTallies, verifyBeacon, verifyAll, computeEntryHash } from "./audit_chain_verifier"
+import type { VerifyData, AuditEntry } from "./audit_chain_types"
+
+// Helper to build a minimal valid entry
+function makeEntry(overrides: Partial<AuditEntry> & { sequence_number: number; action: string; entry_hash: string }): AuditEntry {
+  return {
+    actor_id: "",
+    actor_handle: "",
+    option_title: "",
+    accepted: "",
+    preferred: "",
+    metadata: "",
+    previous_hash: "",
+    created_at: "2026-05-05T12:00:00Z",
+    ...overrides,
+  }
+}
+
+// Build a valid 2-entry chain using actual hash computation
+async function buildValidChain(): Promise<{ entries: AuditEntry[]; lastHash: string }> {
+  const entry1Partial = makeEntry({
+    sequence_number: 1,
+    action: "option_added",
+    actor_id: "user-1",
+    actor_handle: "alice",
+    option_title: "Option A",
+    previous_hash: "",
+    entry_hash: "", // placeholder
+  })
+  const hash1 = await computeEntryHash(entry1Partial)
+  entry1Partial.entry_hash = hash1
+
+  const entry2Partial = makeEntry({
+    sequence_number: 2,
+    action: "vote_cast",
+    actor_id: "user-1",
+    actor_handle: "alice",
+    option_title: "Option A",
+    accepted: "1",
+    preferred: "0",
+    previous_hash: hash1,
+    entry_hash: "", // placeholder
+    created_at: "2026-05-05T12:01:00Z",
+  })
+  const hash2 = await computeEntryHash(entry2Partial)
+  entry2Partial.entry_hash = hash2
+
+  return { entries: [entry1Partial, entry2Partial], lastHash: hash2 }
+}
+
+describe("verifyChain", () => {
+  it("passes for a valid chain", async () => {
+    const { entries, lastHash } = await buildValidChain()
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "vote",
+        deadline: "2026-05-06T12:00:00Z",
+        audit_chain_hash: lastHash,
+        lottery_beacon_round: null,
+        lottery_beacon_randomness: null,
+      },
+      audit_chain: entries,
+    }
+
+    const result = await verifyChain(data)
+    expect(result.valid).toBe(true)
+    expect(result.entryCount).toBe(2)
+    expect(result.errors).toEqual([])
+    expect(result.lastHash).toBe(lastHash)
+  })
+
+  it("detects tampered entry_hash", async () => {
+    const { entries } = await buildValidChain()
+    entries[0].entry_hash = "tampered"
+
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "vote",
+        deadline: "2026-05-06T12:00:00Z",
+        audit_chain_hash: null,
+        lottery_beacon_round: null,
+        lottery_beacon_randomness: null,
+      },
+      audit_chain: entries,
+    }
+
+    const result = await verifyChain(data)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes("hash mismatch"))).toBe(true)
+  })
+
+  it("detects broken chain link", async () => {
+    const { entries } = await buildValidChain()
+    entries[1].previous_hash = "wrong"
+
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "vote",
+        deadline: "2026-05-06T12:00:00Z",
+        audit_chain_hash: null,
+        lottery_beacon_round: null,
+        lottery_beacon_randomness: null,
+      },
+      audit_chain: entries,
+    }
+
+    const result = await verifyChain(data)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes("chain link broken"))).toBe(true)
+  })
+
+  it("detects final chain hash mismatch", async () => {
+    const { entries } = await buildValidChain()
+
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "vote",
+        deadline: "2026-05-06T12:00:00Z",
+        audit_chain_hash: "wrong_hash",
+        lottery_beacon_round: null,
+        lottery_beacon_randomness: null,
+      },
+      audit_chain: entries,
+    }
+
+    const result = await verifyChain(data)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes("chain hash mismatch"))).toBe(true)
+  })
+
+  it("passes for empty chain", async () => {
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "vote",
+        deadline: "2026-05-06T12:00:00Z",
+        audit_chain_hash: null,
+        lottery_beacon_round: null,
+        lottery_beacon_randomness: null,
+      },
+      audit_chain: [],
+    }
+
+    const result = await verifyChain(data)
+    expect(result.valid).toBe(true)
+    expect(result.entryCount).toBe(0)
+  })
+})
+
+describe("verifyVoteTallies", () => {
+  it("passes when replayed votes match results", () => {
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "vote",
+        deadline: "2026-05-06T12:00:00Z",
+        audit_chain_hash: null,
+        lottery_beacon_round: null,
+        lottery_beacon_randomness: null,
+      },
+      audit_chain: [
+        makeEntry({ sequence_number: 1, action: "vote_cast", actor_id: "u1", option_title: "A", accepted: "1", preferred: "1", entry_hash: "h1" }),
+        makeEntry({ sequence_number: 2, action: "vote_cast", actor_id: "u2", option_title: "A", accepted: "0", preferred: "0", entry_hash: "h2" }),
+        makeEntry({ sequence_number: 3, action: "vote_cast", actor_id: "u1", option_title: "B", accepted: "1", preferred: "0", entry_hash: "h3" }),
+      ],
+      results: [
+        { position: 1, option_title: "A", accepted_yes: 1, preferred: 1, lottery_sort_key: null },
+        { position: 2, option_title: "B", accepted_yes: 1, preferred: 0, lottery_sort_key: null },
+      ],
+    }
+
+    const result = verifyVoteTallies(data)
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it("detects acceptance count mismatch", () => {
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "vote",
+        deadline: "2026-05-06T12:00:00Z",
+        audit_chain_hash: null,
+        lottery_beacon_round: null,
+        lottery_beacon_randomness: null,
+      },
+      audit_chain: [
+        makeEntry({ sequence_number: 1, action: "vote_cast", actor_id: "u1", option_title: "A", accepted: "1", preferred: "0", entry_hash: "h1" }),
+      ],
+      results: [
+        { position: 1, option_title: "A", accepted_yes: 5, preferred: 0, lottery_sort_key: null },
+      ],
+    }
+
+    const result = verifyVoteTallies(data)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes("acceptance count"))).toBe(true)
+  })
+
+  it("detects preference count mismatch", () => {
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "vote",
+        deadline: "2026-05-06T12:00:00Z",
+        audit_chain_hash: null,
+        lottery_beacon_round: null,
+        lottery_beacon_randomness: null,
+      },
+      audit_chain: [
+        makeEntry({ sequence_number: 1, action: "vote_cast", actor_id: "u1", option_title: "A", accepted: "1", preferred: "1", entry_hash: "h1" }),
+      ],
+      results: [
+        { position: 1, option_title: "A", accepted_yes: 1, preferred: 99, lottery_sort_key: null },
+      ],
+    }
+
+    const result = verifyVoteTallies(data)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes("preference count"))).toBe(true)
+  })
+
+  it("handles vote_updated correctly", () => {
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "vote",
+        deadline: "2026-05-06T12:00:00Z",
+        audit_chain_hash: null,
+        lottery_beacon_round: null,
+        lottery_beacon_randomness: null,
+      },
+      audit_chain: [
+        makeEntry({ sequence_number: 1, action: "vote_cast", actor_id: "u1", option_title: "A", accepted: "0", preferred: "0", entry_hash: "h1" }),
+        makeEntry({ sequence_number: 2, action: "vote_updated", actor_id: "u1", option_title: "A", accepted: "1", preferred: "1", entry_hash: "h2" }),
+      ],
+      results: [
+        { position: 1, option_title: "A", accepted_yes: 1, preferred: 1, lottery_sort_key: null },
+      ],
+    }
+
+    const result = verifyVoteTallies(data)
+    expect(result.valid).toBe(true)
+  })
+
+  it("passes with no votes", () => {
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "lottery",
+        deadline: "2026-05-06T12:00:00Z",
+        audit_chain_hash: null,
+        lottery_beacon_round: null,
+        lottery_beacon_randomness: null,
+      },
+      audit_chain: [],
+    }
+
+    const result = verifyVoteTallies(data)
+    expect(result.valid).toBe(true)
+  })
+})
+
+describe("verifyBeacon", () => {
+  // drand quicknet params
+  const GENESIS_TIME = 1692803367
+  const PERIOD = 3
+
+  it("passes when round and sort keys match", async () => {
+    const deadlineUnix = GENESIS_TIME + 1000 * PERIOD
+    const expectedRound = Math.floor((deadlineUnix - GENESIS_TIME) / PERIOD) + 2
+    const deadline = new Date(deadlineUnix * 1000).toISOString()
+    const randomness = "abcdef1234567890"
+
+    // Compute expected sort key
+    const encoder = new TextEncoder()
+    const sortKeyBytes = await crypto.subtle.digest("SHA-256", encoder.encode(randomness + "Option A"))
+    const sortKey = Array.from(new Uint8Array(sortKeyBytes)).map((b) => b.toString(16).padStart(2, "0")).join("")
+
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "lottery",
+        deadline,
+        audit_chain_hash: null,
+        lottery_beacon_round: expectedRound,
+        lottery_beacon_randomness: randomness,
+      },
+      audit_chain: [],
+      beacon: { round: expectedRound, randomness, verification_url: "" },
+      results: [
+        { position: 1, option_title: "Option A", accepted_yes: 0, preferred: 0, lottery_sort_key: sortKey },
+      ],
+    }
+
+    const fetchRandomness = vi.fn().mockResolvedValue(randomness)
+    const result = await verifyBeacon(data, fetchRandomness)
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+    expect(fetchRandomness).toHaveBeenCalledWith(expectedRound)
+  })
+
+  it("detects round mismatch", async () => {
+    const deadlineUnix = GENESIS_TIME + 1000 * PERIOD
+    const deadline = new Date(deadlineUnix * 1000).toISOString()
+
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "lottery",
+        deadline,
+        audit_chain_hash: null,
+        lottery_beacon_round: 999,
+        lottery_beacon_randomness: "abc",
+      },
+      audit_chain: [],
+      beacon: { round: 999, randomness: "abc", verification_url: "" },
+    }
+
+    const fetchRandomness = vi.fn().mockResolvedValue("abc")
+    const result = await verifyBeacon(data, fetchRandomness)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes("round"))).toBe(true)
+  })
+
+  it("detects randomness mismatch", async () => {
+    const deadlineUnix = GENESIS_TIME + 1000 * PERIOD
+    const expectedRound = Math.floor((deadlineUnix - GENESIS_TIME) / PERIOD) + 2
+    const deadline = new Date(deadlineUnix * 1000).toISOString()
+
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "lottery",
+        deadline,
+        audit_chain_hash: null,
+        lottery_beacon_round: expectedRound,
+        lottery_beacon_randomness: "server_says_this",
+      },
+      audit_chain: [],
+      beacon: { round: expectedRound, randomness: "server_says_this", verification_url: "" },
+    }
+
+    const fetchRandomness = vi.fn().mockResolvedValue("drand_says_that")
+    const result = await verifyBeacon(data, fetchRandomness)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes("randomness"))).toBe(true)
+  })
+
+  it("returns skipped when drand fetch fails", async () => {
+    const deadlineUnix = GENESIS_TIME + 1000 * PERIOD
+    const expectedRound = Math.floor((deadlineUnix - GENESIS_TIME) / PERIOD) + 2
+    const deadline = new Date(deadlineUnix * 1000).toISOString()
+
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "lottery",
+        deadline,
+        audit_chain_hash: null,
+        lottery_beacon_round: expectedRound,
+        lottery_beacon_randomness: "abc",
+      },
+      audit_chain: [],
+      beacon: { round: expectedRound, randomness: "abc", verification_url: "" },
+    }
+
+    const fetchRandomness = vi.fn().mockRejectedValue(new Error("network error"))
+    const result = await verifyBeacon(data, fetchRandomness)
+    expect(result.valid).toBe(true)
+    expect(result.skipped).toBe(true)
+    expect(result.errors.length).toBeGreaterThan(0)
+  })
+
+  it("skips when no beacon present", async () => {
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "vote",
+        deadline: "2026-05-06T12:00:00Z",
+        audit_chain_hash: null,
+        lottery_beacon_round: null,
+        lottery_beacon_randomness: null,
+      },
+      audit_chain: [],
+    }
+
+    const result = await verifyBeacon(data)
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+})
+
+describe("cross-implementation hash consistency", () => {
+  // Reference hash computed by Ruby: Digest::SHA256.hexdigest("v1||1|vote_cast|user-123|alice|Option A|1|0||2026-05-05T12:00:00Z")
+  const REFERENCE_HASH = "69cafa9533d7a4201cc21d45470c78e2589f20d1cfe0ff35cc4ce2c0fa44be35"
+
+  it("computes the same hash as Ruby and Python for a known input", async () => {
+    const entry = makeEntry({
+      sequence_number: 1,
+      action: "vote_cast",
+      actor_id: "user-123",
+      actor_handle: "alice",
+      option_title: "Option A",
+      accepted: "1",
+      preferred: "0",
+      metadata: "",
+      previous_hash: "",
+      entry_hash: "",
+      created_at: "2026-05-05T12:00:00Z",
+    })
+    const hash = await computeEntryHash(entry)
+    expect(hash).toBe(REFERENCE_HASH)
+  })
+
+  it("handles Unicode NFC normalization consistently", async () => {
+    // "é" can be encoded as U+00E9 (precomposed) or U+0065 U+0301 (decomposed)
+    // NFC normalization should produce the same hash for both
+    const entryNFC = makeEntry({
+      sequence_number: 1,
+      action: "option_added",
+      option_title: "\u00E9", // precomposed é
+      entry_hash: "",
+    })
+    const entryNFD = makeEntry({
+      sequence_number: 1,
+      action: "option_added",
+      option_title: "\u0065\u0301", // decomposed é
+      entry_hash: "",
+    })
+    const hashNFC = await computeEntryHash(entryNFC)
+    const hashNFD = await computeEntryHash(entryNFD)
+    expect(hashNFC).toBe(hashNFD)
+  })
+})
+
+describe("verifyAll", () => {
+  it("returns combined results", async () => {
+    const data: VerifyData = {
+      decision: {
+        id: "d1",
+        question: "Test?",
+        subtype: "vote",
+        deadline: "2026-05-06T12:00:00Z",
+        audit_chain_hash: null,
+        lottery_beacon_round: null,
+        lottery_beacon_randomness: null,
+      },
+      audit_chain: [],
+    }
+
+    const result = await verifyAll(data)
+    expect(result.valid).toBe(true)
+    expect(result.chain.valid).toBe(true)
+    expect(result.voteTallies.valid).toBe(true)
+    expect(result.beacon.valid).toBe(true)
+  })
+})

--- a/app/javascript/lib/audit_chain_verifier.ts
+++ b/app/javascript/lib/audit_chain_verifier.ts
@@ -1,0 +1,201 @@
+import type {
+  VerifyData,
+  AuditEntry,
+  ChainResult,
+  VoteTalliesResult,
+  BeaconResult,
+  VerificationResult,
+} from "./audit_chain_types"
+
+// drand quicknet chain parameters (public, independently verifiable)
+const DRAND_GENESIS_TIME = 1692803367
+const DRAND_PERIOD = 3
+
+async function sha256hex(input: string): Promise<string> {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(input)
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data)
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+}
+
+function hashInputV1(entry: AuditEntry): string {
+  const normalizedTitle = entry.option_title ? entry.option_title.normalize("NFC") : ""
+  return [
+    "v1",
+    entry.previous_hash,
+    String(entry.sequence_number),
+    entry.action,
+    entry.actor_id,
+    entry.actor_handle,
+    normalizedTitle,
+    entry.accepted,
+    entry.preferred,
+    entry.metadata,
+    entry.created_at,
+  ].join("|")
+}
+
+export async function computeEntryHash(entry: AuditEntry): Promise<string> {
+  return sha256hex(hashInputV1(entry))
+}
+
+export async function verifyChain(data: VerifyData): Promise<ChainResult> {
+  const entries = data.audit_chain
+  const errors: string[] = []
+  let previousHash = ""
+
+  for (const entry of entries) {
+    const computed = await sha256hex(hashInputV1(entry))
+
+    if (computed !== entry.entry_hash) {
+      errors.push(`Entry #${entry.sequence_number}: hash mismatch`)
+    }
+    if (entry.previous_hash !== previousHash) {
+      errors.push(`Entry #${entry.sequence_number}: chain link broken`)
+    }
+    previousHash = entry.entry_hash
+  }
+
+  const chainHash = data.decision.audit_chain_hash
+  if (chainHash && entries.length > 0) {
+    const lastHash = entries[entries.length - 1].entry_hash
+    if (chainHash !== lastHash) {
+      errors.push("Final chain hash mismatch")
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    entryCount: entries.length,
+    errors,
+    lastHash: entries.length > 0 ? entries[entries.length - 1].entry_hash : null,
+  }
+}
+
+export function verifyVoteTallies(data: VerifyData): VoteTalliesResult {
+  const errors: string[] = []
+  const results = data.results
+
+  // If no results to verify, pass
+  if (!results) {
+    return { valid: true, errors }
+  }
+
+  // Replay votes: keep latest per (actor_id, option_title) pair
+  const votes = new Map<string, { accepted: number; preferred: number }>()
+  for (const entry of data.audit_chain) {
+    if (entry.action === "vote_cast" || entry.action === "vote_updated") {
+      const key = `${entry.actor_id}|${entry.option_title}`
+      votes.set(key, {
+        accepted: parseInt(entry.accepted) || 0,
+        preferred: parseInt(entry.preferred) || 0,
+      })
+    }
+  }
+
+  // Sum totals per option
+  const totals = new Map<string, { accepted: number; preferred: number }>()
+  for (const [key, vote] of votes) {
+    const optionTitle = key.split("|").slice(1).join("|")
+    const current = totals.get(optionTitle) ?? { accepted: 0, preferred: 0 }
+    current.accepted += vote.accepted
+    current.preferred += vote.preferred
+    totals.set(optionTitle, current)
+  }
+
+  // Compare against results
+  for (const result of results) {
+    const expected = totals.get(result.option_title) ?? { accepted: 0, preferred: 0 }
+    if (result.accepted_yes !== expected.accepted) {
+      errors.push(
+        `'${result.option_title}' acceptance count is ${result.accepted_yes}, audit chain shows ${expected.accepted}`,
+      )
+    }
+    if (result.preferred !== expected.preferred) {
+      errors.push(
+        `'${result.option_title}' preference count is ${result.preferred}, audit chain shows ${expected.preferred}`,
+      )
+    }
+  }
+
+  return { valid: errors.length === 0, errors }
+}
+
+export async function verifyBeacon(
+  data: VerifyData,
+  fetchRandomness?: (round: number) => Promise<string>,
+): Promise<BeaconResult> {
+  const errors: string[] = []
+
+  if (!data.beacon) {
+    return { valid: true, skipped: false, errors }
+  }
+
+  // Derive expected round from deadline
+  if (!data.decision.deadline) {
+    errors.push("Decision has no deadline — cannot derive expected beacon round")
+    return { valid: false, skipped: false, errors }
+  }
+
+  const deadlineUnix = Math.floor(new Date(data.decision.deadline).getTime() / 1000)
+  if (Number.isNaN(deadlineUnix)) {
+    errors.push("Decision deadline is invalid — cannot derive expected beacon round")
+    return { valid: false, skipped: false, errors }
+  }
+
+  const expectedRound = Math.floor((deadlineUnix - DRAND_GENESIS_TIME) / DRAND_PERIOD) + 2
+
+  if (data.beacon.round !== expectedRound) {
+    errors.push(
+      `Server claims round ${data.beacon.round}, deadline implies round ${expectedRound}`,
+    )
+  }
+
+  // Fetch randomness from drand if callback provided
+  if (fetchRandomness) {
+    let fetchedRandomness: string
+    try {
+      fetchedRandomness = await fetchRandomness(expectedRound)
+    } catch {
+      return { valid: true, skipped: true, errors: ["Could not reach the drand randomness beacon to verify sort keys."] }
+    }
+
+    if (fetchedRandomness !== data.beacon.randomness) {
+      errors.push(
+        `Beacon randomness does not match drand`,
+      )
+    }
+
+    // Verify sort keys
+    if (data.results) {
+      for (const result of data.results) {
+        if (!result.lottery_sort_key) continue
+        const normalizedTitle = result.option_title.normalize("NFC")
+        const computed = await sha256hex(fetchedRandomness + normalizedTitle)
+        if (computed !== result.lottery_sort_key) {
+          errors.push(`Sort key mismatch for '${result.option_title}'`)
+        }
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, skipped: false, errors }
+}
+
+export async function verifyAll(
+  data: VerifyData,
+  fetchRandomness?: (round: number) => Promise<string>,
+): Promise<VerificationResult> {
+  const chain = await verifyChain(data)
+  const voteTallies = verifyVoteTallies(data)
+  const beacon = await verifyBeacon(data, fetchRandomness)
+
+  return {
+    valid: chain.valid && voteTallies.valid && beacon.valid,
+    chain,
+    voteTallies,
+    beacon,
+  }
+}

--- a/app/javascript/test/setup.ts
+++ b/app/javascript/test/setup.ts
@@ -1,4 +1,10 @@
 import { afterEach } from "vitest"
+import { webcrypto } from "node:crypto"
+
+// jsdom doesn't provide crypto.subtle — use Node's webcrypto
+if (!globalThis.crypto?.subtle) {
+  Object.defineProperty(globalThis, "crypto", { value: webcrypto })
+}
 
 // Clean up DOM after each test
 afterEach(() => {

--- a/app/services/decision_audit_verifier.rb
+++ b/app/services/decision_audit_verifier.rb
@@ -13,9 +13,7 @@ class DecisionAuditVerifier
       expected_sequence = index + 1
 
       # Check sequence continuity
-      if entry.sequence_number != expected_sequence
-        errors << "Entry ##{entry.sequence_number}: sequence gap (expected #{expected_sequence})"
-      end
+      errors << "Entry ##{entry.sequence_number}: sequence gap (expected #{expected_sequence})" if entry.sequence_number != expected_sequence
 
       # Check chain link
       if entry.previous_hash != previous_hash
@@ -35,9 +33,7 @@ class DecisionAuditVerifier
     chain_hash = decision.audit_chain_hash
     if chain_hash.present? && entries.any?
       last_hash = entries.last&.entry_hash
-      if chain_hash != last_hash
-        errors << "Decision chain hash mismatch (stored: #{chain_hash[0..7]}..., last entry: #{last_hash&.slice(0, 8)}...)"
-      end
+      errors << "Decision chain hash mismatch (stored: #{chain_hash[0..7]}..., last entry: #{last_hash&.slice(0, 8)}...)" if chain_hash != last_hash
     end
 
     {
@@ -57,6 +53,109 @@ class DecisionAuditVerifier
       stored_hash: entry.entry_hash,
       computed_hash: recomputed,
       error: valid ? nil : "hash mismatch",
+    }
+  end
+
+  sig { params(decision: Decision).returns(T::Hash[Symbol, T.untyped]) }
+  def self.verify_vote_tallies(decision)
+    totals = replay_vote_totals(decision)
+    errors = T.let([], T::Array[String])
+
+    decision.results.each do |result|
+      title = T.must(result.option_title)
+      expected = totals[title] || { accepted: 0, preferred: 0 }
+      if result.accepted_yes != expected[:accepted]
+        errors << "'#{title}' acceptance count is #{result.accepted_yes}, audit chain shows #{expected[:accepted]}"
+      end
+      if result.preferred != expected[:preferred]
+        errors << "'#{title}' preference count is #{result.preferred}, audit chain shows #{expected[:preferred]}"
+      end
+    end
+
+    { valid: errors.empty?, errors: errors }
+  end
+
+  sig { params(decision: Decision).returns(T::Hash[String, { accepted: Integer, preferred: Integer }]) }
+  def self.replay_vote_totals(decision)
+    entries = DecisionAuditEntry.where(decision_id: decision.id)
+      .where(action: ["vote_cast", "vote_updated"])
+      .order(:sequence_number)
+      .to_a
+
+    # Replay votes: keep latest per (actor_id, option_title) pair
+    votes = T.let({}, T::Hash[[String, String], { accepted: Integer, preferred: Integer }])
+    entries.each do |entry|
+      votes[[entry.actor_id || "", entry.option_title || ""]] = {
+        accepted: entry.accepted || 0,
+        preferred: entry.preferred || 0,
+      }
+    end
+
+    # Sum totals per option
+    totals = T.let({}, T::Hash[String, { accepted: Integer, preferred: Integer }])
+    votes.each do |(_, option_title), vote_data|
+      totals[option_title] ||= { accepted: 0, preferred: 0 }
+      total = T.must(totals[option_title])
+      total[:accepted] += vote_data[:accepted]
+      total[:preferred] += vote_data[:preferred]
+    end
+    totals
+  end
+  private_class_method :replay_vote_totals
+
+  sig { params(decision: Decision, fetched_randomness: T.nilable(String)).returns(T::Hash[Symbol, T.untyped]) }
+  def self.verify_beacon(decision, fetched_randomness:)
+    errors = T.let([], T::Array[String])
+
+    # No beacon drawn — nothing to check
+    return { valid: true, skipped: false, errors: errors } if decision.lottery_beacon_round.blank?
+
+    # Verify round derivation
+    deadline = decision.deadline
+    if deadline.present?
+      expected_round = RandomnessProvider.current.round_for_timestamp(deadline)
+      actual_round = decision.lottery_beacon_round
+      errors << "Server claims round #{actual_round}, deadline implies round #{expected_round}" if actual_round != expected_round
+    end
+
+    # Can't verify randomness or sort keys without fetched randomness
+    if fetched_randomness.blank?
+      return {
+        valid: true,
+        skipped: true,
+        errors: ["Could not fetch randomness from drand to verify sort keys."],
+      }
+    end
+
+    # Verify randomness matches
+    stored_randomness = decision.lottery_beacon_randomness
+    if stored_randomness != fetched_randomness
+      errors << "Beacon randomness does not match: server says #{stored_randomness}, fetched #{fetched_randomness}"
+    end
+
+    # Verify sort keys
+    decision.results.each do |result|
+      next if result.lottery_sort_key.blank?
+
+      normalized_title = T.must(result.option_title).unicode_normalize(:nfc)
+      computed = Digest::SHA256.hexdigest(fetched_randomness + normalized_title)
+      errors << "Sort key mismatch for '#{result.option_title}'" if computed != result.lottery_sort_key
+    end
+
+    { valid: errors.empty?, skipped: false, errors: errors }
+  end
+
+  sig { params(decision: Decision, fetched_randomness: T.nilable(String)).returns(T::Hash[Symbol, T.untyped]) }
+  def self.verify_all(decision, fetched_randomness: nil)
+    chain = verify_chain(decision)
+    vote_tallies = verify_vote_tallies(decision)
+    beacon = verify_beacon(decision, fetched_randomness: fetched_randomness)
+
+    {
+      valid: chain[:valid] && vote_tallies[:valid] && beacon[:valid],
+      chain: chain,
+      vote_tallies: vote_tallies,
+      beacon: beacon,
     }
   end
 end

--- a/app/views/decisions/verify.html.erb
+++ b/app/views/decisions/verify.html.erb
@@ -16,6 +16,15 @@
       Every action on this <%= @decision.is_lottery? ? 'lottery' : 'decision' %> is cryptographically recorded so that anyone can independently verify that nothing was tampered with<% if @decision.beacon_drawn? %> and that the results are correct<% end %>.
     </p>
 
+    <div data-controller="audit-verify"
+         data-audit-verify-url-value="<%= request.path %>.json"
+         style="background: var(--color-canvas-subtle); padding: 16px; border-radius: 6px; margin-bottom: 16px;">
+      <h2 style="font-size: 1.15em; margin: 0 0 12px 0;">Automated Verification</h2>
+      <div data-audit-verify-target="results" style="line-height: 1.6;">
+        <p style="color: var(--color-fg-muted);">Verifying audit chain...</p>
+      </div>
+    </div>
+
     <h2 style="font-size: 1.15em; margin: 0 0 12px 0;">Verify Independently</h2>
 
     <ol style="line-height: 1.8; margin-bottom: 16px; padding-left: 20px;">

--- a/app/views/decisions/verify.md.erb
+++ b/app/views/decisions/verify.md.erb
@@ -3,6 +3,56 @@
 [Back to <%= @decision.is_lottery? ? 'lottery' : 'decision' %>](<%= @decision.path %>)
 
 Every action on this <%= @decision.is_lottery? ? 'lottery' : 'decision' %> is cryptographically recorded so that anyone can independently verify that nothing was tampered with<% if @decision.beacon_drawn? %> and that the results are correct<% end %>.
+<% if @verification_result -%>
+
+## Verification Results
+<% if @verification_result[:chain][:valid] -%>
+
+- **Chain integrity**: PASS — All <%= @verification_result[:chain][:entry_count] %> entries verified — every hash is correct and links to the previous entry.
+<% else -%>
+
+- **Chain integrity**: FAIL — The audit chain has been altered or corrupted. This is a serious integrity issue — it means the recorded history of this decision may not be trustworthy. Do not rely on the displayed results until this is investigated.
+<% @verification_result[:chain][:errors]&.each do |error| -%>
+  - <%= error %>
+<% end -%>
+<% end -%>
+<% if @verification_result[:vote_tallies][:valid] -%>
+
+- **Vote tallies**: PASS — Replayed all votes from the audit chain — totals match the displayed results.
+<% else -%>
+
+- **Vote tallies**: FAIL — The vote totals shown in the results do not match what the audit chain recorded. This means votes may have been added, removed, or changed outside of the audited process. Do not rely on the displayed results until this is investigated.
+<% @verification_result[:vote_tallies][:errors]&.each do |error| -%>
+  - <%= error %>
+<% end -%>
+<% end -%>
+<% if !@decision.beacon_drawn? -%>
+
+- **Beacon verification**: PASS (no beacon drawn yet)
+<% elsif @verification_result[:beacon][:skipped] -%>
+
+- **Beacon verification**: SKIPPED — Could not reach the drand randomness beacon to verify sort keys. This does not indicate a problem with the decision — the drand API may be temporarily unavailable. You can verify the beacon independently using the Python script below.
+<% elsif @verification_result[:beacon][:valid] -%>
+
+- **Beacon verification**: PASS — Randomness round and sort keys verified against the drand beacon.
+<% else -%>
+
+- **Beacon verification**: FAIL — The random sorting could not be verified against the drand randomness beacon. This could mean the sort order was manipulated, or that the wrong beacon round was used.
+<% @verification_result[:beacon][:errors]&.each do |error| -%>
+  - <%= error %>
+<% end -%>
+<% end -%>
+<% if @verification_result[:valid] && !@verification_result[:beacon][:skipped] -%>
+
+**All checks passed.**
+<% elsif @verification_result[:valid] && @verification_result[:beacon][:skipped] -%>
+
+**Chain and vote checks passed. Beacon could not be checked — see above.**
+<% else -%>
+
+**One or more checks failed — see details above.**
+<% end -%>
+<% end -%>
 
 ## Verify Independently
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -39,8 +39,8 @@ Rails.application.configure do
     # TODO: Consider using nonces for inline styles in the future
     policy.style_src :self, :unsafe_inline
 
-    # Connect: allow self (for fetch/XHR requests)
-    policy.connect_src :self
+    # Connect: allow self (for fetch/XHR requests) and drand API (for audit chain beacon verification)
+    policy.connect_src :self, "https://api.drand.sh"
 
     # Frames: prevent clickjacking by disallowing framing
     policy.frame_ancestors :none

--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -19,7 +19,7 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 # Files/patterns to exclude from scanning (dev configs, tests, this script)
-EXCLUDE_FILES=".env.example|check-secrets.sh|secrets.*test|fixtures|database.yml|importmap.rb|randomness_provider/drand.rb|verify-audit-chain.py"
+EXCLUDE_FILES=".env.example|check-secrets.sh|secrets.*test|fixtures|database.yml|importmap.rb|randomness_provider/drand.rb|verify-audit-chain.py|audit_verify_controller.ts|audit_chain_verifier.test.ts"
 
 # Patterns that suggest secrets (high confidence)
 # These patterns look for actual values, not just variable names

--- a/test/controllers/decisions_controller_test.rb
+++ b/test/controllers/decisions_controller_test.rb
@@ -1563,6 +1563,116 @@ class DecisionsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/&#39;/, response.body)
   end
 
+  test "markdown verify page includes server-side verification results" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    @decision.update!(subtype: "vote")
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    vote = Vote.new(tenant: @tenant, collective: @collective, decision: @decision, option: option, decision_participant: participant, accepted: 1, preferred: 0)
+    DecisionActionService.cast_vote!(decision: @decision, vote: vote, actor: @user)
+    DecisionActionService.close_decision!(decision: @decision, actor: @user)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/verify",
+      headers: { "Accept" => "text/markdown" }
+    assert_response :success
+    assert_match(/Verification Results/, response.body)
+    assert_match(/Chain integrity.*PASS.*entries verified/i, response.body)
+    assert_match(/Vote tallies.*PASS.*totals match/i, response.body)
+    assert_match(/Beacon verification.*PASS/i, response.body)
+    assert_match(/All checks passed/i, response.body)
+  end
+
+  test "markdown verify page shows chain failure with integrity warning" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    @decision.update!(subtype: "vote")
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    vote = Vote.new(tenant: @tenant, collective: @collective, decision: @decision, option: option, decision_participant: participant, accepted: 1, preferred: 0)
+    DecisionActionService.cast_vote!(decision: @decision, vote: vote, actor: @user)
+
+    # Tamper with an entry hash to trigger chain failure
+    entry = DecisionAuditEntry.where(decision_id: @decision.id).first
+    ActiveRecord::Base.connection.execute(
+      "ALTER TABLE decision_audit_entries DISABLE TRIGGER enforce_audit_entry_immutability"
+    )
+    ActiveRecord::Base.connection.execute(
+      "UPDATE decision_audit_entries SET entry_hash = 'tampered' WHERE id = '#{entry.id}'"
+    )
+    ActiveRecord::Base.connection.execute(
+      "ALTER TABLE decision_audit_entries ENABLE TRIGGER enforce_audit_entry_immutability"
+    )
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/verify",
+      headers: { "Accept" => "text/markdown" }
+    assert_response :success
+    assert_match(/Chain integrity.*FAIL/i, response.body)
+    assert_match(/altered or corrupted/i, response.body)
+    assert_match(/serious integrity issue/i, response.body)
+    assert_match(/Do not rely/i, response.body)
+    assert_match(/One or more checks failed/i, response.body)
+  end
+
+  test "markdown verify page shows vote tally failure when votes tampered" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    @decision.update!(subtype: "vote")
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    vote = Vote.new(tenant: @tenant, collective: @collective, decision: @decision, option: option, decision_participant: participant, accepted: 1, preferred: 0)
+    DecisionActionService.cast_vote!(decision: @decision, vote: vote, actor: @user)
+    DecisionActionService.close_decision!(decision: @decision, actor: @user)
+
+    # Tamper with the actual vote to create a tally mismatch
+    vote.update_columns(accepted: 0)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/verify",
+      headers: { "Accept" => "text/markdown" }
+    assert_response :success
+    assert_match(/Vote tallies.*FAIL/i, response.body)
+    assert_match(/do not match/i, response.body)
+    assert_match(/added, removed, or changed/i, response.body)
+    assert_match(/Do not rely/i, response.body)
+  end
+
+  test "markdown verify page shows beacon failure when round is wrong" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    @decision.update!(subtype: "vote")
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    vote = Vote.new(tenant: @tenant, collective: @collective, decision: @decision, option: option, decision_participant: participant, accepted: 1, preferred: 0)
+    DecisionActionService.cast_vote!(decision: @decision, vote: vote, actor: @user)
+    DecisionActionService.close_decision!(decision: @decision, actor: @user)
+
+    # Set a wrong beacon round (randomness won't match sort keys either)
+    @decision.update_columns(lottery_beacon_round: 999, lottery_beacon_randomness: "abc")
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/verify",
+      headers: { "Accept" => "text/markdown" }
+    assert_response :success
+    assert_match(/Beacon verification.*FAIL/i, response.body)
+    assert_match(/random sorting could not be verified/i, response.body)
+    assert_match(/manipulated/i, response.body)
+  end
+
   test "updating decision settings creates decision_updated audit entry" do
     sign_in_as(@user, tenant: @tenant)
 

--- a/test/integration/audit_chain_verification_test.rb
+++ b/test/integration/audit_chain_verification_test.rb
@@ -591,6 +591,71 @@ class AuditChainVerificationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # === Cross-implementation consistency ===
+
+  test "Ruby verifier agrees with Python on complete lifecycle" do
+    tenant = @global_tenant
+    collective = @global_collective
+    user = @global_user
+
+    sign_in_as(user, tenant: tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+
+    decision = Decision.new(
+      tenant: tenant, collective: collective, created_by: user,
+      question: "Cross-impl Test?", description: "Testing Ruby and Python agree",
+      deadline: 1.week.from_now, options_open: true, subtype: "vote",
+    )
+    DecisionActionService.create_decision!(decision: decision, actor: user)
+
+    participant = DecisionParticipantManager.new(decision: decision, user: user).find_or_create_participant
+    option_a = Option.new(decision: decision, decision_participant: participant, title: "Alpha")
+    DecisionActionService.add_option!(decision: decision, option: option_a, actor: user)
+    option_b = Option.new(decision: decision, decision_participant: participant, title: "Beta")
+    DecisionActionService.add_option!(decision: decision, option: option_b, actor: user)
+
+    vote_a = Vote.new(
+      tenant: tenant, collective: collective, decision: decision,
+      option: option_a, decision_participant: participant,
+      accepted: 1, preferred: 1,
+    )
+    DecisionActionService.cast_vote!(decision: decision, vote: vote_a, actor: user)
+
+    vote_b = Vote.new(
+      tenant: tenant, collective: collective, decision: decision,
+      option: option_b, decision_participant: participant,
+      accepted: 1, preferred: 0,
+    )
+    DecisionActionService.cast_vote!(decision: decision, vote: vote_b, actor: user)
+
+    DecisionActionService.close_decision!(decision: decision, actor: user)
+
+    randomness = "crossimpl_test_randomness_value"
+    round = expected_round_for(decision.deadline)
+    DecisionActionService.draw_beacon!(decision: decision, round: round, randomness: randomness)
+
+    # Ruby verifier
+    ruby_result = DecisionAuditVerifier.verify_all(decision, fetched_randomness: randomness)
+    assert ruby_result[:valid], "Ruby verifier failed: #{ruby_result.inspect}"
+    assert ruby_result[:chain][:valid]
+    assert ruby_result[:vote_tallies][:valid]
+    assert ruby_result[:beacon][:valid]
+
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    # Python verifier (same data via JSON endpoint)
+    get "/collectives/#{collective.handle}/d/#{decision.truncated_id}/verify.json"
+    assert_response :success
+    json_data = JSON.parse(response.body)
+
+    python_result = run_python_verifier(json_data, expected_round: round, randomness: randomness)
+    assert_equal 0, python_result[:exit_code], "Python verification failed:\n#{python_result[:output]}"
+    assert_match(/All checks passed/, python_result[:output])
+  end
+
   test "verify.json omits beacon and results before decision closes" do
     tenant = @global_tenant
     collective = @global_collective

--- a/test/services/decision_audit_verifier_test.rb
+++ b/test/services/decision_audit_verifier_test.rb
@@ -118,4 +118,148 @@ class DecisionAuditVerifierTest < ActiveSupport::TestCase
     assert_not result[:valid]
     assert result[:errors].any? { |e| e.include?("chain hash mismatch") }
   end
+
+  # --- verify_vote_tallies tests ---
+
+  test "verify_vote_tallies passes when replayed votes match results" do
+    option_b = create_option(decision: @decision, created_by: @user, title: "Option B")
+    user2 = create_user(name: "User Two")
+    @tenant.add_user!(user2)
+    @collective.add_user!(user2)
+
+    participant1 = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    participant2 = DecisionParticipantManager.new(decision: @decision, user: user2).find_or_create_participant
+
+    vote_a = Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: @option, decision_participant: participant1, accepted: 1, preferred: 1)
+    DecisionAuditService.record_vote!(decision: @decision, vote: vote_a, actor: @user)
+
+    vote_b = Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: option_b, decision_participant: participant1, accepted: 1, preferred: 0)
+    DecisionAuditService.record_vote!(decision: @decision, vote: vote_b, actor: @user)
+
+    vote_a2 = Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: @option, decision_participant: participant2, accepted: 0, preferred: 0)
+    DecisionAuditService.record_vote!(decision: @decision, vote: vote_a2, actor: user2)
+
+    result = DecisionAuditVerifier.verify_vote_tallies(@decision)
+    assert result[:valid], "Expected valid but got errors: #{result[:errors]}"
+    assert_empty result[:errors]
+  end
+
+  test "verify_vote_tallies detects acceptance count mismatch" do
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    vote = Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: @option, decision_participant: participant, accepted: 1, preferred: 0)
+    DecisionAuditService.record_vote!(decision: @decision, vote: vote, actor: @user)
+
+    # Tamper: directly update the vote to change the count without an audit entry
+    vote.update_columns(accepted: 0)
+
+    result = DecisionAuditVerifier.verify_vote_tallies(@decision)
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("acceptance count") }
+  end
+
+  test "verify_vote_tallies detects preference count mismatch" do
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    vote = Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: @option, decision_participant: participant, accepted: 1, preferred: 1)
+    DecisionAuditService.record_vote!(decision: @decision, vote: vote, actor: @user)
+
+    # Tamper: directly update the preference
+    vote.update_columns(preferred: 0)
+
+    result = DecisionAuditVerifier.verify_vote_tallies(@decision)
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("preference count") }
+  end
+
+  test "verify_vote_tallies handles vote_updated correctly" do
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    vote = Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: @option, decision_participant: participant, accepted: 0, preferred: 0)
+    DecisionAuditService.record_vote!(decision: @decision, vote: vote, actor: @user)
+
+    # Update the vote
+    vote.update_columns(accepted: 1, preferred: 1)
+    DecisionAuditService.record_vote!(decision: @decision, vote: vote, actor: @user, is_update: true)
+
+    result = DecisionAuditVerifier.verify_vote_tallies(@decision)
+    assert result[:valid], "Expected valid but got errors: #{result[:errors]}"
+  end
+
+  test "verify_vote_tallies passes with no votes (lottery)" do
+    result = DecisionAuditVerifier.verify_vote_tallies(@decision)
+    assert result[:valid]
+    assert_empty result[:errors]
+  end
+
+  # --- verify_beacon tests ---
+
+  test "verify_beacon passes when round and sort keys match" do
+    randomness = "a1b2c3d4e5f6" * 5
+    round = RandomnessProvider.current.round_for_timestamp(T.must(@decision.deadline))
+    @decision.update_columns(
+      lottery_beacon_round: round,
+      lottery_beacon_randomness: randomness,
+    )
+
+    result = DecisionAuditVerifier.verify_beacon(@decision, fetched_randomness: randomness)
+    assert result[:valid], "Expected valid but got errors: #{result[:errors]}"
+  end
+
+  test "verify_beacon detects round mismatch" do
+    randomness = "a1b2c3d4e5f6" * 5
+    wrong_round = 999
+    @decision.update_columns(
+      lottery_beacon_round: wrong_round,
+      lottery_beacon_randomness: randomness,
+    )
+
+    result = DecisionAuditVerifier.verify_beacon(@decision, fetched_randomness: randomness)
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("round") }
+  end
+
+  test "verify_beacon detects sort key mismatch" do
+    randomness = "a1b2c3d4e5f6" * 5
+    round = RandomnessProvider.current.round_for_timestamp(T.must(@decision.deadline))
+    @decision.update_columns(
+      lottery_beacon_round: round,
+      lottery_beacon_randomness: "different_randomness_value",
+    )
+
+    result = DecisionAuditVerifier.verify_beacon(@decision, fetched_randomness: randomness)
+    assert_not result[:valid]
+    assert result[:errors].any? { |e| e.include?("randomness") }
+  end
+
+  test "verify_beacon skips when no beacon present" do
+    result = DecisionAuditVerifier.verify_beacon(@decision, fetched_randomness: nil)
+    assert result[:valid]
+    assert_not result[:skipped]
+    assert_empty result[:errors]
+  end
+
+  test "verify_beacon returns skipped when beacon drawn but no randomness provided" do
+    round = RandomnessProvider.current.round_for_timestamp(T.must(@decision.deadline))
+    @decision.update_columns(
+      lottery_beacon_round: round,
+      lottery_beacon_randomness: "abc123",
+    )
+
+    result = DecisionAuditVerifier.verify_beacon(@decision, fetched_randomness: nil)
+    assert result[:valid]
+    assert result[:skipped]
+    assert result[:errors].any? { |e| e.include?("Could not fetch") }
+  end
+
+  # --- verify_all tests ---
+
+  test "verify_all returns combined results for all checks" do
+    DecisionAuditService.record_option!(
+      decision: @decision, option: @option, actor: @user, action: "option_added",
+    )
+
+    result = DecisionAuditVerifier.verify_all(@decision)
+    assert result[:valid]
+    assert result[:chain][:valid]
+    assert result[:vote_tallies][:valid]
+    assert result[:beacon][:valid]
+  end
 end


### PR DESCRIPTION
Three implementations of the verification logic now exist:
- Python script (existing, for independent verification)
- TypeScript library + Stimulus controller (in-browser, zero-trust)
- Ruby verifier extensions (server-side, for markdown/AI agent UI)

The browser verifier fetches beacon randomness directly from drand, recomputes all hashes via Web Crypto API, replays vote tallies, and shows detailed pass/fail results with clear explanations of what each failure means for users. The server-side verifier uses stored beacon data (no external HTTP calls on page load) and shows results in the markdown response for AI agents.

Error messaging is designed for trust: chain failures warn of integrity issues, tally failures explain votes may have been tampered with, and drand unavailability is clearly distinguished from data problems.