### PR TITLE
Feature/phased deletion

### DIFF
--- a/.claude/plans/data-lifecycle-management.md
+++ b/.claude/plans/data-lifecycle-management.md
@@ -20,18 +20,21 @@ Export an entire collective as a ZIP of JSON files + attachments, designed for r
 
 User-triggered export of records the user owns within a collective (GDPR Article 20 portability). Scope mirrors account-closure deletion scope — only records that would be deleted/scrubbed on closure are in the export. Main collective only initially; private-collective export deferred until ownership policy is resolved. One-way archive (no import).
 
-## Phase 2: Phased Deletion
+## Phase 2: Phased Deletion — **shipped (Notes only); Decisions/Commitments deferred**
 
-Extend `SoftDeletable` with a grace period before hard-delete:
+*Detailed plan: [phased-deletion.md](phased-deletion.md)*
 
-1. **`hard_delete_after` column**: Set automatically in `soft_delete!` to `deleted_at + 30.days`. Configurable per-tenant.
-2. **`HardDeleteExpiredRecordsJob < SystemJob`**: Runs daily. Finds records past grace period across all tenants. Calls `DataDeletionManager` for cascading associated data cleanup.
-3. **Undo window**: `undo_delete!` clears `deleted_at` and `hard_delete_after` during grace period. Content is already scrubbed via `scrub_content!`, but `content_snapshot` preserves original text for admin recovery.
-4. **Admin override**: Immediate hard-delete via existing `DataDeletionManager` console workflow.
+`SoftDeletable` extended with a 30-day grace period and accessor-masking defense-in-depth. `soft_delete!` is metadata-only — content is preserved at rest, hidden by `default_scope`, and masked to `[deleted]` via overridden readers (with `raw_*` escape hatches for audit/undo paths). `undo_delete!` clears the timestamps and restores accessors.
 
-Also fix the two known `DataDeletionManager` bugs:
-- FK violation on events table during `delete_collective!` (missing `Event` in deletion list)
-- Options with wrong `collective_id` during test setup
+**Notes** opt into `participates_in_hard_delete`. Once `hard_delete_after` passes, `HardDeleteExpiredRecordsJob` (daily) calls `DataDeletionManager.system_tombstone_note!` which always tombstones: nulls `title`/`text`/`table_data`, purges attachments, destroys Link records, sets `tombstoned_at`. The row stays in the DB so external references (other-user comments, NoteHistoryEvents) keep resolving. Full row destruction remains available via the console admin `delete_note!` method.
+
+**Decisions** and **Commitments** still soft-delete (hidden, content masked, undo reversible) but never auto-finalize. Their deletion semantics — ownership-after-engagement, audit-chain preservation, withdrawal vs. delete — are deferred to a follow-up phase.
+
+Bug fixes shipped alongside:
+- `Event` cleanup added to `delete_collective!` cascade (FK violation fix)
+- `CollectiveIdMatchesParent` concern enforces `collective_id` consistency on `Option`, `Vote`, `DecisionParticipant`, `CommitmentParticipant`, `DecisionAuditEntry`
+
+Defense-in-depth guard added to `ReminderDeliveryJob` to skip delivery if the linked note has been soft-deleted (in case a partial `cancel!` left an orphan notification).
 
 ## Phase 3: Account Closure (GDPR Right to Erasure)
 
@@ -71,9 +74,9 @@ Decisions use a tamper-evident SHA-256 hash chain (`DecisionAuditEntry`). Hard-d
 
 ## Implementation Order
 
-1. **Data Export** — this sprint (see detailed plan)
-2. **DataDeletionManager bug fixes** — FK violation on events, options collective_id
-3. **`hard_delete_after` + `HardDeleteExpiredRecordsJob`**
+1. ✅ **Data Export** — shipped (Phase 1a + 1b)
+2. ✅ **Phase 2 Notes pipeline** — shipped (grace period, accessor masking, tombstone job, bug fixes)
+3. **Decision/Commitment deletion semantics** — design follow-up (ownership-after-engagement, withdrawal vs. delete, audit-chain preservation)
 4. **Account closure flow** (UI + `force_delete: true`)
 5. **Transparency UI** updates
 6. **Audit chain tombstoning**

--- a/.claude/plans/phased-deletion.md
+++ b/.claude/plans/phased-deletion.md
@@ -1,6 +1,8 @@
 # Phase 2: Phased Deletion
 
-Add a 30-day grace period between user-initiated soft-delete and permanent hard-delete. Phase 2's auto hard-delete pipeline applies to **Notes only**; `Decision` and `Commitment` soft-delete works (grace period, accessor masking, undo) but never auto-hard-deletes — their deletion semantics are a separate design conversation deferred to a follow-up phase.
+Add a 30-day grace period between user-initiated soft-delete and **tombstoning** of Notes (null content, preserve row). Phase 2's auto-finalize pipeline applies to **Notes only** and only tombstones — never hard-destroys the row. Hard-destroy remains available via the existing console admin `delete_note!` method.
+
+`Decision` and `Commitment` soft-delete works (grace period, accessor masking, undo) but never auto-finalizes — their deletion semantics are a separate design conversation deferred to a follow-up phase.
 
 ## Context
 
@@ -34,19 +36,19 @@ From the user's perspective, soft-delete **is** deletion. It:
 
 Undo is possible within the 30-day window.
 
-### Hard-delete-or-tombstone (decided at expiry, Notes only)
+### Tombstone (at expiry, Notes only)
 
-When `hard_delete_after` passes, the `HardDeleteExpiredRecordsJob` calls `DataDeletionManager.system_finalize_note!(note:)`, which inspects the note for **non-creator-owned associated records**:
+When `hard_delete_after` passes, the `HardDeleteExpiredRecordsJob` calls `DataDeletionManager.system_tombstone_note!(note:)`, which:
 
-- Child comments (`subtype = "comment"` notes with `commentable_id` pointing at the parent) created by anyone other than the note's creator
-- `NoteHistoryEvent` rows where `user_id != note.created_by_id` (read confirmations and reminder acknowledgments by other users)
-- `Link` rows where the *other* end of the link belongs to a note owned by someone other than the creator (i.e. another user referenced this note)
+- Nulls `title`, `text`, `table_data` via `update_columns`
+- Purges attachments
+- Destroys all `Link` records involving the note (links are system-generated from parsed `@`-references; they don't belong to any user, and `LinkParser` already treats soft-deleted items as unresolvable, so destroying them on tombstone keeps behavior consistent)
+- Sets `tombstoned_at = Time.current`
+- **Leaves the row in place** — `NoteHistoryEvent` rows, child comments, and any other records that reference the note continue to resolve
 
-**If any such records exist**: tombstone — null `title`/`text`/`table_data` via `update_columns`, purge attachments, set `tombstoned_at`. The note row remains in the DB so external FK references stay valid. B's comment, B's read confirmation, and B's incoming link all continue to resolve to a real (but content-stripped) parent row.
+Always tombstones — no conditional logic, no audit of who-owns-what among references. The row stays forever (until an admin invokes the console `delete_note!` to nuke it). This avoids the complex "who owns this reference?" question and keeps the system pipeline minimal.
 
-**If no such records exist**: hard-delete — destroy the row entirely. The cascade also clears A's own `NoteHistoryEvent` rows and `Link` rows (existing `cascade_delete_note` logic).
-
-The decision is made *at expiry*, not at soft-delete. A note with no other-user activity at delete time may still tombstone if other-user activity has accrued before the grace period ends. The check happens inside the same transaction as the finalize action.
+The action runs inside a transaction with a row lock on the note so concurrent updates are serialized.
 
 ### Why Notes only
 
@@ -60,8 +62,8 @@ That ambiguity ("does a Decision belong to its creator once others engage?") is 
 
 ### DataDeletionManager API
 
-- Existing `delete_note!` / `delete_decision!` / `delete_commitment!` instance methods are unchanged — console admin nuke remains available.
-- New `DataDeletionManager.system_finalize_note!(note:)` class method dispatches at expiry: tombstones if other-user references exist, otherwise destroys via the existing cascade. Only system entry point this PR introduces.
+- Existing `delete_note!` / `delete_decision!` / `delete_commitment!` instance methods are unchanged — console admin nuke remains available for full row destruction.
+- New `DataDeletionManager.system_tombstone_note!(note:)` class method is the only system entry point this PR introduces. Always tombstones; never destroys the row.
 
 ### Bug fixes
 
@@ -94,24 +96,24 @@ Indexed datetime on `notes`, `decisions`, `commitments`. Backfills existing soft
 - Update tests: remove `hard_delete_after` assertions from Decision/Commitment soft-delete tests.
 - Add migration: `tombstoned_at :datetime` column on `notes` (indexed).
 
-### Commit 6 — `system_finalize_note!` on DataDeletionManager
+### Commit 6 — `system_tombstone_note!` on DataDeletionManager
 
-Class method that, inside a transaction:
-- Inspects the note for non-creator-owned references (child comments, history events by other users, links from other users' notes).
-- **If any exist**: tombstone — `update_columns(title: nil, text: nil, table_data: nil, tombstoned_at: Time.current)`. Purge `attachments` if present. Leave NoteHistoryEvent rows, Link rows, child comments untouched.
-- **If none exist**: call existing private `cascade_delete_note` (destroys row + A's own NoteHistoryEvent/Link rows).
+Class method that, inside a transaction with a row lock on the note:
+- Purges attachments
+- Destroys all Link records involving the note
+- `update_columns(title: nil, text: nil, table_data: nil, tombstoned_at: Time.current)`
 
-The other-user-reference predicates live as small private class methods (`has_other_user_comments?`, `has_other_user_history?`, `has_other_user_link?`) so they're independently testable.
+`delete_note!` is refactored to share `cascade_delete_note` (private class helper) so the console admin nuke path stays available unchanged.
 
 ### Commit 7 — `HardDeleteExpiredRecordsJob`
 
-`class HardDeleteExpiredRecordsJob < SystemJob`. Daily schedule. Scoped to `Note` only. Across all tenants, finds notes where `hard_delete_after < Time.current AND tombstoned_at IS NULL`, calls `DataDeletionManager.system_finalize_note!(note:)` on each. One-record-per-transaction so a failure on one note doesn't poison the batch.
+`class HardDeleteExpiredRecordsJob < SystemJob`. Daily schedule. Scoped to `Note` only. Across all tenants, finds notes where `hard_delete_after < Time.current AND tombstoned_at IS NULL`, calls `DataDeletionManager.system_tombstone_note!(note:)` on each. One-record-per-transaction so a failure on one note doesn't poison the batch.
 
 ### Commit 8 — Tests
 
-- `soft_deletable_test.rb`: tombstoned? predicate, undo behavior under non-participating model, `participates_in_hard_delete` semantics.
-- `data_deletion_manager_test.rb`: `system_finalize_note!` — tombstones when other-user comments exist; tombstones when other-user read confirmation exists; tombstones when other-user link exists; hard-deletes when only creator-owned references exist; preserves children/history/links on tombstone; sets tombstoned_at.
-- `hard_delete_expired_records_job_test.rb`: finalizes eligible notes, skips fresh ones, skips already-tombstoned, cross-tenant safe, one-failure-doesn't-block-rest.
+- `soft_deletable_test.rb`: tombstoned? predicate, undo behavior under non-participating model, `participates_in_hard_delete` semantics. (Done in commit 5.)
+- `data_deletion_manager_test.rb`: `system_tombstone_note!` — nulls content fields, sets tombstoned_at, preserves row, destroys Link records, preserves NoteHistoryEvents and child comments. (Done in commit 6.)
+- `hard_delete_expired_records_job_test.rb`: tombstones eligible notes, skips fresh ones, skips already-tombstoned, cross-tenant safe, one-failure-doesn't-block-rest.
 
 ### Commit 9 — Plan doc cleanup
 
@@ -121,7 +123,7 @@ Update `data-lifecycle-management.md` to reflect Phase 2 status (Notes-only hard
 
 - **Decision/Commitment soft-delete is open-ended**: with `participates_in_hard_delete = false`, a soft-deleted Decision sits indefinitely. `default_scope` hides it from feeds, undo works forever. There's no UI today that surfaces "your soft-deleted decisions" — so they're effectively trash that the user can only get back to via the URL. Acceptable as an interim; the follow-up phase needs to address it.
 - **Tombstone UX for orphan comments**: when B's comment's `commentable` returns a tombstoned note, controllers/views need to render `[deleted]` instead of crashing or returning 404. Tombstoned notes still have `deleted_at` set so the accessor masking returns `[deleted]` and `default_scope` hides them from listings — but `with_deleted` lookups will find the row. Verify that existing rendering paths for "view a note with comments" handle a deleted (with_deleted) parent gracefully.
-- **Hard-delete-or-tombstone decision is racy at the boundary**: a non-creator user could add a read confirmation in the ~minute between the job's predicate check and the row deletion. Mitigation: do the predicate check inside the same transaction as the finalize action; lock the note row with `note.lock!` before the check.
+- **Tombstones accumulate**: the row stays forever once tombstoned. For very high-volume tenants this is mostly empty rows, but they're not free. If table size becomes a problem later, a focused follow-up can decide which old tombstones are safe to drop (e.g. no remaining child comments or history events) and add a separate cleanup pass.
 - **Attachment purging timing**: attachments preserved during grace period, purged at tombstone time. If a note has multi-GB attachments, the tombstone update gets slow. Acceptable for now — most notes have small attachments — but watch for it.
 
 ## Out of scope (deferred)

--- a/.claude/plans/phased-deletion.md
+++ b/.claude/plans/phased-deletion.md
@@ -1,125 +1,134 @@
 # Phase 2: Phased Deletion
 
-Add a 30-day grace period between user-initiated soft-delete and permanent hard-delete. Fix two pre-existing bugs in `DataDeletionManager` that the hard-delete pipeline will rely on.
+Add a 30-day grace period between user-initiated soft-delete and permanent hard-delete. Phase 2's auto hard-delete pipeline applies to **Notes only**; `Decision` and `Commitment` soft-delete works (grace period, accessor masking, undo) but never auto-hard-deletes — their deletion semantics are a separate design conversation deferred to a follow-up phase.
 
 ## Context
 
 Today's `SoftDeletable#soft_delete!` is misleadingly named: it sets `deleted_at` **and immediately scrubs content** (writes `[deleted]` over titles/text via `scrub_content!`). There is no grace period, no undo, and no hard-delete pipeline. A "30-day undo" on top of the current scheme would be hollow because the content is gone the moment soft-delete runs.
 
-`DataDeletionManager` has two known bugs (currently captured as `skip`'d tests in `test/services/data_deletion_manager_test.rb`):
+`DataDeletionManager` has two known bugs (originally captured as `skip`'d tests in `test/services/data_deletion_manager_test.rb`):
 - `delete_collective!` doesn't include `Event` in its deletion list → FK violation on `events.collective_id`.
-- `delete_collective!` has no validation that all child records were deleted, so a partial deletion (e.g. options that landed in the wrong collective during a buggy code path) leaves orphans that trip later FK violations.
+- Child records (`Option`, `Vote`, `DecisionParticipant`, `CommitmentParticipant`, `DecisionAuditEntry`) can drift from their parent's `collective_id`, evading collective-scoped cleanup.
 
-Phase 2 builds the grace-period machinery on top of `SoftDeletable` and fixes both bugs so the daily hard-delete job can safely delegate to `DataDeletionManager`.
+Both bugs are prerequisites for the hard-delete pipeline.
 
 ## Resolved decisions
 
-- **Grace-period content semantics**: `soft_delete!` becomes purely metadata — sets `deleted_at` and `hard_delete_after`, removes from search index, unpins. **No DB content scrubbing.** Content is preserved at rest during the grace period, so undo is just clearing timestamps. The DB row is destroyed entirely by `HardDeleteExpiredRecordsJob` at expiry.
-- **Defense-in-depth via accessor masking**: Override the content attribute readers on each soft-deletable model so that when `deleted?` is true they return `[deleted]` (or `nil` for `table_data`), even though the DB still has the real values. This preserves the current behavior of "soft-deleted content reads as `[deleted]` everywhere" without actually destroying the content — so existing tests that assert `[deleted]` keep passing, and any code path that bypasses `default_scope` (e.g. `with_deleted`) still can't accidentally render real content. Provide `raw_*` escape hatches (`raw_title`, `raw_text`, `raw_question`, `raw_description`, `raw_table_data`) for the few legitimate readers: `content_snapshot`, admin recovery, and undo verification.
-- **Daily job ↔ DataDeletionManager**: Add new system-job entry points on `DataDeletionManager` (e.g. `system_delete_note!`, `system_delete_decision!`, `system_delete_commitment!`) that skip the user+token guard but require an explicit `from_system_job: true` kwarg. Existing `delete_*!` methods stay unchanged for the console workflow.
-- **Bug fixes**: Land in the same PR as Phase 2 work, as separate prerequisite commits before the grace-period machinery.
+### Grace-period content semantics
 
-## Scope
+`soft_delete!` becomes purely metadata — sets `deleted_at`, `deleted_by_id`, and (for models that participate in auto hard-delete) `hard_delete_after`. Removes from search index, unpins. **No DB content scrubbing.** Content is preserved at rest during the grace period, so undo is just clearing timestamps.
 
-Three models include `SoftDeletable` today: `Note`, `Decision`, `Commitment`. Phase 2 applies to all three uniformly.
+### Defense-in-depth via accessor masking
+
+Override the content attribute readers on each soft-deletable model so that when `deleted?` is true they return `[deleted]` (or `nil` for `table_data`), even though the DB still has the real values. `raw_*` escape hatches (`raw_title`, `raw_text`, `raw_question`, `raw_description`, `raw_table_data`) read the real values for legitimate consumers (`content_snapshot`, admin recovery, undo verification).
+
+### Soft-delete behavior (Notes)
+
+From the user's perspective, soft-delete **is** deletion. It:
+- Sets `deleted_at`, `deleted_by_id`, `hard_delete_after = now + 30 days`
+- Hides the note from all default queries (via `default_scope`)
+- Masks `title`, `text`, `table_data` via accessor overrides so content is no longer accessible to any reader path
+- Removes the note from the search index
+- Cancels any scheduled reminder for the note
+- Unpins the note from its collective
+
+Undo is possible within the 30-day window.
+
+### Hard-delete-or-tombstone (decided at expiry, Notes only)
+
+When `hard_delete_after` passes, the `HardDeleteExpiredRecordsJob` calls `DataDeletionManager.system_finalize_note!(note:)`, which inspects the note for **non-creator-owned associated records**:
+
+- Child comments (`subtype = "comment"` notes with `commentable_id` pointing at the parent) created by anyone other than the note's creator
+- `NoteHistoryEvent` rows where `user_id != note.created_by_id` (read confirmations and reminder acknowledgments by other users)
+- `Link` rows where the *other* end of the link belongs to a note owned by someone other than the creator (i.e. another user referenced this note)
+
+**If any such records exist**: tombstone — null `title`/`text`/`table_data` via `update_columns`, purge attachments, set `tombstoned_at`. The note row remains in the DB so external FK references stay valid. B's comment, B's read confirmation, and B's incoming link all continue to resolve to a real (but content-stripped) parent row.
+
+**If no such records exist**: hard-delete — destroy the row entirely. The cascade also clears A's own `NoteHistoryEvent` rows and `Link` rows (existing `cascade_delete_note` logic).
+
+The decision is made *at expiry*, not at soft-delete. A note with no other-user activity at delete time may still tombstone if other-user activity has accrued before the grace period ends. The check happens inside the same transaction as the finalize action.
+
+### Why Notes only
+
+For `Decision` and `Commitment`, the parent record is a *container* for collectively-authored data (options, votes, audit-chain entries, participants). The question/description are A's contribution; everything else belongs to other users. Nulling the question would render every existing vote semantically meaningless (`B voted accept on [deleted]`) and the audit chain pins option titles via hashed `option_title` fields, so option content can't be altered without destroying the chain.
+
+That ambiguity ("does a Decision belong to its creator once others engage?") is a real philosophy question we shouldn't half-answer inside this PR. Scope decision: `Decision` and `Commitment` still get the grace-period soft-delete machinery (visibility hidden, content masked, undo within grace period) but the auto hard-delete job never picks them up. Engagement-gating, withdrawal semantics, and audit-chain preservation become a focused follow-up.
+
+### participates_in_hard_delete
+
+`SoftDeletable` exposes a `participates_in_hard_delete` class-level opt-in. Only `Note` opts in. For non-participating models, `soft_delete!` does not set `hard_delete_after`, and `undo_delete!` does not raise on time-based grounds — undo remains possible indefinitely.
+
+### DataDeletionManager API
+
+- Existing `delete_note!` / `delete_decision!` / `delete_commitment!` instance methods are unchanged — console admin nuke remains available.
+- New `DataDeletionManager.system_finalize_note!(note:)` class method dispatches at expiry: tombstones if other-user references exist, otherwise destroys via the existing cascade. Only system entry point this PR introduces.
+
+### Bug fixes
+
+Land in the same PR as prerequisite commits before the grace-period machinery.
 
 ## Implementation plan
 
-### Commit 1 — Bug fix: add Event to `delete_collective!` cascade
+### ✅ Commit 1 — Bug fix: add Event to `delete_collective!` cascade
 
-- `Event` has `belongs_to :tenant, :collective` and `has_many :notifications, :webhook_deliveries, dependent: :destroy`.
-- Add `Event` to the model list in `delete_collective!`. Use `.destroy_all` (not `.delete_all`) so the `dependent: :destroy` cascades fire for notifications and webhook_deliveries. Order: before `Decision`/`Note`/`Commitment` (since events reference those as polymorphic subjects — though that FK is not DB-enforced, ordering still keeps the cleanup sane).
-- Un-skip `test "BUG: delete_collective! fails when collective has events"` and rewrite it as a real test that creates an Event, calls `delete_collective!`, and asserts no FK violation.
+Clear `Event` (and its dependent `Notification`/`NotificationRecipient`/`WebhookDelivery` rows) before the rest of the cascade. Replaces the `skip`'d BUG test with a real reproduction.
 
-### Commit 2 — Bug fix: validate all child records cleared in `delete_collective!`
+### ✅ Commit 2 — Validate parent/child `collective_id` consistency
 
-- After the deletion loop, query each model class to confirm zero rows remain with `collective_id: collective.id`. If any class has leftovers, raise with a clear message (the transaction will roll back).
-- This converts silent partial-deletion bugs into loud failures and gives the hard-delete job a safety net.
-- Un-skip the second BUG test and rewrite it as a real test that exercises the validation path.
+Add `CollectiveIdMatchesParent` concern. Include in `Option`, `Vote`, `DecisionParticipant`, `CommitmentParticipant`, `DecisionAuditEntry`. `NoteHistoryEvent`/`ChatMessage`/`AutomationRuleRun` already have inline equivalents.
 
-### Commit 3 — Migration: add `hard_delete_after` to soft-deletable tables
+### ✅ Commit 3 — Migration: add `hard_delete_after` to soft-deletable tables
 
-- `add_column :notes, :hard_delete_after, :datetime` (indexed). Same for `decisions`, `commitments`.
-- No default; populated by `soft_delete!`. Existing soft-deleted rows are out of scope (none in production yet for this codebase, or any that exist are old enough to skip the grace period — confirm with a console check before deploying).
+Indexed datetime on `notes`, `decisions`, `commitments`. Backfills existing soft-deleted rows.
 
-### Commit 4 — Rework `SoftDeletable#soft_delete!` semantics + accessor masking
+### ✅ Commit 4 — Rework `SoftDeletable#soft_delete!` + accessor masking
 
-- Remove the `scrub_content!` call from `soft_delete!`. Delete the `scrub_content!` method from each model — accessor masking replaces it.
-- Remove `attachments.destroy_all` from `soft_delete!`. Attachments are preserved during grace period and purged by the hard-delete job.
-- Keep search index removal and unpin (these are visibility concerns, correct on soft-delete).
-- `soft_delete!` now sets `deleted_at`, `deleted_by_id`, and `hard_delete_after = deleted_at + grace_period`.
-- Grace period: constant `SoftDeletable::DEFAULT_GRACE_PERIOD = 30.days` for now. Per-tenant override deferred to a follow-up.
-- Add `undo_delete!(by:)` that clears `deleted_at`, `deleted_by_id`, `hard_delete_after`. Re-adds to search index. Raises if `hard_delete_after` has passed (defensive — the row should already be gone by then; if the job is behind, undo should still refuse rather than resurrect something past its window).
-- **Accessor masking** on each soft-deletable model. Pattern (illustrative, per-model):
+`soft_delete!` becomes metadata-only. Accessor masking on Note/Decision/Commitment, with `raw_*` escape hatches. `undo_delete!` added. `scrub_content!` removed; reminder cancellation moved to `on_soft_delete` hook.
 
-  ```ruby
-  # Note
-  alias_method :raw_title, :title
-  alias_method :raw_text, :text
-  alias_method :raw_table_data, :table_data
+### Commit 5 — `participates_in_hard_delete` opt-in + Note tombstone schema
 
-  def title;      deleted? ? "[deleted]" : raw_title; end
-  def text;       deleted? ? "[deleted]" : raw_text;  end
-  def table_data; deleted? ? nil         : raw_table_data; end
-  ```
+- Add `participates_in_hard_delete` class attribute to `SoftDeletable`.
+- Have `Note` opt in.
+- Update `soft_delete!` to only set `hard_delete_after` when the model opts in.
+- Update `undo_delete!` to only enforce the grace-period cutoff when the model opts in.
+- Update tests: remove `hard_delete_after` assertions from Decision/Commitment soft-delete tests.
+- Add migration: `tombstoned_at :datetime` column on `notes` (indexed).
 
-  Fields to mask per model:
-  - `Note`: `title`, `text`, `table_data` (→ nil)
-  - `Decision`: `question`, `description`
-  - `Commitment`: `title`, `description`
-- `content_snapshot` switches to reading `raw_*` so it captures real content even when called on a deleted record. Callers (`api_helper.rb` snapshot capture for abuse reports / admin-deletion audit logs) become safer — order-of-operations no longer matters.
-- Write-path is untouched: setters still write to the real columns. Tests that assert `[deleted]` after `soft_delete!` keep passing because they read through the masked accessor.
+### Commit 6 — `system_finalize_note!` on DataDeletionManager
 
-### Commit 5 — System-job entry points on `DataDeletionManager`
+Class method that, inside a transaction:
+- Inspects the note for non-creator-owned references (child comments, history events by other users, links from other users' notes).
+- **If any exist**: tombstone — `update_columns(title: nil, text: nil, table_data: nil, tombstoned_at: Time.current)`. Purge `attachments` if present. Leave NoteHistoryEvent rows, Link rows, child comments untouched.
+- **If none exist**: call existing private `cascade_delete_note` (destroys row + A's own NoteHistoryEvent/Link rows).
 
-- Add `DataDeletionManager.system_delete_note!(note:)`, `system_delete_decision!(decision:)`, `system_delete_commitment!(commitment:)` as class methods (no actor required).
-- Internally these call the same cascade logic as the existing `delete_*!` methods but skip the user/token guard. Refactor the cascade bodies into private class methods shared between the instance and class entry points.
-- Guard: each system entry checks it's running inside a `SystemJob` (by checking a thread-local set by `SystemJob#before_perform`, or by accepting an explicit `from_system_job: true` kwarg). Simpler: just require explicit `from_system_job: true` — no thread-local needed.
+The other-user-reference predicates live as small private class methods (`has_other_user_comments?`, `has_other_user_history?`, `has_other_user_link?`) so they're independently testable.
 
-### Commit 6 — `HardDeleteExpiredRecordsJob`
+### Commit 7 — `HardDeleteExpiredRecordsJob`
 
-- `class HardDeleteExpiredRecordsJob < SystemJob`.
-- Daily schedule (sidekiq-cron config).
-- Across all tenants, finds `Note`, `Decision`, `Commitment` with `hard_delete_after < Time.current` (use `with_deleted` since `default_scope` hides them; need `unscoped_for_system_job` semantics).
-- For each, calls the appropriate `DataDeletionManager.system_delete_*!` and logs the result. Wrap each in its own transaction so one failing record doesn't block the rest.
-- Counts and reports per-tenant totals to the existing `SecurityAuditLog` or `Rails.logger` (sketch — confirm during impl).
+`class HardDeleteExpiredRecordsJob < SystemJob`. Daily schedule. Scoped to `Note` only. Across all tenants, finds notes where `hard_delete_after < Time.current AND tombstoned_at IS NULL`, calls `DataDeletionManager.system_finalize_note!(note:)` on each. One-record-per-transaction so a failure on one note doesn't poison the batch.
 
-### Commit 7 — Tests
+### Commit 8 — Tests
 
-- `test/models/concerns/soft_deletable_test.rb`: new test class. Cases:
-  - `soft_delete!` sets `deleted_at` + `hard_delete_after`
-  - `soft_delete!` does NOT scrub the DB (raw columns retain real values)
-  - Accessors return `[deleted]` after soft-delete; `raw_*` returns the original content
-  - `soft_delete!` removes from search index
-  - `undo_delete!` clears all three timestamps and restores search index
-  - After `undo_delete!`, accessors return real content again
-  - `undo_delete!` raises if `hard_delete_after` has passed
-  - `content_snapshot` returns real content even when called after soft_delete (via `raw_*`)
-- `test/jobs/hard_delete_expired_records_job_test.rb`: new test class. Cases:
-  - Hard-deletes records past `hard_delete_after`, leaves fresh ones alone
-  - Crosses tenants safely
-  - One failing record doesn't block siblings
-  - Cascades correctly (links, votes, audit entries, etc. — the existing DDM tests already cover this; spot-check end-to-end)
-- Existing model tests asserting `[deleted]` text after `soft_delete!` should continue to pass without modification — the accessor masking preserves that contract.
+- `soft_deletable_test.rb`: tombstoned? predicate, undo behavior under non-participating model, `participates_in_hard_delete` semantics.
+- `data_deletion_manager_test.rb`: `system_finalize_note!` — tombstones when other-user comments exist; tombstones when other-user read confirmation exists; tombstones when other-user link exists; hard-deletes when only creator-owned references exist; preserves children/history/links on tombstone; sets tombstoned_at.
+- `hard_delete_expired_records_job_test.rb`: finalizes eligible notes, skips fresh ones, skips already-tombstoned, cross-tenant safe, one-failure-doesn't-block-rest.
 
-### Commit 8 — Plan doc cleanup
+### Commit 9 — Plan doc cleanup
 
-- Update `data-lifecycle-management.md` to mark Phase 2 status.
-- Move this plan to `completed/2026/05/phased-deletion.md` at PR-merge time.
+Update `data-lifecycle-management.md` to reflect Phase 2 status (Notes-only hard-delete shipped; Decision/Commitment hard-delete deferred). Move this plan to `completed/2026/05/phased-deletion.md` on PR-merge.
 
 ## Risks / things to watch
 
-- **Edit-form footgun (accessor masking)**: if an admin view loads a soft-deleted record (via `with_deleted`) and renders an editable form, the form field will pre-fill with `[deleted]` and a save would write `[deleted]` to the real column. Mitigation: any admin view that uses `with_deleted` MUST render read-only or explicitly use `raw_*` for form prefill. Add a comment in the concern and a brief note in `docs/ARCHITECTURE.md` if applicable.
-- **Other masking bypass paths**: `read_attribute(:title)`, `record[:title]`, `record.attributes`, raw SQL, and JSON serialization that goes through `attributes_for_database` would return real values. We rely on `default_scope` keeping deleted rows out of normal queries. Document this explicitly so future developers know the masking is "render-layer defense", not absolute.
-- **Search index after undo**: undo needs to re-add the record. Confirm `SearchIndexer` exposes an `add`/`upsert` method symmetric to `delete`.
-- **Attachments during grace period**: blob storage costs persist for 30 days post-delete. Acceptable for now; revisit if it becomes a real cost.
-- **Existing soft-deleted rows in production**: their DB content is already scrubbed to `[deleted]` and they have no `hard_delete_after`. Backfill option: set `hard_delete_after = deleted_at + 30.days` for existing rows. They'll be hard-deleted immediately by the first job run, which is correct. Confirm count before deploying.
-- **`Event` cascade order**: Events have polymorphic `subject_type/id` that's not DB-enforced, but deleting Events first is the safe order. Double-check that Notifications/WebhookDeliveries' `dependent: :destroy` is preserved when using `.destroy_all` instead of `.delete_all`.
+- **Decision/Commitment soft-delete is open-ended**: with `participates_in_hard_delete = false`, a soft-deleted Decision sits indefinitely. `default_scope` hides it from feeds, undo works forever. There's no UI today that surfaces "your soft-deleted decisions" — so they're effectively trash that the user can only get back to via the URL. Acceptable as an interim; the follow-up phase needs to address it.
+- **Tombstone UX for orphan comments**: when B's comment's `commentable` returns a tombstoned note, controllers/views need to render `[deleted]` instead of crashing or returning 404. Tombstoned notes still have `deleted_at` set so the accessor masking returns `[deleted]` and `default_scope` hides them from listings — but `with_deleted` lookups will find the row. Verify that existing rendering paths for "view a note with comments" handle a deleted (with_deleted) parent gracefully.
+- **Hard-delete-or-tombstone decision is racy at the boundary**: a non-creator user could add a read confirmation in the ~minute between the job's predicate check and the row deletion. Mitigation: do the predicate check inside the same transaction as the finalize action; lock the note row with `note.lock!` before the check.
+- **Attachment purging timing**: attachments preserved during grace period, purged at tombstone time. If a note has multi-GB attachments, the tombstone update gets slow. Acceptable for now — most notes have small attachments — but watch for it.
 
-## Out of scope (deferred to later phases)
+## Out of scope (deferred)
 
-- Per-tenant grace period configuration (Phase 4 transparency UI).
-- "Deleted on DATE" placeholder UI (Phase 4).
+- Decision/Commitment hard-delete and tombstone semantics — needs design conversation about ownership-after-engagement, withdrawal, audit chain.
+- Close-on-soft-delete for Decisions/Commitments — depends on the above design.
+- Per-tenant grace period configuration.
+- "Deleted on DATE" placeholder UI (Phase 4 transparency).
 - Account closure flow (Phase 3).
-- Audit chain tombstoning for Decisions (Phase 5) — but the hard-delete job will need to be aware of it once Phase 5 lands.
-- Restoring purged attachments — once hard-deleted, attachments are gone. No restore path.
+- Audit chain tombstoning for Decisions (Phase 5).

--- a/.claude/plans/phased-deletion.md
+++ b/.claude/plans/phased-deletion.md
@@ -1,0 +1,125 @@
+# Phase 2: Phased Deletion
+
+Add a 30-day grace period between user-initiated soft-delete and permanent hard-delete. Fix two pre-existing bugs in `DataDeletionManager` that the hard-delete pipeline will rely on.
+
+## Context
+
+Today's `SoftDeletable#soft_delete!` is misleadingly named: it sets `deleted_at` **and immediately scrubs content** (writes `[deleted]` over titles/text via `scrub_content!`). There is no grace period, no undo, and no hard-delete pipeline. A "30-day undo" on top of the current scheme would be hollow because the content is gone the moment soft-delete runs.
+
+`DataDeletionManager` has two known bugs (currently captured as `skip`'d tests in `test/services/data_deletion_manager_test.rb`):
+- `delete_collective!` doesn't include `Event` in its deletion list → FK violation on `events.collective_id`.
+- `delete_collective!` has no validation that all child records were deleted, so a partial deletion (e.g. options that landed in the wrong collective during a buggy code path) leaves orphans that trip later FK violations.
+
+Phase 2 builds the grace-period machinery on top of `SoftDeletable` and fixes both bugs so the daily hard-delete job can safely delegate to `DataDeletionManager`.
+
+## Resolved decisions
+
+- **Grace-period content semantics**: `soft_delete!` becomes purely metadata — sets `deleted_at` and `hard_delete_after`, removes from search index, unpins. **No DB content scrubbing.** Content is preserved at rest during the grace period, so undo is just clearing timestamps. The DB row is destroyed entirely by `HardDeleteExpiredRecordsJob` at expiry.
+- **Defense-in-depth via accessor masking**: Override the content attribute readers on each soft-deletable model so that when `deleted?` is true they return `[deleted]` (or `nil` for `table_data`), even though the DB still has the real values. This preserves the current behavior of "soft-deleted content reads as `[deleted]` everywhere" without actually destroying the content — so existing tests that assert `[deleted]` keep passing, and any code path that bypasses `default_scope` (e.g. `with_deleted`) still can't accidentally render real content. Provide `raw_*` escape hatches (`raw_title`, `raw_text`, `raw_question`, `raw_description`, `raw_table_data`) for the few legitimate readers: `content_snapshot`, admin recovery, and undo verification.
+- **Daily job ↔ DataDeletionManager**: Add new system-job entry points on `DataDeletionManager` (e.g. `system_delete_note!`, `system_delete_decision!`, `system_delete_commitment!`) that skip the user+token guard but require an explicit `from_system_job: true` kwarg. Existing `delete_*!` methods stay unchanged for the console workflow.
+- **Bug fixes**: Land in the same PR as Phase 2 work, as separate prerequisite commits before the grace-period machinery.
+
+## Scope
+
+Three models include `SoftDeletable` today: `Note`, `Decision`, `Commitment`. Phase 2 applies to all three uniformly.
+
+## Implementation plan
+
+### Commit 1 — Bug fix: add Event to `delete_collective!` cascade
+
+- `Event` has `belongs_to :tenant, :collective` and `has_many :notifications, :webhook_deliveries, dependent: :destroy`.
+- Add `Event` to the model list in `delete_collective!`. Use `.destroy_all` (not `.delete_all`) so the `dependent: :destroy` cascades fire for notifications and webhook_deliveries. Order: before `Decision`/`Note`/`Commitment` (since events reference those as polymorphic subjects — though that FK is not DB-enforced, ordering still keeps the cleanup sane).
+- Un-skip `test "BUG: delete_collective! fails when collective has events"` and rewrite it as a real test that creates an Event, calls `delete_collective!`, and asserts no FK violation.
+
+### Commit 2 — Bug fix: validate all child records cleared in `delete_collective!`
+
+- After the deletion loop, query each model class to confirm zero rows remain with `collective_id: collective.id`. If any class has leftovers, raise with a clear message (the transaction will roll back).
+- This converts silent partial-deletion bugs into loud failures and gives the hard-delete job a safety net.
+- Un-skip the second BUG test and rewrite it as a real test that exercises the validation path.
+
+### Commit 3 — Migration: add `hard_delete_after` to soft-deletable tables
+
+- `add_column :notes, :hard_delete_after, :datetime` (indexed). Same for `decisions`, `commitments`.
+- No default; populated by `soft_delete!`. Existing soft-deleted rows are out of scope (none in production yet for this codebase, or any that exist are old enough to skip the grace period — confirm with a console check before deploying).
+
+### Commit 4 — Rework `SoftDeletable#soft_delete!` semantics + accessor masking
+
+- Remove the `scrub_content!` call from `soft_delete!`. Delete the `scrub_content!` method from each model — accessor masking replaces it.
+- Remove `attachments.destroy_all` from `soft_delete!`. Attachments are preserved during grace period and purged by the hard-delete job.
+- Keep search index removal and unpin (these are visibility concerns, correct on soft-delete).
+- `soft_delete!` now sets `deleted_at`, `deleted_by_id`, and `hard_delete_after = deleted_at + grace_period`.
+- Grace period: constant `SoftDeletable::DEFAULT_GRACE_PERIOD = 30.days` for now. Per-tenant override deferred to a follow-up.
+- Add `undo_delete!(by:)` that clears `deleted_at`, `deleted_by_id`, `hard_delete_after`. Re-adds to search index. Raises if `hard_delete_after` has passed (defensive — the row should already be gone by then; if the job is behind, undo should still refuse rather than resurrect something past its window).
+- **Accessor masking** on each soft-deletable model. Pattern (illustrative, per-model):
+
+  ```ruby
+  # Note
+  alias_method :raw_title, :title
+  alias_method :raw_text, :text
+  alias_method :raw_table_data, :table_data
+
+  def title;      deleted? ? "[deleted]" : raw_title; end
+  def text;       deleted? ? "[deleted]" : raw_text;  end
+  def table_data; deleted? ? nil         : raw_table_data; end
+  ```
+
+  Fields to mask per model:
+  - `Note`: `title`, `text`, `table_data` (→ nil)
+  - `Decision`: `question`, `description`
+  - `Commitment`: `title`, `description`
+- `content_snapshot` switches to reading `raw_*` so it captures real content even when called on a deleted record. Callers (`api_helper.rb` snapshot capture for abuse reports / admin-deletion audit logs) become safer — order-of-operations no longer matters.
+- Write-path is untouched: setters still write to the real columns. Tests that assert `[deleted]` after `soft_delete!` keep passing because they read through the masked accessor.
+
+### Commit 5 — System-job entry points on `DataDeletionManager`
+
+- Add `DataDeletionManager.system_delete_note!(note:)`, `system_delete_decision!(decision:)`, `system_delete_commitment!(commitment:)` as class methods (no actor required).
+- Internally these call the same cascade logic as the existing `delete_*!` methods but skip the user/token guard. Refactor the cascade bodies into private class methods shared between the instance and class entry points.
+- Guard: each system entry checks it's running inside a `SystemJob` (by checking a thread-local set by `SystemJob#before_perform`, or by accepting an explicit `from_system_job: true` kwarg). Simpler: just require explicit `from_system_job: true` — no thread-local needed.
+
+### Commit 6 — `HardDeleteExpiredRecordsJob`
+
+- `class HardDeleteExpiredRecordsJob < SystemJob`.
+- Daily schedule (sidekiq-cron config).
+- Across all tenants, finds `Note`, `Decision`, `Commitment` with `hard_delete_after < Time.current` (use `with_deleted` since `default_scope` hides them; need `unscoped_for_system_job` semantics).
+- For each, calls the appropriate `DataDeletionManager.system_delete_*!` and logs the result. Wrap each in its own transaction so one failing record doesn't block the rest.
+- Counts and reports per-tenant totals to the existing `SecurityAuditLog` or `Rails.logger` (sketch — confirm during impl).
+
+### Commit 7 — Tests
+
+- `test/models/concerns/soft_deletable_test.rb`: new test class. Cases:
+  - `soft_delete!` sets `deleted_at` + `hard_delete_after`
+  - `soft_delete!` does NOT scrub the DB (raw columns retain real values)
+  - Accessors return `[deleted]` after soft-delete; `raw_*` returns the original content
+  - `soft_delete!` removes from search index
+  - `undo_delete!` clears all three timestamps and restores search index
+  - After `undo_delete!`, accessors return real content again
+  - `undo_delete!` raises if `hard_delete_after` has passed
+  - `content_snapshot` returns real content even when called after soft_delete (via `raw_*`)
+- `test/jobs/hard_delete_expired_records_job_test.rb`: new test class. Cases:
+  - Hard-deletes records past `hard_delete_after`, leaves fresh ones alone
+  - Crosses tenants safely
+  - One failing record doesn't block siblings
+  - Cascades correctly (links, votes, audit entries, etc. — the existing DDM tests already cover this; spot-check end-to-end)
+- Existing model tests asserting `[deleted]` text after `soft_delete!` should continue to pass without modification — the accessor masking preserves that contract.
+
+### Commit 8 — Plan doc cleanup
+
+- Update `data-lifecycle-management.md` to mark Phase 2 status.
+- Move this plan to `completed/2026/05/phased-deletion.md` at PR-merge time.
+
+## Risks / things to watch
+
+- **Edit-form footgun (accessor masking)**: if an admin view loads a soft-deleted record (via `with_deleted`) and renders an editable form, the form field will pre-fill with `[deleted]` and a save would write `[deleted]` to the real column. Mitigation: any admin view that uses `with_deleted` MUST render read-only or explicitly use `raw_*` for form prefill. Add a comment in the concern and a brief note in `docs/ARCHITECTURE.md` if applicable.
+- **Other masking bypass paths**: `read_attribute(:title)`, `record[:title]`, `record.attributes`, raw SQL, and JSON serialization that goes through `attributes_for_database` would return real values. We rely on `default_scope` keeping deleted rows out of normal queries. Document this explicitly so future developers know the masking is "render-layer defense", not absolute.
+- **Search index after undo**: undo needs to re-add the record. Confirm `SearchIndexer` exposes an `add`/`upsert` method symmetric to `delete`.
+- **Attachments during grace period**: blob storage costs persist for 30 days post-delete. Acceptable for now; revisit if it becomes a real cost.
+- **Existing soft-deleted rows in production**: their DB content is already scrubbed to `[deleted]` and they have no `hard_delete_after`. Backfill option: set `hard_delete_after = deleted_at + 30.days` for existing rows. They'll be hard-deleted immediately by the first job run, which is correct. Confirm count before deploying.
+- **`Event` cascade order**: Events have polymorphic `subject_type/id` that's not DB-enforced, but deleting Events first is the safe order. Double-check that Notifications/WebhookDeliveries' `dependent: :destroy` is preserved when using `.destroy_all` instead of `.delete_all`.
+
+## Out of scope (deferred to later phases)
+
+- Per-tenant grace period configuration (Phase 4 transparency UI).
+- "Deleted on DATE" placeholder UI (Phase 4).
+- Account closure flow (Phase 3).
+- Audit chain tombstoning for Decisions (Phase 5) — but the hard-delete job will need to be aware of it once Phase 5 lands.
+- Restoring purged attachments — once hard-deleted, attachments are gone. No restore path.

--- a/app/jobs/hard_delete_expired_records_job.rb
+++ b/app/jobs/hard_delete_expired_records_job.rb
@@ -1,0 +1,33 @@
+# typed: true
+# frozen_string_literal: true
+
+# Daily sweeper that tombstones soft-deleted Notes whose grace period has
+# expired. Runs across all tenants without setting tenant context — each
+# tombstone is wrapped in its own transaction inside
+# DataDeletionManager.system_tombstone_note! so a failure on one note
+# doesn't block the rest of the batch.
+#
+# Scoped to Note only. Decision and Commitment soft-delete is open-ended
+# (they don't opt into participates_in_hard_delete) so they never have
+# hard_delete_after set and won't show up in this query.
+class HardDeleteExpiredRecordsJob < SystemJob
+  extend T::Sig
+
+  queue_as :low_priority
+
+  sig { void }
+  def perform
+    eligible = Note.unscoped_for_system_job
+      .where.not(deleted_at: nil)
+      .where(tombstoned_at: nil)
+      .where("hard_delete_after < ?", Time.current)
+
+    eligible.find_each do |note|
+      begin
+        DataDeletionManager.system_tombstone_note!(note: note)
+      rescue StandardError => e
+        Rails.logger.error("HardDeleteExpiredRecordsJob: failed to tombstone Note ##{note.id}: #{e.class}: #{e.message}")
+      end
+    end
+  end
+end

--- a/app/jobs/reminder_delivery_job.rb
+++ b/app/jobs/reminder_delivery_job.rb
@@ -73,6 +73,15 @@ class ReminderDeliveryJob < SystemJob
     # If this reminder is linked to a note, use the note's collective for context.
     # Otherwise fall back to find_collective_for_user (for any legacy standalone reminders).
     note = Note.tenant_scoped_only(tenant.id).find_by(reminder_notification_id: notification.id)
+
+    # Defense-in-depth: the note is the source of truth. If it has been soft-
+    # deleted, the reminder should not fire even if the notification record is
+    # still around (e.g. a partial cancel! that didn't fully clean up).
+    if note && note.deleted?
+      Rails.logger.warn("ReminderDeliveryJob: skipping #{reminders.size} reminder(s) for soft-deleted note #{note.id}")
+      return
+    end
+
     collective = if note
       Collective.find_by(id: note.collective_id)
     else

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -74,7 +74,30 @@ class Commitment < ApplicationRecord
   end
 
   def content_snapshot
-    { title: title, description: description }
+    { title: raw_title, description: raw_description }
+  end
+
+  # Accessor masking for soft-deleted records. See SoftDeletable comments.
+  sig { returns(T.nilable(String)) }
+  def raw_title
+    attributes["title"]
+  end
+
+  sig { returns(T.nilable(String)) }
+  def raw_description
+    attributes["description"]
+  end
+
+  sig { returns(T.nilable(String)) }
+  def title
+    return "[deleted]" if deleted?
+    super
+  end
+
+  sig { returns(T.nilable(String)) }
+  def description
+    return "[deleted]" if deleted?
+    super
   end
 
   sig { returns(String) }
@@ -184,11 +207,6 @@ class Commitment < ApplicationRecord
   end
 
   private
-
-  def scrub_content!
-    self.title = "[deleted]"
-    self.description = "[deleted]"
-  end
 
   # Track the creator of this commitment
   def user_item_status_updates

--- a/app/models/commitment_participant.rb
+++ b/app/models/commitment_participant.rb
@@ -6,6 +6,7 @@ class CommitmentParticipant < ApplicationRecord
   include InvalidatesSearchIndex
   include TracksUserItemStatus
   include HasRepresentationSessionEvents
+  include CollectiveIdMatchesParent
 
   self.implicit_order_column = "created_at"
   belongs_to :tenant
@@ -14,6 +15,7 @@ class CommitmentParticipant < ApplicationRecord
   before_validation :set_collective_id
   belongs_to :commitment
   belongs_to :user
+  collective_id_matches :commitment
 
   sig { void }
   def set_tenant_id

--- a/app/models/concerns/collective_id_matches_parent.rb
+++ b/app/models/concerns/collective_id_matches_parent.rb
@@ -1,0 +1,21 @@
+# typed: false
+
+# Enforces that this model's collective_id equals the named parent's collective_id.
+# Without this, ApplicationRecord#set_collective_id may pull from Collective.current_id
+# and end up out of sync with the parent record's collective, producing orphan rows
+# that evade collective-scoped cleanup.
+module CollectiveIdMatchesParent
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def collective_id_matches(parent_name)
+      validate do
+        parent = public_send(parent_name)
+        next if parent.nil? || collective_id.nil?
+        if collective_id != parent.collective_id
+          errors.add(:collective_id, "must match #{parent_name} collective_id")
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/soft_deletable.rb
+++ b/app/models/concerns/soft_deletable.rb
@@ -29,14 +29,26 @@ module SoftDeletable
     belongs_to :deleted_by, class_name: "User", optional: true
   end
 
+  class_methods do
+    # Opt this model into the automatic hard-delete pipeline. Models that opt in
+    # get hard_delete_after set on soft_delete!, and undo_delete! refuses once the
+    # grace period has passed. Models that don't opt in soft-delete forever and
+    # can be undone at any time.
+    def participates_in_hard_delete
+      @participates_in_hard_delete = true
+    end
+
+    def participates_in_hard_delete?
+      @participates_in_hard_delete == true
+    end
+  end
+
   def soft_delete!(by:)
     transaction do
       now = Time.current
-      update!(
-        deleted_at: now,
-        deleted_by_id: by.id,
-        hard_delete_after: now + DEFAULT_GRACE_PERIOD,
-      )
+      updates = { deleted_at: now, deleted_by_id: by.id }
+      updates[:hard_delete_after] = now + DEFAULT_GRACE_PERIOD if self.class.participates_in_hard_delete?
+      update!(updates)
       SearchIndexer.delete(self) if respond_to?(:delete_from_search_index, true)
       collective.unpin_item!(self) if respond_to?(:collective) && collective.respond_to?(:has_pinned?) && collective.has_pinned?(self)
       on_soft_delete if respond_to?(:on_soft_delete, true)
@@ -45,17 +57,26 @@ module SoftDeletable
 
   def undo_delete!(by:)
     return unless deleted?
-    if hard_delete_after.present? && hard_delete_after <= Time.current
+    if self.class.participates_in_hard_delete? && hard_delete_after.present? && hard_delete_after <= Time.current
       raise GracePeriodExpired, "#{self.class.name}##{id} grace period has expired"
     end
     transaction do
-      update!(deleted_at: nil, deleted_by_id: nil, hard_delete_after: nil)
+      updates = { deleted_at: nil, deleted_by_id: nil }
+      updates[:hard_delete_after] = nil if self.class.column_names.include?("hard_delete_after")
+      update!(updates)
       SearchIndexer.reindex(self) if respond_to?(:delete_from_search_index, true)
     end
   end
 
   def deleted?
     deleted_at.present?
+  end
+
+  # True once the row has been finalized (content nulled, row preserved).
+  # Only meaningful for models with a tombstoned_at column.
+  def tombstoned?
+    return false unless self.class.column_names.include?("tombstoned_at")
+    self[:tombstoned_at].present?
   end
 
   # Override in each model to return a hash of text fields for audit logging

--- a/app/models/concerns/soft_deletable.rb
+++ b/app/models/concerns/soft_deletable.rb
@@ -1,7 +1,25 @@
 # typed: false
 
+# Phase-2 grace-period soft delete.
+#
+# soft_delete! is metadata-only — sets deleted_at, deleted_by_id, and
+# hard_delete_after — and removes the row from the search index and any
+# collective pins. It does NOT touch column values; defense-in-depth comes
+# from accessor masking on each model (Note#title etc. return "[deleted]"
+# when deleted? is true).
+#
+# Attachments are preserved during the grace period and purged by the
+# HardDeleteExpiredRecordsJob when the row is destroyed.
+#
+# undo_delete! restores visibility by clearing the timestamps and re-adds
+# the row to the search index. It refuses to act after hard_delete_after
+# has passed (the row should already be gone by then).
 module SoftDeletable
   extend ActiveSupport::Concern
+
+  DEFAULT_GRACE_PERIOD = 30.days
+
+  class GracePeriodExpired < StandardError; end
 
   included do
     scope :not_deleted, -> { where(deleted_at: nil) }
@@ -13,17 +31,26 @@ module SoftDeletable
 
   def soft_delete!(by:)
     transaction do
-      scrub_content!
+      now = Time.current
       update!(
-        deleted_at: Time.current,
-        deleted_by_id: by.id
+        deleted_at: now,
+        deleted_by_id: by.id,
+        hard_delete_after: now + DEFAULT_GRACE_PERIOD,
       )
-      # Remove from search index
       SearchIndexer.delete(self) if respond_to?(:delete_from_search_index, true)
-      # Purge attachments
-      attachments.destroy_all if respond_to?(:attachments)
-      # Unpin from collective (pins are stored in settings JSON, not a separate model)
       collective.unpin_item!(self) if respond_to?(:collective) && collective.respond_to?(:has_pinned?) && collective.has_pinned?(self)
+      on_soft_delete if respond_to?(:on_soft_delete, true)
+    end
+  end
+
+  def undo_delete!(by:)
+    return unless deleted?
+    if hard_delete_after.present? && hard_delete_after <= Time.current
+      raise GracePeriodExpired, "#{self.class.name}##{id} grace period has expired"
+    end
+    transaction do
+      update!(deleted_at: nil, deleted_by_id: nil, hard_delete_after: nil)
+      SearchIndexer.reindex(self) if respond_to?(:delete_from_search_index, true)
     end
   end
 
@@ -32,14 +59,9 @@ module SoftDeletable
   end
 
   # Override in each model to return a hash of text fields for audit logging
+  # and abuse-report snapshots. Should read via raw_* so it returns real
+  # content even when called on a soft-deleted record.
   def content_snapshot
     raise NotImplementedError, "#{self.class.name} must implement #content_snapshot"
-  end
-
-  private
-
-  # Override in each model to set text fields to "[deleted]"
-  def scrub_content!
-    raise NotImplementedError, "#{self.class.name} must implement #scrub_content!"
   end
 end

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -245,15 +245,33 @@ class Decision < ApplicationRecord
   end
 
   def content_snapshot
-    { question: question, description: description }
+    { question: raw_question, description: raw_description }
+  end
+
+  # Accessor masking for soft-deleted records. See SoftDeletable comments.
+  sig { returns(T.nilable(String)) }
+  def raw_question
+    attributes["question"]
+  end
+
+  sig { returns(T.nilable(String)) }
+  def raw_description
+    attributes["description"]
+  end
+
+  sig { returns(T.nilable(String)) }
+  def question
+    return "[deleted]" if deleted?
+    super
+  end
+
+  sig { returns(T.nilable(String)) }
+  def description
+    return "[deleted]" if deleted?
+    super
   end
 
   private
-
-  def scrub_content!
-    self.question = "[deleted]"
-    self.description = "[deleted]"
-  end
 
   # Track the creator of this decision
   def user_item_status_updates

--- a/app/models/decision_audit_entry.rb
+++ b/app/models/decision_audit_entry.rb
@@ -3,6 +3,8 @@
 class DecisionAuditEntry < ApplicationRecord
   extend T::Sig
 
+  include CollectiveIdMatchesParent
+
   ACTIONS = %w[decision_created decision_updated option_added option_removed option_updated vote_cast vote_updated decision_closed beacon_drawn].freeze
   CURRENT_SCHEMA_VERSION = 2
 
@@ -11,6 +13,7 @@ class DecisionAuditEntry < ApplicationRecord
   belongs_to :tenant
   belongs_to :collective
   belongs_to :decision
+  collective_id_matches :decision
 
   validates :action, inclusion: { in: ACTIONS }
   validates :schema_version, inclusion: { in: [1, 2] }

--- a/app/models/decision_participant.rb
+++ b/app/models/decision_participant.rb
@@ -3,6 +3,8 @@
 class DecisionParticipant < ApplicationRecord
   extend T::Sig
 
+  include CollectiveIdMatchesParent
+
   self.implicit_order_column = "created_at"
   belongs_to :tenant
   before_validation :set_tenant_id
@@ -10,6 +12,7 @@ class DecisionParticipant < ApplicationRecord
   before_validation :set_collective_id
   belongs_to :decision
   belongs_to :user
+  collective_id_matches :decision
 
   has_many :votes, dependent: :destroy
   has_many :options, dependent: :destroy

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -113,6 +113,7 @@ class Note < ApplicationRecord
 
   sig { returns(String) }
   def title
+    return "[deleted]" if deleted?
     persisted = super
     persisted.presence || T.must(T.must(text).split("\n").first).truncate(256)
   end
@@ -120,6 +121,37 @@ class Note < ApplicationRecord
   sig { returns(T.nilable(String)) }
   def persisted_title
     attributes["title"]
+  end
+
+  # Accessor masking: when soft-deleted, the public readers return placeholders
+  # even though the DB row preserves the real content for the grace period.
+  # raw_* methods are the escape hatch for legitimate readers (audit snapshots,
+  # undo verification, admin recovery).
+  sig { returns(T.nilable(String)) }
+  def raw_title
+    attributes["title"]
+  end
+
+  sig { returns(T.nilable(String)) }
+  def raw_text
+    attributes["text"]
+  end
+
+  sig { returns(T.untyped) }
+  def raw_table_data
+    attributes["table_data"]
+  end
+
+  sig { returns(T.nilable(String)) }
+  def text
+    return "[deleted]" if deleted?
+    super
+  end
+
+  sig { returns(T.untyped) }
+  def table_data
+    return nil if deleted?
+    super
   end
 
   sig { returns(Integer) }
@@ -316,7 +348,7 @@ class Note < ApplicationRecord
   SEARCHABLE_COMMENTABLE_TYPES = ["Note", "Decision", "Commitment"].freeze
 
   def content_snapshot
-    { title: persisted_title, text: text }
+    { title: raw_title, text: raw_text }
   end
 
   private
@@ -345,10 +377,7 @@ class Note < ApplicationRecord
     end
   end
 
-  def scrub_content!
-    self.title = "[deleted]"
-    self.text = "[deleted]"
-    self.table_data = nil if is_table?
+  def on_soft_delete
     reminder_service.cancel! if is_reminder? && reminder_notification_id.present?
   end
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -13,6 +13,7 @@ class Note < ApplicationRecord
   include TracksUserItemStatus
   include HasRepresentationSessionEvents
   include SoftDeletable
+  participates_in_hard_delete
   SUBTYPES = %w[text reminder table comment statement].freeze
 
   self.implicit_order_column = "created_at"

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -6,6 +6,7 @@ class Option < ApplicationRecord
   include Tracked
   include InvalidatesSearchIndex
   include HasRepresentationSessionEvents
+  include CollectiveIdMatchesParent
 
   self.implicit_order_column = "created_at"
   belongs_to :tenant
@@ -14,6 +15,7 @@ class Option < ApplicationRecord
   before_validation :set_collective_id
   belongs_to :decision_participant
   belongs_to :decision
+  collective_id_matches :decision
 
   has_many :votes, dependent: :destroy
 

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -7,6 +7,7 @@ class Vote < ApplicationRecord
   include InvalidatesSearchIndex
   include TracksUserItemStatus
   include HasRepresentationSessionEvents
+  include CollectiveIdMatchesParent
 
   # Transient attribute — set by DecisionActionService.cast_vote! after recording the audit entry
   attr_accessor :audit_receipt
@@ -19,6 +20,7 @@ class Vote < ApplicationRecord
   belongs_to :option
   belongs_to :decision
   belongs_to :decision_participant
+  collective_id_matches :decision
 
   validates :accepted, inclusion: { in: [0, 1] }
   validates :preferred, inclusion: { in: [0, 1] }

--- a/app/services/data_deletion_manager.rb
+++ b/app/services/data_deletion_manager.rb
@@ -116,26 +116,49 @@ class DataDeletionManager
   sig { params(note: Note, confirmation_token: String).returns(String) }
   def delete_note!(note:, confirmation_token:)
     validate_confirmation_token!(confirmation_token)
-    note_title = note.title
+    note_title = note.raw_title || note.title
     note_id = note.id
+    self.class.send(:cascade_delete_note, note)
+    "Note '#{note_title}' (ID: #{note_id}) has been deleted successfully."
+  end
+
+  # System-job entry point invoked by HardDeleteExpiredRecordsJob once a soft-
+  # deleted note's grace period has expired. Tombstones the note: nulls
+  # the authored content (title/text/table_data), purges attachments, destroys
+  # Link records, and sets tombstoned_at. The row stays in the DB so any
+  # external references (B's comments, NoteHistoryEvents) continue to resolve
+  # to a real row that renders as [deleted]. Full hard-delete remains available
+  # via the console admin delete_note! method.
+  #
+  # Wrapped in a transaction with a row lock so concurrent updates are
+  # serialized. Bypasses the user+token guard; the naming and class-method
+  # placement signal it's intended for SystemJob callers only.
+  sig { params(note: Note).void }
+  def self.system_tombstone_note!(note:)
     ActiveRecord::Base.transaction do
-      # Delete all associated data (always in same collective as parent)
-      NoteHistoryEvent.where(note_id: note.id).each do |event|
-        event.destroy!
-      end
-      # Links can be cross-collective, so query tenant-wide
+      note.lock!
+      note.attachments.destroy_all if note.respond_to?(:attachments) && note.attachments.exists?
       Link.tenant_scoped_only(note.tenant_id).where(from_linkable: note).or(
         Link.tenant_scoped_only(note.tenant_id).where(to_linkable: note)
-      ).each do |link|
-        link.destroy!
-      end
-      # Delete the note itself
+      ).each(&:destroy!)
+      note.update_columns(
+        title: nil,
+        text: nil,
+        table_data: nil,
+        tombstoned_at: Time.current,
+      )
+    end
+  end
+
+  sig { params(note: Note).void }
+  private_class_method def self.cascade_delete_note(note)
+    ActiveRecord::Base.transaction do
+      NoteHistoryEvent.where(note_id: note.id).each(&:destroy!)
+      Link.tenant_scoped_only(note.tenant_id).where(from_linkable: note).or(
+        Link.tenant_scoped_only(note.tenant_id).where(to_linkable: note)
+      ).each(&:destroy!)
       note.destroy!
     end
-    # Log the deletion
-    # Rails.logger.info "Note '#{note_title}' (ID: #{note_id}) has been deleted by user '#{@user.name}' (ID: #{@user.id})."
-    # Notify the user about the deletion
-    "Note '#{note_title}' (ID: #{note_id}) has been deleted successfully."
   end
 
   sig { params(decision: Decision, confirmation_token: String).returns(String) }

--- a/app/services/data_deletion_manager.rb
+++ b/app/services/data_deletion_manager.rb
@@ -33,8 +33,18 @@ class DataDeletionManager
     collective_name = collective.name
     collective_id_value = collective.id
     ActiveRecord::Base.transaction do
+      # Events have notifications and webhook_deliveries with DB-enforced FKs;
+      # clear those (and notification_recipients) before deleting events themselves.
+      event_ids = Event.tenant_scoped_only(collective.tenant_id).where(collective_id: collective.id).pluck(:id)
+      if event_ids.any?
+        notification_ids = Notification.where(event_id: event_ids).pluck(:id)
+        NotificationRecipient.where(notification_id: notification_ids).delete_all if notification_ids.any?
+        Notification.where(event_id: event_ids).delete_all
+        WebhookDelivery.where(event_id: event_ids).delete_all
+      end
       # Delete all associated data (all within same tenant, cross-collective)
       [
+        Event,
         RepresentationSessionEvent, RepresentationSession,
         Link, NoteHistoryEvent, Note,
         DecisionAuditEntry, Vote, Option, DecisionParticipant, Decision,

--- a/config/initializers/sidekiq_cron.rb
+++ b/config/initializers/sidekiq_cron.rb
@@ -38,6 +38,11 @@ Sidekiq.configure_server do |_config|
       "class" => "SweepStuckDataImportsJob",
       "description" => "Mark stuck data imports as failed",
     },
+    "hard_delete_expired_records" => {
+      "cron" => "30 3 * * *", # Daily at 3:30 AM
+      "class" => "HardDeleteExpiredRecordsJob",
+      "description" => "Tombstone soft-deleted Notes whose grace period has expired",
+    },
   }
 
   Sidekiq::Cron::Job.load_from_hash(schedule)

--- a/db/migrate/20260511000002_add_hard_delete_after_to_soft_deletables.rb
+++ b/db/migrate/20260511000002_add_hard_delete_after_to_soft_deletables.rb
@@ -1,0 +1,32 @@
+# typed: false
+
+class AddHardDeleteAfterToSoftDeletables < ActiveRecord::Migration[7.2]
+  TABLES = [:notes, :decisions, :commitments].freeze
+
+  def up
+    TABLES.each do |t|
+      add_column t, :hard_delete_after, :datetime
+      add_index t, :hard_delete_after
+    end
+
+    # Existing soft-deleted rows: schedule them for hard-delete at the same
+    # cutoff new soft-deletes will use (30 days post-deletion). Most existing
+    # rows will already be past that cutoff and will be hard-deleted on the
+    # first job run, which is the intended behavior — their content was
+    # scrubbed under the old soft_delete! semantics so nothing is preserved.
+    TABLES.each do |t|
+      execute(<<~SQL.squish)
+        UPDATE #{t}
+        SET hard_delete_after = deleted_at + INTERVAL '30 days'
+        WHERE deleted_at IS NOT NULL
+      SQL
+    end
+  end
+
+  def down
+    TABLES.each do |t|
+      remove_index t, :hard_delete_after
+      remove_column t, :hard_delete_after
+    end
+  end
+end

--- a/db/migrate/20260512000000_add_tombstoned_at_to_notes.rb
+++ b/db/migrate/20260512000000_add_tombstoned_at_to_notes.rb
@@ -1,0 +1,8 @@
+# typed: false
+
+class AddTombstonedAtToNotes < ActiveRecord::Migration[7.2]
+  def change
+    add_column :notes, :tombstoned_at, :datetime
+    add_index :notes, :tombstoned_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -447,7 +447,8 @@ CREATE TABLE public.commitments (
     deleted_at timestamp(6) without time zone,
     deleted_by_id uuid,
     subtype character varying DEFAULT 'action'::character varying NOT NULL,
-    deadline_event_fired_at timestamp(6) without time zone
+    deadline_event_fired_at timestamp(6) without time zone,
+    hard_delete_after timestamp(6) without time zone
 );
 
 
@@ -728,7 +729,8 @@ CREATE TABLE public.decisions (
     lottery_beacon_round bigint,
     lottery_beacon_randomness character varying,
     deadline_event_fired_at timestamp(6) without time zone,
-    audit_chain_hash character varying
+    audit_chain_hash character varying,
+    hard_delete_after timestamp(6) without time zone
 );
 
 
@@ -844,7 +846,8 @@ CREATE TABLE public.notes (
     reminder_notification_id uuid,
     reminder_scheduled_for timestamp(6) without time zone,
     statementable_type character varying,
-    statementable_id uuid
+    statementable_id uuid,
+    hard_delete_after timestamp(6) without time zone
 );
 
 
@@ -3739,6 +3742,13 @@ CREATE INDEX index_commitments_on_deleted_at ON public.commitments USING btree (
 
 
 --
+-- Name: index_commitments_on_hard_delete_after; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_commitments_on_hard_delete_after ON public.commitments USING btree (hard_delete_after);
+
+
+--
 -- Name: index_commitments_on_tenant_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3932,6 +3942,13 @@ CREATE INDEX index_decisions_on_created_by_id ON public.decisions USING btree (c
 --
 
 CREATE INDEX index_decisions_on_deleted_at ON public.decisions USING btree (deleted_at);
+
+
+--
+-- Name: index_decisions_on_hard_delete_after; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_decisions_on_hard_delete_after ON public.decisions USING btree (hard_delete_after);
 
 
 --
@@ -4149,6 +4166,13 @@ CREATE INDEX index_notes_on_created_by_id ON public.notes USING btree (created_b
 --
 
 CREATE INDEX index_notes_on_deleted_at ON public.notes USING btree (deleted_at);
+
+
+--
+-- Name: index_notes_on_hard_delete_after; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_notes_on_hard_delete_after ON public.notes USING btree (hard_delete_after);
 
 
 --
@@ -9402,6 +9426,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260511000002'),
 ('20260511000001'),
 ('20260511000000'),
 ('20260510000003'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -847,7 +847,8 @@ CREATE TABLE public.notes (
     reminder_scheduled_for timestamp(6) without time zone,
     statementable_type character varying,
     statementable_id uuid,
-    hard_delete_after timestamp(6) without time zone
+    hard_delete_after timestamp(6) without time zone,
+    tombstoned_at timestamp(6) without time zone
 );
 
 
@@ -4194,6 +4195,13 @@ CREATE UNIQUE INDEX index_notes_on_statementable_type_and_statementable_id ON pu
 --
 
 CREATE INDEX index_notes_on_tenant_id ON public.notes USING btree (tenant_id);
+
+
+--
+-- Name: index_notes_on_tombstoned_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_notes_on_tombstoned_at ON public.notes USING btree (tombstoned_at);
 
 
 --
@@ -9426,6 +9434,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260512000000'),
 ('20260511000002'),
 ('20260511000001'),
 ('20260511000000'),

--- a/test/jobs/hard_delete_expired_records_job_test.rb
+++ b/test/jobs/hard_delete_expired_records_job_test.rb
@@ -1,0 +1,120 @@
+# typed: false
+
+require "test_helper"
+
+class HardDeleteExpiredRecordsJobTest < ActiveJob::TestCase
+  def setup
+    @tenant, @collective, @user = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    Tenant.current_id = @tenant.id
+  end
+
+  def teardown
+    Collective.clear_thread_scope
+    Tenant.current_id = nil
+  end
+
+  # Helper: build a soft-deleted note whose hard_delete_after is in the past.
+  def expired_soft_deleted_note(tenant: @tenant, collective: @collective, user: @user, title: "Expired")
+    note = create_note(tenant: tenant, collective: collective, created_by: user, title: title, text: "body")
+    note.soft_delete!(by: user)
+    note.update_columns(hard_delete_after: 1.hour.ago)
+    note
+  end
+
+  test "tombstones notes whose hard_delete_after has passed" do
+    note = expired_soft_deleted_note
+
+    Tenant.current_id = nil
+    HardDeleteExpiredRecordsJob.perform_now
+
+    note.reload
+    assert_not_nil note.tombstoned_at, "expired note should be tombstoned"
+    raw = Note.connection.select_one(
+      "SELECT title, text FROM notes WHERE id = #{Note.connection.quote(note.id)}"
+    )
+    assert_nil raw["title"]
+    assert_nil raw["text"]
+  end
+
+  test "leaves notes with hard_delete_after in the future alone" do
+    note = create_note(tenant: @tenant, collective: @collective, created_by: @user)
+    note.soft_delete!(by: @user)
+    # hard_delete_after default is 30 days out — still in the future.
+
+    Tenant.current_id = nil
+    HardDeleteExpiredRecordsJob.perform_now
+
+    note.reload
+    assert_nil note.tombstoned_at, "future-expiring note must not be tombstoned"
+    assert_equal "[deleted]", note.title, "accessor masking still applies"
+  end
+
+  test "skips notes that are already tombstoned" do
+    note = expired_soft_deleted_note
+    tombstoned_at = 2.days.ago
+    note.update_columns(tombstoned_at: tombstoned_at, title: nil, text: nil)
+
+    Tenant.current_id = nil
+    HardDeleteExpiredRecordsJob.perform_now
+
+    note.reload
+    # Pre-existing tombstoned_at must not be overwritten by a fresh timestamp.
+    assert_in_delta tombstoned_at, note.tombstoned_at, 1.second
+  end
+
+  test "leaves live (non-deleted) notes alone even if hard_delete_after is somehow set" do
+    note = create_note(tenant: @tenant, collective: @collective, created_by: @user)
+    # Pathological state — deleted_at nil, hard_delete_after set. Job should
+    # only process rows where deleted_at IS NOT NULL.
+    note.update_columns(hard_delete_after: 1.hour.ago)
+
+    Tenant.current_id = nil
+    HardDeleteExpiredRecordsJob.perform_now
+
+    note.reload
+    assert_nil note.tombstoned_at
+    assert_not_nil note.title, "live note's content must not be nulled"
+  end
+
+  test "tombstones eligible notes across multiple tenants" do
+    other_tenant = create_tenant(subdomain: "tenant2-#{SecureRandom.hex(4)}")
+    other_user = create_user(email: "other-#{SecureRandom.hex(4)}@example.com", name: "Other #{SecureRandom.hex(4)}")
+    other_tenant.add_user!(other_user)
+    other_collective = create_collective(tenant: other_tenant, created_by: other_user, name: "Other", handle: "other-#{SecureRandom.hex(4)}")
+    other_collective.add_user!(other_user)
+    Tenant.current_id = other_tenant.id
+    Collective.scope_thread_to_collective(subdomain: other_tenant.subdomain, handle: other_collective.handle)
+    other_note = expired_soft_deleted_note(tenant: other_tenant, collective: other_collective, user: other_user, title: "OtherT")
+    # Restore primary tenant scope.
+    Tenant.current_id = @tenant.id
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    first_note = expired_soft_deleted_note
+
+    Tenant.current_id = nil
+    Collective.clear_thread_scope
+    HardDeleteExpiredRecordsJob.perform_now
+
+    assert_not_nil first_note.reload.tombstoned_at
+    assert_not_nil other_note.reload.tombstoned_at
+  end
+
+  test "one failing record does not block the rest of the batch" do
+    note_a = expired_soft_deleted_note(title: "A")
+    note_b = expired_soft_deleted_note(title: "B")
+    fail_for_id = note_a.id
+
+    stub = ->(note:) {
+      raise StandardError, "boom" if note.id == fail_for_id
+      note.update_columns(title: nil, text: nil, table_data: nil, tombstoned_at: Time.current)
+    }
+
+    DataDeletionManager.stub(:system_tombstone_note!, stub) do
+      Tenant.current_id = nil
+      HardDeleteExpiredRecordsJob.perform_now
+    end
+
+    assert_nil note_a.reload.tombstoned_at, "the failing note must not be tombstoned"
+    assert_not_nil note_b.reload.tombstoned_at, "the sibling note must still be tombstoned"
+  end
+end

--- a/test/jobs/reminder_delivery_job_test.rb
+++ b/test/jobs/reminder_delivery_job_test.rb
@@ -267,6 +267,35 @@ class ReminderDeliveryJobTest < ActiveJob::TestCase
     assert_equal @collective.identity_user.id, event.user_id
   end
 
+  test "skips delivery when the linked note has been soft-deleted" do
+    # Defense-in-depth: if Note#soft_delete! ran on_soft_delete to cancel the
+    # reminder, the notification + recipient would already be destroyed and
+    # the job's main query wouldn't find them. This test simulates a partial-
+    # cleanup state (note marked deleted but notification still around) and
+    # asserts the job refuses to deliver.
+    notification = ReminderService.create!(
+      user: @user, title: "Orphan reminder", scheduled_for: 1.day.from_now,
+    )
+    nr = notification.notification_recipients.first
+    nr.update!(scheduled_for: 1.minute.ago)
+
+    note = Note.create!(
+      tenant: @tenant, collective: @collective, created_by: @user, updated_by: @user,
+      text: "Remember", subtype: "reminder",
+      reminder_notification_id: notification.id,
+      reminder_scheduled_for: 1.day.from_now.in_time_zone("UTC"),
+    )
+    # Bypass soft_delete! to leave notification + recipient intact.
+    note.update_columns(deleted_at: Time.current)
+
+    Collective.clear_thread_scope
+    ReminderDeliveryJob.perform_now
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    nr.reload
+    assert_equal "pending", nr.status, "reminder for soft-deleted note must not be delivered"
+  end
+
   test "does not create NoteHistoryEvent for standalone reminders" do
     notification = ReminderService.create!(
       user: @user,

--- a/test/models/collective_id_consistency_test.rb
+++ b/test/models/collective_id_consistency_test.rb
@@ -1,0 +1,86 @@
+# typed: false
+
+require "test_helper"
+
+# Enforces that child records (Option, Vote, DecisionParticipant, CommitmentParticipant)
+# have a collective_id matching their parent's collective_id.
+#
+# Without these validations, ApplicationRecord#set_collective_id (which pulls from
+# Collective.current_id) can populate a child with a different collective than its
+# parent if the thread-local scope is misaligned. The orphan then evades collective-
+# scoped cleanup in DataDeletionManager#delete_collective!. These validations make
+# such a state unreachable.
+class CollectiveIdConsistencyTest < ActiveSupport::TestCase
+  setup do
+    @tenant_a, @collective_a, @user = create_tenant_collective_user
+    @collective_b = create_collective(tenant: @tenant_a, created_by: @user, name: "B", handle: "b-#{SecureRandom.hex(4)}")
+    @collective_b.add_user!(@user)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant_a.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant_a.subdomain, handle: @collective_a.handle)
+    @decision = create_decision(tenant: @tenant_a, collective: @collective_a, created_by: @user)
+    @participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    @commitment = create_commitment(tenant: @tenant_a, collective: @collective_a, created_by: @user)
+  end
+
+  teardown do
+    Tenant.clear_thread_scope
+    Collective.clear_thread_scope
+  end
+
+  test "Option rejects collective_id that does not match its decision" do
+    option = Option.new(
+      tenant: @tenant_a, collective: @collective_b,
+      decision: @decision, decision_participant: @participant, title: "X",
+    )
+    assert_not option.valid?
+    assert_includes option.errors[:collective_id].first.to_s, "decision"
+  end
+
+  test "Vote rejects collective_id that does not match its decision" do
+    option = create_option(tenant: @tenant_a, collective: @collective_a, decision: @decision, created_by: @user)
+    vote = Vote.new(
+      tenant: @tenant_a, collective: @collective_b,
+      decision: @decision, option: option, decision_participant: @participant,
+      accepted: 1, preferred: 0,
+    )
+    assert_not vote.valid?
+    assert_includes vote.errors[:collective_id].first.to_s, "decision"
+  end
+
+  test "DecisionParticipant rejects collective_id that does not match its decision" do
+    participant = DecisionParticipant.new(
+      tenant: @tenant_a, collective: @collective_b,
+      decision: @decision, user: @user,
+    )
+    assert_not participant.valid?
+    assert_includes participant.errors[:collective_id].first.to_s, "decision"
+  end
+
+  test "CommitmentParticipant rejects collective_id that does not match its commitment" do
+    participant = CommitmentParticipant.new(
+      tenant: @tenant_a, collective: @collective_b,
+      commitment: @commitment, user: @user,
+    )
+    assert_not participant.valid?
+    assert_includes participant.errors[:collective_id].first.to_s, "commitment"
+  end
+
+  test "matching collective_id passes validation" do
+    option = Option.new(
+      tenant: @tenant_a, collective: @collective_a,
+      decision: @decision, decision_participant: @participant, title: "ok",
+    )
+    assert option.valid?, option.errors.full_messages.to_sentence
+  end
+
+  test "DecisionAuditEntry rejects collective_id that does not match its decision" do
+    entry = DecisionAuditEntry.new(
+      tenant: @tenant_a, collective: @collective_b,
+      decision: @decision, action: "decision_created",
+      actor_id: @user.id, actor_handle: "u",
+      sequence_number: 0, previous_hash: "0" * 64, entry_hash: "1" * 64,
+    )
+    assert_not entry.valid?
+    assert_includes entry.errors[:collective_id].first.to_s, "decision"
+  end
+end

--- a/test/models/concerns/soft_deletable_test.rb
+++ b/test/models/concerns/soft_deletable_test.rb
@@ -259,7 +259,19 @@ class SoftDeletableTest < ActiveSupport::TestCase
     assert_equal 5000, snapshot[:text].length
   end
 
-  # --- Grace period: hard_delete_after ---
+  # --- Grace period: hard_delete_after only set when model opts in ---
+
+  test "Note opts into the hard-delete pipeline" do
+    assert Note.participates_in_hard_delete?
+  end
+
+  test "Decision does NOT opt into the hard-delete pipeline" do
+    assert_not Decision.participates_in_hard_delete?
+  end
+
+  test "Commitment does NOT opt into the hard-delete pipeline" do
+    assert_not Commitment.participates_in_hard_delete?
+  end
 
   test "Note#soft_delete! sets hard_delete_after to deleted_at + grace period" do
     note = create_note(tenant: @tenant, collective: @collective, created_by: @user)
@@ -269,16 +281,45 @@ class SoftDeletableTest < ActiveSupport::TestCase
     assert_in_delta expected, note.hard_delete_after, 1.second
   end
 
-  test "Decision#soft_delete! sets hard_delete_after" do
+  test "Decision#soft_delete! does NOT set hard_delete_after (no auto hard-delete)" do
     d = create_decision(tenant: @tenant, collective: @collective, created_by: @user)
     d.soft_delete!(by: @user)
-    assert_not_nil d.hard_delete_after
+    assert_nil d.hard_delete_after
   end
 
-  test "Commitment#soft_delete! sets hard_delete_after" do
+  test "Commitment#soft_delete! does NOT set hard_delete_after" do
     c = create_commitment(tenant: @tenant, collective: @collective, created_by: @user)
     c.soft_delete!(by: @user)
-    assert_not_nil c.hard_delete_after
+    assert_nil c.hard_delete_after
+  end
+
+  test "Decision#undo_delete! works indefinitely (no grace-period cutoff)" do
+    d = create_decision(tenant: @tenant, collective: @collective, created_by: @user)
+    d.soft_delete!(by: @user)
+    # Even far in the future, undo works because Decision doesn't participate in hard-delete.
+    travel_to 1.year.from_now do
+      assert_nothing_raised { d.undo_delete!(by: @user) }
+    end
+    d.reload
+    assert_not d.deleted?
+  end
+
+  # --- tombstoned? predicate ---
+
+  test "Note#tombstoned? is false by default and true when tombstoned_at is set" do
+    note = create_note(tenant: @tenant, collective: @collective, created_by: @user)
+    assert_not note.tombstoned?
+
+    note.update_columns(tombstoned_at: Time.current)
+    assert note.tombstoned?
+  end
+
+  test "Decision#tombstoned? always returns false (no tombstoned_at column)" do
+    d = create_decision(tenant: @tenant, collective: @collective, created_by: @user)
+    assert_not d.tombstoned?
+
+    d.soft_delete!(by: @user)
+    assert_not d.tombstoned?
   end
 
   # --- Content preservation in DB (defense-in-depth assertion) ---

--- a/test/models/concerns/soft_deletable_test.rb
+++ b/test/models/concerns/soft_deletable_test.rb
@@ -322,6 +322,30 @@ class SoftDeletableTest < ActiveSupport::TestCase
     assert_not d.tombstoned?
   end
 
+  # --- Reminder cancellation on soft_delete (Note) ---
+
+  test "Note#soft_delete! cancels a scheduled reminder and destroys the notification" do
+    notification = ReminderService.create!(
+      user: @user, title: "Due", scheduled_for: 1.day.from_now,
+    )
+    notification_id = notification.id
+    recipient_id = notification.notification_recipients.first.id
+
+    note = Note.create!(
+      tenant: @tenant, collective: @collective, created_by: @user, updated_by: @user,
+      text: "Remember", subtype: "reminder",
+      reminder_notification_id: notification.id,
+      reminder_scheduled_for: 1.day.from_now.in_time_zone("UTC"),
+    )
+
+    note.soft_delete!(by: @user)
+    note.reload
+
+    assert_nil note.reminder_notification_id, "note's reminder_notification_id must be cleared"
+    assert_nil Notification.find_by(id: notification_id), "notification must be destroyed"
+    assert_nil NotificationRecipient.find_by(id: recipient_id), "notification_recipient must be destroyed"
+  end
+
   # --- Content preservation in DB (defense-in-depth assertion) ---
 
   test "Note#soft_delete! does NOT scrub the underlying DB columns" do

--- a/test/models/concerns/soft_deletable_test.rb
+++ b/test/models/concerns/soft_deletable_test.rb
@@ -258,4 +258,157 @@ class SoftDeletableTest < ActiveSupport::TestCase
     snapshot = note.content_snapshot
     assert_equal 5000, snapshot[:text].length
   end
+
+  # --- Grace period: hard_delete_after ---
+
+  test "Note#soft_delete! sets hard_delete_after to deleted_at + grace period" do
+    note = create_note(tenant: @tenant, collective: @collective, created_by: @user)
+    note.soft_delete!(by: @user)
+    assert_not_nil note.hard_delete_after
+    expected = note.deleted_at + SoftDeletable::DEFAULT_GRACE_PERIOD
+    assert_in_delta expected, note.hard_delete_after, 1.second
+  end
+
+  test "Decision#soft_delete! sets hard_delete_after" do
+    d = create_decision(tenant: @tenant, collective: @collective, created_by: @user)
+    d.soft_delete!(by: @user)
+    assert_not_nil d.hard_delete_after
+  end
+
+  test "Commitment#soft_delete! sets hard_delete_after" do
+    c = create_commitment(tenant: @tenant, collective: @collective, created_by: @user)
+    c.soft_delete!(by: @user)
+    assert_not_nil c.hard_delete_after
+  end
+
+  # --- Content preservation in DB (defense-in-depth assertion) ---
+
+  test "Note#soft_delete! does NOT scrub the underlying DB columns" do
+    note = create_note(
+      tenant: @tenant, collective: @collective, created_by: @user,
+      title: "Original Title", text: "Original text content"
+    )
+    note.soft_delete!(by: @user)
+
+    # Raw DB columns still hold the original values
+    raw = Note.connection.select_one(
+      "SELECT title, text FROM notes WHERE id = #{Note.connection.quote(note.id)}"
+    )
+    assert_equal "Original Title", raw["title"]
+    assert_equal "Original text content", raw["text"]
+  end
+
+  test "Decision#soft_delete! does NOT scrub the underlying DB columns" do
+    d = create_decision(
+      tenant: @tenant, collective: @collective, created_by: @user,
+      question: "Should we?", description: "Details here"
+    )
+    d.soft_delete!(by: @user)
+    raw = Decision.connection.select_one(
+      "SELECT question, description FROM decisions WHERE id = #{Decision.connection.quote(d.id)}"
+    )
+    assert_equal "Should we?", raw["question"]
+    assert_equal "Details here", raw["description"]
+  end
+
+  test "Commitment#soft_delete! does NOT scrub the underlying DB columns" do
+    c = create_commitment(
+      tenant: @tenant, collective: @collective, created_by: @user,
+      title: "Do the thing", description: "Details here"
+    )
+    c.soft_delete!(by: @user)
+    raw = Commitment.connection.select_one(
+      "SELECT title, description FROM commitments WHERE id = #{Commitment.connection.quote(c.id)}"
+    )
+    assert_equal "Do the thing", raw["title"]
+    assert_equal "Details here", raw["description"]
+  end
+
+  # --- raw_* escape hatches return real content even when deleted ---
+
+  test "Note#raw_title and Note#raw_text return real values after soft_delete" do
+    note = create_note(
+      tenant: @tenant, collective: @collective, created_by: @user,
+      title: "Real Title", text: "Real text"
+    )
+    note.soft_delete!(by: @user)
+
+    assert_equal "[deleted]", note.title
+    assert_equal "[deleted]", note.text
+    assert_equal "Real Title", note.raw_title
+    assert_equal "Real text", note.raw_text
+  end
+
+  test "Decision#raw_question and Decision#raw_description return real values after soft_delete" do
+    d = create_decision(
+      tenant: @tenant, collective: @collective, created_by: @user,
+      question: "Real Q?", description: "Real D"
+    )
+    d.soft_delete!(by: @user)
+
+    assert_equal "[deleted]", d.question
+    assert_equal "[deleted]", d.description
+    assert_equal "Real Q?", d.raw_question
+    assert_equal "Real D", d.raw_description
+  end
+
+  test "Commitment#raw_title and Commitment#raw_description return real values after soft_delete" do
+    c = create_commitment(
+      tenant: @tenant, collective: @collective, created_by: @user,
+      title: "Real T", description: "Real D"
+    )
+    c.soft_delete!(by: @user)
+
+    assert_equal "[deleted]", c.title
+    assert_equal "[deleted]", c.description
+    assert_equal "Real T", c.raw_title
+    assert_equal "Real D", c.raw_description
+  end
+
+  test "Note#content_snapshot returns real values even after soft_delete" do
+    note = create_note(
+      tenant: @tenant, collective: @collective, created_by: @user,
+      title: "Snap Title", text: "Snap text"
+    )
+    note.soft_delete!(by: @user)
+
+    assert_equal({ title: "Snap Title", text: "Snap text" }, note.content_snapshot)
+  end
+
+  # --- undo_delete! ---
+
+  test "Note#undo_delete! clears all three timestamps and restores visibility" do
+    note = create_note(
+      tenant: @tenant, collective: @collective, created_by: @user,
+      title: "Restore me", text: "body"
+    )
+    note.soft_delete!(by: @user)
+    assert note.deleted?
+
+    note.undo_delete!(by: @user)
+    note.reload
+
+    assert_not note.deleted?
+    assert_nil note.deleted_at
+    assert_nil note.deleted_by_id
+    assert_nil note.hard_delete_after
+    assert_equal "Restore me", note.title
+    assert_equal "body", note.text
+  end
+
+  test "undo_delete! raises if hard_delete_after has passed" do
+    note = create_note(tenant: @tenant, collective: @collective, created_by: @user)
+    note.soft_delete!(by: @user)
+    note.update_columns(hard_delete_after: 1.minute.ago)
+
+    assert_raises(SoftDeletable::GracePeriodExpired) do
+      note.undo_delete!(by: @user)
+    end
+  end
+
+  test "undo_delete! is a no-op on a non-deleted record" do
+    note = create_note(tenant: @tenant, collective: @collective, created_by: @user)
+    assert_nothing_raised { note.undo_delete!(by: @user) }
+    assert_not note.deleted?
+  end
 end

--- a/test/services/data_deletion_manager_test.rb
+++ b/test/services/data_deletion_manager_test.rb
@@ -119,6 +119,67 @@ class DataDeletionManagerTest < ActiveSupport::TestCase
     assert_equal 0, Decision.where(id: decision.id).count
   end
 
+  # --- system_tombstone_note! ---
+
+  test "system_tombstone_note! nulls content, preserves row, sets tombstoned_at" do
+    note = create_note(
+      tenant: @tenant, collective: @collective, created_by: @user,
+      title: "Original Title", text: "Original body",
+    )
+
+    Tenant.clear_thread_scope
+    Collective.clear_thread_scope
+    DataDeletionManager.system_tombstone_note!(note: note)
+
+    persisted = Note.unscoped.find_by(id: note.id)
+    assert persisted, "row must remain"
+    assert_not_nil persisted.tombstoned_at
+    raw = Note.connection.select_one(
+      "SELECT title, text, table_data FROM notes WHERE id = #{Note.connection.quote(note.id)}"
+    )
+    assert_nil raw["title"]
+    assert_nil raw["text"]
+    assert_nil raw["table_data"]
+  end
+
+  test "system_tombstone_note! destroys Link records involving the note" do
+    note = create_note(tenant: @tenant, collective: @collective, created_by: @user)
+    other_user = create_user(email: "tomblink-#{SecureRandom.hex(4)}@example.com", name: "Tomb Link #{SecureRandom.hex(4)}")
+    @tenant.add_user!(other_user)
+    @collective.add_user!(other_user)
+    other_note = create_note(tenant: @tenant, collective: @collective, created_by: other_user, title: "B note")
+    Link.create!(tenant: @tenant, collective: @collective, from_linkable: other_note, to_linkable: note)
+
+    Tenant.clear_thread_scope
+    Collective.clear_thread_scope
+    DataDeletionManager.system_tombstone_note!(note: note)
+
+    assert_equal 0, Link.where(to_linkable_id: note.id).count, "links must be destroyed"
+    assert Note.unscoped.where(id: other_note.id).exists?, "the other note must survive"
+  end
+
+  test "system_tombstone_note! preserves NoteHistoryEvents and child comments" do
+    note = create_note(tenant: @tenant, collective: @collective, created_by: @user)
+    other_user = create_user(email: "pres-other-#{SecureRandom.hex(4)}@example.com", name: "Preserve #{SecureRandom.hex(4)}")
+    @tenant.add_user!(other_user)
+    @collective.add_user!(other_user)
+    comment = create_note(
+      tenant: @tenant, collective: @collective, created_by: other_user,
+      text: "B's comment", subtype: "comment", commentable: note,
+    )
+    NoteHistoryEvent.create!(
+      tenant: @tenant, collective: @collective, note: note, user: other_user,
+      event_type: "read_confirmation", happened_at: Time.current,
+    )
+
+    Tenant.clear_thread_scope
+    Collective.clear_thread_scope
+    DataDeletionManager.system_tombstone_note!(note: note)
+
+    assert Note.unscoped.where(id: comment.id).exists?, "comment must survive"
+    assert NoteHistoryEvent.where(note_id: note.id).exists?, "history events must survive"
+  end
+
   test "delete_collective! cleans up events referencing the collective" do
     # Reproduces a FK violation: Tracked callbacks insert Event rows that
     # reference the collective. delete_collective! must clear them or

--- a/test/services/data_deletion_manager_test.rb
+++ b/test/services/data_deletion_manager_test.rb
@@ -119,25 +119,27 @@ class DataDeletionManagerTest < ActiveSupport::TestCase
     assert_equal 0, Decision.where(id: decision.id).count
   end
 
-  # === Pre-existing bugs in delete_collective! ===
-  # These tests document FK violations that exist in the current delete_collective! implementation.
-  # They are skipped so they show up in test output as a reminder to fix.
+  test "delete_collective! cleans up events referencing the collective" do
+    # Reproduces a FK violation: Tracked callbacks insert Event rows that
+    # reference the collective. delete_collective! must clear them or
+    # PG::ForeignKeyViolation is raised on the final collective.destroy!.
+    tenant, collective, user = create_tenant_collective_user
+    Tenant.scope_thread_to_tenant(subdomain: tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
 
-  test "BUG: delete_collective! fails when collective has events (FK violation on events table)" do
-    skip "Pre-existing bug: delete_collective! does not delete events records. " \
-         "When a collective contains decisions/votes that triggered Tracked callbacks, " \
-         "the events table has rows referencing the collective. delete_collective! doesn't " \
-         "include Event in its deletion list, causing: PG::ForeignKeyViolation on collectives. " \
-         "Fix: add Event to the model list in delete_collective! (before other models that events reference)."
-  end
+    note = create_note(tenant: tenant, collective: collective, created_by: user)
+    assert Event.where(collective_id: collective.id).exists?,
+           "expected Tracked callbacks to have created Event rows for the collective"
 
-  test "BUG: delete_collective! with separate tenant fails to delete options (FK violation)" do
-    skip "Pre-existing bug: delete_collective! with a freshly created tenant/collective can fail " \
-         "if the test helper create_option uses default @tenant/@collective instead of the local ones, " \
-         "causing options to land in the wrong collective. The bulk delete_all then misses them, " \
-         "and DecisionParticipant deletion hits a FK violation from orphaned options. " \
-         "This is a test setup issue but also reveals that delete_collective! has no error handling " \
-         "for partial deletion failures — it should validate all child records were removed."
+    ddm = DataDeletionManager.new(user: user)
+    assert_difference -> { Collective.count }, -1 do
+      ddm.delete_collective!(collective: collective, confirmation_token: ddm.confirmation_token)
+    end
+    assert_equal 0, Event.where(collective_id: collective.id).count,
+                 "events referencing the deleted collective must be removed"
+  ensure
+    Tenant.clear_thread_scope
+    Collective.clear_thread_scope
   end
 
   test "DataDeletionManager deletes user PII and marks user as deleted with correct confirmation_token" do

--- a/test/services/user_data_export_service_test.rb
+++ b/test/services/user_data_export_service_test.rb
@@ -302,7 +302,7 @@ class UserDataExportServiceTest < ActiveSupport::TestCase
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: other_collective.handle)
 
     other_decision = create_decision(tenant: @tenant, collective: other_collective, created_by: @user, question: "Other group decision")
-    other_option = create_option(decision: other_decision, created_by: @user, title: "Other option")
+    other_option = create_option(tenant: @tenant, collective: other_collective, decision: other_decision, created_by: @user, title: "Other option")
     other_participant = DecisionParticipantManager.new(decision: other_decision, user: @user).find_or_create_participant
     Vote.create!(
       tenant: @tenant, collective: other_collective, decision: other_decision, option: other_option,


### PR DESCRIPTION
## Phase 2: Phased Deletion

Adds a 30-day grace period between user-initiated soft-delete and the permanent finalize step for Notes, plus two prerequisite bug fixes in `DataDeletionManager`.

From the user's POV, soft-delete is deletion: the note disappears from feeds, content reads as `[deleted]` everywhere via accessor masking, scheduled reminders are canceled, and search-index entries are removed. Under the hood, the DB row is preserved so undo within the 30-day window cleanly restores everything. When `hard_delete_after` passes, a daily `SystemJob` tombstones the note (nulls content, purges attachments, destroys Link records, sets `tombstoned_at`) while leaving the row in place so other users' comments / history events continue to resolve.

`Decision` and `Commitment` get the same soft-delete machinery but **never auto-finalize**. Their deletion semantics — ownership-after-engagement, audit-chain preservation, withdrawal vs. delete — are deferred to a follow-up phase to avoid half-answering hard product questions.

## Bug fixes (prerequisite)

- **`delete_collective!` Event FK**: `Tracked.after_create_commit` insert `Event` rows referencing the collective. `delete_collective!` never cleared them, so `collective.destroy!` hit `PG::ForeignKeyViolation`. Fix: clear `Event` (plus its dependent `Notification` / `NotificationRecipient` / `WebhookDelivery` rows) before the rest of the cascade.
- **`collective_id` consistency**: `Option`, `Vote`, `DecisionParticipant`, `CommitmentParticipant`, and `DecisionAuditEntry` had no validation pinning their `collective_id` to the parent's. `ApplicationRecord#set_collective_id` pulls from `Collective.current_id`, so a misaligned thread scope could produce orphan rows that evade collective-scoped cleanup. New `CollectiveIdMatchesParent` concern, included in the five child models. (`NoteHistoryEvent`, `ChatMessage`, `AutomationRuleRun` already had equivalent inline validations.)

## Soft-delete rework

`SoftDeletable#soft_delete!` is now metadata-only:

- Sets `deleted_at`, `deleted_by_id`, conditional `hard_delete_after`
- Removes from search index
- Unpins from collective
- Calls `on_soft_delete` hook (Note uses it to cancel scheduled reminders)
- **Does not scrub DB content** — the columns retain their real values

Defense-in-depth comes from **accessor masking** on Note/Decision/Commitment:

```ruby
def title
  return "[deleted]" if deleted?
  super
end
```

`raw_title` / `raw_text` / `raw_question` / `raw_description` / `raw_table_data` are escape hatches for legitimate readers (`content_snapshot`, admin recovery, undo). Existing tests that asserted `[deleted]` after `soft_delete!` keep passing because the masking preserves the previous read contract.

`undo_delete!(by:)` clears the timestamps and re-adds to the search index; refuses with `GracePeriodExpired` if `hard_delete_after` has passed (for models that opt into the hard-delete pipeline).

## Tombstone pipeline (Notes only)

- New `SoftDeletable.participates_in_hard_delete` class-level opt-in. Only `Note` opts in. For non-participating models, `soft_delete!` doesn't set `hard_delete_after` and `undo_delete!` works indefinitely.
- New `tombstoned_at :datetime` column on `notes`.
- New `DataDeletionManager.system_tombstone_note!(note:)` — always tombstones inside a transaction with a row lock: nulls `title`/`text`/`table_data` via `update_columns`, purges attachments, destroys all Link records involving the note, sets `tombstoned_at`. The row stays so other-user comments / NoteHistoryEvents keep resolving.
- New `HardDeleteExpiredRecordsJob < SystemJob` — daily at 3:30 AM. Scoped to `Note`. Finds notes where `deleted_at IS NOT NULL AND hard_delete_after < NOW() AND tombstoned_at IS NULL`. Per-note errors are rescued and logged so a single failure doesn't poison the batch.
- Console `delete_note!` still does full row destruction (refactored to share `cascade_delete_note` private helper). Return message now reads `raw_title` so admins see the real title even on already-soft-deleted notes.

**Why Links are destroyed unconditionally**: Link records are system-generated from `@`-references parsed out of text. They don't belong to any user. `LinkParser` already treats soft-deleted items as unresolvable, so destroying them on tombstone is consistent with existing read behavior.

## Reminder-delivery guard

Defense-in-depth in `ReminderDeliveryJob`: if a reminder's linked note has been soft-deleted but the `Notification` record wasn't fully cleaned up (e.g. a partial `cancel!`), skip delivery and log a warning. The note is the source of truth. The happy path is unchanged because `on_soft_delete` calls `NoteReminderService#cancel!` which destroys the notification + recipients during soft-delete.

## What's deferred

- **Decision / Commitment auto-finalize**: needs a design conversation about whether a Decision belongs to its creator once others engage, how withdrawal differs from delete, and what happens to the audit chain.
- **Tombstone garbage collection**: rows stay forever. Acceptable at current scale; revisit if `notes` table size becomes a problem.
- **Per-tenant grace period configuration**: hardcoded at 30 days.
- **Transparency UI** (Phase 4 of the data lifecycle roadmap).
- **Account closure flow** (Phase 3).

## Test plan

- [x] `test/services/data_deletion_manager_test.rb` — Event FK cascade, `system_tombstone_note!` (content nulled, row preserved, links destroyed, NoteHistoryEvents and child comments preserved)
- [x] `test/models/collective_id_consistency_test.rb` — invariant validations across 5 child models
- [x] `test/models/concerns/soft_deletable_test.rb` — accessor masking, raw_* escape hatches, undo behavior, `tombstoned?` predicate, reminder cancellation on soft-delete, `participates_in_hard_delete` opt-in semantics, DB columns preserved
- [x] `test/jobs/hard_delete_expired_records_job_test.rb` — tombstones expired notes, leaves fresh ones, skips already-tombstoned, cross-tenant safe, one-failure-doesn't-block-rest
- [x] `test/jobs/reminder_delivery_job_test.rb` — guard skips delivery for soft-deleted notes
- [x] Full test sweep across `test/models`, `test/services`, `test/jobs`: 2,322 runs, 0 failures, 0 errors, 0 skips
- [x] Sorbet `srb tc` clean

## Migration safety

- `notes.hard_delete_after` / `decisions.hard_delete_after` / `commitments.hard_delete_after` — additive datetime columns, indexed. Backfill populates existing soft-deleted rows so the first job run finalizes them (their content was already scrubbed under the old `soft_delete!` semantics; nothing is preserved by waiting).
- `notes.tombstoned_at` — additive datetime column, indexed. No backfill needed.
