### PR TITLE
Eliminate flaky 429s in anon-read tests by fixing per-IP isolation

### DIFF
--- a/test/integration/anonymous_read_access_bypass_test.rb
+++ b/test/integration/anonymous_read_access_bypass_test.rb
@@ -23,20 +23,8 @@ class AnonymousReadAccessBypassTest < ActionDispatch::IntegrationTest
     set_up_private_tenant
     Tenant.clear_thread_scope
     Collective.clear_thread_scope
-    # Per-test unique IP so the per-IP anon-read rate-limit counter in Redis
-    # is isolated per test and parallel workers don't collide.
-    @test_ip = "10.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(254) + 1}"
-  end
-
-  # Inject @test_ip as REMOTE_ADDR into every request so we don't have to
-  # remember on each get/post call.
-  def process(method, path, **kwargs)
-    if @test_ip
-      env = (kwargs[:env] || {}).dup
-      env["REMOTE_ADDR"] ||= @test_ip
-      kwargs = kwargs.merge(env: env)
-    end
-    super
+    @test_ip = fresh_test_ip
+    self.remote_addr = @test_ip
   end
 
   def teardown

--- a/test/integration/anonymous_read_access_controllers_test.rb
+++ b/test/integration/anonymous_read_access_controllers_test.rb
@@ -31,9 +31,8 @@ class AnonymousReadAccessControllersTest < ActionDispatch::IntegrationTest
     Tenant.clear_thread_scope
     Collective.clear_thread_scope
 
-    # Per-test unique IP so the per-IP rate-limit counter in Redis can't
-    # collide across parallel workers (which all share Redis DB 15).
-    @test_ip = unique_ip
+    @test_ip = fresh_test_ip
+    self.remote_addr = @test_ip
   end
 
   def teardown
@@ -201,13 +200,4 @@ class AnonymousReadAccessControllersTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  private
-
-  def unique_ip
-    # 10.0.0.0/8 is private-use. Use SecureRandom (not rand) — Ruby's default
-    # Random shares state across forked test workers, so the first `rand` in
-    # each worker returns the same value, causing IP collisions and shared
-    # rate-limit counters in the test Redis DB.
-    "10.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(254) + 1}"
-  end
 end

--- a/test/integration/anonymous_read_access_markdown_structure_test.rb
+++ b/test/integration/anonymous_read_access_markdown_structure_test.rb
@@ -55,7 +55,8 @@ class AnonymousReadAccessMarkdownStructureTest < ActionDispatch::IntegrationTest
     Tenant.clear_thread_scope
     Collective.clear_thread_scope
 
-    @test_ip = "10.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(254) + 1}"
+    @test_ip = fresh_test_ip
+    self.remote_addr = @test_ip
   end
 
   def teardown
@@ -63,12 +64,6 @@ class AnonymousReadAccessMarkdownStructureTest < ActionDispatch::IntegrationTest
     Tenant.reset_anon_readable_subdomains!
     Tenant.clear_thread_scope
     Collective.clear_thread_scope
-  end
-
-  def process(method, path, **kwargs)
-    env = (kwargs[:env] || {}).dup
-    env["REMOTE_ADDR"] ||= @test_ip
-    super(method, path, **kwargs.merge(env: env))
   end
 
   # ---- Helpers ----

--- a/test/integration/anonymous_read_access_route_sweep_test.rb
+++ b/test/integration/anonymous_read_access_route_sweep_test.rb
@@ -175,7 +175,7 @@ class AnonymousReadAccessRouteSweepTest < ActionDispatch::IntegrationTest
     ] + HelpController::TOPICS.map { |t| "/help/#{t.tr("_", "-")}" }
 
     failures = urls.filter_map do |url|
-      get url, env: { "REMOTE_ADDR" => fresh_ip }
+      get url, env: { "REMOTE_ADDR" => fresh_test_ip }
       problems = []
       problems << "status=#{response.status} (expected 302)" unless response.status == 302
       problems << "location=#{response.location.inspect} (expected /login)" unless response.location&.match?(%r{/login})
@@ -225,7 +225,7 @@ class AnonymousReadAccessRouteSweepTest < ActionDispatch::IntegrationTest
     Collective.clear_thread_scope
 
     host! "#{PUBLIC_SUBDOMAIN}.#{ENV.fetch("HOSTNAME", nil)}"
-    get note.path, env: { "REMOTE_ADDR" => fresh_ip }
+    get note.path, env: { "REMOTE_ADDR" => fresh_test_ip }
     assert_redirected_to %r{/login}
   end
 
@@ -239,7 +239,7 @@ class AnonymousReadAccessRouteSweepTest < ActionDispatch::IntegrationTest
     Collective.clear_thread_scope
 
     host! "#{PUBLIC_SUBDOMAIN}.#{ENV.fetch("HOSTNAME", nil)}"
-    get "/n/#{secret_note.truncated_id}", env: { "REMOTE_ADDR" => fresh_ip }
+    get "/n/#{secret_note.truncated_id}", env: { "REMOTE_ADDR" => fresh_test_ip }
     # Should NOT find — the note belongs to a different tenant, tenant-scoped
     # default_scope filters it out.
     assert_includes [302, 404], response.status,
@@ -254,7 +254,7 @@ class AnonymousReadAccessRouteSweepTest < ActionDispatch::IntegrationTest
     # (no anon content is served for an unknown tenant).
     host! "no-such-subdomain.#{ENV.fetch("HOSTNAME", nil)}"
     begin
-      get "/help", env: { "REMOTE_ADDR" => fresh_ip }
+      get "/help", env: { "REMOTE_ADDR" => fresh_test_ip }
     rescue RuntimeError => e
       assert_match(/invalid subdomain/i, e.message)
       return
@@ -271,17 +271,13 @@ class AnonymousReadAccessRouteSweepTest < ActionDispatch::IntegrationTest
     Tenant.reset_anon_readable_subdomains!
 
     host! "#{auth_sub}.#{ENV.fetch("HOSTNAME", nil)}"
-    get "/help", env: { "REMOTE_ADDR" => fresh_ip }
+    get "/help", env: { "REMOTE_ADDR" => fresh_test_ip }
     # Either redirected (auth subdomain redirects everything non-auth) or
     # 404 (no main collective). Must NOT be 200.
     assert response.status >= 300, "AUTH_SUBDOMAIN should not expose anon reads even when misconfigured into the env var (got #{response.status})"
   end
 
   private
-
-  def fresh_ip
-    "10.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(254) + 1}"
-  end
 
   # Iterate routes and classify each response. Returns [leaks, unexpected]:
   #   leaks      — 2xx responses for (controller, action) NOT in allowlist
@@ -316,7 +312,7 @@ class AnonymousReadAccessRouteSweepTest < ActionDispatch::IntegrationTest
       next if SKIPPED_PATH_PREFIXES.any? { |p| path.start_with?(p) }
 
       begin
-        get path, env: { "REMOTE_ADDR" => fresh_ip }
+        get path, env: { "REMOTE_ADDR" => fresh_test_ip }
       rescue ActionController::UrlGenerationError, ActionController::RoutingError
         next
       rescue StandardError

--- a/test/integration/anonymous_read_access_user_profiles_test.rb
+++ b/test/integration/anonymous_read_access_user_profiles_test.rb
@@ -25,7 +25,8 @@ class AnonymousReadAccessUserProfilesTest < ActionDispatch::IntegrationTest
     set_up_private_tenant
     Tenant.clear_thread_scope
     Collective.clear_thread_scope
-    @test_ip = "10.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(254) + 1}"
+    @test_ip = fresh_test_ip
+    self.remote_addr = @test_ip
   end
 
   def teardown
@@ -33,12 +34,6 @@ class AnonymousReadAccessUserProfilesTest < ActionDispatch::IntegrationTest
     Tenant.reset_anon_readable_subdomains!
     Tenant.clear_thread_scope
     Collective.clear_thread_scope
-  end
-
-  def process(method, path, **kwargs)
-    env = (kwargs[:env] || {}).dup
-    env["REMOTE_ADDR"] ||= @test_ip
-    super(method, path, **kwargs.merge(env: env))
   end
 
   private

--- a/test/integration/anonymous_read_access_views_test.rb
+++ b/test/integration/anonymous_read_access_views_test.rb
@@ -29,7 +29,8 @@ class AnonymousReadAccessViewsTest < ActionDispatch::IntegrationTest
     Tenant.clear_thread_scope
     Collective.clear_thread_scope
 
-    @test_ip = "10.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(254) + 1}"
+    @test_ip = fresh_test_ip
+    self.remote_addr = @test_ip
   end
 
   def teardown
@@ -37,15 +38,6 @@ class AnonymousReadAccessViewsTest < ActionDispatch::IntegrationTest
     Tenant.reset_anon_readable_subdomains!
     Tenant.clear_thread_scope
     Collective.clear_thread_scope
-  end
-
-  def process(method, path, **kwargs)
-    if @test_ip
-      env = (kwargs[:env] || {}).dup
-      env["REMOTE_ADDR"] ||= @test_ip
-      kwargs = kwargs.merge(env: env)
-    end
-    super
   end
 
   # ---- Anon sees "Log in to comment" CTA on commentable show pages ----

--- a/test/integration/meta_tags_test.rb
+++ b/test/integration/meta_tags_test.rb
@@ -46,7 +46,8 @@ class MetaTagsTest < ActionDispatch::IntegrationTest
     Tenant.clear_thread_scope
     Collective.clear_thread_scope
 
-    @test_ip = "10.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(256)}.#{SecureRandom.random_number(254) + 1}"
+    @test_ip = fresh_test_ip
+    self.remote_addr = @test_ip
   end
 
   def teardown
@@ -54,15 +55,6 @@ class MetaTagsTest < ActionDispatch::IntegrationTest
     Tenant.reset_anon_readable_subdomains!
     Tenant.clear_thread_scope
     Collective.clear_thread_scope
-  end
-
-  def process(method, path, **kwargs)
-    if @test_ip
-      env = (kwargs[:env] || {}).dup
-      env["REMOTE_ADDR"] ||= @test_ip
-      kwargs = kwargs.merge(env: env)
-    end
-    super
   end
 
   def host_for(subdomain)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -78,6 +78,13 @@ class ActiveSupport::TestCase
   # Note: When running with COVERAGE=true, consider using workers: 1 for accurate results
   parallelize(workers: ENV['COVERAGE'] ? 1 : :number_of_processors)
 
+  # Stamp each parallel worker with a unique id so fresh_test_ip can hand out
+  # non-overlapping IP ranges. Rails' built-in TEST_ENV_NUMBER is only set
+  # when database multiplexing is configured, which this app doesn't do.
+  parallelize_setup do |worker|
+    ENV["TEST_WORKER_NUMBER"] = worker.to_s
+  end
+
   # Note: No fixtures loaded - we create test data programmatically
   # fixtures :all  # Removed - no fixture YAML files exist
 
@@ -287,6 +294,41 @@ end
 
 # Integration test helpers for controller tests
 class ActionDispatch::IntegrationTest
+  # Returns a guaranteed-unique IPv4 address (within 10.0.0.0/8) for use as
+  # REMOTE_ADDR in tests that exercise per-IP rate limits (Rack::Attack or
+  # `enforce_anonymous_read_rate_limit`).
+  #
+  # USAGE in a test's setup block:
+  #   self.remote_addr = fresh_test_ip
+  #
+  # This sets the integration session's REMOTE_ADDR default — every get/post
+  # in that test then uses the unique IP. Do NOT use a `process` override or
+  # `@test_ip = fresh_test_ip` with a process method — get/post route through
+  # `integration_session.process`, not the TestCase's process, so a TestCase
+  # `process` override silently does nothing (the requests fall back to
+  # 127.0.0.1, and across parallel workers all those 127.0.0.1 requests
+  # accumulate against the same Redis counter → spurious 429s).
+  #
+  # Per-IP throttle counters live in Redis DB 15, which is SHARED across all
+  # parallel test workers and the entire test run. If two tests pick the same
+  # IP (possible with random IPs in a 16M space and ~hundreds of tests, even
+  # with SecureRandom) the second test inherits the first's quota usage.
+  #
+  # This helper guarantees uniqueness two ways:
+  #   - TEST_WORKER_NUMBER (set in parallelize_setup above) in the second
+  #     octet → each parallel worker fork gets its own /16 range.
+  #   - Monotonic counter in the third/fourth octets → within a worker, every
+  #     call produces a fresh IP, guaranteed.
+  #
+  # Each worker has ~64K addresses; in practice each runs ~500 tests, well
+  # under the wrap point.
+  @@_fresh_test_ip_seq = 0
+  def fresh_test_ip
+    @@_fresh_test_ip_seq += 1
+    worker = ENV["TEST_WORKER_NUMBER"].to_i
+    "10.#{worker % 256}.#{(@@_fresh_test_ip_seq / 254) % 256}.#{(@@_fresh_test_ip_seq % 254) + 1}"
+  end
+
   # Sign in a user for integration tests
   # In integration tests, we need to simulate the login process
   # The app checks session[:user_id] for authentication


### PR DESCRIPTION
Investigating CI flakes (1-in-N runs, different test each time, always 429), discovered the existing per-test-IP isolation pattern in the seven anon-read test files was a no-op:

- Each test set @test_ip = "10.<random>" via SecureRandom in setup, then defined `def process(method, path, **kwargs)` to inject REMOTE_ADDR.
- But Rails routes get/post through `integration_session.process`, NOT through a TestCase `process` method. The override silently never ran.
- Every "anon" GET in those tests actually went out with REMOTE_ADDR 127.0.0.1 (the integration session's default).
- Across 4 parallel workers + Redis DB 15 shared, the 127.0.0.1 anon-read counter accumulated past the 60/min cap → 429 on whichever test happened to hit when the counter was full.

Fixes:

1. New `fresh_test_ip` helper in test_helper.rb that returns a guaranteed-unique IP per call: TEST_WORKER_NUMBER (set in a new parallelize_setup) namespaces the second octet per parallel worker; a monotonic counter fills the third/fourth. No randomness, no birthday-paradox collisions, ever.

2. Each test file's setup now calls `self.remote_addr = fresh_test_ip` (the integration session's REMOTE_ADDR accessor). This is the actually-correct hook: get/post/etc. then default to that IP. The useless `def process` overrides are removed.

3. The route-sweep test continues to pass `env: { "REMOTE_ADDR" => ... }` per request because it needs a different IP per loop iteration (the env: hash overrides remote_addr at request time).

Verified with 3 sequential 99-test runs (0 failures each) plus a full 1777-test integration+controllers regression (0 failures).