### PR TITLE
Agent runner observability and tool use

### DIFF
--- a/.claude/plans/agent-runner-observability-and-tool-use.md
+++ b/.claude/plans/agent-runner-observability-and-tool-use.md
@@ -76,3 +76,101 @@ This is a model-behavior problem on top of an agent-runner gap:
 
 Both sprints stand alone; either can be done first depending on which
 pain is sharper.
+
+---
+
+## Notes from initial exploration (captured before compaction)
+
+### What the savedPath replay actually does
+
+In **chat mode only**, `AgentLoop` replays the chat session's saved
+`current_path` right after the initial `/whoami` navigation
+(`agent-runner/src/services/AgentLoop.ts` ~line 250). I initially
+misread this as a wasted step (it triggers even when the LLM is
+unreachable) and tried to delete it. It's load-bearing for two reasons:
+
+1. **Action validity is page-scoped.** `executeAction` rejects any
+   action name not in `currentActions`, and `currentActions` is set by
+   `navigate`. Turn 1 navigates to a note; turn 2 says "add a comment";
+   without the replay turn 2 is back at `/` with the wrong action set.
+2. **Chat-history rehydration drops tool calls.** Only user/assistant
+   text crosses turn boundaries. The agent has no memory of pages it
+   visited previously, so the replay re-fetches that content into the
+   LLM's message context.
+
+Task mode (the path Trio takes for `@trio` mentions) does NOT replay —
+it always starts at `/whoami` and lets the LLM drive from there. So
+Sprint A timeline work should treat the chat-mode "second navigate" as
+mandatory infrastructure, not LLM-spent steps. A future task-mode
+multi-turn pattern would need similar state.
+
+The replay is now annotated in code with both reasons.
+
+### What the empty `think` step actually means
+
+Sprint A Concern 1 was framed around "think steps are opaque." Concrete
+shapes observed:
+
+- `response_preview` empty (often just `"\n"`) → LLM emitted only tool
+  calls, no text content. Normal behavior for many models. The tool
+  call surfaces as the *next* step (navigate/execute).
+- `response_preview` non-empty → LLM emitted text alongside (or instead
+  of) tool calls. The `done` tool's message goes here too.
+
+Reasoning models (`trinity-large-thinking`, Claude extended thinking,
+OpenAI o-series) put their actual reasoning in a separate
+`reasoning` / `thinking` response field that `LLMClient.chat` doesn't
+currently parse. That's the real "opaque think" — and it's where most
+of the visibility win lives. Sprint A's "capture reasoning" item is
+the highest-value piece, not "tool-call summary in empty think."
+
+### Tool-use failure pattern observed
+
+Trio on `trinity-large-thinking` completed a mention-triggered task in
+6 steps without ever calling `post_comment`. It navigated correctly,
+read the note, then emitted its answer as the message argument to the
+`done` tool and stopped. The user saw nothing because `done.message`
+isn't surfaced outside the task run record. Claude on the same prompt
+took 14–18 steps and used the right tool.
+
+Worth probing whether this is a prompt-clarity issue (the system prompt
+doesn't explicitly say "done isn't a way to reach users; you must call
+post_comment") or a model capability issue. Sprint B's stronger
+guardrails are the cheap first move. A "completed without invoking an
+outward-communication tool" warning would catch this regression at
+run time and turn an invisible failure into a visible one.
+
+### Model configuration plumbing (current state)
+
+- `default` alias in `config/litellm_config.yaml` points at Arcee's
+  `trinity-large-thinking` via the Arcee API (requires `ARCEE_API_KEY`).
+- `trinity-large-thinking-free` alias routes the same model through
+  OpenRouter's free tier (requires `OPENROUTER_API_KEY`). LiteLLM
+  provider prefix is `openrouter/`, not `openai/`.
+- New trios get their model from `TRIO_DEFAULT_MODEL` env var (recently
+  added in `TrioSeeder.default_model`). Unset = no `model` key in
+  `agent_configuration`, agent-runner falls back to the `default`
+  alias.
+- Per-agent override: any agent's owner can set `model` on the agent
+  via its settings page. `TrioSeeder.refresh` does NOT overwrite an
+  existing model value, so manual overrides persist.
+
+### Dev environment gotchas
+
+- The agent-runner container is **built from source** (no volume
+  mount). To pick up local changes:
+  `docker compose --profile llm build agent-runner && docker compose --profile llm up -d agent-runner`.
+- The LiteLLM container is volume-mounted for the config file, but
+  env vars are only loaded at container CREATE time. To pick up
+  `.env` changes use `docker compose --profile llm up -d --force-recreate litellm`
+  (not `restart`).
+
+### What's committed on this branch so far
+
+- `aa985e0` — savedPath replay documentation + tests (captured the
+  insight above so the next reviewer doesn't repeat my mistake).
+- `39d5256` — `TRIO_DEFAULT_MODEL` env var support; `.env.example`
+  documentation refresh; OpenRouter trinity-large-thinking-free alias
+  in `litellm_config.yaml`.
+
+Neither is in the Sprint A/B scope yet — both are groundwork.

--- a/.env.example
+++ b/.env.example
@@ -62,12 +62,17 @@ SMTP_PASSWORD=
 SMTP_DOMAIN=
 MAILER_FROM_ADDRESS=
 # LLM keys for LiteLLM (used by agent-runner; required for AI agents and Trio).
-# The default model is Arcee's trinity-large-thinking, so ARCEE_API_KEY is the
-# one to set in a fresh install. The others are only needed if you switch the
-# default model in config/litellm_config.yaml or reference them by name.
+# Set the key for whichever provider(s) your model_name aliases in
+# config/litellm_config.yaml point to.
 # ARCEE_API_KEY=
 # ANTHROPIC_API_KEY=
 # OPENAI_API_KEY=
+# OPENROUTER_API_KEY=
+#
+# Default LLM model for newly-seeded Trio agents. Must match a model_name
+# alias in config/litellm_config.yaml. Unset = let the agent-runner fall
+# back to the "default" alias (which itself is configurable in litellm_config).
+# TRIO_DEFAULT_MODEL=trinity-large-thinking-free
 #
 # Monitoring and Alerting
 # Sentry error tracking (https://sentry.io)

--- a/agent-runner/src/core/StepBuilder.ts
+++ b/agent-runner/src/core/StepBuilder.ts
@@ -59,15 +59,27 @@ export function executeStep(detail: {
 }
 
 /**
+ * Compact summary of a single tool call emitted by the LLM, stored on the
+ * think step so the timeline can show *what the LLM asked for* even when
+ * response_preview is empty (common when the model emits only tool calls).
+ */
+export interface ToolCallSummary {
+  readonly name: string;
+  readonly arguments: string;
+}
+
+/**
  * Build a think step record.
  * Matches Ruby: add_step("think", { step_number:, prompt_preview:, response_preview:, llm_error: })
- * llm_error is only included if present (non-null).
+ * llm_error, tool_calls, and reasoning are only included when present.
  */
 export function thinkStep(detail: {
   readonly stepNumber: number;
   readonly promptPreview: string;
   readonly responsePreview: string;
   readonly llmError: string | null;
+  readonly toolCalls?: readonly ToolCallSummary[] | undefined;
+  readonly reasoning?: string | undefined;
 }, timestamp: Date): StepRecord {
   const stepDetail: Record<string, unknown> = {
     step_number: detail.stepNumber,
@@ -76,6 +88,15 @@ export function thinkStep(detail: {
   };
   if (detail.llmError !== null) {
     stepDetail["llm_error"] = detail.llmError;
+  }
+  if (detail.toolCalls !== undefined && detail.toolCalls.length > 0) {
+    stepDetail["tool_calls"] = detail.toolCalls.map((tc) => ({
+      name: tc.name,
+      arguments: tc.arguments,
+    }));
+  }
+  if (detail.reasoning !== undefined && detail.reasoning !== "") {
+    stepDetail["reasoning"] = detail.reasoning;
   }
   return {
     type: "think",

--- a/agent-runner/src/services/AgentLoop.ts
+++ b/agent-runner/src/services/AgentLoop.ts
@@ -249,7 +249,17 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
       const whoamiResult = yield* navigateTo("/whoami");
       leakageDetector = extractCanary(whoamiResult.content);
 
-      // Navigate to saved path if different from /whoami
+      // Replay the previous turn's navigation. This is load-bearing for two
+      // reasons, not just a "resume where we left off" nicety:
+      //   1. Action validity is page-scoped. `executeAction` rejects any
+      //      action that isn't in `currentActions`, and `currentActions` is
+      //      set by `navigate`. If turn 1 read a note and turn 2 says "add a
+      //      comment", the LLM's execute_action("add_comment") fails unless
+      //      we restore the note's page state.
+      //   2. The chat-history rehydration only carries user/assistant text
+      //      across turns — the agent's prior navigation results aren't in
+      //      the new message context. Re-navigating restores the page
+      //      content the LLM may need to reason about.
       if (savedPath && savedPath !== "/whoami") {
         yield* navigateTo(savedPath);
       }

--- a/agent-runner/src/services/AgentLoop.ts
+++ b/agent-runner/src/services/AgentLoop.ts
@@ -373,12 +373,21 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
           }
         }
 
-        // Record "think" step (matches Ruby think() recording)
+        // Record "think" step (matches Ruby think() recording).
+        // Capture toolCalls + reasoning so the timeline can show *what the LLM
+        // asked for* even when content is empty — common when the model emits
+        // only tool calls (no prose), or when reasoning lives in a separate
+        // field (DeepSeek R1, Claude extended thinking, OpenAI o-series).
         yield* addStep(thinkStep({
           stepNumber: stepNumberForThink,
           promptPreview: messages[messages.length - 1]?.content ?? "",
           responsePreview: response.content ?? "",
           llmError: null,
+          toolCalls: response.toolCalls.map((tc) => ({
+            name: tc.function.name,
+            arguments: tc.function.arguments,
+          })),
+          reasoning: response.reasoning,
         }, new Date()));
 
         // Add assistant response to history

--- a/agent-runner/src/services/HarmonicClient.ts
+++ b/agent-runner/src/services/HarmonicClient.ts
@@ -169,10 +169,15 @@ export const HarmonicClientLive = Layer.effect(
     const executeAction: HarmonicClientService["executeAction"] = (path, action, params, token, subdomain) =>
       Effect.tryPromise({
         try: async () => {
+          // Strip the query string before appending `/actions/<name>` —
+          // the agent's currentPath can include `?comment_id=…`, but
+          // action URLs are on the bare resource path.
+          const basePath = path.split("?")[0] ?? path;
+          const actionPath = `${basePath}/actions/${action}`;
           const response = await railsHttp.request({
             method: "POST",
             subdomain,
-            path: `${path}/actions/${action}`,
+            path: actionPath,
             headers: {
               "X-Forwarded-Proto": "https",
               "Content-Type": "application/json",
@@ -192,7 +197,7 @@ export const HarmonicClientLive = Layer.effect(
         catch: (error) =>
           new HarmonicApiError({
             message: error instanceof Error ? error.message : String(error),
-            path: `${path}/actions/${action}`,
+            path: `${(path.split("?")[0] ?? path)}/actions/${action}`,
           }),
       });
 

--- a/agent-runner/src/services/LLMClient.ts
+++ b/agent-runner/src/services/LLMClient.ts
@@ -18,6 +18,13 @@ export interface LLMResponse {
     readonly inputTokens: number;
     readonly outputTokens: number;
   };
+  /**
+   * Model-emitted chain-of-thought / reasoning text, when the provider exposes
+   * it as a separate field. Different vendors use different shapes — we
+   * normalize to a single optional string. Undefined when: not a reasoning
+   * model, or reasoning hidden by the provider.
+   */
+  readonly reasoning: string | undefined;
 }
 
 export interface LLMClientService {
@@ -35,7 +42,14 @@ interface CompletionChoice {
   readonly message?: {
     readonly content?: string | null;
     readonly tool_calls?: readonly RawToolCall[];
+    // Reasoning models surface chain-of-thought in different fields:
+    //   reasoning_content — DeepSeek R1, Anthropic via LiteLLM passthrough
+    //   reasoning         — some OpenRouter providers
+    readonly reasoning_content?: string | null;
+    readonly reasoning?: string | null;
   };
+  // OpenAI o-series surfaces reasoning at the choice level instead.
+  readonly reasoning?: string | null;
   readonly finish_reason?: string;
 }
 
@@ -131,6 +145,12 @@ export const LLMClientLive = Layer.effect(
               },
             }));
 
+          const reasoning =
+            message?.reasoning_content ??
+            message?.reasoning ??
+            choice?.reasoning ??
+            undefined;
+
           return {
             content: message?.content ?? undefined,
             toolCalls,
@@ -140,6 +160,7 @@ export const LLMClientLive = Layer.effect(
               inputTokens: data.usage?.prompt_tokens ?? 0,
               outputTokens: data.usage?.completion_tokens ?? 0,
             },
+            reasoning: reasoning ?? undefined,
           } satisfies LLMResponse;
         },
         catch: (error) =>

--- a/agent-runner/test/core/StepBuilder.test.ts
+++ b/agent-runner/test/core/StepBuilder.test.ts
@@ -120,6 +120,80 @@ describe("StepBuilder", () => {
 
       expect(step.detail).not.toHaveProperty("llm_error");
     });
+
+    it("includes tool_calls when present", () => {
+      const step = thinkStep({
+        stepNumber: 1,
+        promptPreview: "prompt",
+        responsePreview: "",
+        llmError: null,
+        toolCalls: [
+          { name: "navigate", arguments: '{"path":"/notifications"}' },
+          { name: "execute_action", arguments: '{"action":"create_note","params":{"body":"hi"}}' },
+        ],
+      }, timestamp);
+
+      expect(step.detail["tool_calls"]).toEqual([
+        { name: "navigate", arguments: '{"path":"/notifications"}' },
+        { name: "execute_action", arguments: '{"action":"create_note","params":{"body":"hi"}}' },
+      ]);
+    });
+
+    it("omits tool_calls when none were emitted", () => {
+      const step = thinkStep({
+        stepNumber: 1,
+        promptPreview: "prompt",
+        responsePreview: "All done",
+        llmError: null,
+        toolCalls: [],
+      }, timestamp);
+
+      expect(step.detail).not.toHaveProperty("tool_calls");
+    });
+
+    it("omits tool_calls when undefined", () => {
+      const step = thinkStep({
+        stepNumber: 0,
+        promptPreview: "prompt",
+        responsePreview: "response",
+        llmError: null,
+      }, timestamp);
+
+      expect(step.detail).not.toHaveProperty("tool_calls");
+    });
+
+    it("includes reasoning when present", () => {
+      const step = thinkStep({
+        stepNumber: 2,
+        promptPreview: "prompt",
+        responsePreview: "",
+        llmError: null,
+        reasoning: "The user asked about notifications, so I should navigate there first.",
+      }, timestamp);
+
+      expect(step.detail["reasoning"]).toBe(
+        "The user asked about notifications, so I should navigate there first.",
+      );
+    });
+
+    it("omits reasoning when undefined or empty", () => {
+      const stepUndefined = thinkStep({
+        stepNumber: 0,
+        promptPreview: "prompt",
+        responsePreview: "response",
+        llmError: null,
+      }, timestamp);
+      const stepEmpty = thinkStep({
+        stepNumber: 0,
+        promptPreview: "prompt",
+        responsePreview: "response",
+        llmError: null,
+        reasoning: "",
+      }, timestamp);
+
+      expect(stepUndefined.detail).not.toHaveProperty("reasoning");
+      expect(stepEmpty.detail).not.toHaveProperty("reasoning");
+    });
   });
 
   describe("errorStep", () => {

--- a/agent-runner/test/services/AgentLoop.test.ts
+++ b/agent-runner/test/services/AgentLoop.test.ts
@@ -122,6 +122,7 @@ interface MockOptions {
   readonly navigateErrors?: Record<string, string>;  // path → error message
   readonly llmErrorOnCall?: number;  // fail on the Nth LLM call (0-indexed)
   readonly chatHistory?: readonly ChatHistoryMsg[];
+  readonly chatCurrentPath?: string;  // historyResponse.current_state.current_path
 }
 
 function buildTestLayers(
@@ -183,7 +184,10 @@ function buildTestLayers(
         content: m.content,
         timestamp: m.timestamp ?? new Date().toISOString(),
       }));
-      return Effect.succeed({ messages, current_state: {} });
+      const current_state = options?.chatCurrentPath !== undefined
+        ? { current_path: options.chatCurrentPath }
+        : {};
+      return Effect.succeed({ messages, current_state });
     },
   });
 
@@ -1040,6 +1044,57 @@ describe("AgentLoop", () => {
       const firstPrompt = state.llmMessages[0] ?? [];
       expect(userTurnCount(firstPrompt, "brand new question")).toBe(1);
       expect(userTurnCount(firstPrompt, "stale prior question")).toBe(1);
+    });
+
+    it("replays the previous turn's current_path so cross-turn actions remain valid", async () => {
+      // Each chat turn replays the saved current_path right after /whoami.
+      // This is intentional and load-bearing: `executeAction` validates the
+      // action name against `currentActions`, which is set by `navigate`. If
+      // turn 1 navigates to a note and turn 2 says "add a comment", the
+      // LLM's execute_action("add_comment") would fail validation unless we
+      // re-establish the page state on turn 2. The replay also re-loads the
+      // page content into the new turn's message context — the chat history
+      // rehydration only carries user/assistant text, not prior navigation
+      // results, so without the replay the LLM has no memory of the page.
+      const state = createMockState();
+      await runWithMocks(
+        chatTask("now add a comment"),
+        state,
+        [makeLLMResponse({ content: "ok" })],
+        undefined,
+        undefined,
+        {
+          chatHistory: [
+            { role: "user", content: "please read this note" },
+            { role: "assistant", content: "got it" },
+          ],
+          chatCurrentPath: "/collectives/chariot/n/abc123",
+        },
+      );
+
+      expect(state.navigatePaths).toEqual([
+        "/whoami",
+        "/collectives/chariot/n/abc123",
+      ]);
+    });
+
+    it("does not replay current_path when it equals /whoami", async () => {
+      // /whoami is the always-first navigation; skipping the replay when it
+      // would land on the same place avoids a duplicate fetch.
+      const state = createMockState();
+      await runWithMocks(
+        chatTask("hello"),
+        state,
+        [makeLLMResponse({ content: "hi" })],
+        undefined,
+        undefined,
+        {
+          chatHistory: [{ role: "user", content: "first" }],
+          chatCurrentPath: "/whoami",
+        },
+      );
+
+      expect(state.navigatePaths).toEqual(["/whoami"]);
     });
   });
 });

--- a/agent-runner/test/services/AgentLoop.test.ts
+++ b/agent-runner/test/services/AgentLoop.test.ts
@@ -58,6 +58,7 @@ function makeLLMResponse(overrides?: Partial<LLMResponse>): LLMResponse {
     finishReason: "stop",
     model: "test-model",
     usage: { inputTokens: 100, outputTokens: 50 },
+    reasoning: undefined,
     ...overrides,
   };
 }
@@ -1095,6 +1096,88 @@ describe("AgentLoop", () => {
       );
 
       expect(state.navigatePaths).toEqual(["/whoami"]);
+    });
+  });
+
+  // --- Sprint A: think-step observability ---
+
+  describe("think step observability", () => {
+    it("records tool_calls on the think step when the LLM emits tool calls", async () => {
+      const state = createMockState();
+      await runWithMocks(
+        makeTask(),
+        state,
+        [
+          makeLLMResponse({
+            content: undefined,
+            toolCalls: [
+              makeNavigateToolCall("/notifications", "call_1"),
+              makeExecuteToolCall("mark_read", { id: 42 }, "call_2"),
+            ],
+            finishReason: "tool_calls",
+          }),
+          makeLLMResponse({ content: "Done", toolCalls: [], finishReason: "stop" }),
+          makeLLMResponse({ content: '{"scratchpad": null}', toolCalls: [], finishReason: "stop" }),
+        ],
+        {
+          "/whoami": { content: WHOAMI_CONTENT, availableActions: ["mark_read"] },
+          "/notifications": { content: "# Notifications", availableActions: ["mark_read"] },
+        },
+        { "mark_read": { content: "Marked", success: true } },
+      );
+
+      const thinkSteps = state.stepsCalled.filter((s) => s.type === "think");
+      const firstThink = thinkSteps[0];
+      expect(firstThink).toBeDefined();
+      const toolCalls = firstThink?.detail["tool_calls"] as ReadonlyArray<{ name: string; arguments: string }>;
+      expect(toolCalls).toBeDefined();
+      expect(toolCalls.length).toBe(2);
+      expect(toolCalls[0]?.name).toBe("navigate");
+      expect(toolCalls[0]?.arguments).toContain('"path":"/notifications"');
+      expect(toolCalls[1]?.name).toBe("execute_action");
+      expect(toolCalls[1]?.arguments).toContain('"action":"mark_read"');
+    });
+
+    it("omits tool_calls on the think step when the LLM only emitted text", async () => {
+      const state = createMockState();
+      await runWithMocks(
+        makeTask(),
+        state,
+        [makeLLMResponse({ content: "Done", toolCalls: [], finishReason: "stop" })],
+      );
+
+      const thinkSteps = state.stepsCalled.filter((s) => s.type === "think");
+      expect(thinkSteps[0]?.detail).not.toHaveProperty("tool_calls");
+    });
+
+    it("records reasoning on the think step when the LLM response carries it", async () => {
+      const state = createMockState();
+      await runWithMocks(
+        makeTask(),
+        state,
+        [
+          makeLLMResponse({
+            content: "Done",
+            toolCalls: [],
+            finishReason: "stop",
+            reasoning: "The user just said hello; respond and stop.",
+          }),
+          makeLLMResponse({ content: '{"scratchpad": null}', toolCalls: [], finishReason: "stop" }),
+        ],
+      );
+
+      const thinkSteps = state.stepsCalled.filter((s) => s.type === "think");
+      expect(thinkSteps[0]?.detail["reasoning"]).toBe(
+        "The user just said hello; respond and stop.",
+      );
+    });
+
+    it("omits reasoning on the think step when the LLM response carries none", async () => {
+      const state = createMockState();
+      await runWithMocks(makeTask(), state, [makeLLMResponse()]);
+
+      const thinkSteps = state.stepsCalled.filter((s) => s.type === "think");
+      expect(thinkSteps[0]?.detail).not.toHaveProperty("reasoning");
     });
   });
 });

--- a/agent-runner/test/services/HarmonicClient.test.ts
+++ b/agent-runner/test/services/HarmonicClient.test.ts
@@ -51,6 +51,47 @@ function runNavigate(
   return Effect.runPromiseExit(program.pipe(Effect.provide(layer)));
 }
 
+function runExecuteAction(
+  requestHandler: (opts: RailsRequestOptions) => RailsResponse,
+  path: string,
+  action: string,
+  params: Record<string, unknown> = {},
+): Promise<Exit.Exit<{ content: string; success: boolean }, HarmonicApiError>> {
+  const layer = buildTestLayer(requestHandler);
+  const program = Effect.gen(function* () {
+    const client = yield* HarmonicClient;
+    return yield* client.executeAction(path, action, params, "test-token", "app");
+  });
+  return Effect.runPromiseExit(program.pipe(Effect.provide(layer)));
+}
+
+describe("executeAction URL construction", () => {
+  it("strips ?query string from path before appending /actions/<name>", async () => {
+    let observedPath = "";
+    const handler = (opts: RailsRequestOptions) => {
+      observedPath = opts.path;
+      return makeResponse(200, "Comment added");
+    };
+
+    const exit = await runExecuteAction(handler, "/d/abc?comment_id=xyz", "add_comment", { text: "hi" });
+
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(observedPath).toBe("/d/abc/actions/add_comment");
+  });
+
+  it("works correctly when path has no query string", async () => {
+    let observedPath = "";
+    const handler = (opts: RailsRequestOptions) => {
+      observedPath = opts.path;
+      return makeResponse(200, "OK");
+    };
+
+    await runExecuteAction(handler, "/d/abc", "vote", { option_title: "yes" });
+
+    expect(observedPath).toBe("/d/abc/actions/vote");
+  });
+});
+
 describe("navigate redirect following", () => {
   it("follows a single redirect", async () => {
     const requests: string[] = [];

--- a/agent-runner/test/services/LLMClient.test.ts
+++ b/agent-runner/test/services/LLMClient.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Effect, Layer } from "effect";
+import { LLMClient, LLMClientLive } from "../../src/services/LLMClient.js";
+import { Config } from "../../src/config/Config.js";
+
+const ConfigTest = Layer.succeed(Config, {
+  harmonicInternalUrl: "http://test:3000",
+  harmonicHostname: "test.local",
+  agentRunnerSecret: "test-secret",
+  redisUrl: "redis://test:6379",
+  llmBaseUrl: "http://litellm:4000",
+  llmGatewayMode: "litellm" as const,
+  stripeGatewayKey: undefined,
+  streamName: "test_tasks",
+  consumerGroup: "test_group",
+  consumerName: "test_consumer",
+  maxConcurrentTasks: 10,
+  streamMaxLen: 1000,
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function runChat(body: unknown) {
+  const fetchSpy = vi.fn(async () => jsonResponse(body));
+  vi.stubGlobal("fetch", fetchSpy);
+  const program = Effect.gen(function* () {
+    const client = yield* LLMClient;
+    return yield* client.chat([], undefined, [], undefined);
+  });
+  return Effect.runPromise(
+    program.pipe(Effect.provide(LLMClientLive.pipe(Layer.provide(ConfigTest)))),
+  );
+}
+
+describe("LLMClient", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("captures reasoning_content from message (DeepSeek / Anthropic via LiteLLM)", async () => {
+    const result = await runChat({
+      choices: [
+        {
+          message: {
+            content: "Final answer",
+            reasoning_content: "Step 1: think. Step 2: act.",
+          },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+
+    expect(result.reasoning).toBe("Step 1: think. Step 2: act.");
+    expect(result.content).toBe("Final answer");
+  });
+
+  it("captures reasoning from message (some OpenRouter providers)", async () => {
+    const result = await runChat({
+      choices: [
+        {
+          message: {
+            content: null,
+            reasoning: "Thinking through the problem...",
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: { name: "navigate", arguments: '{"path":"/x"}' },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    });
+
+    expect(result.reasoning).toBe("Thinking through the problem...");
+    expect(result.toolCalls.length).toBe(1);
+  });
+
+  it("captures reasoning from choice-level field (OpenAI o-series shape)", async () => {
+    const result = await runChat({
+      choices: [
+        {
+          message: { content: "Answer" },
+          reasoning: "Chain-of-thought here.",
+          finish_reason: "stop",
+        },
+      ],
+    });
+
+    expect(result.reasoning).toBe("Chain-of-thought here.");
+  });
+
+  it("returns undefined reasoning when none is provided", async () => {
+    const result = await runChat({
+      choices: [
+        { message: { content: "Plain response" }, finish_reason: "stop" },
+      ],
+    });
+
+    expect(result.reasoning).toBeUndefined();
+  });
+});

--- a/app/assets/stylesheets/pulse/_components.css
+++ b/app/assets/stylesheets/pulse/_components.css
@@ -461,6 +461,18 @@
   border-bottom: none;
 }
 
+.pulse-comment-highlighted {
+  background-color: var(--color-attention-subtle, #fff8c5);
+  border-left: 3px solid var(--color-attention-emphasis, #d4a72c);
+  padding-left: 8px;
+  animation: pulse-comment-flash 1.5s ease-out;
+}
+
+@keyframes pulse-comment-flash {
+  0% { background-color: var(--color-attention-emphasis, #d4a72c); }
+  100% { background-color: var(--color-attention-subtle, #fff8c5); }
+}
+
 .pulse-comment-header {
   display: flex;
   align-items: center;

--- a/app/components/comment_component.html.erb
+++ b/app/components/comment_component.html.erb
@@ -44,11 +44,11 @@
   <% end %>
 
   <% if @comment.deleted? %>
-    <div class="pulse-comment-body pulse-body-text-muted">
+    <div class="pulse-comment-body markdown-body pulse-body-text-muted">
       <em>[deleted]</em>
     </div>
   <% else %>
-    <div class="pulse-comment-body">
+    <div class="pulse-comment-body markdown-body">
       <%= helpers.markdown_inline(@comment.text) %>
     </div>
   <% end %>

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,8 +76,31 @@ class ApplicationController < ActionController::Base
     @current_collective
   end
 
+  # Query params preserved in the canonical `current_path` (used in the
+  # markdown frontmatter `path:`). Add params here when they carry meaning
+  # the agent needs to see — search queries, comment highlights, pagination
+  # cursors, time-range filters. Anything not listed is dropped so the
+  # frontmatter URL stays clean and predictable.
+  PRESERVED_QUERY_PARAMS = %w[
+    q
+    comment_id
+    cycle
+    cursor
+    offset
+    status
+    before
+    after
+  ].freeze
+
   def current_path
-    @current_path ||= request.path
+    return @current_path if defined?(@current_path) && @current_path
+
+    preserved = PRESERVED_QUERY_PARAMS.each_with_object({}) do |key, h|
+      val = params[key]
+      h[key] = val.to_s if val.present?
+    end
+
+    @current_path = preserved.any? ? "#{request.path}?#{preserved.to_query}" : request.path
   end
 
   def api_token_present?

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -23,9 +23,6 @@ class SearchController < ApplicationController
     @end_position = @offset + @results.size
     @next_offset = @offset + @results.size
 
-    # Set current_path to include query string for markdown frontmatter
-    @current_path = params[:q].present? ? "/search?q=#{ERB::Util.url_encode(params[:q])}" : "/search"
-
     respond_to do |format|
       format.html
       format.md

--- a/app/javascript/controllers/comment_thread_controller.ts
+++ b/app/javascript/controllers/comment_thread_controller.ts
@@ -6,8 +6,48 @@ import { getCsrfToken } from "../utils/csrf"
  * - Shows/hides reply forms
  * - Updates the reply target when replying to nested comments
  * - Submits replies via AJAX and refreshes the thread
+ * - On page load, scrolls to and highlights the comment in `?comment_id=` if present
  */
 export default class CommentThreadController extends Controller {
+  connect(): void {
+    this.highlightCommentFromUrl()
+  }
+
+  private highlightCommentFromUrl(): void {
+    const params = new URLSearchParams(window.location.search)
+    const commentId = params.get("comment_id")
+    if (!commentId) return
+
+    const target = document.getElementById(`n-${commentId}`)
+    if (!target) return
+
+    // If the target is inside a collapsed replies group, expand it first so
+    // the scroll lands on a visible element.
+    const collapsedReplies = target.closest(".pulse-comment-replies[hidden]") as HTMLElement | null
+    if (collapsedReplies) {
+      collapsedReplies.hidden = false
+      const toggleButton = document.querySelector(
+        `.pulse-replies-toggle[aria-controls="${collapsedReplies.id}"]`
+      ) as HTMLElement | null
+      if (toggleButton) {
+        toggleButton.classList.remove("is-collapsed")
+        toggleButton.setAttribute("aria-expanded", "true")
+        const textSpan = toggleButton.querySelector(".pulse-replies-toggle-text") as HTMLElement | null
+        const replyCount = toggleButton.dataset.replyCount
+        if (textSpan && replyCount) {
+          const count = parseInt(replyCount, 10)
+          const replyWord = count === 1 ? "reply" : "replies"
+          textSpan.textContent = `Hide ${replyWord}`
+        }
+      }
+    }
+
+    // Run after layout so smooth-scroll picks up the now-visible element.
+    requestAnimationFrame(() => {
+      target.scrollIntoView({ behavior: "smooth", block: "center" })
+      target.classList.add("pulse-comment-highlighted")
+    })
+  }
 
   private async refreshCommentsList(): Promise<void> {
     // Find the parent comments section and get the refresh URL

--- a/app/javascript/controllers/task_run_status_controller.ts
+++ b/app/javascript/controllers/task_run_status_controller.ts
@@ -392,6 +392,8 @@ export default class TaskRunStatusController extends Controller<HTMLElement> {
     const stepNumber = (detail.step_number as number) || 0
     const llmError = detail.llm_error as string | undefined
     const responsePreview = detail.response_preview as string | undefined
+    const toolCalls = detail.tool_calls as Array<{ name?: string; arguments?: string }> | undefined
+    const reasoning = detail.reasoning as string | undefined
 
     let html = `<div class="pulse-feed-item-content">LLM reasoning (step ${stepNumber + 1})`
 
@@ -405,6 +407,31 @@ export default class TaskRunStatusController extends Controller<HTMLElement> {
 
     if (llmError) {
       html += `<p style="color: var(--color-danger-fg); margin: 8px 0 0 0; font-size: 13px;">${this.escapeHtml(llmError)}</p>`
+    }
+
+    if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+      const tcParts = toolCalls.map((tc, i) => {
+        const name = this.escapeHtml(String(tc?.name ?? ""))
+        const args = this.escapeHtml(String(tc?.arguments ?? ""))
+        const sep = i < toolCalls.length - 1 ? "," : ""
+        return `<code class="pulse-code" style="font-size: 11px; margin-right: 4px;">${name}(${args})</code>${sep}`
+      })
+      html += `<p class="pulse-muted" style="margin: 8px 0 0 0;">Tool calls: ${tcParts.join(" ")}</p>`
+    }
+
+    if (reasoning) {
+      // Open by default — for reasoning models this is the most useful field.
+      html += `
+        <details class="pulse-accordion" style="margin-top: 12px;" open>
+          <summary class="pulse-accordion-header">
+            <span class="pulse-accordion-title">View model reasoning</span>
+            <span class="pulse-accordion-icon"><svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="14" height="14"><path fill-rule="evenodd" d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"></path></svg></span>
+          </summary>
+          <div class="pulse-accordion-content">
+            <pre style="font-size: 12px; overflow-x: auto; white-space: pre-wrap; margin: 0;">${this.escapeHtml(reasoning)}</pre>
+          </div>
+        </details>
+      `
     }
 
     if (responsePreview) {

--- a/app/models/ai_agent_task_run_resource.rb
+++ b/app/models/ai_agent_task_run_resource.rb
@@ -37,6 +37,15 @@ class AiAgentTaskRunResource < ApplicationRecord
     record&.ai_agent_task_run
   end
 
+  # Return the stored value of the `display_path` column.
+  # ApplicationRecord defines `display_path` as a fallback that returns `path`,
+  # which assumes the model has a `collective` and `path_prefix`. This model
+  # doesn't — the precomputed URL lives in the column of the same name.
+  sig { returns(T.nilable(String)) }
+  def display_path
+    self[:display_path]
+  end
+
   # Load the resource bypassing default scope (needed because resources may be in different collectives)
   sig { returns(T.untyped) }
   def resource_unscoped

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -151,6 +151,14 @@ class ApplicationRecord < ActiveRecord::Base
     "#{T.unsafe(self).collective.path}/#{T.unsafe(self).path_prefix}/#{T.unsafe(self).truncated_id}"
   end
 
+  # Default to `path`. Override in models where a display URL differs from
+  # the canonical resource URL — Note does this for comments to surface them
+  # inside their parent thread (see Note#display_path).
+  sig { returns(T.nilable(String)) }
+  def display_path
+    path
+  end
+
   sig { returns(T.nilable(String)) }
   def shareable_link
     subdomain = T.unsafe(self).tenant.subdomain

--- a/app/models/automation_rule_run_resource.rb
+++ b/app/models/automation_rule_run_resource.rb
@@ -37,6 +37,15 @@ class AutomationRuleRunResource < ApplicationRecord
     record&.automation_rule_run
   end
 
+  # Return the stored value of the `display_path` column.
+  # ApplicationRecord defines `display_path` as a fallback that returns `path`,
+  # which assumes the model has a `collective` and `path_prefix`. This model
+  # doesn't — the precomputed URL lives in the column of the same name.
+  sig { returns(T.nilable(String)) }
+  def display_path
+    self[:display_path]
+  end
+
   # Load the resource bypassing default scope (needed because resources may be in different collectives)
   sig { returns(T.untyped) }
   def resource_unscoped

--- a/app/models/concerns/commentable.rb
+++ b/app/models/concerns/commentable.rb
@@ -64,6 +64,11 @@ module Commentable
       threads[comment.id] = descendants
     end
 
+    # Every comment returned here has `self` as its root commentable.
+    # Inject it so render-time calls to `comment.path` /
+    # `comment.root_commentable` don't walk the polymorphic chain.
+    (top_level + threads.values.flatten).each { |c| c.root_commentable = self }
+
     { top_level: top_level, threads: threads }
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -327,18 +327,22 @@ class Note < ApplicationRecord
     @root_commentable = cur
   end
 
-  # For comments, return the root commentable's path with a `?comment_id=`
-  # query param pointing at this specific comment. Callers landing on that
-  # URL see the full surrounding conversation in one navigation instead of
-  # the isolated /n/<comment-id> page. Non-comments use the standard
-  # `{collective_path}/n/{truncated_id}` form inherited from ApplicationRecord.
+  # The URL to link to when surfacing this note in a display context —
+  # comment lists, mention notifications, agent task prompts. For comments,
+  # returns the root commentable's path with `?comment_id=<truncated_id>` so
+  # the caller lands on the full thread with this comment marked, rather
+  # than the isolated /n/<comment-id> page. For non-comments, equals `path`.
+  #
+  # Use `path` (not `display_path`) when building API URLs by suffix
+  # concatenation (form actions, JS action endpoints, etc.) — `path` is the
+  # canonical bare resource URL.
   sig { returns(T.nilable(String)) }
-  def path
-    return super unless is_comment? && has_commentable?
+  def display_path
+    return path unless is_comment? && has_commentable?
 
     root = root_commentable
     root_path = root.respond_to?(:path) ? root.path : nil
-    return super if root_path.blank?
+    return path if root_path.blank?
 
     "#{root_path}?comment_id=#{truncated_id}"
   end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -298,6 +298,51 @@ class Note < ApplicationRecord
     !is_comment? && !is_statement?
   end
 
+  # The non-comment ancestor this conversation is *about* — the Decision /
+  # standalone Note / Commitment / etc. that the thread is rooted on. Returns
+  # self for non-comments. Walks up the polymorphic `commentable` chain while
+  # the parent is itself a Note (i.e. another comment).
+  #
+  # Result is memoized per instance. Bulk callers that already know the root
+  # (e.g. Commentable#comments_with_threads) should set it via
+  # `root_commentable=` after preloading to avoid the polymorphic walk
+  # entirely — that's the hot path for rendering a thread.
+  sig { params(value: T.untyped).void }
+  def root_commentable=(value)
+    @root_commentable = value
+  end
+
+  sig { returns(T.untyped) }
+  def root_commentable
+    return @root_commentable if defined?(@root_commentable)
+    return @root_commentable = self unless is_comment? && has_commentable?
+
+    cur = T.let(T.unsafe(self).commentable, T.untyped)
+    depth = 0
+    while cur.is_a?(Note) && T.unsafe(cur).is_comment? && T.unsafe(cur).has_commentable?
+      cur = T.unsafe(cur).commentable
+      depth += 1
+      break if depth > 20 # cycle / depth guard
+    end
+    @root_commentable = cur
+  end
+
+  # For comments, return the root commentable's path with a `?comment_id=`
+  # query param pointing at this specific comment. Callers landing on that
+  # URL see the full surrounding conversation in one navigation instead of
+  # the isolated /n/<comment-id> page. Non-comments use the standard
+  # `{collective_path}/n/{truncated_id}` form inherited from ApplicationRecord.
+  sig { returns(T.nilable(String)) }
+  def path
+    return super unless is_comment? && has_commentable?
+
+    root = root_commentable
+    root_path = root.respond_to?(:path) ? root.path : nil
+    return super if root_path.blank?
+
+    "#{root_path}?comment_id=#{truncated_id}"
+  end
+
   # Returns all descendants (replies, replies to replies, etc.) chronologically
   # Uses PostgreSQL recursive CTE for efficient single-query fetching
   # IMPORTANT: find_by_sql bypasses default_scope, so we must filter by tenant/collective

--- a/app/services/actions_helper.rb
+++ b/app/services/actions_helper.rb
@@ -455,9 +455,11 @@ class ActionsHelper
     # Comment action (shared across notes, decisions, commitments)
     "add_comment" => {
       description: "Add a comment",
-      params_string: "(text)",
+      params_string: "(text, replying_to_id)",
       params: [
         { name: "text", type: "string", description: "The text of the comment" },
+        { name: "replying_to_id", type: "string", required: false,
+          description: "Optional for comment threads", },
       ],
       authorization: :collective_member,
     },

--- a/app/services/api_helper.rb
+++ b/app/services/api_helper.rb
@@ -145,6 +145,15 @@ class ApiHelper
 
   sig { params(commentable: T.nilable(T.any(Note, Decision, Commitment, RepresentationSession))).returns(Note) }
   def create_note(commentable: nil)
+    # If a caller passes `replying_to_id`, the new note nests under that
+    # specific comment. The original `commentable` (from the URL) only
+    # determines the thread — `replying_to_id` selects the parent within it.
+    # Validation: the target must share a root commentable with the original.
+    if commentable.present? && params[:replying_to_id].present?
+      thread_root = commentable.is_a?(Note) ? commentable.root_commentable : commentable
+      commentable = resolve_replying_to(thread_root)
+    end
+
     note = T.let(nil, T.nilable(Note))
     ActiveRecord::Base.transaction do
       check_not_blocked_for_comment!(commentable) if commentable
@@ -1304,6 +1313,30 @@ class ApiHelper
 
   def check_not_blocked_for_comment!(commentable)
     check_not_blocked!(commentable, action: "comment on")
+  end
+
+  # Resolve `params[:replying_to_id]` to a Note in the current thread, or
+  # raise a RecordInvalid the controller can surface to the caller. Validates
+  # both existence and thread membership — a comment whose root commentable
+  # is a different resource is rejected to prevent agents accidentally
+  # threading into the wrong conversation.
+  sig do
+    params(root: T.any(Note, Decision, Commitment, RepresentationSession))
+      .returns(Note)
+  end
+  def resolve_replying_to(root)
+    target = Note.where(subtype: "comment").find_by(truncated_id: params[:replying_to_id])
+    if target.nil?
+      raise ActiveRecord::RecordInvalid.new(
+        Note.new.tap { |r| r.errors.add(:replying_to_id, "no such comment in this thread (id: #{params[:replying_to_id]})") }
+      )
+    end
+    if target.root_commentable != root
+      raise ActiveRecord::RecordInvalid.new(
+        Note.new.tap { |r| r.errors.add(:replying_to_id, "the comment is in a different thread") }
+      )
+    end
+    target
   end
 
   def check_not_blocked!(resource, action: "interact with")

--- a/app/services/automation_template_renderer.rb
+++ b/app/services/automation_template_renderer.rb
@@ -99,8 +99,10 @@ class AutomationTemplateRenderer
       "type" => subject.class.name.underscore,
     }
 
-    # Add common fields if available
-    context["path"] = subject.path if subject.respond_to?(:path)
+    # Add common fields if available. Use display_path so comment subjects
+    # surface as {root}?comment_id={id} — landing recipients (humans + agents)
+    # in the full thread with the comment marked, in one navigation.
+    context["path"] = subject.display_path if subject.respond_to?(:display_path)
     context["title"] = extract_title(subject)
     context["text"] = extract_text(subject)
     context["created_by"] = build_user_context(subject.created_by) if subject.respond_to?(:created_by) && subject.created_by

--- a/app/services/notification_dispatcher.rb
+++ b/app/services/notification_dispatcher.rb
@@ -58,7 +58,7 @@ class NotificationDispatcher
         notification_type: "mention",
         title: "#{actor_name} mentioned you",
         body: note.text.to_s.truncate(200),
-        url: note.path
+        url: note.display_path
       )
     end
 
@@ -133,7 +133,7 @@ class NotificationDispatcher
       notification_type: "participation",
       title: "#{actor_name} #{vote_type} on your decision",
       body: decision.description.to_s.truncate(200),
-      url: decision.path
+      url: decision.display_path
     )
   end
 
@@ -155,7 +155,7 @@ class NotificationDispatcher
         notification_type: "participation",
         title: "A decision you participated in was resolved",
         body: decision.description.to_s.truncate(200),
-        url: decision.path
+        url: decision.display_path
       )
     end
   end
@@ -178,7 +178,7 @@ class NotificationDispatcher
       notification_type: "participation",
       title: "#{actor_name} joined your commitment",
       body: commitment.description.to_s.truncate(200),
-      url: commitment.path
+      url: commitment.display_path
     )
   end
 
@@ -200,7 +200,7 @@ class NotificationDispatcher
         notification_type: "participation",
         title: "Critical mass reached on a commitment you joined",
         body: commitment.description.to_s.truncate(200),
-        url: commitment.path
+        url: commitment.display_path
       )
     end
   end
@@ -239,7 +239,7 @@ class NotificationDispatcher
         notification_type: "mention",
         title: "#{actor_name} mentioned you in a decision",
         body: decision.question.to_s.truncate(200),
-        url: decision.path
+        url: decision.display_path
       )
     end
 
@@ -273,7 +273,7 @@ class NotificationDispatcher
         notification_type: "mention",
         title: "#{actor_name} mentioned you in a commitment",
         body: commitment.title.to_s.truncate(200),
-        url: commitment.path
+        url: commitment.display_path
       )
     end
 
@@ -308,7 +308,7 @@ class NotificationDispatcher
         notification_type: "mention",
         title: "#{actor_name} mentioned you in a decision option",
         body: option.title.to_s.truncate(200),
-        url: decision&.path
+        url: decision&.display_path
       )
     end
 
@@ -410,12 +410,14 @@ class NotificationDispatcher
     obj.created_by
   end
 
-  # Helper to safely get path from polymorphic objects
+  # Helper to safely get the display URL from polymorphic objects. Uses
+  # `display_path` so comment-subtype Notes surface the in-thread URL
+  # (`{root}?comment_id={id}`) — recipients land on the full conversation.
   sig { params(obj: T.untyped).returns(T.nilable(String)) }
   def self.get_path(obj)
-    return nil unless obj.respond_to?(:path)
+    return nil unless obj.respond_to?(:display_path)
 
-    obj.path
+    obj.display_path
   end
 
   sig { params(decision: Decision).returns(T::Array[User]) }

--- a/app/services/trio_seeder.rb
+++ b/app/services/trio_seeder.rb
@@ -68,6 +68,17 @@ class TrioSeeder
     trio
   end
 
+  # Default LLM model for new Trio agents. Resolved from the
+  # TRIO_DEFAULT_MODEL env var so deployments can switch Trio's model
+  # without a code change. The value must match a `model_name` alias in
+  # config/litellm_config.yaml. Operators can override per-trio later via
+  # the agent settings page — TrioSeeder.refresh does not overwrite
+  # existing values.
+  sig { returns(T.nilable(String)) }
+  def self.default_model
+    ENV["TRIO_DEFAULT_MODEL"].presence
+  end
+
   sig { returns(T::Hash[String, T.untyped]) }
   def build_agent_configuration
     # identity_prompt is intentionally omitted — system agents resolve their
@@ -77,7 +88,10 @@ class TrioSeeder
     # grantable actions allowed" per CapabilityCheck. An empty array would
     # mean "no actions allowed", which would prevent Trio from posting any
     # comment or other response.
-    { "mode" => "internal" }
+    cfg = { "mode" => "internal" }
+    model = self.class.default_model
+    cfg["model"] = model if model
+    cfg
   end
 
   sig { returns(String) }

--- a/app/views/ai_agents/show_run.md.erb
+++ b/app/views/ai_agents/show_run.md.erb
@@ -78,6 +78,22 @@ LLM reasoning (step <%= detail[:step_number].to_i + 1 %>)<% if detail[:llm_error
 
 **LLM Error:** <%= detail[:llm_error] %>
 <% end -%>
+<% if detail[:tool_calls].is_a?(Array) && detail[:tool_calls].any? -%>
+
+Tool calls:
+<% detail[:tool_calls].each do |tc| -%>
+<% tc = tc.is_a?(Hash) ? tc.with_indifferent_access : {} -%>
+- `<%= tc[:name] %>(<%= tc[:arguments] %>)`
+<% end -%>
+<% end -%>
+<% if detail[:reasoning].present? -%>
+
+**Model reasoning:**
+
+```
+<%= detail[:reasoning] %>
+```
+<% end -%>
 <% if params[:debug] == "true" && detail[:prompt_preview].present? -%>
 
 <details>

--- a/app/views/shared/_comments_section.md.erb
+++ b/app/views/shared/_comments_section.md.erb
@@ -17,22 +17,22 @@ No comments yet.
 <% top_level_comments.each do |comment| -%>
 <% marker = comment.truncated_id == linked_comment_id ? "📌 " : "" -%>
 <% if comment.deleted? -%>
-* <%= marker %>*[deleted]* (<%= time_ago_in_words(comment.created_at) %> ago)
+* <%= marker %>[`<%= comment.truncated_id %>`](<%= comment.display_path %>) - *[deleted]* (<%= time_ago_in_words(comment.created_at) %> ago)
 <% elsif comment.created_by && blocked_user_ids.include?(comment.created_by.id) -%>
-* <%= marker %>*[Comment from a user you have blocked]*
+* <%= marker %>[`<%= comment.truncated_id %>`](<%= comment.display_path %>) - *[Comment from a user you have blocked]*
 <% else -%>
-* <%= marker %><%= comment.created_by ? user_link_md(comment.created_by) : 'Unknown' %> (<%= time_ago_in_words(comment.created_at) %> ago): [<%= comment.text.to_s.gsub(/\n+/, ' ') %>](<%= comment.path %>)
+* <%= marker %>[`<%= comment.truncated_id %>`](<%= comment.display_path %>) - <%= comment.created_by ? user_link_md(comment.created_by) : 'Unknown' %> (<%= time_ago_in_words(comment.created_at) %> ago): <%= comment.text.to_s.gsub(/\n+/, ' ') %>
 <% end -%>
 <% descendants = threads[comment.id] || [] -%>
 <% descendants.each do |reply| -%>
 <% show_context = reply.commentable_id != comment.id -%>
 <% reply_marker = reply.truncated_id == linked_comment_id ? "📌 " : "" -%>
 <% if reply.deleted? -%>
-  * <%= reply_marker %>*[deleted]* (<%= time_ago_in_words(reply.created_at) %> ago)
+  * <%= reply_marker %>[`<%= reply.truncated_id %>`](<%= reply.display_path %>) - *[deleted]* (<%= time_ago_in_words(reply.created_at) %> ago)
 <% elsif reply.created_by && blocked_user_ids.include?(reply.created_by.id) -%>
-  * <%= reply_marker %>*[Reply from a user you have blocked]*
+  * <%= reply_marker %>[`<%= reply.truncated_id %>`](<%= reply.display_path %>) - *[Reply from a user you have blocked]*
 <% else -%>
-  * <%= reply_marker %><% if show_context && reply.commentable.present? && reply.commentable.created_by.present? -%>↳ Replying to @<%= reply.commentable.created_by.handle %>: <% end -%><%= reply.created_by ? user_link_md(reply.created_by) : 'Unknown' %> (<%= time_ago_in_words(reply.created_at) %> ago): [<%= reply.text.to_s.gsub(/\n+/, ' ') %>](<%= reply.path %>)
+  * <%= reply_marker %>[`<%= reply.truncated_id %>`](<%= reply.display_path %>) <% if show_context && reply.commentable.present? && reply.commentable.created_by.present? -%>↳ Replying to `<%= reply.commentable.truncated_id %>` (@<%= reply.commentable.created_by.handle %>) <% end -%>- <%= reply.created_by ? user_link_md(reply.created_by) : 'Unknown' %> (<%= time_ago_in_words(reply.created_at) %> ago): <%= reply.text.to_s.gsub(/\n+/, ' ') %>
 <% end -%>
 <% end -%>
 <% end -%>

--- a/app/views/shared/_comments_section.md.erb
+++ b/app/views/shared/_comments_section.md.erb
@@ -9,24 +9,30 @@ No comments yet.
   comment_data = resource.comments_with_threads
   top_level_comments = comment_data[:top_level]
   threads = comment_data[:threads]
+  # When the caller arrived via ?comment_id=<id> (e.g. an agent following a
+  # mention link), mark the matching comment inline so its position in the
+  # thread is preserved.
+  linked_comment_id = params[:comment_id].presence
 -%>
 <% top_level_comments.each do |comment| -%>
+<% marker = comment.truncated_id == linked_comment_id ? "📌 " : "" -%>
 <% if comment.deleted? -%>
-* *[deleted]* (<%= time_ago_in_words(comment.created_at) %> ago)
+* <%= marker %>*[deleted]* (<%= time_ago_in_words(comment.created_at) %> ago)
 <% elsif comment.created_by && blocked_user_ids.include?(comment.created_by.id) -%>
-* *[Comment from a user you have blocked]*
+* <%= marker %>*[Comment from a user you have blocked]*
 <% else -%>
-* <%= comment.created_by ? user_link_md(comment.created_by) : 'Unknown' %> (<%= time_ago_in_words(comment.created_at) %> ago): [<%= comment.text.to_s.gsub(/\n+/, ' ').truncate(100) %>](<%= comment.path %>)
+* <%= marker %><%= comment.created_by ? user_link_md(comment.created_by) : 'Unknown' %> (<%= time_ago_in_words(comment.created_at) %> ago): [<%= comment.text.to_s.gsub(/\n+/, ' ') %>](<%= comment.path %>)
 <% end -%>
 <% descendants = threads[comment.id] || [] -%>
 <% descendants.each do |reply| -%>
 <% show_context = reply.commentable_id != comment.id -%>
+<% reply_marker = reply.truncated_id == linked_comment_id ? "📌 " : "" -%>
 <% if reply.deleted? -%>
-  * *[deleted]* (<%= time_ago_in_words(reply.created_at) %> ago)
+  * <%= reply_marker %>*[deleted]* (<%= time_ago_in_words(reply.created_at) %> ago)
 <% elsif reply.created_by && blocked_user_ids.include?(reply.created_by.id) -%>
-  * *[Reply from a user you have blocked]*
+  * <%= reply_marker %>*[Reply from a user you have blocked]*
 <% else -%>
-  * <% if show_context && reply.commentable.present? && reply.commentable.created_by.present? -%>↳ Replying to @<%= reply.commentable.created_by.handle %>: <% end -%><%= reply.created_by ? user_link_md(reply.created_by) : 'Unknown' %> (<%= time_ago_in_words(reply.created_at) %> ago): [<%= reply.text.to_s.gsub(/\n+/, ' ').truncate(100) %>](<%= reply.path %>)
+  * <%= reply_marker %><% if show_context && reply.commentable.present? && reply.commentable.created_by.present? -%>↳ Replying to @<%= reply.commentable.created_by.handle %>: <% end -%><%= reply.created_by ? user_link_md(reply.created_by) : 'Unknown' %> (<%= time_ago_in_words(reply.created_at) %> ago): [<%= reply.text.to_s.gsub(/\n+/, ' ') %>](<%= reply.path %>)
 <% end -%>
 <% end -%>
 <% end -%>

--- a/app/views/shared/_task_run_steps_timeline.html.erb
+++ b/app/views/shared/_task_run_steps_timeline.html.erb
@@ -107,6 +107,26 @@
             </p>
           <% end %>
           <% unless is_redacted %>
+            <% if detail[:tool_calls].is_a?(Array) && detail[:tool_calls].any? %>
+              <p class="pulse-muted" style="margin: 8px 0 0 0;">
+                Tool calls:
+                <% detail[:tool_calls].each_with_index do |tc, tc_idx| %>
+                  <% tc = tc.is_a?(Hash) ? tc.with_indifferent_access : {} %>
+                  <code class="pulse-code" style="font-size: 11px; margin-right: 4px;"><%= tc[:name] %>(<%= tc[:arguments] %>)</code><%= "," if tc_idx < detail[:tool_calls].length - 1 %>
+                <% end %>
+              </p>
+            <% end %>
+            <% if detail[:reasoning].present? %>
+              <details class="pulse-accordion" style="margin-top: 12px;" open>
+                <summary class="pulse-accordion-header">
+                  <span class="pulse-accordion-title">View model reasoning</span>
+                  <span class="pulse-accordion-icon"><%= octicon 'chevron-right', height: 14 %></span>
+                </summary>
+                <div class="pulse-accordion-content">
+                  <pre style="font-size: 12px; overflow-x: auto; white-space: pre-wrap; margin: 0;"><%= detail[:reasoning] %></pre>
+                </div>
+              </details>
+            <% end %>
             <% if show_debug && detail[:prompt_preview].present? %>
               <details class="pulse-accordion" style="margin-top: 12px;">
                 <summary class="pulse-accordion-header">

--- a/app/views/system_admin/show_task_run.md.erb
+++ b/app/views/system_admin/show_task_run.md.erb
@@ -59,6 +59,22 @@ Error: <%= detail[:error] %>
 <% if detail[:llm_error].present? -%>
 LLM Error: <%= detail[:llm_error] %>
 <% end -%>
+<% if !redacted && detail[:tool_calls].is_a?(Array) && detail[:tool_calls].any? -%>
+
+Tool calls:
+<% detail[:tool_calls].each do |tc| -%>
+<% tc = tc.is_a?(Hash) ? tc.with_indifferent_access : {} -%>
+- `<%= tc[:name] %>(<%= tc[:arguments] %>)`
+<% end -%>
+<% end -%>
+<% if !redacted && detail[:reasoning].present? -%>
+
+Model reasoning:
+
+```
+<%= detail[:reasoning] %>
+```
+<% end -%>
 <% if !redacted && detail[:response_preview].present? -%>
 
 ```

--- a/config/litellm_config.yaml
+++ b/config/litellm_config.yaml
@@ -14,6 +14,11 @@ model_list:
       api_base: https://api.arcee.ai/api/v1
       api_key: os.environ/ARCEE_API_KEY
 
+  - model_name: trinity-large-thinking-free
+    litellm_params:
+      model: openrouter/arcee-ai/trinity-large-thinking:free
+      api_key: os.environ/OPENROUTER_API_KEY
+
   # Anthropic Claude (requires ANTHROPIC_API_KEY env var).
   # LiteLLM requires the `anthropic/` provider prefix on the underlying model.
   - model_name: claude-sonnet-4

--- a/mcp-server/src/handlers.test.ts
+++ b/mcp-server/src/handlers.test.ts
@@ -192,6 +192,20 @@ describe("handleExecuteAction", () => {
       expect.anything()
     );
   });
+
+  it("strips ?query string from path before constructing action URL", async () => {
+    // After navigating to a comment-context URL like /d/abc?comment_id=xyz,
+    // the action URL is on the bare resource path — concatenating
+    // /actions/<name> after the query produces a malformed URL.
+    state.currentPath = "/d/abc?comment_id=xyz";
+    const mockFn = mockFetch(200, "Comment added");
+    await handleExecuteAction("add_comment", { text: "hi", replying_to_id: "xyz" }, config, state, mockFn);
+
+    expect(mockFn).toHaveBeenCalledWith(
+      "http://localhost:3000/d/abc/actions/add_comment",
+      expect.anything()
+    );
+  });
 });
 
 describe("handleSearch", () => {

--- a/mcp-server/src/handlers.ts
+++ b/mcp-server/src/handlers.ts
@@ -111,9 +111,15 @@ export async function handleExecuteAction(
   }
 
   try {
-    // Get the base resource path (strip any /actions suffix or /actions/... suffix)
-    // This handles the case where user navigated to an actions index or action description page
+    // Get the base resource path (strip query string + any /actions suffix
+    // or /actions/... suffix). The query string strip matters for URLs like
+    // /d/<id>?comment_id=<id> — we want /d/<id>/actions/<name>, not
+    // /d/<id>?comment_id=.../actions/<name>.
     let basePath = state.currentPath;
+    const queryIndex = basePath.indexOf("?");
+    if (queryIndex !== -1) {
+      basePath = basePath.substring(0, queryIndex);
+    }
     const actionsWithSlashIndex = basePath.indexOf("/actions/");
     if (actionsWithSlashIndex !== -1) {
       // Path like /notifications/actions/mark_read -> /notifications

--- a/test/controllers/system_admin_controller_test.rb
+++ b/test/controllers/system_admin_controller_test.rb
@@ -261,7 +261,16 @@ class SystemAdminControllerTest < ActionDispatch::IntegrationTest
     task_run.agent_session_steps.create!(position: 0, step_type: "navigate",
       detail: { "path" => "/collectives/test", "content_preview" => "SENSITIVE_PAGE_CONTENT" })
     task_run.agent_session_steps.create!(position: 1, step_type: "think",
-      detail: { "step_number" => 0, "prompt_preview" => "SENSITIVE_PROMPT", "response_preview" => "SENSITIVE_LLM_RESPONSE" })
+      detail: {
+        "step_number" => 0,
+        "prompt_preview" => "SENSITIVE_PROMPT",
+        "response_preview" => "SENSITIVE_LLM_RESPONSE",
+        "reasoning" => "SENSITIVE_REASONING",
+        "tool_calls" => [
+          { "name" => "execute_action",
+            "arguments" => '{"action":"create_note","params":{"body":"SENSITIVE_TOOL_ARGS"}}' },
+        ],
+      })
     task_run.agent_session_steps.create!(position: 2, step_type: "execute",
       detail: { "action" => "create_note", "params" => { "text" => "SENSITIVE_PARAMS" }, "success" => true, "content_preview" => "SENSITIVE_RESULT" })
     task_run.agent_session_steps.create!(position: 3, step_type: "done",
@@ -283,6 +292,10 @@ class SystemAdminControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/SENSITIVE_PAGE_CONTENT/, response.body)
     assert_no_match(/SENSITIVE_PROMPT/, response.body)
     assert_no_match(/SENSITIVE_LLM_RESPONSE/, response.body)
+    assert_no_match(/SENSITIVE_REASONING/, response.body,
+      "Model reasoning is treated like LLM response — redacted for non-system agents")
+    assert_no_match(/SENSITIVE_TOOL_ARGS/, response.body,
+      "Tool call arguments can contain tenant content (note bodies, etc.) — redact for non-system agents")
     assert_no_match(/SENSITIVE_PARAMS/, response.body)
     assert_no_match(/SENSITIVE_RESULT/, response.body)
     assert_no_match(/SENSITIVE_DONE_MESSAGE/, response.body)

--- a/test/integration/markdown_ui_test.rb
+++ b/test/integration/markdown_ui_test.rb
@@ -2299,4 +2299,51 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
     task_run&.destroy
     destroy_user!(ai_agent)
   end
+
+  test "GET ai_agent task run markdown surfaces tool_calls and reasoning on think steps" do
+    @tenant.enable_feature_flag!("ai_agents")
+
+    ai_agent = User.create!(
+      name: "Observability Test Agent",
+      email: "obs-test-#{SecureRandom.hex(4)}@not-real.com",
+      user_type: "ai_agent",
+      parent_id: @user.id,
+    )
+    tu = @tenant.add_user!(ai_agent)
+    ai_agent.tenant_user = tu
+
+    task_run = AiAgentTaskRun.create!(
+      tenant: @tenant,
+      ai_agent: ai_agent,
+      initiated_by: @user,
+      task: "Check notifications",
+      max_steps: AiAgentTaskRun::DEFAULT_MAX_STEPS,
+      status: "completed",
+      success: true,
+      final_message: "Done",
+      steps_count: 1,
+      started_at: 1.minute.ago,
+      completed_at: Time.current,
+    )
+    task_run.agent_session_steps.create!(position: 0, step_type: "think", detail: {
+      "step_number" => 0,
+      "response_preview" => "",
+      "tool_calls" => [
+        { "name" => "navigate", "arguments" => '{"path":"/notifications"}' },
+      ],
+      "reasoning" => "I should check the user's notifications first.",
+    })
+
+    get "/ai-agents/#{ai_agent.handle}/runs/#{task_run.id}", headers: @headers
+    assert_equal 200, response.status
+
+    assert_match(/Tool calls:/, response.body, "Should label tool calls")
+    assert_match(/`navigate\(/, response.body, "Should show tool name")
+    assert_match(%r{/notifications}, response.body, "Should show tool arguments path")
+    assert_match(/Model reasoning:/, response.body, "Should label model reasoning")
+    assert_match(/notifications first\./, response.body, "Should include reasoning text")
+  ensure
+    task_run&.destroy
+    destroy_user!(ai_agent)
+  end
 end

--- a/test/integration/markdown_ui_test.rb
+++ b/test/integration/markdown_ui_test.rb
@@ -472,6 +472,136 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
     assert commitment.comments.exists?, "Comment should have been created on commitment"
   end
 
+  test "HTML inline reply form on a comment posts to the bare /n/<id>/comments endpoint" do
+    # Regression guard: if Note#path ever silently shifts to a query-decorated
+    # URL again, the inline reply form's action becomes
+    # `/d/<id>?comment_id=<x>/comments` — malformed; submitting POSTs to
+    # `/d/<id>` with a garbage query and 404s the reply. Inspecting the
+    # rendered form action and round-tripping a submit catches that
+    # silently-broken case.
+    decision = create_decision(collective: @collective, created_by: @user, question: "Test?")
+    comment = decision.add_comment(text: "the original", created_by: @user)
+
+    sign_in_as(@user, tenant: @tenant)
+
+    get "/collectives/#{@collective.handle}/d/#{decision.truncated_id}"
+    assert_response :success
+    assert response.content_type.starts_with?("text/html"), "Should be the HTML view, not markdown"
+
+    expected_action = "#{@collective.path}/n/#{comment.truncated_id}/comments"
+    assert_match(
+      %r{<form\b[^>]*\bclass="pulse-reply-form"[^>]*\baction="#{Regexp.escape(expected_action)}"|<form\b[^>]*\baction="#{Regexp.escape(expected_action)}"[^>]*\bclass="pulse-reply-form"}m,
+      response.body,
+      "HTML reply form's action must be the bare comment-note /comments endpoint — " \
+        "if it includes ?comment_id=, comment.path has wrongly shifted to display semantics",
+    )
+
+    # Round-trip: post a reply to that exact URL and verify the threading.
+    post expected_action, params: { text: "html reply works" }
+    assert response.successful? || response.redirect?,
+      "POST to the form action should succeed; got #{response.status}"
+
+    reply = Note.find_by(text: "html reply works")
+    assert_equal comment, reply.commentable,
+      "Reply should be nested under the comment whose form was used"
+  end
+
+  test "POST add_comment with replying_to_id creates a nested reply, not a sibling" do
+    decision = create_decision(collective: @collective, created_by: @user, question: "Test decision?")
+    target = decision.add_comment(text: "the original comment", created_by: @user)
+
+    post "/collectives/#{@collective.handle}/d/#{decision.truncated_id}/actions/add_comment",
+      params: { text: "the reply", replying_to_id: target.truncated_id }.to_json,
+      headers: @headers
+    assert_equal 200, response.status
+
+    reply = Note.find_by(text: "the reply")
+    assert reply.present?, "Reply note should have been created"
+    assert_equal target, reply.commentable,
+      "Reply's commentable should be the target comment, not the decision"
+    assert_equal decision, reply.root_commentable,
+      "Reply's root_commentable should walk up to the decision"
+  end
+
+  test "POST add_comment on a comment-note URL with replying_to_id targets the replying_to_id, not the URL" do
+    # If a caller posts to /n/<comment-id>/actions/add_comment and also
+    # passes replying_to_id, the param wins — the new note nests under the
+    # comment named by replying_to_id, even if it's a sibling of the URL's
+    # comment in the same thread.
+    decision = create_decision(collective: @collective, created_by: @user, question: "Test?")
+    url_comment = decision.add_comment(text: "the URL target", created_by: @user)
+    sibling = decision.add_comment(text: "a sibling in the same thread", created_by: @user)
+
+    post "/collectives/#{@collective.handle}/n/#{url_comment.truncated_id}/actions/add_comment",
+      params: { text: "should nest under sibling", replying_to_id: sibling.truncated_id }.to_json,
+      headers: @headers
+    assert_equal 200, response.status
+
+    reply = Note.find_by(text: "should nest under sibling")
+    assert_equal sibling, reply.commentable,
+      "replying_to_id should override the URL's comment target"
+    assert_equal decision, reply.root_commentable
+  end
+
+  test "POST add_comment with replying_to_id also works when the root is a standalone Note" do
+    # A standalone Note is itself a Note instance, but it's the *root* of the
+    # thread (subtype != "comment"). Earlier the guard incorrectly skipped
+    # replying_to_id handling for any Note commentable, breaking this case.
+    note = create_note(collective: @collective, created_by: @user, title: "A note")
+    target = note.add_comment(text: "first comment on the note", created_by: @user)
+
+    post "/collectives/#{@collective.handle}/n/#{note.truncated_id}/actions/add_comment",
+      params: { text: "reply to first", replying_to_id: target.truncated_id }.to_json,
+      headers: @headers
+    assert_equal 200, response.status
+
+    reply = Note.find_by(text: "reply to first")
+    assert_equal target, reply.commentable,
+      "Reply's commentable should be the target comment, not the parent note"
+    assert_equal note, reply.root_commentable
+  end
+
+  test "POST add_comment without replying_to_id creates a top-level sibling (existing behavior)" do
+    decision = create_decision(collective: @collective, created_by: @user, question: "Test decision?")
+    decision.add_comment(text: "earlier comment", created_by: @user)
+
+    post "/collectives/#{@collective.handle}/d/#{decision.truncated_id}/actions/add_comment",
+      params: { text: "top-level reply" }.to_json,
+      headers: @headers
+    assert_equal 200, response.status
+
+    new_comment = Note.find_by(text: "top-level reply")
+    assert_equal decision, new_comment.commentable,
+      "Without replying_to_id, new comment should be a direct child of the decision"
+  end
+
+  test "POST add_comment with non-existent replying_to_id returns an error" do
+    decision = create_decision(collective: @collective, created_by: @user, question: "Test decision?")
+
+    post "/collectives/#{@collective.handle}/d/#{decision.truncated_id}/actions/add_comment",
+      params: { text: "the reply", replying_to_id: "deadbeef" }.to_json,
+      headers: @headers
+
+    # api_helper raises RecordInvalid which the controller surfaces as an
+    # action_error markdown response (200 OK with error text in body).
+    assert_match(/no such comment/i, response.body, "Should surface a clear error")
+    refute Note.exists?(text: "the reply"), "Should not have created the comment"
+  end
+
+  test "POST add_comment with a replying_to_id from a different thread is rejected" do
+    decision_a = create_decision(collective: @collective, created_by: @user, question: "Decision A?")
+    decision_b = create_decision(collective: @collective, created_by: @user, question: "Decision B?")
+    target_in_b = decision_b.add_comment(text: "comment on B", created_by: @user)
+
+    post "/collectives/#{@collective.handle}/d/#{decision_a.truncated_id}/actions/add_comment",
+      params: { text: "wrong-thread reply", replying_to_id: target_in_b.truncated_id }.to_json,
+      headers: @headers
+
+    assert_match(/different thread/i, response.body,
+      "Should reject cross-thread replying_to_id with a clear error")
+    refute Note.exists?(text: "wrong-thread reply"), "Should not have created the comment"
+  end
+
   # Conditional action display tests
   test "commitment show page shows join_commitment action when user has not joined" do
     commitment = create_commitment(collective: @collective, created_by: @user, title: "Test commitment")
@@ -2147,7 +2277,11 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
     assert is_markdown?
     assert_match(/## Comments \(1\)/, response.body, "Should show Comments section with count 1")
     assert_match(/This is a test comment/, response.body, "Should show comment text")
-    assert_match(/\[This is a test comment\]\(#{Regexp.escape(comment.path)}\)/, response.body, "Should link to comment")
+    # Comment line links via the truncated_id, not the body text. The href
+    # is the comment's display_path (root with ?comment_id=), not the bare
+    # /n/<id> path which is reserved for API endpoints.
+    assert_match(/\[`#{comment.truncated_id}`\]\(#{Regexp.escape(comment.display_path)}\)/, response.body,
+      "Should link via comment truncated_id pointing at display_path")
   ensure
     comment&.destroy
     note&.destroy
@@ -2180,8 +2314,9 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
     get note.path, headers: @headers
     assert_equal 200, response.status
     assert is_markdown?
-    # The nested reply should show "↳ Replying to @handle:" because it's a reply to first_reply, not top_level_comment
-    assert_match(/↳ Replying to @#{@user.handle}:/, response.body, "Should show 'Replying to @handle' for nested reply")
+    # The nested reply should show "↳ Replying to `<parent-id>` (@handle)" because it's a reply to first_reply, not top_level_comment
+    assert_match(/↳ Replying to `#{first_reply.truncated_id}` \(@#{@user.handle}\)/, response.body,
+      "Should show 'Replying to <id> (@handle)' for nested reply")
     assert_match(/Nested reply to first reply/, response.body, "Should show nested reply text")
   ensure
     nested_reply&.destroy

--- a/test/integration/markdown_ui_test.rb
+++ b/test/integration/markdown_ui_test.rb
@@ -2147,7 +2147,7 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
     assert is_markdown?
     assert_match(/## Comments \(1\)/, response.body, "Should show Comments section with count 1")
     assert_match(/This is a test comment/, response.body, "Should show comment text")
-    assert_match(/\[This is a test comment\]\(#{comment.path}\)/, response.body, "Should link to comment")
+    assert_match(/\[This is a test comment\]\(#{Regexp.escape(comment.path)}\)/, response.body, "Should link to comment")
   ensure
     comment&.destroy
     note&.destroy
@@ -2298,6 +2298,67 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
   ensure
     task_run&.destroy
     destroy_user!(ai_agent)
+  end
+
+  test "GET decision with ?comment_id= marks the targeted comment inline (preserves chronological order)" do
+    decision = create_decision(collective: @collective, created_by: @user, question: "Test decision?")
+    target = decision.add_comment(text: "this is the linked one", created_by: @user)
+    other = decision.add_comment(text: "unrelated comment", created_by: @user)
+
+    get "/collectives/#{@collective.handle}/d/#{decision.truncated_id}?comment_id=#{target.truncated_id}", headers: @headers
+    assert_equal 200, response.status
+
+    # Inline marker on the matching comment only
+    assert_match(/📌.+this is the linked one/, response.body,
+      "Should mark the targeted comment inline with 📌")
+    assert_no_match(/📌.+unrelated comment/, response.body,
+      "Should not mark unrelated comments")
+
+    # Frontmatter `path:` preserves comment_id so agents see the canonical URL
+    assert_match(/^path: \/collectives\/#{@collective.handle}\/d\/#{decision.truncated_id}\?comment_id=#{target.truncated_id}$/,
+      response.body, "Frontmatter path should retain comment_id")
+  end
+
+  test "GET decision without ?comment_id= shows no inline marker and bare path in frontmatter" do
+    decision = create_decision(collective: @collective, created_by: @user, question: "Test decision?")
+    decision.add_comment(text: "regular comment", created_by: @user)
+
+    get "/collectives/#{@collective.handle}/d/#{decision.truncated_id}", headers: @headers
+    assert_equal 200, response.status
+
+    assert_no_match(/📌/, response.body, "Should not render any marker without comment_id")
+    assert_match(/^path: \/collectives\/#{@collective.handle}\/d\/#{decision.truncated_id}$/, response.body,
+      "Frontmatter path should be the bare path when no comment_id")
+  end
+
+  test "GET decision with ?comment_id= matching a nested reply marks the nested reply" do
+    decision = create_decision(collective: @collective, created_by: @user, question: "Test decision?")
+    top = decision.add_comment(text: "top-level", created_by: @user)
+    nested = top.add_comment(text: "deep nested target", created_by: @user)
+
+    get "/collectives/#{@collective.handle}/d/#{decision.truncated_id}?comment_id=#{nested.truncated_id}", headers: @headers
+    assert_equal 200, response.status
+
+    assert_match(/📌.+deep nested target/, response.body)
+    assert_no_match(/📌.+top-level/, response.body)
+  end
+
+  test "GET search with ?q= preserves the query in the frontmatter path" do
+    get "/search?q=hello", headers: @headers
+    assert_equal 200, response.status
+    assert_match(/^path: \/search\?q=hello$/, response.body,
+      "Frontmatter path should preserve ?q= for search")
+  end
+
+  test "frontmatter path drops query params not on the preserved whitelist" do
+    decision = create_decision(collective: @collective, created_by: @user, question: "Test?")
+
+    get "/collectives/#{@collective.handle}/d/#{decision.truncated_id}?debug=1&unknown=foo", headers: @headers
+    assert_equal 200, response.status
+
+    # Unknown params are stripped from the frontmatter path
+    assert_match(/^path: \/collectives\/#{@collective.handle}\/d\/#{decision.truncated_id}$/, response.body,
+      "Whitelisted-only: unknown query params shouldn't appear in the canonical path")
   end
 
   test "GET ai_agent task run markdown surfaces tool_calls and reasoning on think steps" do

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -1769,16 +1769,18 @@ class NoteTest < ActiveSupport::TestCase
     assert_not note2.is_statement?
   end
 
-  # --- Comment path / root_commentable ---
+  # --- Comment display_path / root_commentable ---
   #
-  # Comments are notes with their own /n/<id> URL, but for navigation purposes
-  # we want callers (mention dispatch, search, feed) to land on the comment's
-  # root context (the Decision / non-comment Note / Commitment the conversation
-  # is *about*) with the specific comment identified via ?comment_id=. That
-  # gives an agent or human the full surrounding context in one navigation
-  # instead of an isolated comment page that links back via "Replying to X".
+  # Comments are notes with their own /n/<id> URL (returned by Note#path,
+  # used for API endpoints — forms, action POSTs). For *display* purposes
+  # (mention dispatch, comment lists, notification URLs) we want callers
+  # to land on the comment's root context — the Decision / non-comment
+  # Note / Commitment the conversation is *about* — with the specific
+  # comment identified via ?comment_id=. That's what Note#display_path
+  # returns. Path stays bare so suffix-concat patterns (form actions,
+  # /actions/<name> endpoints) keep working.
 
-  test "non-comment Note#path is unchanged by the comment redirect" do
+  test "Note#path stays bare canonical for non-comments" do
     tenant, collective, user = create_tenant_collective_user
     note = Note.create!(
       tenant: tenant, collective: collective, created_by: user, updated_by: user,
@@ -1786,6 +1788,25 @@ class NoteTest < ActiveSupport::TestCase
     )
 
     assert_equal "#{collective.path}/n/#{note.truncated_id}", note.path
+  end
+
+  test "Note#path stays bare canonical for comments (so form/API concat still works)" do
+    tenant, collective, user = create_tenant_collective_user
+    decision = create_decision(tenant: tenant, collective: collective, created_by: user)
+    comment = decision.add_comment(text: "hi", created_by: user)
+
+    assert_equal "#{collective.path}/n/#{comment.truncated_id}", comment.path,
+      "Note#path must remain the bare /n/<id> URL — callers concatenate /comments, /actions/<name>"
+  end
+
+  test "Note#display_path equals #path for non-comments" do
+    tenant, collective, user = create_tenant_collective_user
+    note = Note.create!(
+      tenant: tenant, collective: collective, created_by: user, updated_by: user,
+      title: "A standalone note", text: "hello",
+    )
+
+    assert_equal note.path, note.display_path
   end
 
   test "Note#root_commentable returns self for non-comments" do
@@ -1816,15 +1837,15 @@ class NoteTest < ActiveSupport::TestCase
     assert_equal decision, leaf.root_commentable
   end
 
-  test "comment on a decision: #path points at the decision with comment_id query param" do
+  test "comment on a decision: #display_path points at the decision with comment_id query param" do
     tenant, collective, user = create_tenant_collective_user
     decision = create_decision(tenant: tenant, collective: collective, created_by: user)
     comment = decision.add_comment(text: "hi", created_by: user)
 
-    assert_equal "#{decision.path}?comment_id=#{comment.truncated_id}", comment.path
+    assert_equal "#{decision.path}?comment_id=#{comment.truncated_id}", comment.display_path
   end
 
-  test "comment on a standalone Note: #path points at the parent note" do
+  test "comment on a standalone Note: #display_path points at the parent note" do
     tenant, collective, user = create_tenant_collective_user
     parent = Note.create!(
       tenant: tenant, collective: collective, created_by: user, updated_by: user,
@@ -1832,19 +1853,19 @@ class NoteTest < ActiveSupport::TestCase
     )
     comment = parent.add_comment(text: "a comment", created_by: user)
 
-    assert_equal "#{parent.path}?comment_id=#{comment.truncated_id}", comment.path
+    assert_equal "#{parent.path}?comment_id=#{comment.truncated_id}", comment.display_path
   end
 
-  test "nested comment: #path still points at the root commentable, not the parent comment" do
+  test "nested comment: #display_path still points at the root commentable, not the parent comment" do
     tenant, collective, user = create_tenant_collective_user
     decision = create_decision(tenant: tenant, collective: collective, created_by: user)
     top = decision.add_comment(text: "top", created_by: user)
     leaf = top.add_comment(text: "leaf", created_by: user)
 
-    assert_equal "#{decision.path}?comment_id=#{leaf.truncated_id}", leaf.path
+    assert_equal "#{decision.path}?comment_id=#{leaf.truncated_id}", leaf.display_path
   end
 
-  test "comments_with_threads injects root_commentable so #path is O(1) per comment" do
+  test "comments_with_threads injects root_commentable so #display_path is O(1) per comment" do
     tenant, collective, user = create_tenant_collective_user
     decision = create_decision(tenant: tenant, collective: collective, created_by: user)
     top = decision.add_comment(text: "top", created_by: user)
@@ -1853,14 +1874,14 @@ class NoteTest < ActiveSupport::TestCase
 
     data = decision.comments_with_threads
 
-    # Calling .path on the deepest comment must not trigger any new
+    # Calling .display_path on the deepest comment must not trigger any new
     # commentable lookups — the root has been injected during the bulk
     # preload, so the walk is bypassed entirely.
     leaf_from_threads = data[:threads][top.id].find { |c| c.id == leaf.id }
-    queries = capture_sql { leaf_from_threads.path }
+    queries = capture_sql { leaf_from_threads.display_path }
 
     assert_equal 0, queries.length,
-      "Expected zero SQL queries for #path after root injection; got: #{queries.inspect}"
+      "Expected zero SQL queries for #display_path after root injection; got: #{queries.inspect}"
   end
 
   private

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -1768,4 +1768,112 @@ class NoteTest < ActiveSupport::TestCase
     note2 = Note.new(subtype: "text", tenant: tenant, collective: collective, created_by: user, updated_by: user)
     assert_not note2.is_statement?
   end
+
+  # --- Comment path / root_commentable ---
+  #
+  # Comments are notes with their own /n/<id> URL, but for navigation purposes
+  # we want callers (mention dispatch, search, feed) to land on the comment's
+  # root context (the Decision / non-comment Note / Commitment the conversation
+  # is *about*) with the specific comment identified via ?comment_id=. That
+  # gives an agent or human the full surrounding context in one navigation
+  # instead of an isolated comment page that links back via "Replying to X".
+
+  test "non-comment Note#path is unchanged by the comment redirect" do
+    tenant, collective, user = create_tenant_collective_user
+    note = Note.create!(
+      tenant: tenant, collective: collective, created_by: user, updated_by: user,
+      title: "A standalone note", text: "hello",
+    )
+
+    assert_equal "#{collective.path}/n/#{note.truncated_id}", note.path
+  end
+
+  test "Note#root_commentable returns self for non-comments" do
+    tenant, collective, user = create_tenant_collective_user
+    note = Note.create!(
+      tenant: tenant, collective: collective, created_by: user, updated_by: user,
+      title: "A standalone note", text: "hello",
+    )
+
+    assert_equal note, note.root_commentable
+  end
+
+  test "Note#root_commentable walks one hop up to the commentable for direct comments" do
+    tenant, collective, user = create_tenant_collective_user
+    decision = create_decision(tenant: tenant, collective: collective, created_by: user)
+    comment = decision.add_comment(text: "hi", created_by: user)
+
+    assert_equal decision, comment.root_commentable
+  end
+
+  test "Note#root_commentable walks up the full chain for nested comments" do
+    tenant, collective, user = create_tenant_collective_user
+    decision = create_decision(tenant: tenant, collective: collective, created_by: user)
+    top = decision.add_comment(text: "top", created_by: user)
+    mid = top.add_comment(text: "mid", created_by: user)
+    leaf = mid.add_comment(text: "leaf", created_by: user)
+
+    assert_equal decision, leaf.root_commentable
+  end
+
+  test "comment on a decision: #path points at the decision with comment_id query param" do
+    tenant, collective, user = create_tenant_collective_user
+    decision = create_decision(tenant: tenant, collective: collective, created_by: user)
+    comment = decision.add_comment(text: "hi", created_by: user)
+
+    assert_equal "#{decision.path}?comment_id=#{comment.truncated_id}", comment.path
+  end
+
+  test "comment on a standalone Note: #path points at the parent note" do
+    tenant, collective, user = create_tenant_collective_user
+    parent = Note.create!(
+      tenant: tenant, collective: collective, created_by: user, updated_by: user,
+      title: "parent", text: "body",
+    )
+    comment = parent.add_comment(text: "a comment", created_by: user)
+
+    assert_equal "#{parent.path}?comment_id=#{comment.truncated_id}", comment.path
+  end
+
+  test "nested comment: #path still points at the root commentable, not the parent comment" do
+    tenant, collective, user = create_tenant_collective_user
+    decision = create_decision(tenant: tenant, collective: collective, created_by: user)
+    top = decision.add_comment(text: "top", created_by: user)
+    leaf = top.add_comment(text: "leaf", created_by: user)
+
+    assert_equal "#{decision.path}?comment_id=#{leaf.truncated_id}", leaf.path
+  end
+
+  test "comments_with_threads injects root_commentable so #path is O(1) per comment" do
+    tenant, collective, user = create_tenant_collective_user
+    decision = create_decision(tenant: tenant, collective: collective, created_by: user)
+    top = decision.add_comment(text: "top", created_by: user)
+    mid = top.add_comment(text: "mid", created_by: user)
+    leaf = mid.add_comment(text: "leaf", created_by: user)
+
+    data = decision.comments_with_threads
+
+    # Calling .path on the deepest comment must not trigger any new
+    # commentable lookups — the root has been injected during the bulk
+    # preload, so the walk is bypassed entirely.
+    leaf_from_threads = data[:threads][top.id].find { |c| c.id == leaf.id }
+    queries = capture_sql { leaf_from_threads.path }
+
+    assert_equal 0, queries.length,
+      "Expected zero SQL queries for #path after root injection; got: #{queries.inspect}"
+  end
+
+  private
+
+  # Capture SQL queries issued during the block.
+  def capture_sql
+    queries = []
+    callback = ->(_name, _start, _finish, _id, payload) do
+      sql = payload[:sql]
+      next if payload[:name] == "SCHEMA" || sql.start_with?("BEGIN", "COMMIT", "ROLLBACK", "SAVEPOINT", "RELEASE SAVEPOINT")
+      queries << sql
+    end
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") { yield }
+    queries
+  end
 end

--- a/test/services/trio_seeder_test.rb
+++ b/test/services/trio_seeder_test.rb
@@ -67,6 +67,29 @@ class TrioSeederTest < ActiveSupport::TestCase
     assert_equal "internal", trio.agent_configuration["mode"]
   end
 
+  test "trio is seeded with the model from TRIO_DEFAULT_MODEL env var" do
+    previous = ENV["TRIO_DEFAULT_MODEL"]
+    ENV["TRIO_DEFAULT_MODEL"] = "trinity-large-thinking-free"
+
+    trio = TrioSeeder.ensure_for(@main)
+
+    assert_equal "trinity-large-thinking-free", trio.agent_configuration["model"]
+  ensure
+    ENV["TRIO_DEFAULT_MODEL"] = previous
+  end
+
+  test "trio omits the model key when TRIO_DEFAULT_MODEL is unset" do
+    previous = ENV["TRIO_DEFAULT_MODEL"]
+    ENV.delete("TRIO_DEFAULT_MODEL")
+
+    trio = TrioSeeder.ensure_for(@main)
+
+    assert_not trio.agent_configuration.key?("model"),
+      "expected model key absent so the agent-runner falls back to its default model alias"
+  ensure
+    ENV["TRIO_DEFAULT_MODEL"] = previous
+  end
+
   test "trio resolves its identity prompt from the static source" do
     trio = TrioSeeder.ensure_for(@main)
 


### PR DESCRIPTION
## Summary

Improvements to how external agents interact with Harmonic, plus the observability to debug them. Three threads:

1. **Comment thread context for agents** — a "comment" is its own `Note` with its own `/n/<id>` URL. Agents following mention links landed on that isolated page with only "Replying to Decision X" as a breadcrumb, then faced an ambiguous `add_comment` action. This PR routes them straight to the root thread with the target highlighted, and gives them a way to reply at the right level.
2. **Agent-runner timeline surfaces tool calls and reasoning** — reasoning models (trinity-large-thinking, DeepSeek R1, Claude extended thinking, o-series) put their chain-of-thought in a separate field the runner was discarding. Steps that emitted only tool calls also looked blank in the timeline.
3. **Operational flexibility** — `TRIO_DEFAULT_MODEL` env var, plus chat-mode navigation replay documented and tested (no functional change).

## Comment thread context

- `Note#display_path` returns `{root_commentable.path}?comment_id={truncated_id}` for comments, walking the polymorphic `commentable` chain to the non-comment root. `Note#path` stays the bare canonical URL so suffix-concat callers (HTML forms, JS endpoint construction, `/actions/<name>`) keep working. Only display callers (mention/reply automation templates, notification URLs, markdown comments section) opt into `display_path`.
- `ApplicationController#current_path` preserves a query-param whitelist (`q`, `comment_id`, `cycle`, `cursor`, `offset`, `status`, `before`, `after`) so frontmatter `path:` echoes the canonical URL the agent was sent to. Replaces ad-hoc `q`-preservation in `SearchController`.
- Markdown comments now show a 📌 marker on the linked comment, `↳ Replying to <parent_id> (@handle)` between id and author for nested replies, and inline full text (truncation removed since the link no longer goes to a permalink with the full body).
- HTML view scrolls to and flashes `#n-<truncated-id>` on connect, expanding any collapsed reply group along the way.
- `add_comment` accepts optional `replying_to_id`. Validation: target must share a root commentable with the request's resource (cross-thread / unknown id rejections surface as `RecordInvalid`). Authorization, capability, and not-blocked checks all run against the re-pointed commentable.
- **Client-side URL builder hygiene** — both `agent-runner/HarmonicClient.executeAction` and `mcp-server/handleExecuteAction` strip the query string from `currentPath` before appending `/actions/<name>`. Without this, an agent at `/<root>?comment_id=<id>` builds `/<root>?comment_id=<id>/actions/<name>`, which the HTTP layer parses as path `/<root>` with a garbage query — Rails 404s the POST.
- **Perf** — `Note#root_commentable` memoizes per instance and exposes a writer so `Commentable#comments_with_threads` can inject the known root on every descendant after preload. Zero extra queries for `path` / `display_path` lookups even on deep threads. SQL-capture test guards the invariant.
- A regression test for the HTML inline reply form (post via on-page reply form, assert it hits the bare `/n/<id>/comments` endpoint) guards against `#path` ever shifting to display semantics again.

## Agent-runner observability

- `LLMClient` normalizes the `reasoning` field across three vendor shapes (`message.reasoning_content`, `message.reasoning`, `choice.reasoning`) into a single optional field on `LLMResponse`.
- `thinkStep` records reasoning plus a compact summary of emitted tool calls (name + raw arguments JSON).
- Timeline UI (HTML partial, owner markdown, sysadmin markdown, live JS streaming) renders "Tool calls:" inline and "View model reasoning" as an open-by-default accordion.
- Tool-call args and reasoning are gated by the existing `redacted` flag in sys-admin views — both can contain tenant content. Redaction test seeds a `SENSITIVE_TOOL_ARGS` sentinel inside `execute_action` params to guard against regression.

## Operational

- `TRIO_DEFAULT_MODEL` controls Trio's seeded default model. When unset, the model key is omitted from `agent_configuration` so the agent-runner falls back to the `default` alias in `litellm_config.yaml` — operators can switch Trio's model from `.env` without touching code. `trinity-large-thinking` and `trinity-large-thinking-free` registered as litellm aliases.
- Chat-mode `savedPath` replay after `/whoami` is documented + tested (rationale at call site: page-scoped action validity, and chat history doesn't carry navigation results across turns).

## Test plan

- [ ] CI green: Ruby tests, agent-runner tests, mcp-server tests
- [x] Follow a mention link to a nested comment — frontmatter `path:` includes `?comment_id=`, 📌 marker appears, nested replies show `↳ Replying to ...` breadcrumb
- [x] HTML inline reply form on a deeply nested comment posts to the bare `/n/<id>/comments` endpoint
- [x] Agent task with a reasoning-capable model — `/system-admin/.../task-runs/<id>` shows "Tool calls:" and a "View model reasoning" accordion
- [x] Redacted sys-admin view of the same task — tool-call args and reasoning hidden
- [x] `TRIO_DEFAULT_MODEL` honored after restart; unset value falls back to the `default` alias
