### PR TITLE
Add Recent Cycles section to homepage sidebar

### DIFF
--- a/app/assets/stylesheets/pulse/_sidebar.css
+++ b/app/assets/stylesheets/pulse/_sidebar.css
@@ -444,3 +444,47 @@
 }
 
 /* Note: Resource icons use CSS classes like .note-icon instead of <img> tags */
+
+/* Recent Cycles */
+.pulse-recent-cycles-section {
+  padding: 16px;
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.pulse-recent-cycles-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pulse-recent-cycles-list li {
+  margin-bottom: 2px;
+}
+
+.pulse-recent-cycles-list li:last-child {
+  margin-bottom: 0;
+}
+
+.pulse-recent-cycle-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--color-fg-default);
+  text-decoration: none;
+  padding: 4px 6px;
+  border-radius: 4px;
+}
+
+.pulse-recent-cycle-item:hover {
+  background-color: var(--color-canvas-subtle);
+  color: var(--color-accent-fg);
+}
+
+.pulse-recent-cycle-item.current {
+  font-weight: 600;
+}
+
+.pulse-recent-cycle-label {
+  flex: 1;
+}

--- a/app/controllers/pulse_controller.rb
+++ b/app/controllers/pulse_controller.rb
@@ -43,6 +43,10 @@ class PulseController < ApplicationController
     @team = @current_collective.team
     @heartbeats = Heartbeat.where_in_cycle(@cycle)
     @pinned_items = @current_collective.pinned_items
+    @recent_cycle_summaries = Cycle.recent_summaries(
+      collective: @current_collective,
+      tenant: current_tenant
+    )
 
     # Build unified feed (sorted by created_at desc)
     build_unified_feed
@@ -85,7 +89,7 @@ class PulseController < ApplicationController
       reminder_events_scope: NoteHistoryEvent
         .where(event_type: "reminder", collective_id: @current_collective.id)
         .where("note_history_events.happened_at >= ?", cycle_start),
-      limit: 100,
+      limit: 100
     ).feed_items
   end
 end

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -16,6 +16,8 @@ class Cycle
     T::Hash[String, T::Hash[Symbol, String]],
   )
 
+  ALLOWED_BUCKET_UNITS = T.let(["day", "week", "month", "year"].freeze, T::Array[String])
+
   RecentCycleSummary = Struct.new(
     :cycle_start, :notes_count, :decisions_count, :commitments_count, :total_count,
     keyword_init: true,
@@ -78,7 +80,7 @@ class Cycle
   end
   def self.recent_summaries(collective:, tenant:, limit: 6)
     unit = T.must(collective.tempo_unit)
-    raise "Invalid unit: #{unit}" unless ["day", "week", "month", "year"].include?(unit)
+    raise "Invalid unit: #{unit}" unless ALLOWED_BUCKET_UNITS.include?(unit)
 
     bucket_sql = bucket_sql_for(unit, collective.timezone.tzinfo.name)
     cutoff = (limit + 1).send(unit.pluralize).ago
@@ -92,8 +94,12 @@ class Cycle
 
   sig { params(unit: String, tz_name: String).returns(Arel::Nodes::SqlLiteral) }
   def self.bucket_sql_for(unit, tz_name)
-    quoted_tz = ApplicationRecord.connection.quote(tz_name)
-    Arel.sql("date_trunc('#{unit}', (created_at AT TIME ZONE 'UTC' AT TIME ZONE #{quoted_tz}))")
+    Arel.sql(
+      ApplicationRecord.sanitize_sql_for_conditions([
+        "date_trunc(?, (created_at AT TIME ZONE 'UTC' AT TIME ZONE ?))",
+        unit, tz_name,
+      ])
+    )
   end
   private_class_method :bucket_sql_for
 

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -6,6 +6,21 @@ class Cycle
   sig { returns(String) }
   attr_accessor :name
 
+  CYCLE_NAME_PREFIXES = T.let(
+    {
+      "day" => { current: "today", previous: "yesterday", next: "tomorrow" },
+      "week" => { current: "this-week", previous: "last-week", next: "next-week" },
+      "month" => { current: "this-month", previous: "last-month", next: "next-month" },
+      "year" => { current: "this-year", previous: "last-year", next: "next-year" },
+    }.freeze,
+    T::Hash[String, T::Hash[Symbol, String]],
+  )
+
+  RecentCycleSummary = Struct.new(
+    :cycle_start, :notes_count, :decisions_count, :commitments_count, :total_count,
+    keyword_init: true,
+  )
+
   sig { params(tempo: String).returns(T::Array[String]) }
   def self.end_of_cycle_options(tempo:)
     [
@@ -45,6 +60,101 @@ class Cycle
   sig { params(collective: Collective).returns(Cycle) }
   def self.new_from_collective(collective)
     new_from_tempo(tenant: T.must(collective.tenant), collective: collective)
+  end
+
+  # Returns one summary struct per cycle period (bucketed by the collective's
+  # tempo) within the last `limit` periods. Only periods that contain at least
+  # one (non-deleted) note, decision, or commitment will appear.
+  #
+  # Queries Note/Decision/Commitment directly rather than the `cycle_data`
+  # view so the default soft-delete scope is applied. Comments are excluded
+  # from the note count to match the homepage feed.
+  sig do
+    params(
+      collective: Collective,
+      tenant: Tenant,
+      limit: Integer
+    ).returns(T::Array[RecentCycleSummary])
+  end
+  def self.recent_summaries(collective:, tenant:, limit: 6)
+    unit = T.must(collective.tempo_unit)
+    raise "Invalid unit: #{unit}" unless ["day", "week", "month", "year"].include?(unit)
+
+    bucket_sql = bucket_sql_for(unit, collective.timezone.tzinfo.name)
+    cutoff = (limit + 1).send(unit.pluralize).ago
+
+    notes = counts_by_bucket(Note.where(commentable_type: nil), tenant, collective, cutoff, bucket_sql)
+    decisions = counts_by_bucket(Decision, tenant, collective, cutoff, bucket_sql)
+    commitments = counts_by_bucket(Commitment, tenant, collective, cutoff, bucket_sql)
+
+    build_summaries(notes, decisions, commitments).first(limit)
+  end
+
+  sig { params(unit: String, tz_name: String).returns(Arel::Nodes::SqlLiteral) }
+  def self.bucket_sql_for(unit, tz_name)
+    quoted_tz = ApplicationRecord.connection.quote(tz_name)
+    Arel.sql("date_trunc('#{unit}', (created_at AT TIME ZONE 'UTC' AT TIME ZONE #{quoted_tz}))")
+  end
+  private_class_method :bucket_sql_for
+
+  sig do
+    params(
+      notes: T::Hash[T.untyped, Integer],
+      decisions: T::Hash[T.untyped, Integer],
+      commitments: T::Hash[T.untyped, Integer]
+    ).returns(T::Array[RecentCycleSummary])
+  end
+  def self.build_summaries(notes, decisions, commitments)
+    all_buckets = notes.keys | decisions.keys | commitments.keys
+    summaries = all_buckets.map do |bucket|
+      n = notes[bucket].to_i
+      d = decisions[bucket].to_i
+      c = commitments[bucket].to_i
+      RecentCycleSummary.new(
+        cycle_start: bucket,
+        notes_count: n,
+        decisions_count: d,
+        commitments_count: c,
+        total_count: n + d + c
+      )
+    end
+    summaries.sort_by { |s| -s.cycle_start.to_i }
+  end
+  private_class_method :build_summaries
+
+  sig do
+    params(
+      scope: T.any(T.class_of(ApplicationRecord), ActiveRecord::Relation),
+      tenant: Tenant,
+      collective: Collective,
+      cutoff: ActiveSupport::TimeWithZone,
+      bucket_sql: Arel::Nodes::SqlLiteral
+    ).returns(T::Hash[T.untyped, Integer])
+  end
+  def self.counts_by_bucket(scope, tenant, collective, cutoff, bucket_sql)
+    scope
+      .where(tenant_id: tenant.id, collective_id: collective.id)
+      .where(created_at: cutoff..)
+      .group(bucket_sql)
+      .pluck(bucket_sql, Arel.sql("COUNT(*)"))
+      .to_h
+  end
+  private_class_method :counts_by_bucket
+
+  # Converts a numeric offset + unit into a cycle name string
+  # (e.g. -1, "week" -> "last-week"; -3, "day" -> "3-days-ago").
+  sig { params(offset: Integer, unit: String).returns(String) }
+  def self.cycle_name_for_offset(offset, unit)
+    names = CYCLE_NAME_PREFIXES[unit] or raise "Invalid unit: #{unit}"
+    case offset
+    when 0 then T.must(names[:current])
+    when -1 then T.must(names[:previous])
+    when 1 then T.must(names[:next])
+    else
+      raise "Future #{unit} offsets not named" if offset.positive?
+
+      "#{-offset}-#{unit.pluralize}-ago"
+    end
   end
 
   sig do

--- a/app/views/pulse/_sidebar.html.erb
+++ b/app/views/pulse/_sidebar.html.erb
@@ -2,6 +2,9 @@
   <%= render 'pulse/sidebar_collective_info' %>
   <%= render 'pulse/sidebar_pinned' %>
   <%= render 'pulse/sidebar_cycle' %>
+  <% if @recent_cycle_summaries.present? %>
+    <%= render 'pulse/sidebar_recent_cycles' %>
+  <% end %>
   <% unless @current_collective&.private_workspace? %>
     <%= render 'pulse/sidebar_heartbeats' %>
   <% end %>

--- a/app/views/pulse/_sidebar_recent_cycles.html.erb
+++ b/app/views/pulse/_sidebar_recent_cycles.html.erb
@@ -1,0 +1,33 @@
+<%
+  unit = @current_collective.tempo_unit
+  tz = @current_collective.timezone.name
+  current_cycle_start = Time.current.in_time_zone(tz).send("beginning_of_#{unit}")
+%>
+<div class="pulse-recent-cycles-section">
+  <div class="pulse-section-label">Recent Cycles</div>
+  <ul class="pulse-recent-cycles-list">
+    <% @recent_cycle_summaries.each do |summary| %>
+      <%
+        bucket_start = summary.cycle_start.in_time_zone(tz)
+        offset = case unit
+                 when "day" then (bucket_start.to_date - current_cycle_start.to_date).to_i
+                 when "week" then ((bucket_start.to_date - current_cycle_start.to_date) / 7).to_i
+                 when "month" then (bucket_start.year - current_cycle_start.year) * 12 + (bucket_start.month - current_cycle_start.month)
+                 when "year" then bucket_start.year - current_cycle_start.year
+                 end
+        next if offset > 0
+        cycle_name = ::Cycle.cycle_name_for_offset(offset, unit)
+        is_current = offset.zero?
+        href = is_current ? @current_collective.path : "#{@current_collective.path}?cycle=#{cycle_name}"
+      %>
+      <li>
+        <a href="<%= href %>"
+           class="pulse-recent-cycle-item<%= ' current' if is_current %>"
+           title="<%= "#{summary.notes_count} notes, #{summary.decisions_count} decisions, #{summary.commitments_count} commitments" %>">
+          <span class="pulse-recent-cycle-label"><%= cycle_name.titleize %></span>
+          <span class="pulse-nav-count"><%= summary.total_count %></span>
+        </a>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/test/models/cycle_test.rb
+++ b/test/models/cycle_test.rb
@@ -111,13 +111,13 @@ class CycleTest < ActiveSupport::TestCase
 
   test "start_date for yesterday is beginning of yesterday" do
     cycle = Cycle.new(name: "yesterday", tenant: @tenant, collective: @collective)
-    expected = (Time.current - 1.day).in_time_zone("UTC").beginning_of_day.to_date
+    expected = 1.day.ago.in_time_zone("UTC").beginning_of_day.to_date
     assert_equal expected, cycle.start_date.to_date
   end
 
   test "start_date for tomorrow is beginning of tomorrow" do
     cycle = Cycle.new(name: "tomorrow", tenant: @tenant, collective: @collective)
-    expected = (Time.current + 1.day).in_time_zone("UTC").beginning_of_day.to_date
+    expected = 1.day.from_now.in_time_zone("UTC").beginning_of_day.to_date
     assert_equal expected, cycle.start_date.to_date
   end
 
@@ -158,7 +158,7 @@ class CycleTest < ActiveSupport::TestCase
       cycle = Cycle.new(name: "today", tenant: @tenant, collective: @collective)
       display = cycle.display_window
       # Should not have double spaces (e.g., "January  9" should be "January 9")
-      refute_match(/  /, display, "display_window should not contain double spaces: #{display}")
+      assert_no_match(/  /, display, "display_window should not contain double spaces: #{display}")
       # Should contain the single-digit day without leading space padding
       assert_match(/January 9/, display, "display_window should format single-digit day without padding: #{display}")
     end
@@ -166,7 +166,7 @@ class CycleTest < ActiveSupport::TestCase
 
   test "display_window formats week as range" do
     cycle = Cycle.new(name: "this-week", tenant: @tenant, collective: @collective)
-    assert_match(/-/, cycle.display_window)  # Contains dash for range
+    assert_match(/-/, cycle.display_window) # Contains dash for range
   end
 
   test "display_duration returns 1 day for day unit" do
@@ -259,17 +259,17 @@ class CycleTest < ActiveSupport::TestCase
 
   test "is_current_cycle? returns false for yesterday" do
     cycle = Cycle.new(name: "yesterday", tenant: @tenant, collective: @collective)
-    refute cycle.is_current_cycle?
+    assert_not cycle.is_current_cycle?
   end
 
   test "is_current_cycle? returns false for last-week" do
     cycle = Cycle.new(name: "last-week", tenant: @tenant, collective: @collective)
-    refute cycle.is_current_cycle?
+    assert_not cycle.is_current_cycle?
   end
 
   test "is_current_cycle? returns false for last-month" do
     cycle = Cycle.new(name: "last-month", tenant: @tenant, collective: @collective)
-    refute cycle.is_current_cycle?
+    assert_not cycle.is_current_cycle?
   end
 
   # === Multi-step Navigation Tests ===
@@ -420,8 +420,274 @@ class CycleTest < ActiveSupport::TestCase
     cycle = Cycle.new(name: "today", tenant: @tenant, collective: @collective)
     options = cycle.sort_by_options
 
-    assert options.any? { |o| o[1].include?("deadline") }
-    assert options.any? { |o| o[1].include?("created_at") }
-    assert options.any? { |o| o[1].include?("updated_at") }
+    assert(options.any? { |o| o[1].include?("deadline") })
+    assert(options.any? { |o| o[1].include?("created_at") })
+    assert(options.any? { |o| o[1].include?("updated_at") })
+  end
+
+  # === Recent Summaries Tests ===
+
+  test "recent_summaries returns empty when collective has no content" do
+    @collective.settings["tempo"] = "weekly"
+    @collective.save!
+
+    summaries = Cycle.recent_summaries(collective: @collective, tenant: @tenant)
+    assert_equal [], summaries.to_a
+  end
+
+  test "recent_summaries returns one row per cycle bucket with counts" do
+    @collective.settings["tempo"] = "weekly"
+    @collective.save!
+
+    travel_to Time.zone.local(2026, 5, 15, 12, 0, 0) do
+      # This week (May 11-17, 2026): 2 notes, 1 decision
+      create_note(title: "n1")
+      create_note(title: "n2")
+      create_decision(question: "d1?")
+
+      # Last week
+      last_week_note = create_note(title: "n3")
+      last_week_commitment = create_commitment(title: "c1")
+      last_week_time = Time.zone.local(2026, 5, 8, 12, 0, 0)
+      last_week_note.update_columns(created_at: last_week_time)
+      last_week_commitment.update_columns(created_at: last_week_time)
+
+      summaries = Cycle.recent_summaries(collective: @collective, tenant: @tenant).to_a
+
+      assert_equal 2, summaries.length
+
+      this_week = summaries.find { |s| s.notes_count == 2 }
+      last_week = summaries.find { |s| s.notes_count == 1 }
+      assert_not_nil this_week
+      assert_not_nil last_week
+
+      assert_equal 3, this_week.total_count
+      assert_equal 2, this_week.notes_count
+      assert_equal 1, this_week.decisions_count
+      assert_equal 0, this_week.commitments_count
+
+      assert_equal 2, last_week.total_count
+      assert_equal 1, last_week.notes_count
+      assert_equal 0, last_week.decisions_count
+      assert_equal 1, last_week.commitments_count
+    end
+  end
+
+  test "recent_summaries orders most recent first" do
+    @collective.settings["tempo"] = "weekly"
+    @collective.save!
+
+    travel_to Time.zone.local(2026, 5, 15, 12, 0, 0) do
+      create_note(title: "this-week")
+      last_week_note = create_note(title: "last-week")
+      last_week_note.update_columns(created_at: Time.zone.local(2026, 5, 8, 12, 0, 0))
+      two_weeks_ago_note = create_note(title: "two-weeks-ago")
+      two_weeks_ago_note.update_columns(created_at: Time.zone.local(2026, 5, 1, 12, 0, 0))
+
+      summaries = Cycle.recent_summaries(collective: @collective, tenant: @tenant).to_a
+      starts = summaries.map(&:cycle_start)
+      assert_equal starts.sort.reverse, starts
+    end
+  end
+
+  test "recent_summaries is scoped to collective" do
+    @collective.settings["tempo"] = "weekly"
+    @collective.save!
+    other_collective = create_collective(
+      tenant: @tenant,
+      created_by: @user,
+      handle: "other-collective-#{SecureRandom.hex(4)}"
+    )
+
+    create_note(collective: @collective, title: "ours")
+    create_note(collective: other_collective, title: "theirs")
+
+    summaries = Cycle.recent_summaries(collective: @collective, tenant: @tenant).to_a
+    total = summaries.sum(&:total_count)
+    assert_equal 1, total
+  end
+
+  test "recent_summaries excludes cycles older than limit" do
+    @collective.settings["tempo"] = "weekly"
+    @collective.save!
+
+    travel_to Time.zone.local(2026, 5, 15, 12, 0, 0) do
+      create_note(title: "recent")
+      ancient = create_note(title: "ancient")
+      ancient.update_columns(created_at: Time.zone.local(2025, 1, 1, 12, 0, 0))
+
+      summaries = Cycle.recent_summaries(collective: @collective, tenant: @tenant, limit: 6).to_a
+      assert_equal 1, summaries.length
+    end
+  end
+
+  test "recent_summaries excludes comments from note count" do
+    @collective.settings["tempo"] = "weekly"
+    @collective.save!
+
+    travel_to Time.zone.local(2026, 5, 15, 12, 0, 0) do
+      parent = create_note(title: "parent")
+      create_note(title: "real note")
+      create_note(title: "comment-1", commentable: parent)
+      create_note(title: "comment-2", commentable: parent)
+
+      summaries = Cycle.recent_summaries(collective: @collective, tenant: @tenant).to_a
+      # parent + real note = 2 (comments excluded)
+      assert_equal 2, summaries.first.notes_count
+    end
+  end
+
+  test "recent_summaries excludes soft-deleted items" do
+    @collective.settings["tempo"] = "weekly"
+    @collective.save!
+
+    travel_to Time.zone.local(2026, 5, 15, 12, 0, 0) do
+      kept = create_note(title: "kept")
+      deleted = create_note(title: "deleted")
+      deleted.soft_delete!(by: @user)
+
+      summaries = Cycle.recent_summaries(collective: @collective, tenant: @tenant).to_a
+      assert_equal 1, summaries.length
+      assert_equal 1, summaries.first.notes_count
+      assert_equal 1, summaries.first.total_count
+      kept.destroy
+    end
+  end
+
+  test "recent_summaries buckets by day when tempo is daily" do
+    @collective.settings["tempo"] = "daily"
+    @collective.save!
+
+    travel_to Time.zone.local(2026, 5, 15, 12, 0, 0) do
+      create_note(title: "today")
+      yest = create_note(title: "yesterday")
+      yest.update_columns(created_at: Time.zone.local(2026, 5, 14, 12, 0, 0))
+
+      summaries = Cycle.recent_summaries(collective: @collective, tenant: @tenant).to_a
+      assert_equal 2, summaries.length
+    end
+  end
+
+  test "recent_summaries buckets by month when tempo is monthly" do
+    @collective.settings["tempo"] = "monthly"
+    @collective.save!
+
+    travel_to Time.zone.local(2026, 5, 15, 12, 0, 0) do
+      create_note(title: "may")
+      april = create_note(title: "april")
+      april.update_columns(created_at: Time.zone.local(2026, 4, 10, 12, 0, 0))
+      march = create_note(title: "march")
+      march.update_columns(created_at: Time.zone.local(2026, 3, 5, 12, 0, 0))
+
+      summaries = Cycle.recent_summaries(collective: @collective, tenant: @tenant).to_a
+      assert_equal 3, summaries.length
+    end
+  end
+
+  test "recent_summaries is scoped to tenant" do
+    @collective.settings["tempo"] = "weekly"
+    @collective.save!
+
+    other_tenant = create_tenant(subdomain: "other-#{SecureRandom.hex(4)}")
+    other_user = create_user(email: "other_#{SecureRandom.hex(4)}@example.com")
+    other_tenant.add_user!(other_user)
+    other_collective = Collective.create!(
+      tenant: other_tenant,
+      created_by: other_user,
+      handle: "other-#{SecureRandom.hex(4)}",
+      name: "Other",
+    )
+
+    create_note(collective: @collective, title: "ours")
+    Note.create!(
+      tenant: other_tenant,
+      collective: other_collective,
+      created_by: other_user,
+      title: "theirs",
+      text: "x",
+      subtype: "text",
+      deadline: 1.week.from_now,
+    )
+
+    summaries = Cycle.recent_summaries(collective: @collective, tenant: @tenant).to_a
+    assert_equal 1, summaries.sum(&:total_count)
+  end
+
+  test "recent_summaries respects collective timezone for bucket boundaries" do
+    @collective.settings["tempo"] = "daily"
+    @collective.settings["timezone"] = "Australia/Sydney"
+    @collective.save!
+
+    # Sydney is UTC+10/+11. A note created at 23:00 UTC on May 14 is May 15 in Sydney.
+    travel_to Time.zone.local(2026, 5, 16, 12, 0, 0) do
+      sydney_may_15 = create_note(title: "sydney-may-15")
+      sydney_may_15.update_columns(created_at: Time.utc(2026, 5, 14, 23, 0, 0))
+
+      sydney_may_14 = create_note(title: "sydney-may-14")
+      sydney_may_14.update_columns(created_at: Time.utc(2026, 5, 13, 23, 0, 0))
+
+      summaries = Cycle.recent_summaries(collective: @collective, tenant: @tenant).to_a
+      # Two distinct day buckets in Sydney time
+      assert_equal 2, summaries.length
+    end
+  end
+
+  test "recent_summaries returns RecentCycleSummary structs" do
+    @collective.settings["tempo"] = "weekly"
+    @collective.save!
+    create_note(title: "n")
+    summaries = Cycle.recent_summaries(collective: @collective, tenant: @tenant).to_a
+    assert_kind_of Cycle::RecentCycleSummary, summaries.first
+  end
+
+  # === cycle_name_for_offset Tests ===
+
+  test "cycle_name_for_offset returns named cycles for current and recent offsets in day unit" do
+    assert_equal "today", Cycle.cycle_name_for_offset(0, "day")
+    assert_equal "yesterday", Cycle.cycle_name_for_offset(-1, "day")
+    assert_equal "2-days-ago", Cycle.cycle_name_for_offset(-2, "day")
+    assert_equal "5-days-ago", Cycle.cycle_name_for_offset(-5, "day")
+  end
+
+  test "cycle_name_for_offset returns named cycles for week unit" do
+    assert_equal "this-week", Cycle.cycle_name_for_offset(0, "week")
+    assert_equal "last-week", Cycle.cycle_name_for_offset(-1, "week")
+    assert_equal "3-weeks-ago", Cycle.cycle_name_for_offset(-3, "week")
+  end
+
+  test "cycle_name_for_offset returns named cycles for month unit" do
+    assert_equal "this-month", Cycle.cycle_name_for_offset(0, "month")
+    assert_equal "last-month", Cycle.cycle_name_for_offset(-1, "month")
+    assert_equal "4-months-ago", Cycle.cycle_name_for_offset(-4, "month")
+  end
+
+  test "cycle_name_for_offset handles offset 1 as next" do
+    assert_equal "tomorrow", Cycle.cycle_name_for_offset(1, "day")
+    assert_equal "next-week", Cycle.cycle_name_for_offset(1, "week")
+    assert_equal "next-month", Cycle.cycle_name_for_offset(1, "month")
+    assert_equal "next-year", Cycle.cycle_name_for_offset(1, "year")
+  end
+
+  test "cycle_name_for_offset raises for offsets beyond +1 (no name)" do
+    assert_raises(RuntimeError) { Cycle.cycle_name_for_offset(2, "week") }
+    assert_raises(RuntimeError) { Cycle.cycle_name_for_offset(5, "day") }
+  end
+
+  test "cycle_name_for_offset raises for invalid unit" do
+    assert_raises(RuntimeError) { Cycle.cycle_name_for_offset(0, "decade") }
+  end
+
+  test "cycle_name_for_offset round-trips through Cycle parsing" do
+    # Names produced should parse back to the same offset via Cycle#offset
+    [
+      [0, "day"], [-1, "day"], [-3, "day"],
+      [0, "week"], [-1, "week"], [-2, "week"],
+      [0, "month"], [-1, "month"], [-5, "month"],
+    ].each do |offset, unit|
+      name = Cycle.cycle_name_for_offset(offset, unit)
+      cycle = Cycle.new(name: name, tenant: @tenant, collective: @collective)
+      assert_equal offset, cycle.offset, "expected #{name} to have offset #{offset}"
+      assert_equal unit, cycle.unit, "expected #{name} to have unit #{unit}"
+    end
   end
 end


### PR DESCRIPTION
Shows which recent cycles have content so collectives don't look dead when the current cycle is empty. Counts exclude soft-deleted items and comments to match the homepage feed.