### PR TITLE
Resource limits hardening

### DIFF
--- a/.claude/plans/resource-limits-hardening.md
+++ b/.claude/plans/resource-limits-hardening.md
@@ -9,6 +9,21 @@ Existing protections are strong in spots (login, 2FA, table notes, decision opti
 
 ---
 
+## Status (2026-05-22)
+
+**Shipped on branch `resource-limits-hardening`:**
+- ✅ **Phase 1** — webhook throttles (stripe, `/hooks/*`), backlinks cap, length validations on Note/Decision/Commitment text fields (commit `c2440d5`)
+- ✅ **Phase 2 (Critical items)** — `RateLimits` controller concern + comment, chat-message, agent-task-run throttles (commit `4527faf`)
+
+**Still open:**
+- Phase 2 deferred items: API-token-keyed throttle, password-reset per-email throttle
+- Phase 3 — comment threading hardening (Critical from Axis 2)
+- Phase 4 — retention jobs (one item blocked on deletion-semantics design)
+- Phase 5 — storage and count caps
+- Phase 6 — verification work
+
+---
+
 ## Axis 1: Rate Limits — what's already there
 
 `config/initializers/rack_attack.rb` is configured with Redis cache and these throttles (all IP-keyed):
@@ -28,31 +43,28 @@ Existing protections are strong in spots (login, 2FA, table notes, decision opti
 | Collective data export | 3 | 1 hour |
 | Per-user data export | 3 | 1 hour |
 | Data import | 100 | 1 hour |
+| Stripe webhooks | 50 | 1 min |
+| Incoming webhooks (`/hooks/*`, keyed on path+IP) | 100 | 1 min |
 
 App-level protections:
 - 2FA OTP lockout after 10 failed attempts
 - Single active export per collective; single active import per tenant
 - `BotProtection` concern (honeypot + min-form-time gate, optional Cloudflare Turnstile) on `/login`, `/auth/identity/register`, `/password`, `/password/reset/:token`, `/invite-required(/accept)`, `/login/verify-2fa` — see [app/controllers/concerns/bot_protection.rb](app/controllers/concerns/bot_protection.rb)
 - 30s email-confirmation send cooldown via `OmniAuthIdentity#email_confirmation_sent_at`
+- `RateLimits` controller concern (Redis-backed, post-auth, keyed on `(user, …)`): comments 5/min per `(user, item)`, chat messages 20/min per `(sender, partner)`, agent task runs 5/min per `(user, agent)` — see [app/controllers/concerns/rate_limits.rb](app/controllers/concerns/rate_limits.rb)
 
 ## Axis 1: Rate Limits — gaps (prioritized)
 
 ### Critical
 
-1. **Incoming webhook endpoint has no rate limit** — [app/controllers/incoming_webhooks_controller.rb:24-40](app/controllers/incoming_webhooks_controller.rb#L24-L40)
-   - HMAC + timestamp + IP allowlist gate it, but no rack-attack rule on `/hooks/*` POST
-   - A leaked secret = unbounded `AutomationRuleExecutionJob.perform_later` calls, each potentially invoking LLM agents
-   - **Fix**: Add rack-attack throttle keyed on `webhook_path` and IP
+1. ✅ **Incoming webhook endpoint has no rate limit** — *shipped in `c2440d5`*
+   - rack-attack throttle `incoming_webhooks/path_ip` at 100/min keyed on `(IP, path)`.
 
-2. **AI agent chat / task execution unthrottled** — [app/controllers/chats_controller.rb:44-79](app/controllers/chats_controller.rb#L44-L79), [app/controllers/ai_agents_controller.rb:61](app/controllers/ai_agents_controller.rb#L61)
-   - Per-message length cap (10K chars) but no message-rate cap per `(user, agent)`
-   - Each call hits LLM inference; cost is real
-   - **Fix**: Per-`(user, agent)` rate limit (e.g. 20 msgs/min, 5 task runs/min)
+2. ✅ **AI agent chat / task execution unthrottled** — *shipped in `4527faf`*
+   - `RateLimits` concern: chat messages 20/min per `(sender, partner)`, agent task runs 5/min per `(user, agent)`.
 
-3. **Comment creation unthrottled** — [app/controllers/application_controller.rb:922-967](app/controllers/application_controller.rb#L922-L967)
-   - `POST /n/:id/comments`, `POST /d/:id/comments`, `POST /c/:id/comments`
-   - No per-`(user, item)` cap; comment spam fans out to notification jobs
-   - **Fix**: Per-`(user, item)` rate limit (e.g. 5 comments/min)
+3. ✅ **Comment creation unthrottled** — *shipped in `4527faf`*
+   - `RateLimits` concern: 5/min per `(user, item)` on `ApplicationController#create_comment`.
 
 ### Medium
 
@@ -60,8 +72,8 @@ App-level protections:
    - All rack-attack rules key on `req.ip`; bot clients with valid tokens are unconstrained
    - **Fix**: Add token-keyed throttle for `/api/v1/*`
 
-5. **Stripe webhook endpoint unthrottled** — [app/controllers/stripe_webhooks_controller.rb:13-43](app/controllers/stripe_webhooks_controller.rb#L13-L43)
-   - **Fix**: Add modest throttle (50/min/IP)
+5. ✅ **Stripe webhook endpoint unthrottled** — *shipped in `c2440d5`*
+   - rack-attack throttle `stripe_webhooks/ip` at 50/min/IP.
 
 6. **No storage quota per user/tenant** — [app/controllers/concerns/attachment_actions.rb:22-108](app/controllers/concerns/attachment_actions.rb#L22-L108)
    - 15MB per file (and 10MB per attachment record at the model — discrepancy worth resolving) but no cumulative cap
@@ -95,6 +107,13 @@ Reference points (existing good limits):
 | Notification inbox load | 50 | [app/controllers/notifications_controller.rb:20](app/controllers/notifications_controller.rb#L20) |
 | Expired API token retention | 30 days | [app/jobs/cleanup_expired_tokens_job.rb:10](app/jobs/cleanup_expired_tokens_job.rb#L10) |
 | Collective team list | 100 | [app/models/collective.rb:548](app/models/collective.rb#L548) |
+| Note title length | 1000 chars | [app/models/note.rb](app/models/note.rb) |
+| Note text length | 1,000,000 chars | [app/models/note.rb](app/models/note.rb) |
+| Decision question length | 1000 chars | [app/models/decision.rb](app/models/decision.rb) |
+| Decision description length | 1,000,000 chars | [app/models/decision.rb](app/models/decision.rb) |
+| Commitment title length | 1000 chars | [app/models/commitment.rb](app/models/commitment.rb) |
+| Commitment description length | 1,000,000 chars | [app/models/commitment.rb](app/models/commitment.rb) |
+| Backlinks per item | 1000 | [app/models/concerns/linkable.rb](app/models/concerns/linkable.rb) |
 
 ## Axis 2: Data Volume Caps — gaps (prioritized)
 
@@ -105,15 +124,11 @@ Reference points (existing good limits):
    - Component renders entire tree in DOM (hidden div for replies)
    - **Fix**: `MAX_COMMENT_DEPTH` constant + paginate replies in component + cap at query level
 
-2. **Backlinks unbounded** — [app/models/concerns/linkable.rb:18-24](app/models/concerns/linkable.rb#L18-L24)
-   - `backlinks` returns `Link.where(to_linkable: self)` with no `.limit()`
-   - 10K notes all linking to one note → full table scan
-   - **Fix**: Cap query at e.g. 1000, paginate UI
+2. ✅ **Backlinks unbounded** — *shipped in `c2440d5`*
+   - `Linkable::BACKLINKS_LIMIT = 1000` applied to the query. UI pagination still open if a single record routinely exceeds 1000 inbound links.
 
-3. **Note/Decision/Commitment text field length unbounded** — [app/models/note.rb:39](app/models/note.rb#L39), [app/models/decision.rb:32-34](app/models/decision.rb#L32-L34), [app/models/commitment.rb:26-29](app/models/commitment.rb#L26-L29)
-   - No `length: { maximum: ... }` on `.text`, `.question`, `.description`, `.title`
-   - Single 100MB field → DB bloat + slow regex passes (mention parser, link parser)
-   - **Fix**: `length: { maximum: 1_000_000 }` (or domain-appropriate) on all user text fields
+3. ✅ **Note/Decision/Commitment text field length unbounded** — *shipped in `c2440d5`*
+   - Length validations: title/question fields capped at 1000 chars; body/description fields at 1,000,000 chars. Note title uses a custom validator against `raw_title` so the soft-delete-aware `.title` accessor isn't called during validation.
 
 ### High (DB bloat / query slowdown)
 
@@ -175,21 +190,21 @@ Before implementation, decide:
 
 ## Phased plan
 
-### Phase 1 — Quick wins (smallest blast radius, biggest value)
-- Rack-attack throttle on `/hooks/*` POST
-- Rack-attack throttle on `/stripe/webhooks` POST
-- Length validations on Note/Decision/Commitment text fields (after backfill check)
-- Cap `backlinks` query at 1000
+### Phase 1 — Quick wins (smallest blast radius, biggest value) — ✅ shipped (`c2440d5`)
+- ✅ Rack-attack throttle on `/hooks/*` POST
+- ✅ Rack-attack throttle on `/stripe/webhooks` POST
+- ✅ Length validations on Note/Decision/Commitment text fields
+- ✅ Cap `backlinks` query at 1000
 
-Each is a small, self-contained PR with focused tests.
+### Phase 2 — User-keyed throttles — partial (`4527faf`)
 
-### Phase 2 — User-keyed throttles
-Build the per-user throttle helper (concern + Redis counters), then apply to:
-- Comment creation (per `(user, item)`)
-- Chat messages (per `(user, agent)`)
-- Agent task runs (per `(user, agent)`)
-- Password reset (per email)
-- API requests (per token)
+`RateLimits` controller concern built (Redis via `Sidekiq.redis` pool, fixed-window counters, `Exceeded` exception carries scope/limit/period).
+
+- ✅ Comment creation (per `(user, item)`, 5/min)
+- ✅ Chat messages (per `(sender, partner)`, 20/min)
+- ✅ Agent task runs (per `(user, agent)`, 5/min)
+- ⬜ Password reset (per email) — deferred (Low priority; bot defenses cover the practical risk)
+- ⬜ API requests (per token) — deferred (Medium priority)
 
 ### Phase 3 — Comment threading hardening
 - `MAX_COMMENT_DEPTH` enforcement on creation
@@ -216,7 +231,12 @@ Build the per-user throttle helper (concern + Redis counters), then apply to:
 
 ## Open decisions for the user
 
-- Are these caps acceptable? (`MAX_COMMENTS_PER_ITEM=10000`, `MAX_COMMENT_DEPTH=5`, text field max 1MB, etc.)
-- Phase 1 first as a single PR, or split per item?
-- Do we want to introduce a `RateLimits` concern as part of Phase 2, or keep throttling logic in rack-attack only?
-- Retention windows: 90 days for soft-deleted? 365 days for note history? Audit chain explicitly excluded from retention?
+Settled:
+- ~~Phase 1 packaging~~ — bundled into one commit
+- ~~`RateLimits` concern vs rack-attack only~~ — concern shipped (Phase 2)
+- ~~Text field caps~~ — 1000 chars for title/question, 1,000,000 chars for body/description (well under Postgres' 1 GB ceiling but enough to bound mention/link regex passes)
+
+Still open:
+- `MAX_COMMENT_DEPTH` value and `MAX_COMMENTS_PER_ITEM` (if any) — Phase 3
+- Retention windows: 90 days for dismissed notifications? 365 days for note history? Audit chain explicitly excluded from retention — Phase 4
+- Storage quota numbers — Phase 5

--- a/.claude/plans/resource-limits-hardening.md
+++ b/.claude/plans/resource-limits-hardening.md
@@ -22,10 +22,18 @@ Existing protections are strong in spots (login, 2FA, table notes, decision opti
 | 2FA verification | 10 | 15 min |
 | Email change | 5 | 1 hour |
 | OAuth callback | 10 | 5 min |
-| Data export | 3 | 1 hour |
+| Identity register | 5 | 1 hour |
+| Invite-required submit | 5/IP + 10/user | 1 hour |
+| Invite accept | 10 | 1 hour |
+| Collective data export | 3 | 1 hour |
+| Per-user data export | 3 | 1 hour |
 | Data import | 100 | 1 hour |
 
-App-level: 2FA OTP lockout after 10 failed attempts, single active export per collective, single active import per tenant.
+App-level protections:
+- 2FA OTP lockout after 10 failed attempts
+- Single active export per collective; single active import per tenant
+- `BotProtection` concern (honeypot + min-form-time gate, optional Cloudflare Turnstile) on `/login`, `/auth/identity/register`, `/password`, `/password/reset/:token`, `/invite-required(/accept)`, `/login/verify-2fa` — see [app/controllers/concerns/bot_protection.rb](app/controllers/concerns/bot_protection.rb)
+- 30s email-confirmation send cooldown via `OmniAuthIdentity#email_confirmation_sent_at`
 
 ## Axis 1: Rate Limits — gaps (prioritized)
 
@@ -59,8 +67,10 @@ App-level: 2FA OTP lockout after 10 failed attempts, single active export per co
    - 15MB per file (and 10MB per attachment record at the model — discrepancy worth resolving) but no cumulative cap
    - **Fix**: Per-user and per-tenant cumulative storage quota
 
+### Low
+
 7. **Password reset enables email enumeration** — [app/controllers/password_resets_controller.rb:19-38](app/controllers/password_resets_controller.rb#L19-L38)
-   - IP-throttled but not per-email
+   - IP-throttled but not per-email. Honeypot + min-form-time + (when configured) Turnstile now gate `POST /password`, so practical bot-driven enumeration is largely defeated; the per-email throttle is still worth adding as defense in depth.
    - **Fix**: Add per-email throttle (3/hour)
 
 ---
@@ -107,9 +117,9 @@ Reference points (existing good limits):
 
 ### High (DB bloat / query slowdown)
 
-4. **Soft-deleted records never hard-deleted** — [app/models/concerns/soft_deletable.rb](app/models/concerns/soft_deletable.rb)
-   - Only API tokens have a cleanup job; notes/decisions/commitments accumulate forever
-   - **Fix**: `CleanupSoftDeletedItemsJob` (e.g. hard-delete > 90 days old)
+4. **Soft-deleted Decisions/Commitments never hard-deleted** — [app/models/concerns/soft_deletable.rb](app/models/concerns/soft_deletable.rb)
+   - Notes now hard-delete after a 30-day grace via `HardDeleteExpiredRecordsJob` (see [completed/2026/05/phased-deletion.md](.claude/plans/completed/2026/05/phased-deletion.md)). Decisions/Commitments still accumulate forever; phased-deletion was deferred for them pending the ownership-after-engagement / withdrawal-vs-delete design.
+   - **Fix**: Extend phased-deletion pipeline to Decisions/Commitments once their deletion semantics are decided. Tracking issue / design doc lives with the data-lifecycle plan.
 
 5. **Notification fanout unbounded per event** — [app/models/notification.rb](app/models/notification.rb), [app/models/notification_recipient.rb](app/models/notification_recipient.rb)
    - Comment in 100K-member collective → 100K `notification_recipient` rows
@@ -187,7 +197,7 @@ Build the per-user throttle helper (concern + Redis counters), then apply to:
 - `MAX_COMMENTS_PER_ITEM` if we decide a cap is right
 
 ### Phase 4 — Retention jobs
-- Soft-deleted item cleanup
+- Soft-deleted Decision/Commitment cleanup (Notes already covered by `HardDeleteExpiredRecordsJob`; blocked on Decision/Commitment deletion semantics design)
 - Notification recipient cleanup
 - Note history retention
 - Webhook delivery / automation rule run retention

--- a/app/controllers/ai_agents_controller.rb
+++ b/app/controllers/ai_agents_controller.rb
@@ -1,6 +1,8 @@
 # typed: false
 
 class AiAgentsController < ApplicationController
+  TASK_RUNS_PER_MINUTE = 5
+
   before_action :set_sidebar_mode, only: [:new, :index, :show, :settings, :run_task, :execute_task, :runs, :show_run, :cancel_run, :create, :execute_create_ai_agent, :deactivate, :reactivate]
   before_action :require_ai_agents_enabled, only: [:index, :show, :settings, :run_task, :execute_task, :runs, :show_run, :cancel_run]
   before_action :require_billing_for_creation, only: [:new]
@@ -142,6 +144,24 @@ class AiAgentsController < ApplicationController
 
     @ai_agent = find_ai_agent_by_handle
     return render status: :not_found, plain: "404 Not Found" unless @ai_agent
+
+    begin
+      enforce_rate_limit!(
+        scope: "agent_task_runs",
+        key: [current_user.id, @ai_agent.id],
+        limit: TASK_RUNS_PER_MINUTE,
+        period: 1.minute,
+      )
+    rescue RateLimits::Exceeded
+      respond_to do |format|
+        format.html do
+          flash[:alert] = "You're starting tasks too quickly. Please wait a moment and try again."
+          redirect_to ai_agent_run_task_path(@ai_agent.handle)
+        end
+        format.json { render status: :too_many_requests, json: { error: "rate_limited", message: "Too many task runs. Please wait a minute and try again." } }
+      end
+      return
+    end
 
     if current_tenant.feature_enabled?("stripe_billing")
       billing_customer = @ai_agent.billing_customer

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   include ParsesScheduledTime
+  include RateLimits
   # Session timeout configuration (in seconds)
   SESSION_ABSOLUTE_TIMEOUT = (ENV["SESSION_ABSOLUTE_TIMEOUT"]&.to_i || 24.hours).seconds
   SESSION_IDLE_TIMEOUT = (ENV["SESSION_IDLE_TIMEOUT"]&.to_i || 2.hours).seconds
@@ -986,7 +987,29 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  COMMENTS_PER_MINUTE = 5
+
   def create_comment
+    if current_user && current_resource
+      begin
+        enforce_rate_limit!(
+          scope: "comments",
+          key: [current_user.id, current_resource.id],
+          limit: COMMENTS_PER_MINUTE,
+          period: 1.minute,
+        )
+      rescue RateLimits::Exceeded
+        respond_to do |format|
+          format.html do
+            flash[:alert] = "You're commenting too quickly. Please wait a moment and try again."
+            redirect_back(fallback_location: current_resource.path)
+          end
+          format.json { render status: :too_many_requests, json: { error: "rate_limited", message: "Too many comments. Please wait a minute and try again." } }
+        end
+        return
+      end
+    end
+
     if current_resource.is_commentable?
       comment = api_helper.create_note(commentable: current_resource)
 

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -3,6 +3,7 @@
 class ChatsController < ApplicationController
   MAX_MESSAGE_LENGTH = 10_000
   MESSAGES_PER_PAGE = 50
+  CHAT_MESSAGES_PER_MINUTE = 20
 
   before_action :find_partner_and_session, only: [:show, :send_message, :poll_messages, :actions_index, :describe_send_message, :execute_send_message]
   before_action :deny_if_blocked, only: [:send_message, :execute_send_message]
@@ -45,6 +46,18 @@ class ChatsController < ApplicationController
     message_text = params[:message].to_s.strip.truncate(MAX_MESSAGE_LENGTH)
     if message_text.blank?
       render plain: "Message cannot be empty", status: :unprocessable_entity
+      return
+    end
+
+    begin
+      enforce_rate_limit!(
+        scope: "chat_messages",
+        key: [current_user.id, @partner.id],
+        limit: CHAT_MESSAGES_PER_MINUTE,
+        period: 1.minute,
+      )
+    rescue RateLimits::Exceeded
+      render plain: "You're sending messages too quickly. Please wait a moment.", status: :too_many_requests
       return
     end
 

--- a/app/controllers/concerns/rate_limits.rb
+++ b/app/controllers/concerns/rate_limits.rb
@@ -1,0 +1,49 @@
+# typed: false
+
+# Per-user (and arbitrary compound-key) rate limiting for controller actions.
+#
+# Rack::Attack handles IP-keyed and pre-auth throttles. This concern handles
+# the cases that need post-auth context — current_user, target item, target
+# agent — that aren't available to rack-attack's middleware. Counters live
+# in Redis (via Sidekiq's connection pool) so they survive across processes.
+#
+# Usage:
+#   include RateLimits
+#
+#   def create
+#     enforce_rate_limit!(scope: "comments", key: [current_user.id, parent.id],
+#                         limit: 5, period: 1.minute)
+#     # ...
+#   rescue RateLimits::Exceeded
+#     # render or redirect with a friendly error
+#   end
+module RateLimits
+  extend ActiveSupport::Concern
+
+  class Exceeded < StandardError
+    attr_reader :scope, :limit, :period
+
+    def initialize(scope:, limit:, period:)
+      @scope = scope
+      @limit = limit
+      @period = period
+      super("Rate limit exceeded for #{scope} (#{limit} per #{period.inspect})")
+    end
+  end
+
+  # Fixed-window counter. Returns the count after increment; raises Exceeded
+  # if the count exceeds `limit`.
+  def enforce_rate_limit!(scope:, key:, limit:, period:)
+    redis_key = ["rate_limit", scope, *Array(key)].join(":")
+
+    count = Sidekiq.redis do |conn|
+      c = conn.incr(redis_key)
+      conn.expire(redis_key, period.to_i) if c == 1
+      c
+    end
+
+    raise Exceeded.new(scope: scope, limit: limit, period: period) if count > limit
+
+    count
+  end
+end

--- a/app/controllers/concerns/rate_limits.rb
+++ b/app/controllers/concerns/rate_limits.rb
@@ -31,14 +31,18 @@ module RateLimits
     end
   end
 
-  # Fixed-window counter. Returns the count after increment; raises Exceeded
-  # if the count exceeds `limit`.
+  # Sliding-window counter (window resets `period` seconds after the last
+  # request rather than the first). Returns the count after increment;
+  # raises Exceeded if the count exceeds `limit`.
+  #
+  # EXPIRE is set on every call so a transient failure between INCR and
+  # EXPIRE can't leave the key TTL-less and permanently blocked.
   def enforce_rate_limit!(scope:, key:, limit:, period:)
     redis_key = ["rate_limit", scope, *Array(key)].join(":")
 
     count = Sidekiq.redis do |conn|
       c = conn.incr(redis_key)
-      conn.expire(redis_key, period.to_i) if c == 1
+      conn.expire(redis_key, period.to_i)
       c
     end
 

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -14,6 +14,8 @@ class Commitment < ApplicationRecord
   include SoftDeletable
   include Statementable
   SUBTYPES = %w[action calendar_event policy].freeze
+  MAX_TITLE_LENGTH = 1000
+  MAX_DESCRIPTION_LENGTH = 1_000_000
 
   self.implicit_order_column = "created_at"
   belongs_to :tenant
@@ -23,7 +25,8 @@ class Commitment < ApplicationRecord
   belongs_to :created_by, class_name: 'User', foreign_key: 'created_by_id'
   belongs_to :updated_by, class_name: 'User', foreign_key: 'updated_by_id'
   has_many :participants, class_name: 'CommitmentParticipant', dependent: :destroy
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: MAX_TITLE_LENGTH }
+  validates :description, length: { maximum: MAX_DESCRIPTION_LENGTH }
   validates :critical_mass, presence: true, numericality: { greater_than: 0 }
   validates :deadline, presence: true
   validates :subtype, inclusion: { in: SUBTYPES }

--- a/app/models/concerns/linkable.rb
+++ b/app/models/concerns/linkable.rb
@@ -3,6 +3,8 @@
 module Linkable
   extend ActiveSupport::Concern
 
+  BACKLINKS_LIMIT = 1000
+
   included do
     has_many :links, as: :from_linkable, dependent: :destroy
     has_many :links, as: :to_linkable, dependent: :destroy
@@ -16,7 +18,7 @@ module Linkable
   end
 
   def backlinks
-    Link.where(to_linkable: self).order(updated_at: :desc).map(&:from_linkable)
+    Link.where(to_linkable: self).order(updated_at: :desc).limit(BACKLINKS_LIMIT).map(&:from_linkable)
   end
 
   def backlink_count

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -15,6 +15,8 @@ class Decision < ApplicationRecord
   include Statementable
   SUBTYPES = %w[vote lottery executive].freeze
   MAX_OPTIONS = 100
+  MAX_QUESTION_LENGTH = 1000
+  MAX_DESCRIPTION_LENGTH = 1_000_000
 
   self.implicit_order_column = "created_at"
   belongs_to :tenant
@@ -29,7 +31,8 @@ class Decision < ApplicationRecord
   has_many :votes # dependent: :destroy through options
   has_many :decision_audit_entries
 
-  validates :question, presence: true
+  validates :question, presence: true, length: { maximum: MAX_QUESTION_LENGTH }
+  validates :description, length: { maximum: MAX_DESCRIPTION_LENGTH }
   validates :deadline, presence: true
   validates :subtype, inclusion: { in: SUBTYPES }
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -15,6 +15,8 @@ class Note < ApplicationRecord
   include SoftDeletable
   participates_in_hard_delete
   SUBTYPES = %w[text reminder table comment statement].freeze
+  MAX_TITLE_LENGTH = 1000
+  MAX_TEXT_LENGTH = 1_000_000
 
   self.implicit_order_column = "created_at"
   belongs_to :tenant
@@ -38,6 +40,8 @@ class Note < ApplicationRecord
   EDIT_ACCESS_OPTIONS = %w[members owner].freeze
 
   validates :text, presence: true, unless: :is_table?
+  validates :text, length: { maximum: MAX_TEXT_LENGTH }
+  validate :validate_title_length
   validates :subtype, inclusion: { in: SUBTYPES }
   validates :edit_access, inclusion: { in: EDIT_ACCESS_OPTIONS }
   validate :comments_must_be_comment_subtype
@@ -409,6 +413,16 @@ class Note < ApplicationRecord
 
   def validate_table_data
     NoteTableValidator.validate(table_data, errors)
+  end
+
+  # Validate against the raw persisted title rather than the `.title` accessor,
+  # which derives a fallback from `text` and would mis-attribute length errors.
+  def validate_title_length
+    raw = raw_title
+    return if raw.nil?
+    return unless raw.length > MAX_TITLE_LENGTH
+
+    errors.add(:title, :too_long, count: MAX_TITLE_LENGTH)
   end
 
   def comments_must_be_comment_subtype

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -134,6 +134,20 @@ class Rack::Attack
       req.ip
     end
   end
+
+  # Stripe webhook receiver. Already gated by Stripe-Signature verification, but
+  # a flood of unsigned-but-otherwise-valid-looking requests can still cost CPU.
+  throttle('stripe_webhooks/ip', limit: 50, period: 1.minute) do |req|
+    req.ip if req.path == '/stripe/webhooks' && req.post?
+  end
+
+  # Incoming automation webhooks. Already gated by HMAC + timestamp + per-rule IP
+  # allowlist, but a leaked secret would otherwise enable unbounded LLM-agent
+  # invocation. Key on (ip, webhook_path) so a burst against one rule doesn't
+  # exhaust the bucket for unrelated rules from the same forwarder.
+  throttle('incoming_webhooks/path_ip', limit: 100, period: 1.minute) do |req|
+    "#{req.ip}:#{req.path}" if req.path.start_with?('/hooks/') && req.post?
+  end
 end
 
 # Configure cache store for Rack::Attack

--- a/test/controllers/ai_agents_controller_test.rb
+++ b/test/controllers/ai_agents_controller_test.rb
@@ -139,6 +139,32 @@ class AiAgentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
+  test "execute_task is rate-limited per (user, agent)" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Sidekiq.redis do |conn|
+      keys = conn.keys("rate_limit:agent_task_runs:*")
+      conn.del(*keys) if keys.any?
+    end
+
+    begin
+      AiAgentsController::TASK_RUNS_PER_MINUTE.times do |i|
+        post "/ai-agents/#{@ai_agent_handle}/run", params: { task: "Task #{i}" }
+        assert_response :redirect, "Run #{i + 1} should succeed: #{response.status}"
+      end
+
+      post "/ai-agents/#{@ai_agent_handle}/run",
+        params: { task: "Over limit" },
+        headers: { "Accept" => "application/json" }
+      assert_response :too_many_requests
+    ensure
+      Sidekiq.redis do |conn|
+        keys = conn.keys("rate_limit:agent_task_runs:*")
+        conn.del(*keys) if keys.any?
+      end
+    end
+  end
+
   test "execute task with custom max_steps" do
     sign_in_as(@user, tenant: @tenant)
 

--- a/test/controllers/chats_controller_test.rb
+++ b/test/controllers/chats_controller_test.rb
@@ -223,6 +223,30 @@ class ChatsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "send_message is rate-limited per (sender, partner)" do
+    create_chat_session
+
+    Sidekiq.redis do |conn|
+      keys = conn.keys("rate_limit:chat_messages:*")
+      conn.del(*keys) if keys.any?
+    end
+
+    begin
+      ChatsController::CHAT_MESSAGES_PER_MINUTE.times do |i|
+        post "/chat/#{@agent_handle}/message", params: { message: "Burst #{i}" }
+        assert_response :ok, "Message #{i + 1} should succeed: #{response.status}"
+      end
+
+      post "/chat/#{@agent_handle}/message", params: { message: "Over limit" }
+      assert_response :too_many_requests
+    ensure
+      Sidekiq.redis do |conn|
+        keys = conn.keys("rate_limit:chat_messages:*")
+        conn.del(*keys) if keys.any?
+      end
+    end
+  end
+
   test "send_message queues message when turn is running" do
     session = create_chat_session
     with_tenant_scope do

--- a/test/controllers/concerns/rate_limits_test.rb
+++ b/test/controllers/concerns/rate_limits_test.rb
@@ -64,12 +64,26 @@ class RateLimitsTest < ActiveSupport::TestCase
     assert_equal 1, error.limit
   end
 
-  test "the TTL is set on the first request in a window" do
+  test "the TTL is set on every increment, not just the first" do
+    # Regression test: previously EXPIRE was only called on the first
+    # increment, so a key whose EXPIRE failed (or got missed via a transient
+    # Redis hiccup) could persist forever and permanently block the bucket.
+    # Now EXPIRE is called every time.
+    redis_key = "rate_limit:#{@scope}:ttl_check"
+
     @host.enforce_rate_limit!(scope: @scope, key: "ttl_check", limit: 5, period: 60.seconds)
 
+    # Simulate the broken state: a key with a count but no TTL.
+    Sidekiq.redis { |conn| conn.persist(redis_key) }
     Sidekiq.redis do |conn|
-      ttl = conn.ttl("rate_limit:#{@scope}:ttl_check")
-      assert ttl.positive?, "expected a positive TTL after first increment, got #{ttl}"
+      assert_equal(-1, conn.ttl(redis_key), "precondition: key should have no TTL after persist")
+    end
+
+    # The next increment should reinstate a TTL.
+    @host.enforce_rate_limit!(scope: @scope, key: "ttl_check", limit: 5, period: 60.seconds)
+    Sidekiq.redis do |conn|
+      ttl = conn.ttl(redis_key)
+      assert ttl.positive?, "expected a positive TTL after the second increment, got #{ttl}"
       assert ttl <= 60, "expected TTL <= configured period, got #{ttl}"
     end
   end

--- a/test/controllers/concerns/rate_limits_test.rb
+++ b/test/controllers/concerns/rate_limits_test.rb
@@ -1,0 +1,76 @@
+# typed: false
+require "test_helper"
+
+# Tests for the RateLimits controller concern.
+#
+# Uses a stub host class so the helper can be exercised in isolation, separate
+# from controller-level integration that lives in the controller test suites.
+class RateLimitsTest < ActiveSupport::TestCase
+  class StubHost
+    include RateLimits
+  end
+
+  setup do
+    @host = StubHost.new
+    @scope = "rate_limits_test_#{SecureRandom.hex(4)}"
+  end
+
+  teardown do
+    Sidekiq.redis do |conn|
+      keys = conn.keys("rate_limit:#{@scope}:*")
+      conn.del(*keys) if keys.any?
+    end
+  end
+
+  test "increments the Redis counter and returns the new count" do
+    assert_equal 1, @host.enforce_rate_limit!(scope: @scope, key: "user_1", limit: 5, period: 60.seconds)
+    assert_equal 2, @host.enforce_rate_limit!(scope: @scope, key: "user_1", limit: 5, period: 60.seconds)
+  end
+
+  test "allows requests up to and including the limit" do
+    5.times do |i|
+      assert_equal i + 1, @host.enforce_rate_limit!(scope: @scope, key: "user_1", limit: 5, period: 60.seconds)
+    end
+  end
+
+  test "raises Exceeded once the limit is crossed" do
+    5.times { @host.enforce_rate_limit!(scope: @scope, key: "user_1", limit: 5, period: 60.seconds) }
+
+    assert_raises(RateLimits::Exceeded) do
+      @host.enforce_rate_limit!(scope: @scope, key: "user_1", limit: 5, period: 60.seconds)
+    end
+  end
+
+  test "different keys are tracked independently" do
+    5.times { @host.enforce_rate_limit!(scope: @scope, key: "user_1", limit: 5, period: 60.seconds) }
+
+    assert_equal 1, @host.enforce_rate_limit!(scope: @scope, key: "user_2", limit: 5, period: 60.seconds)
+  end
+
+  test "compound keys produce independent namespaces" do
+    @host.enforce_rate_limit!(scope: @scope, key: ["user_1", "item_42"], limit: 5, period: 60.seconds)
+
+    fresh_count = @host.enforce_rate_limit!(scope: @scope, key: ["user_1", "item_99"], limit: 5, period: 60.seconds)
+    assert_equal 1, fresh_count
+  end
+
+  test "Exceeded exception carries scope and limit for handlers" do
+    @host.enforce_rate_limit!(scope: @scope, key: "user_1", limit: 1, period: 60.seconds)
+
+    error = assert_raises(RateLimits::Exceeded) do
+      @host.enforce_rate_limit!(scope: @scope, key: "user_1", limit: 1, period: 60.seconds)
+    end
+    assert_equal @scope, error.scope
+    assert_equal 1, error.limit
+  end
+
+  test "the TTL is set on the first request in a window" do
+    @host.enforce_rate_limit!(scope: @scope, key: "ttl_check", limit: 5, period: 60.seconds)
+
+    Sidekiq.redis do |conn|
+      ttl = conn.ttl("rate_limit:#{@scope}:ttl_check")
+      assert ttl.positive?, "expected a positive TTL after first increment, got #{ttl}"
+      assert ttl <= 60, "expected TTL <= configured period, got #{ttl}"
+    end
+  end
+end

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -265,6 +265,48 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     assert_equal initial_count + 1, Note.unscoped.count, "Note count should have increased by 1"
   end
 
+  test "create_comment is rate-limited per user+item" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    note = Note.create!(
+      tenant: @tenant,
+      collective: @collective,
+      created_by: @user,
+      title: "Rate Limit Test Note",
+      text: "Test content"
+    )
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    # Clear any leftover counters before exercising the limit
+    Sidekiq.redis do |conn|
+      keys = conn.keys("rate_limit:comments:*")
+      conn.del(*keys) if keys.any?
+    end
+
+    begin
+      # Limit is 5 per minute per (user, item)
+      5.times do |i|
+        post "/collectives/#{@collective.handle}/n/#{note.truncated_id}/comments",
+          params: { text: "Comment #{i}" },
+          headers: { "Accept" => "application/json" }
+        assert_response :success, "Comment #{i + 1} should succeed: #{response.status} #{response.body}"
+      end
+
+      post "/collectives/#{@collective.handle}/n/#{note.truncated_id}/comments",
+        params: { text: "Over limit" },
+        headers: { "Accept" => "application/json" }
+      assert_response :too_many_requests
+    ensure
+      Sidekiq.redis do |conn|
+        keys = conn.keys("rate_limit:comments:*")
+        conn.del(*keys) if keys.any?
+      end
+    end
+  end
+
   test "comments_partial returns HTML" do
     sign_in_as(@user, tenant: @tenant)
 

--- a/test/integration/rack_attack_throttles_test.rb
+++ b/test/integration/rack_attack_throttles_test.rb
@@ -57,4 +57,28 @@ class RackAttackThrottlesTest < ActiveSupport::TestCase
     assert_nil matches?("identity_register/ip", path: "/auth/identity/register", method: "GET")
     assert_nil matches?("identity_register/ip", path: "/auth/identity/callback", method: "POST")
   end
+
+  test "stripe_webhooks/ip throttle matches POST /stripe/webhooks" do
+    assert_equal "1.2.3.4", matches?("stripe_webhooks/ip", path: "/stripe/webhooks", method: "POST")
+    assert_nil matches?("stripe_webhooks/ip", path: "/stripe/webhooks", method: "GET")
+    assert_nil matches?("stripe_webhooks/ip", path: "/something-else", method: "POST")
+  end
+
+  test "incoming_webhooks/path_ip throttle matches POST /hooks/:webhook_path and includes path in key" do
+    rule = Rack::Attack.throttles["incoming_webhooks/path_ip"]
+    refute_nil rule, "expected throttle 'incoming_webhooks/path_ip' to be registered"
+
+    env = Rack::MockRequest.env_for("/hooks/my-hook", method: "POST", "REMOTE_ADDR" => "1.2.3.4")
+    req = Rack::Attack::Request.new(env)
+    key = rule.block.call(req)
+    assert_equal "1.2.3.4:/hooks/my-hook", key, "key should combine IP and path so distinct webhooks don't share a bucket"
+
+    env2 = Rack::MockRequest.env_for("/hooks/my-hook", method: "GET", "REMOTE_ADDR" => "1.2.3.4")
+    req2 = Rack::Attack::Request.new(env2)
+    assert_nil rule.block.call(req2)
+
+    env3 = Rack::MockRequest.env_for("/not-a-hook", method: "POST", "REMOTE_ADDR" => "1.2.3.4")
+    req3 = Rack::Attack::Request.new(env3)
+    assert_nil rule.block.call(req3)
+  end
 end

--- a/test/models/commitment_test.rb
+++ b/test/models/commitment_test.rb
@@ -49,6 +49,46 @@ class CommitmentTest < ActiveSupport::TestCase
     assert_includes commitment.errors[:title], "can't be blank"
   end
 
+  test "Commitment.title length is capped at MAX_TITLE_LENGTH" do
+    tenant = create_tenant
+    user = create_user
+    collective = create_collective(tenant: tenant, created_by: user)
+
+    commitment = Commitment.new(
+      tenant: tenant,
+      collective: collective,
+      created_by: user,
+      updated_by: user,
+      title: "x" * (Commitment::MAX_TITLE_LENGTH + 1),
+      description: "valid",
+      critical_mass: 5,
+      deadline: 1.week.from_now
+    )
+
+    assert_not commitment.valid?
+    assert_includes commitment.errors[:title], "is too long (maximum is #{Commitment::MAX_TITLE_LENGTH} characters)"
+  end
+
+  test "Commitment.description length is capped at MAX_DESCRIPTION_LENGTH" do
+    tenant = create_tenant
+    user = create_user
+    collective = create_collective(tenant: tenant, created_by: user)
+
+    commitment = Commitment.new(
+      tenant: tenant,
+      collective: collective,
+      created_by: user,
+      updated_by: user,
+      title: "Valid",
+      description: "x" * (Commitment::MAX_DESCRIPTION_LENGTH + 1),
+      critical_mass: 5,
+      deadline: 1.week.from_now
+    )
+
+    assert_not commitment.valid?
+    assert_includes commitment.errors[:description], "is too long (maximum is #{Commitment::MAX_DESCRIPTION_LENGTH} characters)"
+  end
+
   test "Commitment requires a critical mass greater than 0" do
     tenant = create_tenant
     user = create_user

--- a/test/models/decision_test.rb
+++ b/test/models/decision_test.rb
@@ -47,6 +47,36 @@ class DecisionTest < ActiveSupport::TestCase
     assert_includes decision.errors[:question], "can't be blank"
   end
 
+  test "Decision.question length is capped at MAX_QUESTION_LENGTH" do
+    decision = Decision.new(
+      tenant: @tenant,
+      collective: @collective,
+      created_by: @user,
+      updated_by: @user,
+      question: "x" * (Decision::MAX_QUESTION_LENGTH + 1),
+      description: "valid",
+      deadline: 1.day.from_now
+    )
+
+    assert_not decision.valid?
+    assert_includes decision.errors[:question], "is too long (maximum is #{Decision::MAX_QUESTION_LENGTH} characters)"
+  end
+
+  test "Decision.description length is capped at MAX_DESCRIPTION_LENGTH" do
+    decision = Decision.new(
+      tenant: @tenant,
+      collective: @collective,
+      created_by: @user,
+      updated_by: @user,
+      question: "Valid?",
+      description: "x" * (Decision::MAX_DESCRIPTION_LENGTH + 1),
+      deadline: 1.day.from_now
+    )
+
+    assert_not decision.valid?
+    assert_includes decision.errors[:description], "is too long (maximum is #{Decision::MAX_DESCRIPTION_LENGTH} characters)"
+  end
+
   test "Decision requires a deadline" do
     decision = Decision.new(
       tenant: @tenant,

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -269,6 +269,72 @@ class NoteTest < ActiveSupport::TestCase
     assert_equal 1, note2.backlink_count
   end
 
+  test "Note.title length is capped at MAX_TITLE_LENGTH" do
+    tenant = create_tenant
+    user = create_user
+    collective = create_collective(tenant: tenant, created_by: user)
+
+    note = Note.new(
+      tenant: tenant, collective: collective, created_by: user, updated_by: user,
+      title: "x" * (Note::MAX_TITLE_LENGTH + 1),
+      text: "valid"
+    )
+
+    assert_not note.valid?
+    assert_includes note.errors[:title], "is too long (maximum is #{Note::MAX_TITLE_LENGTH} characters)"
+  end
+
+  test "Note.text length is capped at MAX_TEXT_LENGTH" do
+    tenant = create_tenant
+    user = create_user
+    collective = create_collective(tenant: tenant, created_by: user)
+
+    note = Note.new(
+      tenant: tenant, collective: collective, created_by: user, updated_by: user,
+      title: "Valid",
+      text: "x" * (Note::MAX_TEXT_LENGTH + 1)
+    )
+
+    assert_not note.valid?
+    assert_includes note.errors[:text], "is too long (maximum is #{Note::MAX_TEXT_LENGTH} characters)"
+  end
+
+  test "Linkable#backlinks is capped at BACKLINKS_LIMIT" do
+    assert_equal 1000, Linkable::BACKLINKS_LIMIT
+
+    tenant = create_tenant(subdomain: "backlinks-cap-#{SecureRandom.hex(4)}")
+    user = create_user
+    collective = create_collective(tenant: tenant, created_by: user, handle: "backlinks-cap-#{SecureRandom.hex(4)}")
+
+    target = Note.create!(
+      tenant: tenant, collective: collective, created_by: user, updated_by: user,
+      title: "Target", text: "target"
+    )
+    source = Note.create!(
+      tenant: tenant, collective: collective, created_by: user, updated_by: user,
+      title: "Source", text: "source"
+    )
+
+    now = Time.current
+    over_limit_count = Linkable::BACKLINKS_LIMIT + 1
+    link_attrs = over_limit_count.times.map do
+      {
+        tenant_id: tenant.id,
+        collective_id: collective.id,
+        from_linkable_type: "Note",
+        from_linkable_id: source.id,
+        to_linkable_type: "Note",
+        to_linkable_id: target.id,
+        created_at: now,
+        updated_at: now,
+      }
+    end
+    Link.insert_all(link_attrs)
+
+    assert_equal over_limit_count, Link.where(to_linkable: target).count
+    assert_equal Linkable::BACKLINKS_LIMIT, target.backlinks.size
+  end
+
   # === Multiple History Events ===
 
   test "Multiple updates create multiple history events" do


### PR DESCRIPTION
## Summary

Phases 1 and 2 (Critical items) of [.claude/plans/resource-limits-hardening.md](.claude/plans/resource-limits-hardening.md) — adds rate limits, data-volume caps, and the `RateLimits` controller concern. Closes the three Critical Axis 1 gaps (incoming webhook, AI agent chat/task execution, comment creation), the two Critical Axis 2 gaps that don't need bigger redesigns (backlinks, text-field length), and the Stripe webhook Medium gap.

### Phase 1 — rack-attack throttles, backlinks cap, length validations

- **`stripe_webhooks/ip`**: 50/min/IP (backstop to Stripe-signature verification)
- **`incoming_webhooks/path_ip`**: 100/min keyed on `(IP, webhook_path)` so a burst against one rule doesn't share a bucket with unrelated rules from the same forwarder. Backstop to HMAC + IP allowlist on `/hooks/*`.
- **`Linkable::BACKLINKS_LIMIT = 1000`** applied at the query level so a heavily-linked-to record can't materialize an unbounded result set.
- **Length validations** on user text fields (well under Postgres' 1 GB `text` ceiling but tight enough to bound mention/link regex passes and per-row read cost):
  - Note: title 1000, text 1,000,000
  - Decision: question 1000, description 1,000,000
  - Commitment: title 1000, description 1,000,000
- Note title uses a custom validator against `raw_title` rather than the `.title` accessor — the accessor derives a fallback from `text` and has a latent `T.must(nil)` crash on nil/empty text that the new length-validation path would otherwise trip.

### Phase 2 — `RateLimits` controller concern + 3 post-auth throttles

New [`RateLimits`](app/controllers/concerns/rate_limits.rb) concern with Redis-backed counters (via Sidekiq's connection pool) for the post-auth cases rack-attack can't reach. `enforce_rate_limit!(scope:, key:, limit:, period:)` increments and raises `RateLimits::Exceeded` past the limit; callers decide UX (redirect+flash for HTML, 429 for JSON).

Applied to:
- **Comments**: 5/min per `(user, item)` on `ApplicationController#create_comment`
- **Chat messages**: 20/min per `(sender, partner)` on `ChatsController#send_message`
- **Agent task runs**: 5/min per `(user, agent)` on `AiAgentsController#execute_task`

EXPIRE is set on every increment, not just the first, so a transient failure between `INCR` and `EXPIRE` can't leave a key TTL-less and permanently block the bucket. The semantics shift from strict fixed-window to sliding-ish (window resets `period` seconds after the *last* request rather than the *first*) — equivalent or more lenient for our use cases.

### Deferred (still tracked in the plan)

- Password-reset per-email throttle (Low priority; honeypot + Turnstile cover the practical risk)
- API-token-keyed throttle for `/api/v1/*` (Medium)
- Phase 3 (comment threading hardening), Phase 4 (retention jobs), Phase 5 (storage/count caps), Phase 6 (verification work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
