### PR TITLE
Feature/audit chain receipts

### DIFF
--- a/.claude/plans/audit-chain-receipts-impl.md
+++ b/.claude/plans/audit-chain-receipts-impl.md
@@ -1,0 +1,106 @@
+# Audit Chain Receipts Implementation
+
+## Context
+
+After voting, users receive a receipt hash (the `entry_hash` of their last audit entry). Currently this only appears as a flash notice that disappears after one page load. We need to make receipts persistent and visible so that:
+- Anyone can see each voter's receipt on the voters page
+- Anyone can click a receipt to see that voter's full audit trail
+- This creates full transparency — anyone can verify anyone else's votes
+
+## Items
+
+### 1. Receipt hashes on voters page
+
+Add each voter's receipt hash next to their name on the voters page. Show the first 8 characters as a `<code>` element, linking to the receipt verification page.
+
+**Files:**
+- `app/controllers/decisions_controller.rb` — `voters_page` action: load receipts for all voters in a single query
+- `app/views/decisions/voters_page.html.erb` — show truncated receipt hash next to each voter name, linked to receipt route
+- `app/views/decisions/voters_page.md.erb` — same for markdown
+
+**Data loading (controller):**
+Query all receipts in one batch to avoid N+1:
+```ruby
+receipt_entries = DecisionAuditEntry
+  .where(decision_id: @decision.id, action: ["vote_cast", "vote_updated"])
+  .order(:sequence_number)
+# Group by actor_id, keeping the last entry per actor (the receipt)
+@receipts_by_voter = receipt_entries.group_by(&:actor_id).transform_values(&:last)
+```
+
+**Display (template):**
+Next to each voter name in the "By voter" tab, show:
+```
+<a href="/d/:decision_id/verify/:receipt_hash"><code>a1b2c3d4...</code></a>
+```
+
+### 2. Receipt verification route and page
+
+New route: `GET /d/:decision_id/verify/:receipt_hash`
+
+Shows all audit entries for the user associated with the given receipt hash. Supports HTML, markdown, and JSON formats.
+
+**Files:**
+- `config/routes.rb` — add route `get '/verify/:receipt_hash' => 'decisions#verify_receipt'`
+- `app/controllers/decisions_controller.rb` — new `verify_receipt` action
+- `app/views/decisions/verify_receipt.html.erb` — new template
+- `app/views/decisions/verify_receipt.md.erb` — new markdown template
+
+**Controller logic (`verify_receipt`):**
+1. Find the audit entry matching the receipt hash: `DecisionAuditEntry.find_by(decision_id: @decision.id, entry_hash: params[:receipt_hash])`
+2. If not found, render 404
+3. Get the actor_id from that entry
+4. Load ALL audit entries for that actor on this decision: `DecisionAuditEntry.where(decision_id: @decision.id, actor_id: actor_id).order(:sequence_number)`
+5. Render the full vote history
+
+**Page content:**
+- Breadcrumb: Collective → Decision → Verify → Receipt
+- Header: "Vote receipt for @handle"
+- Full timeline of entries (each showing: sequence #, action, option title, accepted/preferred, timestamp, entry hash)
+- Link back to the main verify page
+- JSON format returns the entries array for programmatic verification
+
+### 3. Update `receipt_for_user` to work with the new flow
+
+The existing `DecisionAuditEntry.receipt_for_user(decision, user)` returns the last entry for a user. This is still useful — the voters page uses it to get the receipt hash. But the receipt page needs to find a user by receipt hash, which is a different lookup path.
+
+**New class method on `DecisionAuditEntry`:**
+```ruby
+def self.find_by_receipt(decision, receipt_hash)
+  find_by(decision_id: decision.id, entry_hash: receipt_hash)
+end
+```
+
+### 4. Tests
+
+**Controller tests** (`test/controllers/decisions_controller_test.rb`):
+- Voters page shows receipt hashes next to voter names
+- Voters page receipt hashes link to receipt verification route
+- Receipt verification page renders for valid receipt hash
+- Receipt verification page shows full vote history for the voter
+- Receipt verification page returns 404 for invalid hash
+- Receipt verification page works for markdown format
+- Receipt verification JSON returns entries array
+
+**Model tests** (`test/models/decision_audit_entry_test.rb`):
+- `find_by_receipt` returns the correct entry
+- `find_by_receipt` returns nil for unknown hash
+
+## Key Files
+
+- `app/controllers/decisions_controller.rb` — voters_page action (~line 352), new verify_receipt action
+- `app/views/decisions/voters_page.html.erb` — add receipt hashes
+- `app/views/decisions/voters_page.md.erb` — add receipt hashes (markdown)
+- `app/views/decisions/verify_receipt.html.erb` — new page
+- `app/views/decisions/verify_receipt.md.erb` — new page (markdown)
+- `config/routes.rb` — new route (~line 516)
+- `app/models/decision_audit_entry.rb` — new `find_by_receipt` method
+- `test/controllers/decisions_controller_test.rb` — new tests
+
+## Verification
+
+- `docker compose exec web bundle exec rails test test/controllers/decisions_controller_test.rb` — all tests pass
+- `docker compose exec web bundle exec rails test test/models/decision_audit_entry_test.rb` — model tests pass
+- `docker compose exec web bundle exec srb tc` — Sorbet clean
+- Manual: vote on a decision, check voters page shows receipt hash, click it, see full vote history
+- Manual: verify markdown format with `curl -H "Accept: text/markdown"`

--- a/.claude/plans/vote-receipt-email-optin.md
+++ b/.claude/plans/vote-receipt-email-optin.md
@@ -1,0 +1,90 @@
+# Vote Receipt Email Opt-In
+
+## Context
+
+The `VoteReceiptMailer` exists with complete HTML and text templates, but `send_vote_receipt_email` in `ApiHelper` is a no-op because there's no opt-in mechanism. Users should be able to check a box on the voting form to receive an email receipt when they vote.
+
+The preference is per-user per-decision: a checkbox directly above the submit button on the voting form. The entire feature is behind a feature flag that cascades app → tenant → collective, so it can be disabled at any level.
+
+## Implementation
+
+### 1. Feature flag: `vote_receipt_emails`
+
+Add to `config/feature_flags.yml`:
+```yaml
+vote_receipt_emails:
+  name: "Vote Receipt Emails"
+  description: "Allows voters to opt in to receiving email receipts when they vote"
+  app_enabled: true
+  default_tenant: true
+  default_collective: true
+  collective_level: true
+```
+
+Enabled by default at all levels. Can be disabled per-collective or per-tenant.
+
+### 2. Migration: add `vote_receipt_email` to `decision_participants`
+
+Add a boolean column `vote_receipt_email` (default false) to the `decision_participants` table. This stores whether the user wants email receipts for this specific decision.
+
+### 3. Checkbox on voting form
+
+Add a checkbox labeled "Email me a receipt" above the submit button, only shown when the feature flag is enabled.
+
+- File: `app/views/decisions/_options_section.html.erb` (inside `.pulse-vote-submit-row`, before the submit button)
+- The checkbox name: `vote_receipt_email` with value "1" / hidden field "0"
+- Remembers the user's previous choice via `@participant.decision_participant&.vote_receipt_email`
+- Only rendered when `FeatureFlagService.enabled?("vote_receipt_emails", collective: @current_collective)`
+
+### 4. Pass checkbox through submit_votes
+
+- File: `app/controllers/decisions_controller.rb` — `submit_votes` action
+- Read `params[:vote_receipt_email]` and update the decision participant's preference
+- Find or create the `DecisionParticipant`, then update `vote_receipt_email` before creating votes
+
+### 5. Wire up send_vote_receipt_email
+
+- File: `app/services/api_helper.rb` — `send_vote_receipt_email` method
+- Check feature flag AND `current_decision_participant.vote_receipt_email?`
+- Get the receipt hash via `DecisionAuditEntry.receipt_for_user`
+- Send via `VoteReceiptMailer.receipt_email(...).deliver_later`
+- One email per vote transaction (not one per option)
+
+### 6. Update email template to link to receipt page
+
+- File: `app/views/vote_receipt_mailer/receipt_email.html.erb`
+- Update the verify link to point to `/d/:id/verify/:receipt_hash` (the receipt verification page)
+- Same for `receipt_email.text.erb`
+
+### 7. Markdown voting form
+
+- Check `app/views/decisions/show.md.erb` for vote submission actions and add the opt-in option if applicable
+
+## Key Files
+
+- `config/feature_flags.yml` — new flag definition
+- `db/migrate/TIMESTAMP_add_vote_receipt_email_to_decision_participants.rb` — migration
+- `app/views/decisions/_options_section.html.erb` — checkbox UI
+- `app/controllers/decisions_controller.rb` — submit_votes action (~line 297)
+- `app/services/api_helper.rb` — send_vote_receipt_email (~line 1020), create_votes (~line 650)
+- `app/mailers/vote_receipt_mailer.rb` — existing mailer
+- `app/views/vote_receipt_mailer/receipt_email.html.erb` — update verify link
+- `app/views/vote_receipt_mailer/receipt_email.text.erb` — update verify link
+- `app/models/decision_participant.rb` — new column
+
+## Tests
+
+- Feature flag: checkbox hidden when flag disabled, shown when enabled
+- Controller test: checkbox value is saved to decision_participant
+- Controller test: email is sent when opt-in checked AND flag enabled
+- Controller test: email is NOT sent when opt-in unchecked
+- Controller test: email is NOT sent when flag disabled even if opt-in checked
+- Mailer test: email contains receipt hash and links to receipt verification page
+
+## Verification
+
+- `docker compose exec web bundle exec rails test` — targeted test files
+- `docker compose exec web bundle exec srb tc` — Sorbet clean
+- Manual: vote with checkbox checked, verify email arrives in mailcatcher (localhost:1080)
+- Manual: vote with checkbox unchecked, verify no email sent
+- Manual: disable feature flag on collective, verify checkbox disappears

--- a/app/assets/stylesheets/pulse/_components.css
+++ b/app/assets/stylesheets/pulse/_components.css
@@ -3473,5 +3473,16 @@ dialog.pulse-dialog form {
 .verification-fail { color: var(--color-danger-fg); }
 .verification-error { color: var(--color-fg-muted); }
 
+/* Vote receipt highlight */
+.receipt-hash {
+  background: var(--color-attention-subtle);
+  padding: 2px 6px;
+  border-radius: 3px;
+  text-decoration: none;
+  color: inherit;
+}
+a.receipt-hash { font-size: 0.75em; }
+.receipt-hash code { background: none; }
+
 /* highlight.js overrides to match app theme */
 .hljs { background: transparent !important; padding: 0 !important; }

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -570,6 +570,7 @@ class DecisionsController < ApplicationController
       end
       format.json do
         json = {
+          generated_at: Time.current.iso8601,
           decision: {
             id: @decision.id,
             question: @decision.question,
@@ -602,7 +603,7 @@ class DecisionsController < ApplicationController
             verification_url: @verification_url,
           }
         end
-        if @decision.beacon_drawn? || (@decision.closed? && @decision.is_executive?)
+        if @decision.votes.any? || @decision.beacon_drawn? || (@decision.closed? && @decision.is_executive?)
           json[:results] = @decision.results.map { |r|
             {
               position: r.position,

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -100,7 +100,7 @@ class DecisionsController < ApplicationController
     else
       @options_header = @decision.can_add_options?(@participant) ? 'Add Options & Vote' : 'Vote'
       @votes = current_votes
-      @current_user_has_voted = @votes.any? { |v| v.accepted == 1 || v.preferred == 1 }
+      @current_user_has_voted = @votes.any?
       @show_results = @decision.closed? || @current_user_has_voted
     end
     set_results_view_vars

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -380,6 +380,12 @@ class DecisionsController < ApplicationController
       }
     end
 
+    # Load receipt hashes for all voters in one query (last vote entry per actor)
+    receipt_entries = DecisionAuditEntry
+      .where(decision_id: @decision.id, action: ["vote_cast", "vote_updated"])
+      .order(:sequence_number)
+    @receipts_by_voter = receipt_entries.group_by(&:actor_id).transform_values(&:last)
+
     @votes_by_voter = @decision.voters.sort_by { |u| u.display_name.downcase }.map do |voter|
       voter_votes = all_votes.select { |v| v.decision_participant&.user_id == voter.id && v.accepted == 1 }
       # Sort accepted options in results order
@@ -603,6 +609,38 @@ class DecisionsController < ApplicationController
         end
         render json: json
       end
+    end
+  end
+
+  def verify_receipt
+    @decision = current_decision
+    return render "404", status: 404 unless @decision
+
+    @receipt_hash = params[:receipt_hash]
+    receipt_entry = DecisionAuditEntry.find_by_receipt(@decision, @receipt_hash)
+
+    unless receipt_entry
+      @page_title = "Receipt not found | #{@decision.question}"
+      @sidebar_mode = "resource"
+      return respond_to do |format|
+        format.html { render "verify_receipt_not_found", status: :not_found }
+        format.md { render "verify_receipt_not_found", status: :not_found }
+        format.json { render json: { error: "Receipt not found", receipt_hash: @receipt_hash }, status: :not_found }
+      end
+    end
+
+    actor_id = receipt_entry.actor_id
+    @actor = User.find_by(id: actor_id)
+    @entries = DecisionAuditEntry
+      .where(decision_id: @decision.id, actor_id: actor_id)
+      .order(:sequence_number)
+
+    @page_title = "Vote receipt | #{@decision.question}"
+    @sidebar_mode = "resource"
+
+    respond_to do |format|
+      format.html
+      format.md
     end
   end
 

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -327,6 +327,12 @@ class DecisionsController < ApplicationController
 
     if votes_data.any?
       begin
+        # Save email receipt preference before creating votes (only if param is present)
+        if params.key?(:vote_receipt_email)
+          participant = DecisionParticipantManager.new(decision: @decision, user: @current_user).find_or_create_participant
+          participant.update!(vote_receipt_email: params[:vote_receipt_email] == "1")
+        end
+
         api_helper(params: { votes: votes_data }).create_votes
         receipt_entry = DecisionAuditEntry.receipt_for_user(@decision, @current_user)
         notice = if receipt_entry

--- a/app/javascript/controllers/audit_verify_controller.test.ts
+++ b/app/javascript/controllers/audit_verify_controller.test.ts
@@ -64,7 +64,9 @@ describe("AuditVerifyController", () => {
     const text = resultsText()
     expect(text).toContain("PASS")
     expect(text).toContain("0 entries verified")
-    expect(text).toContain("All checks passed")
+    expect(text).toContain("No beacon drawn yet")
+    expect(text).toContain("No votes have been cast yet")
+    expect(text).toContain("Completed checks passed")
   })
 
   it("uses verification-pass CSS class for passing checks", async () => {
@@ -236,10 +238,10 @@ describe("AuditVerifyController", () => {
 
     const text = resultsText()
     expect(text).toContain("SKIPPED")
-    expect(text).toContain("drand randomness beacon")
+    expect(text).toContain("Could not reach the drand randomness beacon")
     expect(text).toContain("temporarily unavailable")
     expect(text).toContain("Python script below")
-    expect(text).toContain("Chain and vote checks passed")
+    expect(text).toContain("Completed checks passed")
   })
 
   it("renders beacon failure when randomness doesn't match drand", async () => {
@@ -318,10 +320,10 @@ describe("AuditVerifyController", () => {
     await startController()
 
     const text = resultsText()
-    // Chain fails but vote tallies and beacon should still pass
+    // Chain fails, vote tallies and beacon skipped (no votes, no beacon)
     expect(text).toMatch(/Chain integrity:.*FAIL/)
-    expect(text).toMatch(/Vote tallies:.*PASS/)
-    expect(text).toMatch(/Beacon verification:.*PASS/)
+    expect(text).toMatch(/Vote tallies:.*SKIPPED/)
+    expect(text).toMatch(/Beacon verification:.*SKIPPED/)
     expect(text).toContain("One or more checks failed")
   })
 

--- a/app/javascript/controllers/audit_verify_controller.ts
+++ b/app/javascript/controllers/audit_verify_controller.ts
@@ -78,7 +78,9 @@ export default class AuditVerifyController extends Controller {
     }
 
     // Vote tallies
-    if (result.voteTallies.valid) {
+    if (result.voteTallies.skipped) {
+      lines.push(this.warnLine("Vote tallies", result.voteTallies.errors[0] || "Vote tally verification was skipped."))
+    } else if (result.voteTallies.valid) {
       lines.push(this.passLine("Vote tallies", "Replayed all votes from the audit chain — totals match the displayed results."))
     } else {
       lines.push(this.failLine("Vote tallies", this.explainTallyFailure(result.voteTallies.errors)))
@@ -86,9 +88,7 @@ export default class AuditVerifyController extends Controller {
 
     // Beacon
     if (result.beacon.skipped) {
-      lines.push(this.warnLine("Beacon verification", "Could not reach the drand randomness beacon to verify sort keys. " +
-        "This does not indicate a problem with the decision — the drand API may be temporarily unavailable. " +
-        "You can verify the beacon independently using the Python script below."))
+      lines.push(this.warnLine("Beacon verification", result.beacon.errors[0] || "Beacon verification was skipped."))
     } else if (result.beacon.valid) {
       lines.push(this.passLine("Beacon verification", "Randomness round and sort keys verified against the drand beacon."))
     } else {
@@ -96,10 +96,11 @@ export default class AuditVerifyController extends Controller {
     }
 
     // Overall
-    if (result.valid && !result.beacon.skipped) {
+    const anySkipped = result.beacon.skipped || result.voteTallies.skipped
+    if (result.valid && !anySkipped) {
       lines.push(`<p class="verification-pass" style="font-weight: 600; margin: 12px 0 0 0;">All checks passed.</p>`)
-    } else if (result.valid && result.beacon.skipped) {
-      lines.push(`<p style="font-weight: 600; margin: 12px 0 0 0;">Chain and vote checks passed. Beacon could not be checked — see above.</p>`)
+    } else if (result.valid && anySkipped) {
+      lines.push(`<p style="font-weight: 600; margin: 12px 0 0 0;">Completed checks passed. Some checks were skipped — see above.</p>`)
     } else {
       lines.push(`<p class="verification-fail" style="font-weight: 600; margin: 12px 0 0 0;">One or more checks failed — see details above.</p>`)
     }

--- a/app/javascript/controllers/decision_controller.test.ts
+++ b/app/javascript/controllers/decision_controller.test.ts
@@ -95,7 +95,7 @@ describe("DecisionController", () => {
       expect(button.disabled).toBe(false)
     })
 
-    it("becomes disabled again when checkbox is reverted to original state", async () => {
+    it("stays enabled after checkbox is reverted to original state", async () => {
       document.body.innerHTML = buildDecisionHTML([
         { id: "1", title: "Option A", accepted: false, preferred: false },
       ])
@@ -109,10 +109,10 @@ describe("DecisionController", () => {
       checkbox.dispatchEvent(new Event("change"))
       expect(button.disabled).toBe(false)
 
-      // Uncheck it back
+      // Uncheck it back — button stays enabled because user has interacted
       checkbox.checked = false
       checkbox.dispatchEvent(new Event("change"))
-      expect(button.disabled).toBe(true)
+      expect(button.disabled).toBe(false)
     })
 
     it("becomes enabled when star checkbox is changed", async () => {

--- a/app/javascript/controllers/decision_controller.ts
+++ b/app/javascript/controllers/decision_controller.ts
@@ -23,6 +23,7 @@ export default class DecisionController extends Controller {
   private refreshing = false
   private previousOptionsListHtml = ""
   private initialVoteState: string = ""
+  private hasInteracted = false
 
   initialize(): void {
     document.addEventListener("poll", this.refreshOptions.bind(this))
@@ -128,7 +129,7 @@ export default class DecisionController extends Controller {
     if (this.hasVotingHintTarget) {
       this.votingHintTarget.style.display = hasOptions ? "" : "none"
     }
-    const changed = this.hasVoteChanged()
+    const changed = this.hasVoteChanged() || this.hasInteracted
     this.submitButtonTarget.disabled = !changed
     if (this.hasVoteNoticeTarget) {
       this.voteNoticeTarget.style.display = changed ? "" : "none"
@@ -140,7 +141,10 @@ export default class DecisionController extends Controller {
       "input.pulse-acceptance-checkbox, input.pulse-star-checkbox"
     )
     checkboxes.forEach((cb) => {
-      cb.addEventListener("change", () => this.updateSubmitButton())
+      cb.addEventListener("change", () => {
+        this.hasInteracted = true
+        this.updateSubmitButton()
+      })
     })
   }
 

--- a/app/javascript/lib/audit_chain_types.ts
+++ b/app/javascript/lib/audit_chain_types.ts
@@ -52,6 +52,7 @@ export interface ChainResult {
 
 export interface VoteTalliesResult {
   valid: boolean
+  skipped: boolean
   errors: string[]
 }
 

--- a/app/javascript/lib/audit_chain_verifier.test.ts
+++ b/app/javascript/lib/audit_chain_verifier.test.ts
@@ -407,7 +407,8 @@ describe("verifyBeacon", () => {
 
     const result = await verifyBeacon(data)
     expect(result.valid).toBe(true)
-    expect(result.errors).toEqual([])
+    expect(result.skipped).toBe(true)
+    expect(result.errors.some((e) => e.includes("No beacon drawn yet"))).toBe(true)
   })
 })
 

--- a/app/javascript/lib/audit_chain_verifier.ts
+++ b/app/javascript/lib/audit_chain_verifier.ts
@@ -78,9 +78,9 @@ export function verifyVoteTallies(data: VerifyData): VoteTalliesResult {
   const errors: string[] = []
   const results = data.results
 
-  // If no results to verify, pass
+  // If no results and no votes, nothing to verify yet
   if (!results) {
-    return { valid: true, errors }
+    return { valid: true, skipped: true, errors: ["No votes have been cast yet — vote tally verification will be available after voting begins."] }
   }
 
   // Replay votes: keep latest per (actor_id, option_title) pair
@@ -120,7 +120,7 @@ export function verifyVoteTallies(data: VerifyData): VoteTalliesResult {
     }
   }
 
-  return { valid: errors.length === 0, errors }
+  return { valid: errors.length === 0, skipped: false, errors }
 }
 
 export async function verifyBeacon(
@@ -130,7 +130,7 @@ export async function verifyBeacon(
   const errors: string[] = []
 
   if (!data.beacon) {
-    return { valid: true, skipped: false, errors }
+    return { valid: true, skipped: true, errors: ["No beacon drawn yet — beacon verification will be available after the decision closes."] }
   }
 
   // Derive expected round from deadline
@@ -159,7 +159,7 @@ export async function verifyBeacon(
     try {
       fetchedRandomness = await fetchRandomness(expectedRound)
     } catch {
-      return { valid: true, skipped: true, errors: ["Could not reach the drand randomness beacon to verify sort keys."] }
+      return { valid: true, skipped: true, errors: ["Could not reach the drand randomness beacon to verify sort keys. This does not indicate a problem with the decision — the drand API may be temporarily unavailable. You can verify the beacon independently using the Python script below."] }
     }
 
     if (fetchedRandomness !== data.beacon.randomness) {

--- a/app/mailers/vote_receipt_mailer.rb
+++ b/app/mailers/vote_receipt_mailer.rb
@@ -5,7 +5,7 @@ class VoteReceiptMailer < ApplicationMailer
     @user = user
     @decision = decision
     @receipt = receipt
-    @verify_url = "#{decision.shareable_link}/verify"
+    @verify_url = "#{decision.shareable_link}/verify/#{receipt}"
 
     mail(
       to: user.email,

--- a/app/models/decision_audit_entry.rb
+++ b/app/models/decision_audit_entry.rb
@@ -21,4 +21,9 @@ class DecisionAuditEntry < ApplicationRecord
   def self.receipt_for_user(decision, user)
     where(decision_id: decision.id, actor_id: user.id).order(:sequence_number).last
   end
+
+  sig { params(decision: Decision, receipt_hash: String).returns(T.nilable(DecisionAuditEntry)) }
+  def self.find_by_receipt(decision, receipt_hash)
+    find_by(decision_id: decision.id, entry_hash: receipt_hash)
+  end
 end

--- a/app/services/api_helper.rb
+++ b/app/services/api_helper.rb
@@ -1018,11 +1018,22 @@ class ApiHelper
     end
   end
 
-  # TODO: Re-enable when opt-in UI is built. Currently disabled because
-  # there's no preference check — would send unsolicited emails on every vote.
-  # The receipt is still available via flash notice and Vote#audit_receipt.
   private def send_vote_receipt_email(votes)
-    # Disabled — see above
+    return unless FeatureFlagService.enabled?("vote_receipt_emails", collective: current_collective)
+
+    participant = current_decision_participant
+    return unless participant&.vote_receipt_email?
+
+    decision = T.must(current_decision)
+    user = current_user
+    receipt_entry = DecisionAuditEntry.receipt_for_user(decision, user)
+    return unless receipt_entry
+
+    VoteReceiptMailer.receipt_email(
+      user: user,
+      decision: decision,
+      receipt: receipt_entry.entry_hash,
+    ).deliver_later
   end
 
   private def create_or_update_statement!(statementable, text)

--- a/app/services/decision_audit_verifier.rb
+++ b/app/services/decision_audit_verifier.rb
@@ -58,6 +58,11 @@ class DecisionAuditVerifier
 
   sig { params(decision: Decision).returns(T::Hash[Symbol, T.untyped]) }
   def self.verify_vote_tallies(decision)
+    has_votes = decision.votes.any?
+    unless has_votes
+      return { valid: true, skipped: true, errors: ["No votes have been cast yet — vote tally verification will be available after voting begins."] }
+    end
+
     totals = replay_vote_totals(decision)
     errors = T.let([], T::Array[String])
 
@@ -72,7 +77,7 @@ class DecisionAuditVerifier
       end
     end
 
-    { valid: errors.empty?, errors: errors }
+    { valid: errors.empty?, skipped: false, errors: errors }
   end
 
   sig { params(decision: Decision).returns(T::Hash[String, { accepted: Integer, preferred: Integer }]) }
@@ -107,8 +112,10 @@ class DecisionAuditVerifier
   def self.verify_beacon(decision, fetched_randomness:)
     errors = T.let([], T::Array[String])
 
-    # No beacon drawn — nothing to check
-    return { valid: true, skipped: false, errors: errors } if decision.lottery_beacon_round.blank?
+    # No beacon drawn yet
+    if decision.lottery_beacon_round.blank?
+      return { valid: true, skipped: true, errors: ["No beacon drawn yet — beacon verification will be available after the decision closes."] }
+    end
 
     # Verify round derivation
     deadline = decision.deadline

--- a/app/views/decisions/_options_section.html.erb
+++ b/app/views/decisions/_options_section.html.erb
@@ -40,7 +40,19 @@
             <%= render 'options_list_items' %>
           </span>
         </ul>
+        <% receipt_emails_enabled = FeatureFlagService.enabled?("vote_receipt_emails", collective: @current_collective) %>
         <div class="pulse-vote-submit-row" data-decision-target="submitRow" style="margin-top: 8px;<%= @decision.options.empty? ? ' display: none;' : '' %>">
+          <% if receipt_emails_enabled %>
+            <label style="display: flex; align-items: center; gap: 8px; font-size: 0.85em; cursor: pointer; color: var(--color-fg-muted); margin: 0 0 10px 0;">
+              <%= octicon 'mail', height: 14 %>
+              <input type="hidden" name="vote_receipt_email" value="0">
+              <input type="checkbox" name="vote_receipt_email" value="1" <%= "checked" if @participant.vote_receipt_email %> style="accent-color: var(--color-fg-default);">
+              Email me a vote receipt
+              <%= render TooltipComponent.new do %>
+                You'll receive an email with a cryptographic receipt hash after voting. This hash proves your vote was recorded in the audit chain and can be used to verify your vote on the <strong>verify page</strong>.
+              <% end %>
+            </label>
+          <% end %>
           <span style="position: relative; display: inline-block;">
             <button type="submit" class="pulse-action-btn pulse-action-btn-primary" data-decision-target="submitButton" disabled>
               <%= @votes.any? { |v| v.accepted == 1 } ? 'Update Vote' : 'Submit Vote' %>

--- a/app/views/decisions/_options_section.html.erb
+++ b/app/views/decisions/_options_section.html.erb
@@ -55,7 +55,7 @@
           <% end %>
           <span style="position: relative; display: inline-block;">
             <button type="submit" class="pulse-action-btn pulse-action-btn-primary" data-decision-target="submitButton" disabled>
-              <%= @votes.any? { |v| v.accepted == 1 } ? 'Update Vote' : 'Submit Vote' %>
+              <%= @votes.any? ? 'Update Vote' : 'Submit Vote' %>
             </button>
             <span class="pulse-body-text-muted" style="font-size: 0.85em; display: none; position: absolute; left: calc(100% + 12px); top: 50%; transform: translateY(-50%); white-space: nowrap;" data-decision-target="voteNotice">
               <%= @current_collective.id == @current_tenant.main_collective_id ? 'Your vote will be publicly visible.' : 'Your vote will be visible to all members of this collective.' %>

--- a/app/views/decisions/verify.md.erb
+++ b/app/views/decisions/verify.md.erb
@@ -16,7 +16,10 @@ Every action on this <%= @decision.is_lottery? ? 'lottery' : 'decision' %> is cr
   - <%= error %>
 <% end -%>
 <% end -%>
-<% if @verification_result[:vote_tallies][:valid] -%>
+<% if @verification_result[:vote_tallies][:skipped] -%>
+
+- **Vote tallies**: SKIPPED — <%= @verification_result[:vote_tallies][:errors]&.first || "Vote tally verification was skipped." %>
+<% elsif @verification_result[:vote_tallies][:valid] -%>
 
 - **Vote tallies**: PASS — Replayed all votes from the audit chain — totals match the displayed results.
 <% else -%>
@@ -26,12 +29,9 @@ Every action on this <%= @decision.is_lottery? ? 'lottery' : 'decision' %> is cr
   - <%= error %>
 <% end -%>
 <% end -%>
-<% if !@decision.beacon_drawn? -%>
+<% if @verification_result[:beacon][:skipped] -%>
 
-- **Beacon verification**: PASS (no beacon drawn yet)
-<% elsif @verification_result[:beacon][:skipped] -%>
-
-- **Beacon verification**: SKIPPED — Could not reach the drand randomness beacon to verify sort keys. This does not indicate a problem with the decision — the drand API may be temporarily unavailable. You can verify the beacon independently using the Python script below.
+- **Beacon verification**: SKIPPED — <%= @verification_result[:beacon][:errors]&.first || "Beacon verification was skipped." %>
 <% elsif @verification_result[:beacon][:valid] -%>
 
 - **Beacon verification**: PASS — Randomness round and sort keys verified against the drand beacon.
@@ -42,12 +42,13 @@ Every action on this <%= @decision.is_lottery? ? 'lottery' : 'decision' %> is cr
   - <%= error %>
 <% end -%>
 <% end -%>
-<% if @verification_result[:valid] && !@verification_result[:beacon][:skipped] -%>
+<% any_skipped = @verification_result[:beacon][:skipped] || @verification_result[:vote_tallies][:skipped] -%>
+<% if @verification_result[:valid] && !any_skipped -%>
 
 **All checks passed.**
-<% elsif @verification_result[:valid] && @verification_result[:beacon][:skipped] -%>
+<% elsif @verification_result[:valid] && any_skipped -%>
 
-**Chain and vote checks passed. Beacon could not be checked — see above.**
+**Completed checks passed. Some checks were skipped — see above.**
 <% else -%>
 
 **One or more checks failed — see details above.**

--- a/app/views/decisions/verify_receipt.html.erb
+++ b/app/views/decisions/verify_receipt.html.erb
@@ -1,0 +1,57 @@
+<%= render 'shared/pulse_breadcrumb', items: [
+  [@current_collective.name, @current_collective.path],
+  [@decision.is_lottery? ? 'Lottery' : 'Decision', @decision.path],
+  ['Verify', "#{@decision.path}/verify"],
+  'Receipt'
+] %>
+
+<article class="pulse-resource-detail">
+  <h1 style="font-size: 1.5em; margin-bottom: 8px;">Vote receipt for <%= @actor&.display_name || "unknown user" %></h1>
+  <p class="pulse-body-text-muted" style="margin-bottom: 20px;">
+    <%= link_to @decision.question, @decision.path %>
+  </p>
+
+  <div class="pulse-resource-body" style="padding: 16px;">
+    <p style="line-height: 1.6; margin-bottom: 16px;">
+      This page shows all audited actions by <strong><%= @actor&.display_name || "unknown user" %></strong> on this <%= @decision.is_lottery? ? 'lottery' : 'decision' %>.
+      Each entry is part of the cryptographic audit chain and can be independently verified on the <%= link_to "verify page", "#{@decision.path}/verify" %>.
+    </p>
+
+    <table style="width: 100%; border-collapse: collapse; font-size: 0.9em;">
+      <thead>
+        <tr style="border-bottom: 2px solid var(--color-border-default); text-align: left;">
+          <th style="padding: 8px 12px;">#</th>
+          <th style="padding: 8px 12px;">Action</th>
+          <th style="padding: 8px 12px;">Option</th>
+          <th style="padding: 8px 12px;">Accepted</th>
+          <th style="padding: 8px 12px;">Preferred</th>
+          <th style="padding: 8px 12px;">Hash</th>
+          <th style="padding: 8px 12px;">Time</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @entries.each do |entry| %>
+          <tr style="border-bottom: 1px solid var(--color-border-muted);">
+            <td style="padding: 8px 12px;"><%= entry.sequence_number %></td>
+            <td style="padding: 8px 12px;"><code><%= entry.action %></code></td>
+            <td style="padding: 8px 12px;"><%= entry.option_title.present? ? markdown_inline(entry.option_title) : "" %></td>
+            <td style="padding: 8px 12px;"><%= entry.accepted.present? ? (entry.accepted == 1 ? "✅" : "—") : "" %></td>
+            <td style="padding: 8px 12px;"><%= entry.preferred.present? ? (entry.preferred == 1 ? "⭐" : "—") : "" %></td>
+            <td style="padding: 8px 12px;">
+              <% if entry.entry_hash == @receipt_hash %>
+                <span class="receipt-hash"><code title="<%= entry.entry_hash %>"><%= entry.entry_hash[0, 8] %>...</code></span>
+              <% else %>
+                <code title="<%= entry.entry_hash %>"><%= entry.entry_hash[0, 8] %>...</code>
+              <% end %>
+            </td>
+            <td style="padding: 8px 12px;"><%= entry.created_at.strftime("%Y-%m-%d %H:%M:%S UTC") %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <p style="margin-top: 16px; font-size: 0.85em;">
+      Receipt: <code class="receipt-hash" style="word-break: break-all; font-size: 1em;"><%= @receipt_hash %></code>
+    </p>
+  </div>
+</article>

--- a/app/views/decisions/verify_receipt.md.erb
+++ b/app/views/decisions/verify_receipt.md.erb
@@ -1,0 +1,13 @@
+# Vote receipt for <%= @actor&.display_name || "unknown user" %>
+
+[Back to <%= @decision.is_lottery? ? 'lottery' : 'decision' %>](<%= @decision.path %>) | [Verify page](<%= @decision.path %>/verify)
+
+This page shows all audited actions by **<%= @actor&.display_name || "unknown user" %>** on this <%= @decision.is_lottery? ? 'lottery' : 'decision' %>. Each entry is part of the cryptographic audit chain and can be independently verified on the [verify page](<%= @decision.path %>/verify).
+
+## Audit entries
+
+<% @entries.each do |entry| -%>
+- **#<%= entry.sequence_number %>** `<%= entry.action %>`<%= " — #{entry.option_title}" if entry.option_title.present? %><%= " ✅" if entry.accepted == 1 %><%= " ⭐" if entry.preferred == 1 %> — `<%= entry.entry_hash[0, 8] %>...` — <%= entry.created_at.strftime("%Y-%m-%d %H:%M:%S UTC") %>
+<% end -%>
+
+Receipt: `<%= @receipt_hash %>`

--- a/app/views/decisions/verify_receipt_not_found.html.erb
+++ b/app/views/decisions/verify_receipt_not_found.html.erb
@@ -1,0 +1,35 @@
+<%= render 'shared/pulse_breadcrumb', items: [
+  [@current_collective.name, @current_collective.path],
+  [@decision.is_lottery? ? 'Lottery' : 'Decision', @decision.path],
+  ['Verify', "#{@decision.path}/verify"],
+  'Receipt not found'
+] %>
+
+<article class="pulse-resource-detail">
+  <h1 style="font-size: 1.5em; margin-bottom: 8px;">Receipt not found</h1>
+  <p class="pulse-body-text-muted" style="margin-bottom: 20px;">
+    <%= link_to @decision.question, @decision.path %>
+  </p>
+
+  <div class="pulse-resource-body" style="padding: 16px;">
+    <p style="line-height: 1.6; margin-bottom: 16px;">
+      No audit entry matching the hash <code class="receipt-hash" style="word-break: break-all; font-size: 1em;"><%= @receipt_hash %></code> was found for this <%= @decision.is_lottery? ? 'lottery' : 'decision' %>.
+    </p>
+
+    <h2 style="font-size: 1.1em; margin: 0 0 12px 0;">What this could mean</h2>
+
+    <ul style="line-height: 1.8; margin-bottom: 16px; padding-left: 20px;">
+      <li><strong>Typo or truncation</strong> — Receipt hashes are 64 characters long. Make sure you're using the full hash, not a truncated version.</li>
+      <li><strong>Wrong decision</strong> — This receipt may belong to a different decision. Check that you're looking at the right one.</li>
+      <li><strong>Data integrity issue</strong> — If neither of the above apply and you believe your receipt should be valid, this could indicate a problem with the audit chain. You can investigate further on the <%= link_to "verify page", "#{@decision.path}/verify" %>.</li>
+    </ul>
+
+    <h2 style="font-size: 1.1em; margin: 0 0 12px 0;">Where to find your receipt</h2>
+
+    <ul style="line-height: 1.8; margin-bottom: 16px; padding-left: 20px;">
+      <li>Your receipt was shown after you submitted your vote.</li>
+      <li>If you voted via the API, your receipt was returned in the response as <code>audit_receipt</code>.</li>
+      <li>All voter receipts are listed on the <%= link_to "voters page", "#{@decision.path}/voters" %>.</li>
+    </ul>
+  </div>
+</article>

--- a/app/views/decisions/verify_receipt_not_found.md.erb
+++ b/app/views/decisions/verify_receipt_not_found.md.erb
@@ -1,0 +1,17 @@
+# Receipt not found
+
+[Back to <%= @decision.is_lottery? ? 'lottery' : 'decision' %>](<%= @decision.path %>) | [Verify page](<%= @decision.path %>/verify)
+
+No audit entry matching the hash `<%= @receipt_hash %>` was found for this <%= @decision.is_lottery? ? 'lottery' : 'decision' %>.
+
+## What this could mean
+
+- **Typo or truncation** — Receipt hashes are 64 characters long. Make sure you're using the full hash, not a truncated version.
+- **Wrong decision** — This receipt may belong to a different decision. Check that you're looking at the right one.
+- **Data integrity issue** — If neither of the above apply and you believe your receipt should be valid, this could indicate a problem with the audit chain. You can investigate further on the [verify page](<%= @decision.path %>/verify).
+
+## Where to find your receipt
+
+- Your receipt was shown after you submitted your vote.
+- If you voted via the API, your receipt was returned in the response as `audit_receipt`.
+- All voter receipts are listed on the [voters page](<%= @decision.path %>/voters).

--- a/app/views/decisions/voters_page.html.erb
+++ b/app/views/decisions/voters_page.html.erb
@@ -38,11 +38,15 @@
           <% @votes_by_voter.each do |entry| %>
             <div style="margin-bottom: 16px; padding-bottom: 12px; border-bottom: 1px solid var(--color-border-muted);">
               <div class="pulse-body-text-muted" style="font-size: 0.8em; margin-bottom: 2px;">Voter</div>
-              <h3 style="margin-bottom: 8px;">
+              <h3 style="margin-bottom: 8px; display: flex; align-items: center; gap: 8px;">
                 <a href="<%= "/u/#{entry[:voter].handle}" %>" style="display: inline-flex; align-items: center; gap: 4px;">
                   <%= profile_pic(entry[:voter], size: 20) %>
                   <%= entry[:voter].display_name %>
                 </a>
+                <% receipt = @receipts_by_voter[entry[:voter].id] %>
+                <% if receipt %>
+                  <a href="<%= @decision.path %>/verify/<%= receipt.entry_hash %>" class="receipt-hash" title="<%= receipt.entry_hash %>"><code><%= receipt.entry_hash[0, 8] %>...</code></a>
+                <% end %>
               </h3>
               <% if entry[:options].any? %>
                 <% entry[:options].each do |opt| %>

--- a/app/views/decisions/voters_page.md.erb
+++ b/app/views/decisions/voters_page.md.erb
@@ -9,7 +9,8 @@ No one has voted yet.
 ## By Voter
 
 <% @votes_by_voter.each do |entry| -%>
-### <%= user_link_md(entry[:voter]) %>
+<% receipt = @receipts_by_voter[entry[:voter].id] -%>
+### <%= user_link_md(entry[:voter]) %><%= " [`#{receipt.entry_hash[0, 8]}...`](#{@decision.path}/verify/#{receipt.entry_hash})" if receipt %>
 
 <% if entry[:options].any? -%>
 <% entry[:options].each do |opt| -%>

--- a/app/views/vote_receipt_mailer/receipt_email.html.erb
+++ b/app/views/vote_receipt_mailer/receipt_email.html.erb
@@ -30,7 +30,7 @@
     </div>
 
     <div class="footer">
-      <p>Save your audit receipt. After the decision closes, you can use it to confirm your vote was recorded correctly.</p>
+      <p>You can use this receipt to confirm your vote was recorded correctly.</p>
     </div>
   </div>
 </body>

--- a/app/views/vote_receipt_mailer/receipt_email.text.erb
+++ b/app/views/vote_receipt_mailer/receipt_email.text.erb
@@ -6,4 +6,4 @@ You can verify your vote was included in the audit chain:
 <%= @verify_url %>
 
 ---
-Save your audit receipt. After the decision closes, you can use it to confirm your vote was recorded correctly.
+You can use this receipt to confirm your vote was recorded correctly.

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -52,3 +52,11 @@ feature_flags:
     default_tenant: false
     default_collective: false
     collective_level: false
+
+  vote_receipt_emails:
+    name: "Vote Receipt Emails"
+    description: "Allows voters to opt in to receiving email receipts when they vote"
+    app_enabled: true
+    default_tenant: true
+    default_collective: true
+    collective_level: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -514,6 +514,7 @@ Rails.application.routes.draw do
       post '/attachments/:attachment_id/actions/remove_attachment' => 'decisions#remove_attachment'
       post '/submit_votes' => 'decisions#submit_votes'
       get '/verify' => 'decisions#verify'
+      get '/verify/:receipt_hash' => 'decisions#verify_receipt'
       get '/actions/add_statement' => 'decisions#describe_add_statement'
       post '/actions/add_statement' => 'decisions#add_statement_action'
       post '/duplicate' => 'decisions#duplicate'

--- a/db/migrate/20260507200842_add_vote_receipt_email_to_decision_participants.rb
+++ b/db/migrate/20260507200842_add_vote_receipt_email_to_decision_participants.rb
@@ -1,0 +1,5 @@
+class AddVoteReceiptEmailToDecisionParticipants < ActiveRecord::Migration[7.2]
+  def change
+    add_column :decision_participants, :vote_receipt_email, :boolean, default: false, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -618,7 +618,8 @@ CREATE TABLE public.decision_participants (
     user_id uuid,
     participant_uid character varying DEFAULT ''::character varying NOT NULL,
     tenant_id uuid NOT NULL,
-    collective_id uuid
+    collective_id uuid,
+    vote_receipt_email boolean DEFAULT false NOT NULL
 );
 
 
@@ -9211,6 +9212,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260507200842'),
 ('20260506234024'),
 ('20260505203614'),
 ('20260503232136'),

--- a/sorbet/rbi/dsl/decision_participant.rbi
+++ b/sorbet/rbi/dsl/decision_participant.rbi
@@ -1058,6 +1058,9 @@ class DecisionParticipant
     sig { void }
     def restore_user_id!; end
 
+    sig { void }
+    def restore_vote_receipt_email!; end
+
     sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
     def saved_change_to_collective_id; end
 
@@ -1117,6 +1120,12 @@ class DecisionParticipant
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_user_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+    def saved_change_to_vote_receipt_email; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_vote_receipt_email?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(::String) }
     def tenant_id; end
@@ -1253,6 +1262,51 @@ class DecisionParticipant
     sig { void }
     def user_id_will_change!; end
 
+    sig { returns(T::Boolean) }
+    def vote_receipt_email; end
+
+    sig { params(value: T::Boolean).returns(T::Boolean) }
+    def vote_receipt_email=(value); end
+
+    sig { returns(T::Boolean) }
+    def vote_receipt_email?; end
+
+    sig { returns(T.nilable(T::Boolean)) }
+    def vote_receipt_email_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def vote_receipt_email_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def vote_receipt_email_came_from_user?; end
+
+    sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+    def vote_receipt_email_change; end
+
+    sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+    def vote_receipt_email_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def vote_receipt_email_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(T::Boolean)) }
+    def vote_receipt_email_in_database; end
+
+    sig { returns(T.nilable([T::Boolean, T::Boolean])) }
+    def vote_receipt_email_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def vote_receipt_email_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(T::Boolean)) }
+    def vote_receipt_email_previously_was; end
+
+    sig { returns(T.nilable(T::Boolean)) }
+    def vote_receipt_email_was; end
+
+    sig { void }
+    def vote_receipt_email_will_change!; end
+
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_collective_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
@@ -1282,6 +1336,9 @@ class DecisionParticipant
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_user_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_vote_receipt_email?(from: T.unsafe(nil), to: T.unsafe(nil)); end
   end
 
   module GeneratedRelationMethods

--- a/test/controllers/decisions_controller_test.rb
+++ b/test/controllers/decisions_controller_test.rb
@@ -783,6 +783,82 @@ class DecisionsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Option A/, response.body)
   end
 
+  # === Vote Receipt Email Tests ===
+
+  test "submit_votes saves vote_receipt_email preference on decision participant" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    post "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/submit_votes",
+      params: {
+        votes: { "0" => { option_title: "Option A", accepted: "1", preferred: "0" } },
+        vote_receipt_email: "1",
+      }
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    participant.reload
+    assert participant.vote_receipt_email, "Expected vote_receipt_email to be true"
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+  end
+
+  test "submit_votes preserves vote_receipt_email preference when param is missing" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    participant.update!(vote_receipt_email: true)
+    option = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    # Submit without vote_receipt_email param (e.g., API call)
+    post "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/submit_votes",
+      params: {
+        votes: { "0" => { option_title: "Option A", accepted: "1", preferred: "0" } },
+      }
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    participant.reload
+    assert participant.vote_receipt_email, "Expected vote_receipt_email to remain true when param is missing"
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+  end
+
+  test "submit_votes clears vote_receipt_email preference when unchecked" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    participant.update!(vote_receipt_email: true)
+    option = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    post "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/submit_votes",
+      params: {
+        votes: { "0" => { option_title: "Option A", accepted: "1", preferred: "0" } },
+        vote_receipt_email: "0",
+      }
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    participant.reload
+    assert_not participant.vote_receipt_email, "Expected vote_receipt_email to be false"
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+  end
+
   test "cannot vote via API action on closed decision" do
     sign_in_as(@user, tenant: @tenant)
 

--- a/test/controllers/decisions_controller_test.rb
+++ b/test/controllers/decisions_controller_test.rb
@@ -1788,8 +1788,8 @@ class DecisionsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Verification Results/, response.body)
     assert_match(/Chain integrity.*PASS.*entries verified/i, response.body)
     assert_match(/Vote tallies.*PASS.*totals match/i, response.body)
-    assert_match(/Beacon verification.*PASS/i, response.body)
-    assert_match(/All checks passed/i, response.body)
+    assert_match(/Beacon verification.*SKIPPED.*No beacon drawn yet/i, response.body)
+    assert_match(/Completed checks passed/i, response.body)
   end
 
   test "markdown verify page shows chain failure with integrity warning" do

--- a/test/controllers/decisions_controller_test.rb
+++ b/test/controllers/decisions_controller_test.rb
@@ -859,6 +859,46 @@ class DecisionsControllerTest < ActionDispatch::IntegrationTest
     Tenant.clear_thread_scope
   end
 
+  # === Vote Update Edge Cases ===
+
+  test "user who unchecks all options is still recognized as having voted" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+
+    # First: vote with acceptance
+    post "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/submit_votes",
+      params: { votes: { "0" => { option_title: "Option A", accepted: "1", preferred: "0" } } }
+    assert_redirected_to @decision.path
+
+    # Then: update to uncheck all options
+    post "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/submit_votes",
+      params: { votes: { "0" => { option_title: "Option A", accepted: "0", preferred: "0" } } }
+    assert_redirected_to @decision.path
+
+    # The show page should still recognize the user as having voted
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}"
+    assert_response :success
+
+    # The user should still see results (they participated, even if they now accept nothing)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    # Check that vote records still exist
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    votes = Vote.where(decision_participant: participant)
+    assert votes.any?, "Vote records should still exist after unchecking all options"
+
+    # The UI should show "Update Vote" (not "Submit Vote") since the user has already voted
+    assert_match(/Update Vote/, response.body, "User who unchecked all options should still see 'Update Vote'")
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+  end
+
   test "cannot vote via API action on closed decision" do
     sign_in_as(@user, tenant: @tenant)
 

--- a/test/controllers/decisions_controller_test.rb
+++ b/test/controllers/decisions_controller_test.rb
@@ -694,6 +694,95 @@ class DecisionsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Option A/, response.body)
   end
 
+  test "voters page shows receipt hashes next to voter names" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    vote = Vote.new(tenant: @tenant, collective: @collective, decision: @decision, option: option, decision_participant: participant, accepted: 1, preferred: 0)
+    DecisionActionService.cast_vote!(decision: @decision, vote: vote, actor: @user)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/voters"
+    assert_response :success
+
+    # Receipt hash should appear as a truncated code element
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    receipt = DecisionAuditEntry.receipt_for_user(@decision, @user)
+    assert receipt, "Expected receipt entry to exist"
+    truncated = receipt.entry_hash[0, 8]
+    assert_match(/#{truncated}/, response.body)
+    # Receipt should link to the verify receipt route
+    assert_match(/verify\/#{receipt.entry_hash}/, response.body)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+  end
+
+  # === Receipt Verification Page Tests ===
+
+  test "receipt verification page shows voter's full audit history" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option_a = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    option_b = Option.create!(decision: @decision, decision_participant: participant, title: "Option B")
+    vote_a = Vote.new(tenant: @tenant, collective: @collective, decision: @decision, option: option_a, decision_participant: participant, accepted: 1, preferred: 1)
+    DecisionActionService.cast_vote!(decision: @decision, vote: vote_a, actor: @user)
+    vote_b = Vote.new(tenant: @tenant, collective: @collective, decision: @decision, option: option_b, decision_participant: participant, accepted: 1, preferred: 0)
+    DecisionActionService.cast_vote!(decision: @decision, vote: vote_b, actor: @user)
+
+    receipt = DecisionAuditEntry.receipt_for_user(@decision, @user)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/verify/#{receipt.entry_hash}"
+    assert_response :success
+    assert_match(/Vote receipt/, response.body)
+    assert_match(/vote_cast/, response.body)
+    assert_match(/Option A/, response.body)
+    assert_match(/Option B/, response.body)
+    assert_match(@user.display_name, response.body)
+  end
+
+  test "receipt verification page shows helpful not-found page for unknown hash" do
+    sign_in_as(@user, tenant: @tenant)
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/verify/nonexistent_hash"
+    assert_response :not_found
+    assert_match(/Receipt not found/, response.body)
+    assert_match(/nonexistent_hash/, response.body)
+    assert_match(/What this could mean/, response.body)
+    assert_match(/Where to find your receipt/, response.body)
+  end
+
+  test "receipt verification page renders markdown format" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    vote = Vote.new(tenant: @tenant, collective: @collective, decision: @decision, option: option, decision_participant: participant, accepted: 1, preferred: 0)
+    DecisionActionService.cast_vote!(decision: @decision, vote: vote, actor: @user)
+
+    receipt = DecisionAuditEntry.receipt_for_user(@decision, @user)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/verify/#{receipt.entry_hash}",
+      headers: { "Accept" => "text/markdown" }
+    assert_response :success
+    assert_match(/Vote receipt/, response.body)
+    assert_match(/vote_cast/, response.body)
+    assert_match(/Option A/, response.body)
+  end
+
   test "cannot vote via API action on closed decision" do
     sign_in_as(@user, tenant: @tenant)
 

--- a/test/integration/audit_chain_verification_test.rb
+++ b/test/integration/audit_chain_verification_test.rb
@@ -471,6 +471,10 @@ class AuditChainVerificationTest < ActionDispatch::IntegrationTest
 
     json = JSON.parse(response.body)
 
+    # Timestamp
+    assert json["generated_at"].is_a?(String)
+    assert_match(/\d{4}-\d{2}-\d{2}T/, json["generated_at"])
+
     # Decision section
     d = json["decision"]
     assert d.is_a?(Hash)
@@ -573,9 +577,10 @@ class AuditChainVerificationTest < ActionDispatch::IntegrationTest
 
     json_data = JSON.parse(response.body)
 
-    # Pre-close: no beacon, no results — but chain should still verify
+    # Pre-close: no beacon, but results are included (votes exist)
     assert_nil json_data["beacon"]
-    assert_nil json_data["results"]
+    assert json_data["results"].is_a?(Array)
+    assert json_data["results"].length >= 1
     assert json_data["audit_chain"].length >= 3  # created + option_added + vote_cast
 
     Dir.mktmpdir do |dir|

--- a/test/mailers/vote_receipt_mailer_test.rb
+++ b/test/mailers/vote_receipt_mailer_test.rb
@@ -12,7 +12,7 @@ class VoteReceiptMailerTest < ActiveSupport::TestCase
     @decision = create_decision(tenant: @tenant, collective: @collective, created_by: @user)
   end
 
-  test "sends email with receipt hash and verify link" do
+  test "sends email with receipt hash and link to receipt verification page" do
     mail = VoteReceiptMailer.receipt_email(
       user: @user,
       decision: @decision,
@@ -23,10 +23,33 @@ class VoteReceiptMailerTest < ActiveSupport::TestCase
     assert_match(/vote.*recorded/i, mail.subject)
     assert_match(@decision.question, mail.subject)
     assert_match(/abc123def456/, mail.body.encoded)
-    assert_match(/verify/, mail.body.encoded)
+    # Link should go to the receipt verification page, not just the verify page
+    assert_match(/verify\/abc123def456/, mail.body.encoded)
   end
 
-  test "api_helper does not send receipt email (disabled until opt-in UI)" do
+  test "api_helper sends receipt email when opted in and flag enabled" do
+    option_a = create_option(decision: @decision, created_by: @user, title: "Option A")
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    participant.update!(vote_receipt_email: true)
+
+    helper = ApiHelper.new(
+      current_tenant: @tenant,
+      current_collective: @collective,
+      current_user: @user,
+      current_decision: @decision,
+      params: {
+        votes: [
+          { option_title: "Option A", accept: true, prefer: true },
+        ],
+      },
+    )
+
+    assert_enqueued_jobs(1, only: ActionMailer::MailDeliveryJob) do
+      helper.create_votes
+    end
+  end
+
+  test "api_helper does not send receipt email when not opted in" do
     option_a = create_option(decision: @decision, created_by: @user, title: "Option A")
 
     helper = ApiHelper.new(
@@ -41,7 +64,32 @@ class VoteReceiptMailerTest < ActiveSupport::TestCase
       },
     )
 
-    assert_no_enqueued_jobs(only: ActionMailer::MailDeliveryJob) do
+    assert_no_enqueued_emails do
+      helper.create_votes
+    end
+  end
+
+  test "api_helper does not send receipt email when feature flag disabled" do
+    option_a = create_option(decision: @decision, created_by: @user, title: "Option A")
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    participant.update!(vote_receipt_email: true)
+
+    # Disable feature flag at collective level
+    @collective.disable_feature_flag!("vote_receipt_emails")
+
+    helper = ApiHelper.new(
+      current_tenant: @tenant,
+      current_collective: @collective,
+      current_user: @user,
+      current_decision: @decision,
+      params: {
+        votes: [
+          { option_title: "Option A", accept: true, prefer: true },
+        ],
+      },
+    )
+
+    assert_no_enqueued_emails do
       helper.create_votes
     end
   end

--- a/test/models/decision_audit_entry_test.rb
+++ b/test/models/decision_audit_entry_test.rb
@@ -164,4 +164,24 @@ class DecisionAuditEntryTest < ActiveSupport::TestCase
     other_user = create_user(email: "nobody-#{SecureRandom.hex(4)}@example.com", name: "Nobody")
     assert_nil DecisionAuditEntry.receipt_for_user(@decision, other_user)
   end
+
+  test "find_by_receipt returns the entry matching the hash" do
+    entry = DecisionAuditService.record_option!(
+      decision: @decision, option: @option, actor: @user, action: "option_added",
+    )
+    found = DecisionAuditEntry.find_by_receipt(@decision, entry.entry_hash)
+    assert_equal entry.id, found.id
+  end
+
+  test "find_by_receipt returns nil for unknown hash" do
+    assert_nil DecisionAuditEntry.find_by_receipt(@decision, "nonexistent_hash")
+  end
+
+  test "find_by_receipt does not return entries from other decisions" do
+    entry = DecisionAuditService.record_option!(
+      decision: @decision, option: @option, actor: @user, action: "option_added",
+    )
+    other_decision = create_decision(tenant: @tenant, collective: @collective, created_by: @user)
+    assert_nil DecisionAuditEntry.find_by_receipt(other_decision, entry.entry_hash)
+  end
 end

--- a/test/services/decision_audit_verifier_test.rb
+++ b/test/services/decision_audit_verifier_test.rb
@@ -183,10 +183,11 @@ class DecisionAuditVerifierTest < ActiveSupport::TestCase
     assert result[:valid], "Expected valid but got errors: #{result[:errors]}"
   end
 
-  test "verify_vote_tallies passes with no votes (lottery)" do
+  test "verify_vote_tallies skips with no votes" do
     result = DecisionAuditVerifier.verify_vote_tallies(@decision)
     assert result[:valid]
-    assert_empty result[:errors]
+    assert result[:skipped]
+    assert result[:errors].any? { |e| e.include?("No votes") }
   end
 
   # --- verify_beacon tests ---
@@ -232,8 +233,8 @@ class DecisionAuditVerifierTest < ActiveSupport::TestCase
   test "verify_beacon skips when no beacon present" do
     result = DecisionAuditVerifier.verify_beacon(@decision, fetched_randomness: nil)
     assert result[:valid]
-    assert_not result[:skipped]
-    assert_empty result[:errors]
+    assert result[:skipped]
+    assert result[:errors].any? { |e| e.include?("No beacon drawn yet") }
   end
 
   test "verify_beacon returns skipped when beacon drawn but no randomness provided" do


### PR DESCRIPTION
## Summary

- **Vote receipts on voters page**: Each voter's receipt hash is shown next to their name (truncated, amber-highlighted), linking to a new receipt verification page
- **Receipt verification route** (`/d/:id/verify/:hash`): Shows the voter's full audit trail — every audited action on the decision. Invalid hashes show a helpful not-found page explaining what it could mean and where to find valid receipts
- **Vote receipt emails**: Voters can opt in to email receipts via a checkbox on the voting form ("Email me a vote receipt"). Behind the `vote_receipt_emails` feature flag (enabled by default, can be disabled per-collective/tenant). Emails link directly to the receipt verification page
- **Bug fix — voter who unchecks all options**: Previously, a voter who updated their vote to uncheck all options lost their "voted" status — results disappeared and the button reverted to "Submit Vote". Fixed by checking for vote record existence rather than positive acceptance values
- **Bug fix — submit button stays enabled after interaction**: The submit button now stays enabled once the user has toggled any checkbox, allowing voters to submit a vote of non-acceptance for all options
- **Verification messaging improvements**: Beacon and vote tally checks now show SKIPPED (with explanation) instead of misleadingly claiming PASS when nothing was actually verified. Results are now included in verify.json for open decisions when votes exist. Added `generated_at` timestamp to verify.json

## New route

`GET /d/:decision_id/verify/:receipt_hash` — receipt verification page (HTML, markdown)

## Migration

`AddVoteReceiptEmailToDecisionParticipants` — adds `vote_receipt_email` boolean (default false) to `decision_participants`

## Feature flag

`vote_receipt_emails` — allows voters to opt in to email receipts. Enabled by default at all levels, can be disabled per-collective.

## Test plan

- [x] Vote on a decision, check voters page shows receipt hash next to name
- [x] Click receipt hash, verify full audit trail is shown with receipt entry highlighted
- [x] Try an invalid receipt hash URL, verify helpful not-found page
- [x] Check "Email me a vote receipt" checkbox, submit vote, verify email arrives (mailcatcher)
- [x] Uncheck the checkbox, update vote, verify no email sent
- [x] Disable `vote_receipt_emails` flag on a collective, verify checkbox disappears
- [x] Vote, uncheck all options, update — verify results still visible and button says "Update Vote"
- [x] Check verify page on open decision — beacon and vote tallies should show SKIPPED, not PASS
- [x] Check verify.json on open decision with votes — results should be included with `generated_at` timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)
