### PR TITLE
Add sys-admin ops controls: redispatch, cancel, health panel

### DIFF
--- a/app/controllers/system_admin_controller.rb
+++ b/app/controllers/system_admin_controller.rb
@@ -170,6 +170,97 @@ class SystemAdminController < ApplicationController
     end
   end
 
+  # POST /system-admin/agent-runner/actions/redispatch-queued
+  def execute_redispatch_queued_tasks
+    queued = AiAgentTaskRun.unscoped_for_admin(@current_user).where(status: "queued")
+    total = queued.count
+    dispatched = 0
+    failed = 0
+
+    # Each task's dispatch needs its own tenant scope; restore the request's
+    # tenant context once the loop finishes (or aborts) so the response can
+    # log, render, and redirect normally.
+    begin
+      queued.find_each do |task_run|
+        Tenant.scope_thread_to_tenant(subdomain: task_run.tenant.subdomain)
+        AgentRunnerDispatchService.dispatch(task_run)
+        dispatched += 1
+      rescue StandardError => e
+        failed += 1
+        Rails.logger.warn("[SystemAdmin] redispatch failed for #{task_run.id}: #{e.class} #{e.message}")
+      end
+    ensure
+      Tenant.scope_thread_to_tenant(subdomain: @current_tenant.subdomain)
+    end
+
+    SecurityAuditLog.log_admin_action(
+      admin: @current_user,
+      ip: request.remote_ip,
+      action: "redispatch_queued_tasks",
+      details: { total: total, dispatched: dispatched, failed: failed },
+    )
+
+    message = "Redispatched #{dispatched} of #{total} queued task#{'s' unless total == 1}."
+    message += " #{failed} failed." if failed.positive?
+
+    respond_to do |format|
+      format.md { render plain: message }
+      format.html do
+        flash[:notice] = message
+        redirect_to "/system-admin/agent-runner"
+      end
+    end
+  end
+
+  # POST /system-admin/agent-runner/runs/:id/cancel
+  def execute_cancel_task_run
+    task_run = AiAgentTaskRun.unscoped_for_admin(@current_user).find_by(id: params[:id])
+    return render(plain: "404 Not Found", status: :not_found) unless task_run
+
+    unless %w[queued running].include?(task_run.status)
+      respond_to do |format|
+        format.md { render plain: "Task is not running or queued (status: #{task_run.status}).", status: :unprocessable_entity }
+        format.html do
+          flash[:alert] = "Task is not running or queued (status: #{task_run.status})."
+          redirect_to system_admin_task_run_path(task_run.id)
+        end
+      end
+      return
+    end
+
+    task_run.update!(
+      status: "cancelled",
+      completed_at: Time.current,
+      error: "Cancelled by admin",
+    )
+    task_run.notify_parent_automation_runs!
+    # Revoke the ephemeral runner token (`internal: true`, so the default external
+    # scope hides it). Use admin scope so we find tokens belonging to other tenants too.
+    ApiToken.unscoped_for_admin(@current_user)
+      .where(context_id: task_run.id, context_type: "AiAgentTaskRun", deleted_at: nil)
+      .find_each(&:delete!)
+
+    SecurityAuditLog.log_admin_action(
+      admin: @current_user,
+      ip: request.remote_ip,
+      action: "cancel_agent_task_run",
+      details: { task_run_id: task_run.id, agent_id: task_run.ai_agent_id, tenant_id: task_run.tenant_id },
+    )
+
+    respond_to do |format|
+      format.md do
+        @task_run = task_run.reload
+        @task_run.agent_session_steps.load
+        @page_title = "Task Run"
+        render 'show_task_run'
+      end
+      format.html do
+        flash[:notice] = "Task run cancelled."
+        redirect_to system_admin_task_run_path(task_run.id)
+      end
+    end
+  end
+
   private
 
   def ensure_primary_tenant
@@ -227,6 +318,7 @@ class SystemAdminController < ApplicationController
     @webhook_health = load_webhook_health_stats
     @event_activity = load_event_activity_stats
     @system_resources = load_system_resource_stats
+    @system_health = load_system_health_stats
   end
 
   # Lightweight runner-process stats for the dashboard row.
@@ -287,5 +379,40 @@ class SystemAdminController < ApplicationController
       workers_busy: Sidekiq::ProcessSet.new.sum { |p| p["busy"] },
       workers_total: Sidekiq::ProcessSet.new.sum { |p| p["concurrency"] },
     }
+  end
+
+  def load_system_health_stats
+    db_pool = load_db_pool_stats
+    redis_info = load_redis_info
+    {
+      db_pool: db_pool,
+      redis_used_memory: redis_info[:used_memory_human],
+      redis_clients_connected: redis_info[:connected_clients],
+    }
+  end
+
+  def load_db_pool_stats
+    stat = ActiveRecord::Base.connection_pool.stat
+    {
+      size: stat[:size],
+      connections: stat[:connections],
+      busy: stat[:busy],
+      waiting: stat[:waiting],
+    }
+  rescue StandardError
+    nil
+  end
+
+  def load_redis_info
+    redis = Redis.new(url: ENV["REDIS_URL"])
+    info = redis.info
+    {
+      used_memory_human: info["used_memory_human"],
+      connected_clients: info["connected_clients"],
+    }
+  rescue StandardError
+    { used_memory_human: nil, connected_clients: nil }
+  ensure
+    redis&.close
   end
 end

--- a/app/controllers/system_admin_controller.rb
+++ b/app/controllers/system_admin_controller.rb
@@ -149,7 +149,9 @@ class SystemAdminController < ApplicationController
     redis&.close
 
     @status_filter = params[:status]
-    scope = AiAgentTaskRun.unscoped_for_admin(@current_user).order(created_at: :desc)
+    base = AiAgentTaskRun.unscoped_for_admin(@current_user)
+    @queued_task_count = base.where(status: "queued").count
+    scope = base.order(created_at: :desc)
     scope = scope.where(status: @status_filter) if @status_filter.present?
     @recent_task_runs = scope.limit(20)
 
@@ -180,17 +182,16 @@ class SystemAdminController < ApplicationController
     # Each task's dispatch needs its own tenant scope; restore the request's
     # tenant context once the loop finishes (or aborts) so the response can
     # log, render, and redirect normally.
-    begin
+    with_admin_scope_restored do
       queued.find_each do |task_run|
         Tenant.scope_thread_to_tenant(subdomain: task_run.tenant.subdomain)
+        Collective.clear_thread_scope
         AgentRunnerDispatchService.dispatch(task_run)
         dispatched += 1
       rescue StandardError => e
         failed += 1
         Rails.logger.warn("[SystemAdmin] redispatch failed for #{task_run.id}: #{e.class} #{e.message}")
       end
-    ensure
-      Tenant.scope_thread_to_tenant(subdomain: @current_tenant.subdomain)
     end
 
     SecurityAuditLog.log_admin_action(
@@ -228,17 +229,24 @@ class SystemAdminController < ApplicationController
       return
     end
 
-    task_run.update!(
-      status: "cancelled",
-      completed_at: Time.current,
-      error: "Cancelled by admin",
-    )
-    task_run.notify_parent_automation_runs!
-    # Revoke the ephemeral runner token (`internal: true`, so the default external
-    # scope hides it). Use admin scope so we find tokens belonging to other tenants too.
-    ApiToken.unscoped_for_admin(@current_user)
-      .where(context_id: task_run.id, context_type: "AiAgentTaskRun", deleted_at: nil)
-      .find_each(&:delete!)
+    # Mutations and parent-run lookups run in the task's own tenant scope so
+    # default-scoped queries (AutomationRuleRun, etc.) target the right rows
+    # even when admin and task live in different tenants.
+    with_admin_scope_restored do
+      Tenant.scope_thread_to_tenant(subdomain: task_run.tenant.subdomain)
+      Collective.clear_thread_scope
+      task_run.update!(
+        status: "cancelled",
+        completed_at: Time.current,
+        error: "Cancelled by admin",
+      )
+      task_run.notify_parent_automation_runs!
+      # Revoke the ephemeral runner token (`internal: true`, so the default external
+      # scope hides it). Use admin scope so we find tokens belonging to other tenants too.
+      ApiToken.unscoped_for_admin(@current_user)
+        .where(context_id: task_run.id, context_type: "AiAgentTaskRun", deleted_at: nil)
+        .find_each(&:delete!)
+    end
 
     SecurityAuditLog.log_admin_action(
       admin: @current_user,
@@ -262,6 +270,20 @@ class SystemAdminController < ApplicationController
   end
 
   private
+
+  # Run a block under a (possibly different) tenant/collective scope and
+  # always restore the request's original scope afterwards. Cross-tenant
+  # admin actions need this so the response (logging, redirect) runs under
+  # the admin's normal context.
+  def with_admin_scope_restored
+    saved_collective_id = Collective.current_id
+    saved_collective_handle = Current.collective_handle
+    yield
+  ensure
+    Tenant.scope_thread_to_tenant(subdomain: @current_tenant.subdomain) if @current_tenant
+    Current.collective_id = saved_collective_id
+    Current.collective_handle = saved_collective_handle
+  end
 
   def ensure_primary_tenant
     unless @current_tenant&.subdomain == ENV['PRIMARY_SUBDOMAIN']

--- a/app/views/system_admin/agent_runner.html.erb
+++ b/app/views/system_admin/agent_runner.html.erb
@@ -65,17 +65,16 @@
   </div>
 <% end %>
 
-<% queued_count = AiAgentTaskRun.unscoped_for_admin(@current_user).where(status: "queued").count %>
-<%= render 'shared/pulse_accordion', title: 'Queue Actions', icon: 'tools', open: queued_count.positive? do %>
+<%= render 'shared/pulse_accordion', title: 'Queue Actions', icon: 'tools', open: @queued_task_count.positive? do %>
   <p class="pulse-form-hint" style="margin-bottom: 12px;">
     Re-publishes every <code class="pulse-code">queued</code> task run to the
     <code class="pulse-code">agent_tasks</code> Redis stream. Use when the runner
     restarted while tasks were waiting, or after the stream was lost.
   </p>
-  <% if queued_count.positive? %>
+  <% if @queued_task_count.positive? %>
     <details>
       <summary class="pulse-action-btn" style="cursor: pointer; display: inline-block;">
-        <%= octicon 'sync', height: 14 %> Redispatch <%= queued_count %> queued task<%= 's' unless queued_count == 1 %>
+        <%= octicon 'sync', height: 14 %> Redispatch <%= @queued_task_count %> queued task<%= 's' unless @queued_task_count == 1 %>
       </summary>
       <div style="background: var(--color-canvas-subtle); padding: 16px; margin-top: 8px; border-radius: 6px;">
         <p class="pulse-form-hint" style="margin-bottom: 16px;">

--- a/app/views/system_admin/agent_runner.html.erb
+++ b/app/views/system_admin/agent_runner.html.erb
@@ -65,6 +65,37 @@
   </div>
 <% end %>
 
+<% queued_count = AiAgentTaskRun.unscoped_for_admin(@current_user).where(status: "queued").count %>
+<%= render 'shared/pulse_accordion', title: 'Queue Actions', icon: 'tools', open: queued_count.positive? do %>
+  <p class="pulse-form-hint" style="margin-bottom: 12px;">
+    Re-publishes every <code class="pulse-code">queued</code> task run to the
+    <code class="pulse-code">agent_tasks</code> Redis stream. Use when the runner
+    restarted while tasks were waiting, or after the stream was lost.
+  </p>
+  <% if queued_count.positive? %>
+    <details>
+      <summary class="pulse-action-btn" style="cursor: pointer; display: inline-block;">
+        <%= octicon 'sync', height: 14 %> Redispatch <%= queued_count %> queued task<%= 's' unless queued_count == 1 %>
+      </summary>
+      <div style="background: var(--color-canvas-subtle); padding: 16px; margin-top: 8px; border-radius: 6px;">
+        <p class="pulse-form-hint" style="margin-bottom: 16px;">
+          <%= octicon 'alert', height: 12 %>
+          This re-runs dispatch (token issuance, billing pre-check, stream publish)
+          for each queued task. Tasks already picked up by the runner are skipped
+          by the dispatch service.
+        </p>
+        <%= form_tag "/system-admin/agent-runner/actions/redispatch-queued", method: :post do %>
+          <div class="pulse-form-actions">
+            <button type="submit" class="pulse-action-btn">Confirm Redispatch</button>
+          </div>
+        <% end %>
+      </div>
+    </details>
+  <% else %>
+    <p class="pulse-body-text-muted">No queued task runs to redispatch.</p>
+  <% end %>
+<% end %>
+
 <%= render 'shared/pulse_accordion', title: 'Recent Task Runs', icon: 'history', count: @recent_task_runs&.count || 0, open: true do %>
   <div style="margin-bottom: 12px; display: flex; gap: 8px;">
     <% %w[all completed failed cancelled running queued].each do |status| %>

--- a/app/views/system_admin/dashboard.html.erb
+++ b/app/views/system_admin/dashboard.html.erb
@@ -146,5 +146,41 @@
       </span>
     </div>
 
+    <%# System Health Section: DB pool + Redis %>
+    <div class="pulse-monitoring-row">
+      <%= octicon 'database', height: 14 %>
+      <span class="pulse-monitoring-label">DB Pool</span>
+      <span class="pulse-monitoring-values">
+        <% if @system_health[:db_pool] %>
+          <% pool = @system_health[:db_pool] %>
+          <span><%= pool[:busy] %>/<%= pool[:size] %> busy</span>
+          &middot;
+          <span><%= pool[:connections] %> open</span>
+          &middot;
+          <% if pool[:waiting].to_i > 0 %>
+            <span class="pulse-text-warning"><%= pool[:waiting] %> waiting</span>
+          <% else %>
+            <span class="pulse-text-muted">0 waiting</span>
+          <% end %>
+        <% else %>
+          <span class="pulse-text-muted">unavailable</span>
+        <% end %>
+      </span>
+    </div>
+
+    <div class="pulse-monitoring-row">
+      <%= octicon 'pulse', height: 14 %>
+      <span class="pulse-monitoring-label">Redis</span>
+      <span class="pulse-monitoring-values">
+        <% if @system_health[:redis_used_memory] %>
+          <span><%= @system_health[:redis_used_memory] %> used</span>
+          &middot;
+          <span><%= @system_health[:redis_clients_connected] %> clients</span>
+        <% else %>
+          <span class="pulse-text-muted">unavailable</span>
+        <% end %>
+      </span>
+    </div>
+
   </div>
 <% end %>

--- a/app/views/system_admin/dashboard.md.erb
+++ b/app/views/system_admin/dashboard.md.erb
@@ -55,3 +55,16 @@ Node.js service that executes AI agent task runs.
 - Queued jobs: <%= @system_resources[:queue_depth] %>
 - Redis memory: <%= @system_resources[:redis_memory] %>
 - Workers: <%= @system_resources[:workers_busy] %>/<%= @system_resources[:workers_total] %> busy
+
+#### System Health
+<% if @system_health[:db_pool] -%>
+<% pool = @system_health[:db_pool] -%>
+- DB pool: <%= pool[:busy] %>/<%= pool[:size] %> busy, <%= pool[:connections] %> open, <%= pool[:waiting] %> waiting
+<% else -%>
+- DB pool: unavailable
+<% end -%>
+<% if @system_health[:redis_used_memory] -%>
+- Redis: <%= @system_health[:redis_used_memory] %> used, <%= @system_health[:redis_clients_connected] %> clients
+<% else -%>
+- Redis: unavailable
+<% end -%>

--- a/app/views/system_admin/show_task_run.html.erb
+++ b/app/views/system_admin/show_task_run.html.erb
@@ -77,6 +77,31 @@
   The task owner can view full details from their agent's run history.
 </div>
 
+<% if %w[queued running].include?(@task_run.status) %>
+  <%= render 'shared/pulse_accordion', title: 'Actions', icon: 'zap', open: true do %>
+    <div class="pulse-form-actions" style="flex-direction: column; align-items: flex-start;">
+      <details>
+        <summary class="pulse-action-btn-danger" style="cursor: pointer; display: inline-block;">
+          <%= octicon 'stop', height: 14 %> Cancel Task Run
+        </summary>
+        <div style="background: var(--color-canvas-subtle); padding: 16px; margin-top: 8px; border-radius: 6px;">
+          <p class="pulse-form-hint" style="margin-bottom: 16px;">
+            <%= octicon 'alert', height: 12 %>
+            Cancelling marks the task as <code class="pulse-code">cancelled</code>,
+            revokes its ephemeral API tokens, and notifies any parent automation
+            run. The runner may still complete the current step before noticing.
+          </p>
+          <%= form_tag cancel_system_admin_task_run_path(@task_run.id), method: :post do %>
+            <div class="pulse-form-actions">
+              <button type="submit" class="pulse-action-btn-danger">Confirm Cancel</button>
+            </div>
+          <% end %>
+        </div>
+      </details>
+    </div>
+  <% end %>
+<% end %>
+
 <!-- Steps Timeline -->
 <div class="pulse-section-label" style="margin-bottom: 16px;">
   <%= octicon 'list-ordered', height: 12 %> Execution Steps (<%= @task_run.steps_count %>)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,7 +222,9 @@ Rails.application.routes.draw do
   get 'system-admin/sidekiq/jobs/:jid/actions/retry_sidekiq_job' => 'system_admin#describe_retry_sidekiq_job'
   post 'system-admin/sidekiq/jobs/:jid/actions/retry_sidekiq_job' => 'system_admin#execute_retry_sidekiq_job'
   get 'system-admin/agent-runner' => 'system_admin#agent_runner'
+  post 'system-admin/agent-runner/actions/redispatch-queued' => 'system_admin#execute_redispatch_queued_tasks'
   get 'system-admin/agent-runner/runs/:id' => 'system_admin#show_task_run', as: 'system_admin_task_run'
+  post 'system-admin/agent-runner/runs/:id/cancel' => 'system_admin#execute_cancel_task_run', as: 'cancel_system_admin_task_run'
 
   # App Admin (primary tenant only, app_admin role on User)
   # For cross-tenant management: tenants, users across all tenants

--- a/test/controllers/system_admin_controller_test.rb
+++ b/test/controllers/system_admin_controller_test.rb
@@ -512,7 +512,9 @@ class SystemAdminControllerTest < ActionDispatch::IntegrationTest
 
     post cancel_system_admin_task_run_path(task_run.id)
 
-    assert_not_nil token.reload.deleted_at, "API token should be marked deleted"
+    # Internal tokens are hidden by the default scope, so query unscoped
+    refreshed = ApiToken.unscope(where: :internal).unscope(where: :tenant_id).find(token.id)
+    assert_not_nil refreshed.deleted_at, "API token should be marked deleted"
   end
 
   test "cancel refuses for already-completed task" do
@@ -622,9 +624,10 @@ class SystemAdminControllerTest < ActionDispatch::IntegrationTest
     get "/system-admin"
     assert_response :success
 
+    # New labels introduced by the system health panel — not present before.
     assert_match(/DB Pool/, response.body)
-    assert_match(/Redis/, response.body)
-    assert_match(/busy/, response.body)
+    assert_match(/clients/, response.body)
+    assert_match(/waiting/, response.body)
   end
 
   test "dashboard markdown includes system health section" do
@@ -635,6 +638,6 @@ class SystemAdminControllerTest < ActionDispatch::IntegrationTest
     get "/system-admin", headers: { "Accept" => "text/markdown" }
     assert_response :success
     assert_match(/System Health/, response.body)
-    assert_match(/DB pool/, response.body)
+    assert_match(/DB pool:/, response.body)
   end
 end

--- a/test/controllers/system_admin_controller_test.rb
+++ b/test/controllers/system_admin_controller_test.rb
@@ -309,4 +309,332 @@ class SystemAdminControllerTest < ActionDispatch::IntegrationTest
     get "/system-admin/agent-runner/runs/#{SecureRandom.uuid}"
     assert_response :forbidden
   end
+
+  # ============================================================================
+  # SECTION 6: Redispatch Queued Tasks
+  # ============================================================================
+
+  test "sys_admin sees redispatch button when queued tasks exist" do
+    @primary_tenant.add_user!(@sys_admin_user)
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    Collective.scope_thread_to_collective(subdomain: @primary_tenant.subdomain, handle: nil)
+    ai_agent = User.create!(name: "Q Agent", email: "q-#{SecureRandom.hex(4)}@test.com", user_type: "ai_agent", parent_id: @sys_admin_user.id)
+    @primary_tenant.add_user!(ai_agent)
+    AiAgentTaskRun.create!(
+      tenant: @primary_tenant,
+      ai_agent: ai_agent,
+      initiated_by: @sys_admin_user,
+      task: "Some queued task",
+      max_steps: 10,
+      status: "queued",
+    )
+
+    get "/system-admin/agent-runner"
+    assert_response :success
+    assert_match "Redispatch 1 queued task", response.body
+  end
+
+  test "sys_admin executes redispatch and gets flash message" do
+    @primary_tenant.add_user!(@sys_admin_user)
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    Collective.scope_thread_to_collective(subdomain: @primary_tenant.subdomain, handle: nil)
+    ai_agent = User.create!(name: "Q Agent", email: "q-#{SecureRandom.hex(4)}@test.com", user_type: "ai_agent", parent_id: @sys_admin_user.id)
+    @primary_tenant.add_user!(ai_agent)
+    task_run = AiAgentTaskRun.create!(
+      tenant: @primary_tenant,
+      ai_agent: ai_agent,
+      initiated_by: @sys_admin_user,
+      task: "Queued task",
+      max_steps: 10,
+      status: "queued",
+    )
+
+    AgentRunnerDispatchService.stub :dispatch, ->(_tr) { nil } do
+      post "/system-admin/agent-runner/actions/redispatch-queued"
+    end
+
+    assert_redirected_to "/system-admin/agent-runner"
+    assert_match(/Redispatched 1 of 1 queued task/, flash[:notice].to_s)
+    assert_equal "queued", task_run.reload.status
+  end
+
+  test "redispatch reports failures without aborting" do
+    @primary_tenant.add_user!(@sys_admin_user)
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    Collective.scope_thread_to_collective(subdomain: @primary_tenant.subdomain, handle: nil)
+    ai_agent = User.create!(name: "Q Agent", email: "q-#{SecureRandom.hex(4)}@test.com", user_type: "ai_agent", parent_id: @sys_admin_user.id)
+    @primary_tenant.add_user!(ai_agent)
+    2.times do |i|
+      AiAgentTaskRun.create!(
+        tenant: @primary_tenant,
+        ai_agent: ai_agent,
+        initiated_by: @sys_admin_user,
+        task: "Task #{i}",
+        max_steps: 10,
+        status: "queued",
+      )
+    end
+
+    call_count = 0
+    boom = ->(_tr) {
+      call_count += 1
+      raise StandardError, "boom" if call_count == 1
+    }
+    AgentRunnerDispatchService.stub :dispatch, boom do
+      post "/system-admin/agent-runner/actions/redispatch-queued"
+    end
+
+    assert_redirected_to "/system-admin/agent-runner"
+    assert_match(/Redispatched 1 of 2 queued tasks\. 1 failed\./, flash[:notice].to_s)
+  end
+
+  test "redispatch restores request tenant scope even when a task dispatch fails" do
+    # Create a task run in a non-primary tenant so a leaked scope would be visible.
+    @primary_tenant.add_user!(@sys_admin_user)
+    @other_tenant.add_user!(@sys_admin_user)
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    Collective.scope_thread_to_collective(subdomain: @other_tenant.subdomain, handle: nil)
+    ai_agent = User.create!(name: "Q Agent", email: "q-#{SecureRandom.hex(4)}@test.com", user_type: "ai_agent", parent_id: @sys_admin_user.id)
+    @other_tenant.add_user!(ai_agent)
+    AiAgentTaskRun.create!(
+      tenant: @other_tenant,
+      ai_agent: ai_agent,
+      initiated_by: @sys_admin_user,
+      task: "task",
+      max_steps: 10,
+      status: "queued",
+    )
+    Tenant.clear_thread_scope
+
+    AgentRunnerDispatchService.stub :dispatch, ->(_tr) { raise "explode" } do
+      post "/system-admin/agent-runner/actions/redispatch-queued"
+    end
+    assert_redirected_to "/system-admin/agent-runner"
+  end
+
+  test "non-sys-admin cannot redispatch queued tasks" do
+    @primary_tenant.add_user!(@non_sys_admin_user)
+    tu = @primary_tenant.tenant_users.find_by(user: @non_sys_admin_user)
+    tu.add_role!('admin')
+
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as(@non_sys_admin_user, tenant: @primary_tenant)
+
+    post "/system-admin/agent-runner/actions/redispatch-queued"
+    assert_response :forbidden
+  end
+
+  # ============================================================================
+  # SECTION 7: Cancel Task Run
+  # ============================================================================
+
+  test "sys_admin can cancel a running task run" do
+    @primary_tenant.add_user!(@sys_admin_user)
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    Collective.scope_thread_to_collective(subdomain: @primary_tenant.subdomain, handle: nil)
+    ai_agent = User.create!(name: "Run Agent", email: "run-#{SecureRandom.hex(4)}@test.com", user_type: "ai_agent", parent_id: @sys_admin_user.id)
+    @primary_tenant.add_user!(ai_agent)
+    task_run = AiAgentTaskRun.create!(
+      tenant: @primary_tenant,
+      ai_agent: ai_agent,
+      initiated_by: @sys_admin_user,
+      task: "running task",
+      max_steps: 10,
+      status: "running",
+      started_at: Time.current,
+    )
+
+    post cancel_system_admin_task_run_path(task_run.id)
+
+    assert_redirected_to system_admin_task_run_path(task_run.id)
+    task_run.reload
+    assert_equal "cancelled", task_run.status
+    assert_equal "Cancelled by admin", task_run.error
+    assert_not_nil task_run.completed_at
+  end
+
+  test "sys_admin can cancel a queued task run" do
+    @primary_tenant.add_user!(@sys_admin_user)
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    Collective.scope_thread_to_collective(subdomain: @primary_tenant.subdomain, handle: nil)
+    ai_agent = User.create!(name: "Q Agent", email: "qc-#{SecureRandom.hex(4)}@test.com", user_type: "ai_agent", parent_id: @sys_admin_user.id)
+    @primary_tenant.add_user!(ai_agent)
+    task_run = AiAgentTaskRun.create!(
+      tenant: @primary_tenant,
+      ai_agent: ai_agent,
+      initiated_by: @sys_admin_user,
+      task: "queued task",
+      max_steps: 10,
+      status: "queued",
+    )
+
+    post cancel_system_admin_task_run_path(task_run.id)
+
+    assert_redirected_to system_admin_task_run_path(task_run.id)
+    assert_equal "cancelled", task_run.reload.status
+  end
+
+  test "cancel deletes active api tokens for the task run" do
+    @primary_tenant.add_user!(@sys_admin_user)
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    Collective.scope_thread_to_collective(subdomain: @primary_tenant.subdomain, handle: nil)
+    ai_agent = User.create!(name: "Tok Agent", email: "tok-#{SecureRandom.hex(4)}@test.com", user_type: "ai_agent", parent_id: @sys_admin_user.id)
+    @primary_tenant.add_user!(ai_agent)
+    task_run = AiAgentTaskRun.create!(
+      tenant: @primary_tenant,
+      ai_agent: ai_agent,
+      initiated_by: @sys_admin_user,
+      task: "task",
+      max_steps: 10,
+      status: "running",
+      started_at: Time.current,
+    )
+    token = ApiToken.create_internal_token(
+      user: ai_agent,
+      tenant: @primary_tenant,
+      context: task_run,
+      expires_in: 1.hour,
+    )
+
+    post cancel_system_admin_task_run_path(task_run.id)
+
+    assert_not_nil token.reload.deleted_at, "API token should be marked deleted"
+  end
+
+  test "cancel refuses for already-completed task" do
+    @primary_tenant.add_user!(@sys_admin_user)
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    Collective.scope_thread_to_collective(subdomain: @primary_tenant.subdomain, handle: nil)
+    ai_agent = User.create!(name: "C Agent", email: "c-#{SecureRandom.hex(4)}@test.com", user_type: "ai_agent", parent_id: @sys_admin_user.id)
+    @primary_tenant.add_user!(ai_agent)
+    task_run = AiAgentTaskRun.create!(
+      tenant: @primary_tenant,
+      ai_agent: ai_agent,
+      initiated_by: @sys_admin_user,
+      task: "task",
+      max_steps: 10,
+      status: "completed",
+      success: true,
+      completed_at: 1.minute.ago,
+    )
+
+    post cancel_system_admin_task_run_path(task_run.id)
+
+    assert_redirected_to system_admin_task_run_path(task_run.id)
+    follow_redirect!
+    assert_equal "completed", task_run.reload.status
+  end
+
+  test "cancel returns 404 for unknown task" do
+    @primary_tenant.add_user!(@sys_admin_user)
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    post cancel_system_admin_task_run_path(SecureRandom.uuid)
+    assert_response :not_found
+  end
+
+  test "non-sys-admin cannot cancel a task run" do
+    @primary_tenant.add_user!(@non_sys_admin_user)
+    tu = @primary_tenant.tenant_users.find_by(user: @non_sys_admin_user)
+    tu.add_role!('admin')
+
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as(@non_sys_admin_user, tenant: @primary_tenant)
+
+    post cancel_system_admin_task_run_path(SecureRandom.uuid)
+    assert_response :forbidden
+  end
+
+  test "show_task_run renders cancel button for running task" do
+    @primary_tenant.add_user!(@sys_admin_user)
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    Collective.scope_thread_to_collective(subdomain: @primary_tenant.subdomain, handle: nil)
+    email = "cancel-#{SecureRandom.hex(4)}@test.com"
+    ai_agent = User.create!(name: "Cancel Agent", email: email, user_type: "ai_agent", parent_id: @sys_admin_user.id)
+    @primary_tenant.add_user!(ai_agent)
+    task_run = AiAgentTaskRun.create!(
+      tenant: @primary_tenant,
+      ai_agent: ai_agent,
+      initiated_by: @sys_admin_user,
+      task: "task",
+      max_steps: 10,
+      status: "running",
+      started_at: Time.current,
+    )
+
+    get system_admin_task_run_path(task_run.id)
+    assert_response :success
+    assert_match "Cancel Task Run", response.body
+  end
+
+  test "show_task_run hides cancel button for completed task" do
+    @primary_tenant.add_user!(@sys_admin_user)
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    Collective.scope_thread_to_collective(subdomain: @primary_tenant.subdomain, handle: nil)
+    ai_agent = User.create!(name: "Done Agent", email: "done-#{SecureRandom.hex(4)}@test.com", user_type: "ai_agent", parent_id: @sys_admin_user.id)
+    @primary_tenant.add_user!(ai_agent)
+    task_run = AiAgentTaskRun.create!(
+      tenant: @primary_tenant,
+      ai_agent: ai_agent,
+      initiated_by: @sys_admin_user,
+      task: "task",
+      max_steps: 10,
+      status: "completed",
+      success: true,
+      completed_at: 1.minute.ago,
+    )
+
+    get system_admin_task_run_path(task_run.id)
+    assert_response :success
+    assert_no_match(/Cancel Task Run/, response.body)
+  end
+
+  # ============================================================================
+  # SECTION 8: System Health Panel
+  # ============================================================================
+
+  test "dashboard includes DB pool and Redis health stats" do
+    @primary_tenant.add_user!(@sys_admin_user)
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    get "/system-admin"
+    assert_response :success
+
+    assert_match(/DB Pool/, response.body)
+    assert_match(/Redis/, response.body)
+    assert_match(/busy/, response.body)
+  end
+
+  test "dashboard markdown includes system health section" do
+    @primary_tenant.add_user!(@sys_admin_user)
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    get "/system-admin", headers: { "Accept" => "text/markdown" }
+    assert_response :success
+    assert_match(/System Health/, response.body)
+    assert_match(/DB pool/, response.body)
+  end
 end


### PR DESCRIPTION
Implements the three features in .claude/plans/sys-admin-improvements.md:

- Redispatch queued tasks: button on /system-admin/agent-runner that
  re-publishes every `queued` AiAgentTaskRun via AgentRunnerDispatchService.
  Mirrors `rake agent_runner:redispatch_queued` but with confirmation,
  per-task error handling, and an admin audit log entry.
- Cancel stuck task: cancel button on the task run detail page for
  `queued` or `running` runs. Marks the task cancelled, revokes its
  ephemeral internal API token, and notifies any parent automation run.
- System health panel: DB connection pool stats and Redis memory/clients
  on the system-admin dashboard (HTML and markdown).

Includes minitest coverage for happy paths, partial failure, status
guards, token revocation, authorization, and rendered UI affordances.
Cannot run the suite locally (no Docker daemon in this sandbox); the
checks scripts/check-tenant-safety.sh, check-debug-code.sh, and
check-secrets.sh all pass.

https://claude.ai/code/session_01DgJ8ymGMEmTCiPFxAWZNxx