### PR TITLE
Split ai_agents feature flag; consolidate agent settings page

### DIFF
--- a/.claude/plans/split-ai-agents-flag.md
+++ b/.claude/plans/split-ai-agents-flag.md
@@ -1,0 +1,316 @@
+# Split `ai_agents` Feature Flag
+
+## Goal
+
+**1. Split the flag.** Replace the single `ai_agents` feature flag with two independent flags so a tenant can enable external API-based agents without also enabling the internal Task Runner (and vice versa):
+
+- `internal_ai_agents` — gates the Task Runner: agent-runner dispatch, automation execution, run UI.
+- `external_ai_agents` — gates external API-token-based agents: their creation and the agent-management UI's external pathways.
+
+The `api` flag stays as the gate on the API surface itself. The `trio` collective-level flag stays as the per-collective Trio toggle.
+
+**2. Consolidate AI-agent UI.** AI-agent management is currently split across `/u/<handle>/settings` and `/ai-agents/<handle>/settings` with diverged-but-overlapping edit forms over the same `agent_configuration` JSONB. Collapse to a single canonical surface at `/ai-agents/<handle>/settings`. This expands scope but is worth doing now: without it, every conditional in the View-changes section has to be applied to both pages and kept in sync, and the duplicate write paths into `agent_configuration` would remain.
+
+## Why
+
+Today `ai_agents` conflates two distinct capabilities:
+
+1. The **internal Task Runner** — an integrated service the deployment hosts, which dequeues tasks from Redis and runs agents on the operator's account (Trio rides on this path too).
+2. **External AI agents** — User records with `agent_configuration["mode"] = "external"` that interact via REST + API tokens. They don't need the Task Runner at all.
+
+The flag's current description already acknowledges the second category is gated only by `api`, but the controller, dispatcher, and nav code don't actually honor that distinction — turning `ai_agents` off hides external agents' management pages too. Tenants that want only external/API agents have to enable a flag that also stands up the internal Task Runner.
+
+## Current behavior (audit results)
+
+Only four production gate sites check `ai_agents_enabled?`:
+
+| Site | What it gates today | Side |
+|---|---|---|
+| [tenant.rb:268](app/models/tenant.rb#L268) | The predicate itself | infra |
+| [ai_agents_controller.rb:7,486-487](app/controllers/ai_agents_controller.rb#L486-L487) | `index, show, settings, run_task, execute_task, runs, show_run, cancel_run` | **mixed** (index/show/settings are shared across internal+external; runs/run_task are internal-only) |
+| [automation_dispatcher.rb:14](app/services/automation_dispatcher.rb#L14) | All automation rule dispatch | internal |
+| [agent_runner_dispatch_service.rb:28](app/services/agent_runner_dispatch_service.rb#L28) | Pushing tasks onto the `agent_tasks` Redis stream | internal |
+| [_top_right_menu.html.erb:61-70](app/views/layouts/_top_right_menu.html.erb#L61-L70) | Both "Chat" and "AI Agents" nav links | **mixed** (chat works with external agents too) |
+
+Internal vs external is already distinguished in the model:
+
+- [user.rb:230-238](app/models/user.rb#L230-L238) — `internal_ai_agent?` ↔ `agent_configuration["mode"] == "internal"`; `external_ai_agent?` is the inverse.
+- [agent_runner_dispatch_service.rb:37-40](app/services/agent_runner_dispatch_service.rb#L37-L40) — external agents are explicitly refused at dispatch.
+- Trio is internal: [trio_seeder.rb:91](app/services/trio_seeder.rb#L91) seeds `"mode" => "internal"`.
+
+`AiAgentsController` does *not* gate creation/update/deactivation today (only billing gates `new`). So today you can POST to create an agent with the flag off but you can't see the index.
+
+## Scope
+
+### Flag definitions ([config/feature_flags.yml](config/feature_flags.yml))
+
+Remove `ai_agents`. Add:
+
+```yaml
+internal_ai_agents:
+  name: "Internal AI Agents (Task Runner)"
+  description: "Enables the Harmonic-managed Task Runner for executing internal AI agent runs (the agent-runner service, automation rule dispatch, and Trio's runtime path)."
+  app_enabled: true
+  default_tenant: false
+  default_collective: false
+  collective_level: false
+
+external_ai_agents:
+  name: "External AI Agents"
+  description: "Allows users to create AI agents that interact with Harmonic via the API using API tokens. Requires the 'api' flag."
+  app_enabled: true
+  default_tenant: false
+  default_collective: false
+  collective_level: false
+```
+
+Migration path: existing tenants with `ai_agents` set (either value) get both new flags set to the same value, preserving behavior exactly. Feature flag values live in the `tenants.settings` JSONB column under `feature_flags.<flag_name>` ([has_feature_flags.rb:8-21](app/models/concerns/has_feature_flags.rb#L8-L21)) — there is no separate settings table. The migration is a `jsonb_set` on `tenants` mirroring the shape of [db/migrate/20260112131013_migrate_feature_flags_settings.rb](db/migrate/20260112131013_migrate_feature_flags_settings.rb):
+
+```sql
+-- For both new flags, copy the existing ai_agents value (or 'false' default), then delete the old key.
+UPDATE tenants
+SET settings = jsonb_set(
+  settings,
+  '{feature_flags,internal_ai_agents}',
+  COALESCE(settings->'feature_flags'->'ai_agents', 'false'::jsonb),
+  true
+);
+UPDATE tenants
+SET settings = jsonb_set(
+  settings,
+  '{feature_flags,external_ai_agents}',
+  COALESCE(settings->'feature_flags'->'ai_agents', 'false'::jsonb),
+  true
+);
+UPDATE tenants
+SET settings = settings #- '{feature_flags,ai_agents}';
+```
+
+The `collectives` (a.k.a. `studios`) table doesn't need migration since `ai_agents` is `collective_level: false` and never settable per-collective, but a defensive `#-` removal on `studios` is cheap and worth including in case any historical write put it there.
+
+### Tenant predicates ([tenant.rb:268](app/models/tenant.rb#L268))
+
+Replace `ai_agents_enabled?` with `internal_ai_agents_enabled?` and `external_ai_agents_enabled?`. Add a convenience `any_ai_agents_enabled?` (returns `internal || external`) for the shared management-page gate. No grace alias — the old method goes away.
+
+### Controller gates ([ai_agents_controller.rb:7](app/controllers/ai_agents_controller.rb#L7))
+
+Split the single `before_action :require_ai_agents_enabled` into two:
+
+- `before_action :require_any_ai_agents_enabled, only: [:index, :show, :settings, :update_settings, :describe_update_ai_agent, :execute_update_ai_agent, :settings_actions_index]` — pages that manage agents of either type. **Behavior change:** today `update_settings` and the describe/execute update pair are ungated; this brings them under a gate. For tenants where the old `ai_agents` flag was on, the migration sets both new flags on and behavior is identical. For tenants where the old flag was off, agent self-update via the markdown API was reachable before and is now blocked — call this out in the CHANGELOG.
+- `before_action :require_internal_ai_agents_enabled, only: [:run_task, :execute_task, :runs, :show_run, :cancel_run]` — Task-Runner-only actions.
+- Creation (`new, create, execute_create_ai_agent`) — gate on whichever flag matches the **effective** mode. The new form ([new.html.erb:119](app/views/ai_agents/new.html.erb#L119)) defaults the radio to `internal`; the API helper ([api_helper.rb:728](app/services/api_helper.rb#L728)) defaults missing/invalid `params[:mode]` to `external`. These two defaults disagree; the gate code must resolve mode the same way the create path will (`["internal", "external"].include?(params[:mode]) ? params[:mode] : "external"`) so an absent param maps to the external gate. Keep the existing billing gate on `:new`. If neither flag is on, the `new` page itself should 403.
+- `deactivate, reactivate` — leave ungated (you must be able to deactivate an existing agent even if the corresponding flag is turned off later).
+
+### Service gates
+
+- [automation_dispatcher.rb:14](app/services/automation_dispatcher.rb#L14) → `return unless event.tenant&.internal_ai_agents_enabled?`
+- [agent_runner_dispatch_service.rb:28](app/services/agent_runner_dispatch_service.rb#L28) → `return unless tenant&.internal_ai_agents_enabled?`
+
+Both are unambiguously internal — they implement Task Runner dispatch.
+
+### View changes
+
+The new flag combinations make several existing UI surfaces actively wrong (external-only tenants seeing internal-only affordances, empty-state copy assuming the Task Runner, etc.). The gates protect the routes; the views need to stop linking to gated routes and stop describing capabilities the tenant doesn't have. Concrete changes:
+
+**1. Top nav ([_top_right_menu.html.erb:61-70](app/views/layouts/_top_right_menu.html.erb#L61-L70))**
+
+- "AI Agents" link → wrap in `@current_tenant&.any_ai_agents_enabled?`.
+- "Chat" link → unconditional. [chats_controller.rb](app/controllers/chats_controller.rb) has no AI-agent flag gating at all; humans chat regardless. The current coupling of Chat-link visibility to `ai_agents_enabled?` is purely cosmetic and should be removed entirely (don't replace it with `api_enabled?` — there's no semantic basis for that gate either).
+
+**2. User Settings "AI Agents" accordion**
+
+Deleted entirely by the consolidation work below (see "Consolidate AI-agent UI" → C4). No flag-gating needed because the accordion no longer exists.
+
+**3. `/ai-agents/new` form ([ai_agents/new.html.erb:114-147](app/views/ai_agents/new.html.erb#L114-L147))**
+
+The form must adapt to which modes the tenant has enabled:
+
+- Both flags on → current behavior (mode radio with Internal default; Stimulus toggles model selector vs API-token checkbox).
+- Only `internal_ai_agents` → hide the Mode section entirely; submit `mode=internal` via `hidden_field_tag`. The Model selector stays visible; the token-checkbox section is unreachable.
+- Only `external_ai_agents` → hide the Mode section; submit `mode=external` via hidden field. The Model selector is hidden; the token-checkbox section is visible.
+- Neither → the `:new` action 403s per the controller-gate plan, so the view never renders.
+
+This sidesteps the form-vs-api-helper default disagreement noted earlier: in single-mode setups the form sends an explicit `mode`, so the helper's external-default never matters.
+
+**4. Index page ([ai_agents/index.html.erb](app/views/ai_agents/index.html.erb))**
+
+Three changes:
+
+- **Per-agent action buttons (lines 86-96):** wrap "Run Task," "Runs," and "Automations" in `ai_agent.internal_ai_agent? && @current_tenant.internal_ai_agents_enabled?`. This fixes the *pre-existing* bug where external agents show those buttons (they currently lead to a doomed task or a never-firing automation rule), AND handles the new external-only tenant case in one shot.
+- **Body copy (lines 33-38):** the static paragraphs assuming both modes are available need to be parameterized. Three variants:
+  - Both: keep current ("AI Agents can be powered externally through the API or internally using Harmonic's agent runners").
+  - Internal only: "AI Agents are powered by Harmonic's agent runners and can run automated tasks on your behalf."
+  - External only: "AI Agents are powered by your own infrastructure and interact with Harmonic through the API."
+- **Empty state (lines 116-126):** the current "Create an AI Agent to start running automated tasks" assumes internal. Parameterize the same way as the body copy. Internal-only keeps the current copy; external-only becomes "Create an AI Agent to give programmatic access to the API"; both gets a more general phrasing.
+
+**5. Show page ([ai_agents/show.html.erb:95-113](app/views/ai_agents/show.html.erb#L95-L113))**
+
+Same gate as index for the action-row buttons: wrap "Run Task" and "Automations" in `@ai_agent.internal_ai_agent? && @current_tenant.internal_ai_agents_enabled?`. Leave "Chat," "Settings," "View Profile" unconditional.
+
+Also: the "Recent Task Runs" section ([show.html.erb:167+](app/views/ai_agents/show.html.erb#L167)) and the "Automations" section block only render if those collections are non-empty, so they degrade gracefully for external agents already — no change needed beyond hiding the "Create Automation" CTA for external agents (currently always shown when `@automation_rules` is empty). Wrap that CTA in the same `internal_ai_agent? && internal_ai_agents_enabled?` check.
+
+**6. `run_task` view ([ai_agents/run_task.html.erb](app/views/ai_agents/run_task.html.erb))**
+
+This is reachable only when `internal_ai_agents_enabled?` (per the controller gate), but the controller doesn't currently check `@ai_agent.internal_ai_agent?` — an external agent on an internal-enabled tenant can still hit this page via a direct URL. Add an early return in `AiAgentsController#run_task` and `#execute_task`:
+
+```ruby
+return render status: :not_found, plain: "404 Not Found" unless @ai_agent.internal_ai_agent?
+```
+
+This closes a pre-existing UX bug (form → submission → failed run with "cannot dispatch external agents") and is mechanically trivial.
+
+**7. `agent_automations_controller`**
+
+Automations only fire via `AutomationDispatcher` → `AgentRunnerDispatchService`, both of which now gate on `internal_ai_agents_enabled?`. Authoring an automation rule on an external agent, or on any agent when the internal flag is off, produces a rule that will never execute. Gate the controller:
+
+- Add `before_action :require_internal_ai_agents_enabled` to all actions (use the same predicate as `AiAgentsController`, refactored into a shared concern or duplicated — pick during implementation based on how many controllers will need it).
+- Inside the per-agent automations actions, also reject if `@ai_agent.external_ai_agent?`.
+
+Confirm by reading the actual controller during implementation — the grep showed it exists but I didn't audit its before_action chain.
+
+### Consolidate AI-agent UI into `/ai-agents`
+
+The flag-split is the right moment to also collapse a pre-existing UI duplication: AI-agent management is currently split across `/u/<handle>/settings` and `/ai-agents/<handle>/settings`, both rendering edit forms over the same `agent_configuration` JSONB. Without this consolidation, every conditional in the "View changes" section above has to be applied to both pages, and the two would have to be kept in sync indefinitely.
+
+**Diverged duplication today:**
+
+- `/u/<agent>/settings` ([users/settings.html.erb:52-148](app/views/users/settings.html.erb#L52-L148)) → editable Mode radio, Model (conditional), Identity Prompt, full Capabilities checkbox grid. POSTs to `UsersController#update_profile`.
+- `/ai-agents/<agent>/settings` ([ai_agents/settings.html.erb:61-82](app/views/ai_agents/settings.html.erb#L61-L82)) → editable Model (only if internal), Identity Prompt. **No Mode toggle. No Capabilities.** POSTs to `AiAgentsController#update_settings`.
+- Both write paths accept and write to the same fields ([users_controller.rb:264-296](app/controllers/users_controller.rb#L264-L296) handles mode/model/capabilities/identity_prompt; [ai_agents_controller.rb:114-119](app/controllers/ai_agents_controller.rb#L114-L119) does the same).
+- API tokens for AI agents appear in *both* the human's `/u/<self>/settings` aggregate table ([users/settings.html.erb:298-365](app/views/users/settings.html.erb#L298-L365)) and on each per-agent settings page ([ai_agents/settings.html.erb:122-178](app/views/ai_agents/settings.html.erb#L122-L178)).
+
+**Target: `/ai-agents/<handle>/settings` is the single canonical management surface for an AI agent.** `/u/<agent>/settings` for an AI agent stops being a parallel edit page.
+
+**Concrete changes:**
+
+**C1. Move the missing form sections into `/ai-agents/<handle>/settings`.**
+
+[ai_agents/settings.html.erb](app/views/ai_agents/settings.html.erb) absorbs from [users/settings.html.erb](app/views/users/settings.html.erb):
+- The Mode radio + Stimulus controller for show/hide of Internal/External-specific sections (lines 52-81 of users/settings).
+- The Capabilities checkbox grid (lines 89-148 of users/settings), including the action_groups Hash, the `disabled_by_default` list, and the `checkbox-group` Stimulus targets.
+
+Apply the View-changes rules from item 3 (Mode radio hidden when only one flag is enabled, with a hidden field carrying the right value) here, not in the original location.
+
+**C2. Single canonical surface at `/ai-agents/<handle>/settings`; `/u/<agent>/settings` redirects there.**
+
+`UsersController#settings` redirects to `ai_agent_settings_path(@settings_user.handle)` when `@settings_user.ai_agent?` (both HTML and MD). The audit confirmed that almost every section in user-settings is already gated invisible for agents (email/2FA/billing/blocked-users/Workspace-Trio are all under `is_own_settings && human?`). The only thing genuinely unique to user-settings was the profile-image upload, which moves to `/ai-agents/<handle>/settings`.
+
+After this change, agents have one canonical settings surface. No cross-links needed — the redirect makes them invisible from the user-settings URL.
+
+**C3. Loosen authorization on read paths so the agent itself can read its own settings.**
+
+[ai_agents_controller.rb:11](app/controllers/ai_agents_controller.rb#L11) currently applies a single `authorize_parent` before_action to *all* show/settings/update/deactivate/reactivate actions, restricting to `@ai_agent.parent_id == current_user.id`. The agent should be able to read its own settings (so it can introspect via `/ai-agents/<self>/settings.md`) but not edit them.
+
+Split the gate. Replace the single `before_action :authorize_parent, only: [...]` with two:
+
+```ruby
+before_action :authorize_parent_or_self, only: [:show, :settings, :settings_actions_index]
+before_action :authorize_parent, only: [:update_settings, :execute_update_ai_agent, :describe_update_ai_agent, :deactivate, :reactivate]
+
+def authorize_parent_or_self
+  return if @ai_agent.parent_id == current_user&.id
+  return if @ai_agent == current_user
+  render status: :forbidden, plain: "403 Unauthorized"
+end
+```
+
+`authorize_parent` itself stays unchanged. Test that a non-parent, non-self user still 403s on read paths.
+
+**C4. Remove the "AI Agents" link accordion.**
+
+[users/settings.html.erb:442-455](app/views/users/settings.html.erb#L442-L455) is pure navigation; the top nav already provides this entry point. Delete the accordion. The markdown equivalent at [users/settings.md.erb:51](app/views/users/settings.md.erb#L51) (`* [Manage AI Agents](/ai-agents)`) stays — markdown UI relies on inline links for navigation.
+
+**C5. Split the API Tokens accordion in `/u/<self>/settings`.**
+
+The aggregate view at [users/settings.html.erb:296-365](app/views/users/settings.html.erb#L296-L365) shows the human's own tokens AND every AI agent's tokens. Per-agent token management is already on the per-agent settings page; the aggregate view is the only place that lists everything together.
+
+Two options, pick during implementation:
+- **(a) Filter to the human's own tokens.** `@all_api_tokens` becomes the user's personal tokens only; agents' tokens are managed solely on their own pages. Helper text drops the "this includes tokens for your AI agents" line. Cleanest split, loses the aggregate.
+- **(b) Keep the aggregate, but link rows for AI agents to the per-agent settings page** instead of inline token management. The table becomes a read-only at-a-glance view; the "View" link goes to `/ai-agents/<handle>/settings#tokens`. Preserves the aggregate as a discovery aid.
+
+(a) is the strict consolidation; (b) trades a tiny duplication for a useful aggregate. Default to (a) and ship (b) if and when someone misses the aggregate.
+
+**C6. Remove vestigial agent-config branches from `UsersController#update_profile`.**
+
+Once the form at [users/settings.html.erb:52-148](app/views/users/settings.html.erb#L52-L148) is gone, [users_controller.rb:264-296](app/controllers/users_controller.rb#L264-L296) (which handles `identity_prompt`, `mode`, `model`, `capabilities` for AI agents) becomes dead code. Remove.
+
+The documented `update_profile` markdown action is `name + new_handle` only ([actions_helper.rb:503-511](app/services/actions_helper.rb#L503-L511)) — these branches were accidental form-handling, not part of the public markdown contract, so removing them breaks no documented agent self-update path. Agent config edits flow exclusively through `AiAgentsController#execute_update_ai_agent` and the corresponding markdown action.
+
+**Out of scope (mention in plan, don't do):**
+
+- **Workspace AI Assistant accordion** ([users/settings.html.erb:157-209](app/views/users/settings.html.erb#L157-L209)) — this is a Trio toggle for the user's private workspace, exposed in user settings because `CollectivesController#settings` redirects workspace owners away (per the in-file comment at line 158-160). It's a workspace setting that happens to live here for routing reasons, not an AI-agent setting. Moving it would require also fixing the collective-settings redirect. Leave it for a future "workspace settings consolidation" plan.
+
+**Other entry points to `/u/<agent>/settings` to audit during implementation:** the user's own profile page ([users/show.html.erb](app/views/users/show.html.erb)) likely has a "Settings" link for own-agents; the chat partner sidebar may surface settings links; the `/ai-agents` index has a `View Profile` link to `/u/<handle>` (the profile page itself isn't affected, only the settings sub-route). The C2 redirect handles bookmarks transparently, but check that no internal link is constructed in a way that breaks (e.g., a `link_to` that bypasses the redirect by hand-rolling `/u/...`).
+
+### Trio interaction (explicitly out of scope, but document the consequence)
+
+Trio is an internal agent and rides the internal dispatch path. After this change Trio requires `internal_ai_agents` (tenant) + `trio` (collective). If `internal_ai_agents` is off, Trio cannot run regardless of the `trio` flag. This matches today's behavior (`trio` already requires `ai_agents` transitively through the dispatcher). No change to Trio code in this plan.
+
+A future plan could make Trio exempt from `internal_ai_agents` the same way it's exempt from billing. The shape is non-trivial: `AutomationDispatcher.dispatch` takes an `Event` and only later discovers which `ai_agent_id` rules match, so the bypass has to live per-rule inside `find_matching_rules` (allow Trio's rules through even when the flag is off) and then again in `AgentRunnerDispatchService#dispatch` (skip the flag check when `ai_agent.system_role == "trio"`). Out of scope here — flagged so it isn't underestimated later.
+
+### Decision: runtime API gating for external agents
+
+The plan as written gates `external_ai_agents` only at **creation** and **management UI**. It does *not* gate the API request authentication path. Consequence: turning the flag off prevents new external agents from being created, but existing external agents with valid API tokens continue to authenticate and act through the API (subject to the existing `api` flag).
+
+This is the intentional choice because:
+
+1. The `api` flag is the existing, well-understood gate on "external programmatic access works here." Adding a second AND-gate on the same auth path duplicates that concern with no new product semantics.
+2. "Disabling external AI agents" most commonly means "stop the proliferation of new ones," not "instantly revoke every existing agent." Operators who want the revoke semantic can deactivate individual agents, or disable `api` entirely.
+3. The Task Runner gate (`internal_ai_agents` at the dispatcher / runner) genuinely is a runtime gate because it controls a Harmonic-operated service; external agents have no equivalent Harmonic-operated runtime to gate.
+
+If a future need arises ("kill switch for all external agents on a tenant without taking down its human-driven API integrations"), add a check in the API token authentication path (probably `ApiToken#authenticate` or the API auth middleware — read before implementing) that rejects tokens whose owning User is an external AI agent on a tenant where `external_ai_agents` is off. That is an additive change, doesn't affect this plan, and shouldn't be done speculatively.
+
+### Things explicitly NOT changing
+
+- `api` flag — semantics unchanged.
+- `User#internal_ai_agent?` / `external_ai_agent?` — already correct.
+- `CapabilityCheck` / `ActionCapabilityCheck` — key off `User#ai_agent?`, not the flag. No change.
+- Billing/suspension paths ([stripe_service.rb](app/services/stripe_service.rb), [billing_reconciliation_job.rb](app/jobs/billing_reconciliation_job.rb)) — gated on `stripe_billing`, not on `ai_agents`. No change.
+- API token issuance / API auth — already on the `api` flag.
+
+## Test changes
+
+The grep showed ~50+ test files reference `ai_agents`. Most of those are testing AI-agent behavior (model tests, integration tests for runs, etc.) and only incidentally mention the flag name. The mechanical changes:
+
+- Tests that call `tenant.enable_feature_flag!("ai_agents")` / `tenant.set_feature_flag!("ai_agents", true)` ([has_feature_flags.rb:23-39](app/models/concerns/has_feature_flags.rb#L23-L39)) need to pick the right new flag. Audit by test:
+  - Tests exercising run dispatch, automation rules, Trio runtime → `internal_ai_agents`.
+  - Tests exercising external-agent creation, API-token-based agent flows → `external_ai_agents`.
+  - Tests exercising the management UI's index/show/settings → both flags (or use the `any_ai_agents_enabled?` helper).
+- Add new gate-site tests:
+  - `internal_ai_agents` off + `external_ai_agents` on → can create/manage external agents, can't dispatch via agent-runner, can't run a task.
+  - `internal_ai_agents` on + `external_ai_agents` off → Task Runner works for existing internal agents, can't create new external agents.
+  - Both off → management UI 403s on `index`; nav items hidden; user-settings AI Agents accordion hidden.
+- Add view-level tests for the new conditional rendering:
+  - Index page action buttons hidden for external agents (covers both pre-existing bug and external-only case).
+  - `/ai-agents/new` form hides the Mode radio in single-mode tenants and submits a hidden `mode` field with the right value.
+  - Empty-state and body copy match the enabled-flags combination.
+- `AiAgentsController#run_task` / `#execute_task` should 404 for external agents (new behavior — closes pre-existing bug).
+- `agent_automations_controller` actions 403 when `internal_ai_agents` is off, and 404/403 when the agent is external.
+- Consolidation tests:
+  - GET `/u/<agent>/settings` (HTML and MD) redirects to `/ai-agents/<handle>/settings(.md)` when `@settings_user.ai_agent?`.
+  - GET `/ai-agents/<handle>/settings` includes the profile-image upload (the only piece previously unique to user-settings).
+  - `UsersController#update_profile` (per C6) no longer mutates `agent_configuration` (mode/model/capabilities/identity_prompt branches removed). Posting those params via `/u/<agent>/settings/profile` is a no-op for those fields; only `name` and `new_handle` apply.
+  - `/ai-agents/<handle>/settings` now renders the Mode radio (when both flags on) and Capabilities checkboxes; POSTing those fields updates `agent_configuration` correctly.
+  - `authorize_parent` loosening: the agent itself can GET `/ai-agents/<self>/settings(.md)`; cannot POST `update_settings`. A non-parent, non-self user still 403s.
+- Specifically test the Trio-internal coupling: with `trio` collective flag on but `internal_ai_agents` tenant flag off, Trio does not dispatch. This locks in the documented behavior.
+
+Per CLAUDE.md and saved feedback ([feedback_red_green_tdd.md](memory)): write the gate-site tests first, watch them fail with the rename, then implement.
+
+## Rollout
+
+1. Land the YAML + tenant predicate + controller + service + view changes in one PR.
+2. Data migration to copy `ai_agents` → `internal_ai_agents` AND `external_ai_agents` for every tenant that has it set (whether `true` or `false`), then remove the old key. Run-once (not idempotent — the third statement deletes `ai_agents`, so a hypothetical second run would COALESCE-default both new flags back to `false`). Rails' standard `schema_migrations` tracking is the correctness story here; the migration shouldn't be marked `safety_assured` or otherwise made re-runnable.
+3. Remove `ai_agents` from the YAML in the same PR; the data migration handles the cutover.
+4. CHANGELOG entry describing: (a) the flag split + migration semantics; (b) the consolidation — agent-specific configuration is now managed at `/ai-agents/<handle>/settings`, with cross-links to the user-type-agnostic settings at `/u/<handle>/settings`; (c) the closed pre-existing bugs — `run_task` is no longer reachable for external agents (was producing dead-end failed runs).
+
+**Deploy-window note:** between the new code starting up and the migration completing, `tenant.internal_ai_agents_enabled?` will return the YAML default (`false`) for tenants whose new keys haven't been written yet, briefly disabling agent features for tenants that previously had `ai_agents` on. For Harmonic's single-instance deploy this window is short (one `UPDATE tenants` of a JSONB column) and acceptable. If the window matters, a two-step rollout (ship the migration first, then ship the code change) avoids it — but that requires the migration to write keys the running code doesn't yet read, which is harmless.
+
+Otherwise no staged rollout needed — the migration preserves every tenant's current capability set exactly.
+
+## Open questions to confirm during implementation
+
+- Does any fixture or seed file write `ai_agents` directly into `tenants.settings`? Grep `db/seeds*` and `test/fixtures/` — the migration handles arbitrary tenant data but fixture data may need its own update for tests to load correctly.
+- Is there a tenant-admin UI that lists feature flag names verbatim (e.g., a settings panel rendering `FeatureFlagService.all_flags`)? The split changes the displayed label/description; copy-check any such UI.
+- The app-admin `show_user.html.erb` and `collectives/settings.{html,md}.erb` view files reference `ai_agents` per the earlier grep — confirm whether those are flag-related text or unrelated occurrences (e.g., listing a user's agents) before assuming they need updating.
+- Consolidation: are there existing tests covering `UsersController#update_profile`'s mode/model/capabilities/identity_prompt branches that will break when those branches are removed? Update them to assert the no-op behavior or delete if they only existed to cover the removed code.
+- Consolidation: does the user profile page ([users/show.html.erb](app/views/users/show.html.erb)) link to `/u/<handle>/settings` for the page owner? If so, for AI agents that link should either go directly to `/ai-agents/<handle>/settings` or rely on the C2 redirect — pick during implementation.

--- a/app/controllers/ai_agents_controller.rb
+++ b/app/controllers/ai_agents_controller.rb
@@ -4,11 +4,20 @@ class AiAgentsController < ApplicationController
   TASK_RUNS_PER_MINUTE = 5
 
   before_action :set_sidebar_mode, only: [:new, :index, :show, :settings, :run_task, :execute_task, :runs, :show_run, :cancel_run, :create, :execute_create_ai_agent, :deactivate, :reactivate]
-  before_action :require_ai_agents_enabled, only: [:index, :show, :settings, :run_task, :execute_task, :runs, :show_run, :cancel_run]
+  before_action :require_any_ai_agents_enabled, only: [
+    :index, :show, :settings, :update_settings,
+    :describe_update_ai_agent, :execute_update_ai_agent, :settings_actions_index,
+  ]
+  before_action :require_internal_ai_agents_enabled, only: [:run_task, :execute_task, :runs, :show_run, :cancel_run]
+  before_action :require_flag_for_create_mode, only: [:new, :create, :execute_create_ai_agent]
   before_action :require_billing_for_creation, only: [:new]
   before_action :load_credit_balance_for_agents, only: [:index, :new, :run_task]
   before_action :set_ai_agent, only: [:show, :settings, :update_settings, :settings_actions_index, :describe_update_ai_agent, :execute_update_ai_agent, :deactivate, :reactivate]
-  before_action :authorize_parent, only: [:show, :settings, :update_settings, :settings_actions_index, :describe_update_ai_agent, :execute_update_ai_agent, :deactivate, :reactivate]
+  before_action :authorize_parent_or_self, only: [:show, :settings, :settings_actions_index]
+  before_action :authorize_parent, only: [
+    :update_settings, :describe_update_ai_agent, :execute_update_ai_agent,
+    :deactivate, :reactivate,
+  ]
 
   # GET /ai-agents - List all AI agents owned by current user
   def index
@@ -115,7 +124,10 @@ class AiAgentsController < ApplicationController
     config["identity_prompt"] = identity_prompt if identity_prompt.present?
     config["mode"] = mode if mode.present?
     config["model"] = model if mode == "internal" && model.present?
-    config["capabilities"] = capabilities if capabilities.present?
+    if params.key?(:capabilities)
+      caps = Array(capabilities).compact_blank
+      config["capabilities"] = caps & CapabilityCheck::AI_AGENT_GRANTABLE_ACTIONS
+    end
     @ai_agent.agent_configuration = config
 
     if @ai_agent.save
@@ -133,6 +145,7 @@ class AiAgentsController < ApplicationController
 
     @ai_agent = find_ai_agent_by_handle
     return render status: :not_found, plain: "404 Not Found" unless @ai_agent
+    return render status: :not_found, plain: "404 Not Found" unless @ai_agent.internal_ai_agent?
 
     @page_title = "Run Task - #{@ai_agent.display_name}"
     @max_steps_default = AiAgentTaskRun::DEFAULT_MAX_STEPS
@@ -144,6 +157,7 @@ class AiAgentsController < ApplicationController
 
     @ai_agent = find_ai_agent_by_handle
     return render status: :not_found, plain: "404 Not Found" unless @ai_agent
+    return render status: :not_found, plain: "404 Not Found" unless @ai_agent.internal_ai_agent?
 
     begin
       enforce_rate_limit!(
@@ -252,7 +266,7 @@ class AiAgentsController < ApplicationController
     return render status: :not_found, plain: "404 Not Found" unless @task_run
 
     unless @task_run.status.in?(["queued", "running"])
-      flash[:error] = "Can only cancel queued or running tasks"
+      flash[:alert] = "Can only cancel queued or running tasks"
       return redirect_to ai_agent_run_path(@ai_agent.handle, @task_run.id)
     end
 
@@ -360,20 +374,44 @@ class AiAgentsController < ApplicationController
           })
         end
         format.any do
-          flash[:error] = "You must confirm the billing charge to create an AI agent."
+          flash[:alert] = "You must confirm the billing charge to create an AI agent."
           return redirect_to new_ai_agent_path
         end
       end
     end
 
-    @ai_agent = api_helper.create_ai_agent
+    begin
+      @ai_agent = api_helper.create_ai_agent
+    rescue ActiveRecord::RecordNotUnique
+      # Most likely cause: the parameterized name collides with an existing
+      # tenant_user handle. TenantUser auto-suffixes only for reserved
+      # handles, not for general uniqueness, so a user picking a name like
+      # "alice" when @alice already exists hits the DB constraint here.
+      msg = "An account with that handle already exists. Please choose a different name."
+      respond_to do |format|
+        format.md do
+          return render_action_error({
+            action_name: "create_ai_agent",
+            resource: @current_user,
+            error: msg,
+          })
+        end
+        format.any do
+          flash[:alert] = msg
+          return redirect_to new_ai_agent_path
+        end
+      end
+    end
     charged_cents = nil
     if current_tenant.feature_enabled?("stripe_billing")
       assign_billing_customer!(@ai_agent)
-      # If user has no active subscription, mark agent as pending
-      if !current_user.stripe_customer&.active?
+      # Decide whether the new agent needs to wait for billing setup.
+      # Use requires_stripe_billing? rather than stripe_customer.active?
+      # so admins (who are billing-exempt — billable_quantity is always 0)
+      # don't get their agents spuriously pending-flagged.
+      if current_user.requires_stripe_billing?(current_tenant)
         @ai_agent.update!(pending_billing_setup: true)
-      else
+      elsif current_user.stripe_customer&.active?
         result = StripeService.sync_subscription_quantity!(current_user)
         if result.success
           charged_cents = result.charged_cents
@@ -382,6 +420,7 @@ class AiAgentsController < ApplicationController
           @ai_agent.update!(pending_billing_setup: true)
         end
       end
+      # Else: user doesn't need billing (admin / fully exempt) — leave the agent active.
     end
     # Only generate token for external AI agents (not for pending agents)
     if !@ai_agent.pending_billing_setup? && @ai_agent.external_ai_agent? && [true, "true", "1"].include?(params[:generate_token])
@@ -390,11 +429,32 @@ class AiAgentsController < ApplicationController
 
     notice = if @ai_agent.pending_billing_setup?
       "AI Agent #{@ai_agent.display_name} created. Set up billing to activate it."
+    elsif @token
+      "AI Agent #{@ai_agent.display_name} created. Save the token value now — you will not be able to see it again."
     elsif charged_cents && charged_cents > 0
       "AI Agent #{@ai_agent.display_name} created successfully. You were charged $#{format("%.2f", charged_cents / 100.0)} (prorated for the current billing period)."
     else
       "AI Agent #{@ai_agent.display_name} created successfully."
     end
+
+    # When a token was just generated, we must render the show page directly
+    # so the plaintext token is visible. The token is hashed at rest; a
+    # redirect would destroy @token and the user would never see it.
+    # Mirrors ApiTokensController#create's `render "show"`.
+    if @token
+      @page_title = @ai_agent.display_name
+      @automation_rules = AutomationRule.tenant_scoped_only
+        .where(ai_agent_id: @ai_agent.id).order(created_at: :desc).limit(5)
+      @recent_runs = AiAgentTaskRun
+        .where(ai_agent: @ai_agent).order(created_at: :desc).limit(5)
+      flash.now[:notice] = notice
+      respond_to do |format|
+        format.html { render "show" }
+        format.md { render "show" }
+      end
+      return
+    end
+
     flash[:notice] = notice
     redirect_path = @ai_agent.pending_billing_setup? ? "/billing" : ai_agent_path(@ai_agent.handle)
     respond_to do |format|
@@ -483,9 +543,27 @@ class AiAgentsController < ApplicationController
     redirect_to "/billing"
   end
 
-  def require_ai_agents_enabled
-    return if @current_tenant&.ai_agents_enabled?
+  def require_any_ai_agents_enabled
+    return if @current_tenant&.any_ai_agents_enabled?
 
+    render_ai_agents_disabled
+  end
+
+  def require_internal_ai_agents_enabled
+    return if @current_tenant&.internal_ai_agents_enabled?
+
+    render_ai_agents_disabled
+  end
+
+  def require_flag_for_create_mode
+    mode = ["internal", "external"].include?(params[:mode]) ? params[:mode] : "external"
+    return if mode == "internal" && @current_tenant&.internal_ai_agents_enabled?
+    return if mode == "external" && @current_tenant&.external_ai_agents_enabled?
+
+    render_ai_agents_disabled
+  end
+
+  def render_ai_agents_disabled
     respond_to do |format|
       format.html { render status: :forbidden, plain: "403 Forbidden - AI Agents feature is not enabled for this tenant" }
       format.json { render status: :forbidden, json: { error: "AI Agents feature is not enabled for this tenant" } }
@@ -507,6 +585,13 @@ class AiAgentsController < ApplicationController
 
   def authorize_parent
     return render status: :forbidden, plain: "403 Unauthorized" unless @ai_agent.parent_id == current_user&.id
+  end
+
+  def authorize_parent_or_self
+    return if @ai_agent.parent_id == current_user&.id
+    return if @ai_agent == current_user
+
+    render status: :forbidden, plain: "403 Unauthorized"
   end
 
   def find_ai_agent_by_handle

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -13,7 +13,6 @@ class HelpController < ApplicationController
   FEATURE_GATED_TOPICS = {
     "api" => "api",
     "rest_api" => "api",
-    "agents" => "ai_agents",
     "trio" => "trio",
   }.freeze
 
@@ -51,6 +50,8 @@ class HelpController < ApplicationController
   end
 
   def help_topic_available?(topic)
+    return current_tenant.any_ai_agents_enabled? if topic.to_s == "agents"
+
     flag = FEATURE_GATED_TOPICS[topic.to_s]
     return true if flag.nil?
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -158,26 +158,25 @@ class UsersController < ApplicationController
     @settings_user = tu.user
     return render plain: "403 Unauthorized", status: :forbidden unless current_user.can_edit?(@settings_user)
 
+    # AI agents have a single canonical settings surface at
+    # /ai-agents/<handle>/settings. /u/<agent>/settings used to host a
+    # parallel form; redirect to consolidate.
+    if @settings_user.ai_agent?
+      return redirect_to ai_agent_settings_path(@settings_user.handle)
+    end
+
     @settings_user.tenant_user = tu
     @page_title = @settings_user == current_user ? "Your Settings" : "#{@settings_user.display_name}'s Settings"
 
-    # For human users, show their AI agents
-    if @settings_user.human?
-      @ai_agents = @settings_user.ai_agents.includes(:tenant_users, :collective_members).where(tenant_users: { tenant_id: @current_tenant.id })
-      # Collectives where settings user has invite permission (for adding AI agents)
-      @invitable_collectives = @settings_user.collective_members.includes(:collective).select(&:can_invite?).map(&:collective)
+    @ai_agents = @settings_user.ai_agents.includes(:tenant_users, :collective_members).where(tenant_users: { tenant_id: @current_tenant.id })
 
-      # Load all API tokens: user's own + AI agents' tokens
-      # Sorted by: user's tokens first, then agents alphabetically, then by created_at desc
-      user_tokens = @settings_user.api_tokens.external.includes(:user).to_a
-      agent_tokens = @ai_agents.flat_map { |agent| agent.api_tokens.external.includes(:user).to_a }
-      @all_api_tokens = user_tokens.sort_by { |t| -t.created_at.to_i } +
-                        agent_tokens.sort_by { |t| [t.user.display_name.downcase, -t.created_at.to_i] }
-    else
-      @ai_agents = []
-      @invitable_collectives = []
-      @all_api_tokens = @settings_user.api_tokens.external.includes(:user).order(created_at: :desc).to_a
-    end
+    # Load all API tokens the user is responsible for: their own + every AI
+    # agent they own. The per-agent settings page also lists each agent's
+    # tokens; this is the aggregate view.
+    user_tokens = @settings_user.api_tokens.external.includes(:user).to_a
+    agent_tokens = @ai_agents.flat_map { |agent| agent.api_tokens.external.includes(:user).to_a }
+    @all_api_tokens = user_tokens.sort_by { |t| -t.created_at.to_i } +
+                      agent_tokens.sort_by { |t| [t.user.display_name.downcase, -t.created_at.to_i] }
 
     respond_to do |format|
       format.html
@@ -260,42 +259,6 @@ class UsersController < ApplicationController
       TenantUser.for_user_across_tenants(settings_user).where.not(id: tu.id).update_all(
         handle: params[:new_handle]
       )
-    end
-    # Handle identity_prompt for AI agents
-    if settings_user.ai_agent? && params.key?(:identity_prompt)
-      settings_user.agent_configuration ||= {}
-      settings_user.agent_configuration["identity_prompt"] = params[:identity_prompt].presence
-      settings_user.save!
-    end
-    # Handle mode for AI agents (internal vs external)
-    if settings_user.ai_agent? && params.key?(:mode)
-      settings_user.agent_configuration ||= {}
-      mode = params[:mode]
-      settings_user.agent_configuration["mode"] = ["internal", "external"].include?(mode) ? mode : "external"
-      settings_user.save!
-    end
-    # Handle model for internal AI agents
-    if settings_user.ai_agent? && params.key?(:model)
-      settings_user.agent_configuration ||= {}
-      settings_user.agent_configuration["model"] = params[:model].presence
-      settings_user.save!
-    end
-    # Handle capabilities for AI agents
-    # Checked = allowed, unchecked = blocked (standard checkbox model)
-    # Empty array (all unchecked) = NO grantable actions allowed
-    # nil (key absent) = all grantable actions allowed (backwards compatible default)
-    if settings_user.ai_agent?
-      settings_user.agent_configuration ||= {}
-      capabilities = params[:capabilities]
-      if capabilities.is_a?(Array) && capabilities.any?
-        # Filter to only valid grantable actions
-        valid_caps = capabilities & CapabilityCheck::AI_AGENT_GRANTABLE_ACTIONS
-        settings_user.agent_configuration["capabilities"] = valid_caps
-      else
-        # All boxes unchecked = save empty array (nothing allowed)
-        settings_user.agent_configuration["capabilities"] = []
-      end
-      settings_user.save!
     end
     flash[:notice] = "Profile updated successfully"
     redirect_to "#{settings_user.path}/settings"

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -265,8 +265,18 @@ class Tenant < ApplicationRecord
   end
 
   sig { returns(T::Boolean) }
-  def ai_agents_enabled?
-    FeatureFlagService.tenant_enabled?(self, "ai_agents")
+  def internal_ai_agents_enabled?
+    FeatureFlagService.tenant_enabled?(self, "internal_ai_agents")
+  end
+
+  sig { returns(T::Boolean) }
+  def external_ai_agents_enabled?
+    FeatureFlagService.tenant_enabled?(self, "external_ai_agents")
+  end
+
+  sig { returns(T::Boolean) }
+  def any_ai_agents_enabled?
+    internal_ai_agents_enabled? || external_ai_agents_enabled?
   end
 
   # Check if a feature is enabled at the tenant level (with cascade from app)

--- a/app/services/agent_runner_dispatch_service.rb
+++ b/app/services/agent_runner_dispatch_service.rb
@@ -25,7 +25,7 @@ class AgentRunnerDispatchService
 
     # Precondition checks
     return unless ai_agent&.ai_agent?
-    return unless tenant&.ai_agents_enabled?
+    return unless tenant&.internal_ai_agents_enabled?
 
     # Only dispatch tasks that are still queued. Guards against a race where
     # the rake `agent_runner:redispatch_queued` task enumerates queued runs

--- a/app/services/automation_dispatcher.rb
+++ b/app/services/automation_dispatcher.rb
@@ -11,8 +11,6 @@ class AutomationDispatcher
   # Dispatch an event to all matching automation rules
   sig { params(event: Event).void }
   def self.dispatch(event)
-    return unless event.tenant&.ai_agents_enabled?
-
     matching_rules = find_matching_rules(event)
     return if matching_rules.empty?
 

--- a/app/services/automation_executor.rb
+++ b/app/services/automation_executor.rb
@@ -43,6 +43,22 @@ class AutomationExecutor
       return
     end
 
+    # Agent-owned rules trigger the AI agent via the Task Runner — gated on
+    # the internal AI agents flag and the agent being internal-mode. System
+    # agents (Trio) run on the deployment's account and are inherently
+    # internal-mode; exempt them from both checks, same as billing.
+    unless ai_agent.system?
+      unless @rule.tenant.internal_ai_agents_enabled?
+        @run.mark_failed!("Internal AI Agents are not enabled for this tenant.")
+        return
+      end
+
+      unless ai_agent.internal_ai_agent?
+        @run.mark_failed!("Agent-owned automations require an internal-mode agent. External agents cannot be triggered by the Task Runner.")
+        return
+      end
+    end
+
     # Agent must be active (not archived, suspended, or pending billing)
     if ai_agent.pending_billing_setup?
       @run.mark_failed!("Agent is pending billing setup. Set up billing at /billing to activate this agent.")
@@ -272,6 +288,19 @@ class AutomationExecutor
 
     agent = User.find_by(id: agent_id)
     return { "status" => "failed", "error" => "Agent not found or not an AI agent" } unless agent&.ai_agent?
+
+    # trigger_agent dispatches via the Task Runner — gated on the internal AI
+    # agents flag and the target agent being internal-mode. System agents (Trio)
+    # are exempt from both checks (same as billing).
+    unless agent.system?
+      unless @rule.tenant.internal_ai_agents_enabled?
+        return { "status" => "failed", "error" => "Internal AI Agents are not enabled for this tenant." }
+      end
+
+      unless agent.internal_ai_agent?
+        return { "status" => "failed", "error" => "Cannot trigger external agents via the Task Runner. trigger_agent requires an internal-mode agent." }
+      end
+    end
 
     # Billing gate: if stripe_billing is enabled, agent must have active billing.
     # System agents (e.g., Trio) are exempt — same as the gate above and in

--- a/app/services/stripe_service.rb
+++ b/app/services/stripe_service.rb
@@ -96,6 +96,15 @@ class StripeService
   # - Stripe API error: returns success: false with a human-readable error.
   sig { params(user: T.untyped).returns(SyncResult) }
   def self.sync_subscription_quantity!(user)
+    # Admins are exempt from the $3/month subscription — their billable_quantity
+    # always returns 0 regardless of resources (see User#billable_quantity).
+    # Syncing would interpret that 0 as "all resources removed" and cancel any
+    # subscription they hold. Admins may legitimately hold a StripeCustomer
+    # record (with active or inactive subscription) for LLM credit attribution —
+    # credit grants attach to the customer ID, not the subscription. Skipping
+    # sync entirely preserves whatever subscription state they intentionally have.
+    return SyncResult.new(success: true) if user.respond_to?(:sys_admin?) && (user.sys_admin? || user.app_admin?)
+
     sc = user.stripe_customer
     return SyncResult.new(success: true) unless sc&.active? && sc.stripe_subscription_id.present?
 

--- a/app/views/ai_agents/index.html.erb
+++ b/app/views/ai_agents/index.html.erb
@@ -30,11 +30,22 @@
       </div>
     <% end %>
 
+    <%
+      internal_enabled = @current_tenant.internal_ai_agents_enabled?
+      external_enabled = @current_tenant.external_ai_agents_enabled?
+    %>
+
     <p class="pulse-muted" style="margin-bottom: 24px;">
       AI Agents in Harmonic are identities for AI agents managed by you, the primary agent.
     </p>
     <p class="pulse-muted" style="margin-bottom: 24px;">
-      AI Agents can be powered externally through the API or internally using Harmonic's agent runners.
+      <% if internal_enabled && external_enabled %>
+        AI Agents can be powered externally through the API or internally using Harmonic's agent runners.
+      <% elsif internal_enabled %>
+        AI Agents are powered by Harmonic's agent runners and can run automated tasks on your behalf.
+      <% else %>
+        AI Agents are powered by your own infrastructure and interact with Harmonic through the API.
+      <% end %>
     </p>
 
     <% if @ai_agents.any? %>
@@ -84,12 +95,14 @@
               </div>
               <div class="pulse-ai-agent-actions">
                 <% unless ai_agent.archived? %>
-                  <a href="<%= ai_agent_run_task_path(ai_agent.handle) %>" class="pulse-action-btn-small">
-                    <%= octicon 'play', height: 12 %> Run Task
-                  </a>
-                  <a href="<%= ai_agent_runs_path(ai_agent.handle) %>" class="pulse-action-btn-small">
-                    <%= octicon 'history', height: 12 %> Runs
-                  </a>
+                  <% if ai_agent.internal_ai_agent? && internal_enabled %>
+                    <a href="<%= ai_agent_run_task_path(ai_agent.handle) %>" class="pulse-action-btn-small">
+                      <%= octicon 'play', height: 12 %> Run Task
+                    </a>
+                    <a href="<%= ai_agent_runs_path(ai_agent.handle) %>" class="pulse-action-btn-small">
+                      <%= octicon 'history', height: 12 %> Runs
+                    </a>
+                  <% end %>
                   <a href="/ai-agents/<%= ai_agent.handle %>/automations" class="pulse-action-btn-small">
                     <%= octicon 'zap', height: 12 %> Automations
                   </a>
@@ -117,7 +130,15 @@
       <div class="pulse-empty-state" style="text-align: center; padding: 48px 24px;">
         <%= octicon 'command-palette', height: 48, class: 'pulse-muted' %>
         <h3 style="margin: 16px 0 8px 0;">No AI Agents Yet</h3>
-        <p class="pulse-muted" style="margin-bottom: 16px;">Create an AI Agent to start running automated tasks.</p>
+        <p class="pulse-muted" style="margin-bottom: 16px;">
+          <% if internal_enabled && external_enabled %>
+            Create an AI Agent to run automated tasks or interact with Harmonic through the API.
+          <% elsif internal_enabled %>
+            Create an AI Agent to start running automated tasks.
+          <% else %>
+            Create an AI Agent to give programmatic access to the API.
+          <% end %>
+        </p>
         <a href="/ai-agents/new" class="pulse-action-btn">
           <%= octicon 'person-add', height: 14 %>
           Create AI Agent

--- a/app/views/ai_agents/new.html.erb
+++ b/app/views/ai_agents/new.html.erb
@@ -111,40 +111,54 @@
         <% end %>
       </section>
 
-      <section class="pulse-settings-section">
-        <label class="pulse-label">Mode</label>
-        <small class="pulse-hint" style="margin-bottom: 12px; display: block;">Choose how this AI Agent will be powered.</small>
-        <div style="display: flex; flex-direction: column; gap: 12px;">
-          <label class="pulse-radio-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
-            <%= radio_button_tag :mode, "internal", true, data: { action: "ai-agent-mode#updateVisibility" } %>
-            <span>
-              <strong>Internal</strong>
-              <small class="pulse-hint" style="display: block; margin-top: 2px;">Powered by Harmonic's agent runners. No API access.</small>
-            </span>
-          </label>
-          <label class="pulse-radio-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
-            <%= radio_button_tag :mode, "external", false, data: { action: "ai-agent-mode#updateVisibility" } %>
-            <span>
-              <strong>External</strong>
-              <small class="pulse-hint" style="display: block; margin-top: 2px;">Powered by your own infrastructure through the API. Agent skill documents and MCP server are available.</small>
-            </span>
-          </label>
-        </div>
-      </section>
+      <%
+        internal_enabled = @current_tenant.internal_ai_agents_enabled?
+        external_enabled = @current_tenant.external_ai_agents_enabled?
+        both_modes = internal_enabled && external_enabled
+      %>
 
-      <section class="pulse-settings-section" data-ai-agent-mode-target="internalOnly">
-        <label for="model" class="pulse-label">Model</label>
-        <%= form.select :model, available_llm_models, {}, class: "pulse-form-select" %>
-        <small class="pulse-hint">The LLM model this AI Agent will use for reasoning. Models are defined in <code>config/litellm_config.yaml</code>.</small>
-      </section>
+      <% if both_modes %>
+        <section class="pulse-settings-section">
+          <label class="pulse-label">Mode</label>
+          <small class="pulse-hint" style="margin-bottom: 12px; display: block;">Choose how this AI Agent will be powered.</small>
+          <div style="display: flex; flex-direction: column; gap: 12px;">
+            <label class="pulse-radio-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+              <%= radio_button_tag :mode, "internal", true, data: { action: "ai-agent-mode#updateVisibility" } %>
+              <span>
+                <strong>Internal</strong>
+                <small class="pulse-hint" style="display: block; margin-top: 2px;">Powered by Harmonic's agent runners. No API access.</small>
+              </span>
+            </label>
+            <label class="pulse-radio-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+              <%= radio_button_tag :mode, "external", false, data: { action: "ai-agent-mode#updateVisibility" } %>
+              <span>
+                <strong>External</strong>
+                <small class="pulse-hint" style="display: block; margin-top: 2px;">Powered by your own infrastructure through the API. Agent skill documents and MCP server are available.</small>
+              </span>
+            </label>
+          </div>
+        </section>
+      <% else %>
+        <%= hidden_field_tag :mode, internal_enabled ? "internal" : "external" %>
+      <% end %>
 
-      <section class="pulse-settings-section" data-ai-agent-mode-target="externalOnly" style="display: none;">
-        <label class="pulse-checkbox-label">
-          <%= form.check_box :generate_token, checked: true %>
-          Generate an API token for this AI Agent
-        </label>
-        <small class="pulse-hint">Required for the AI Agent to access the API.</small>
-      </section>
+      <% if internal_enabled %>
+        <section class="pulse-settings-section" data-ai-agent-mode-target="internalOnly">
+          <label for="model" class="pulse-label">Model</label>
+          <%= form.select :model, available_llm_models, {}, class: "pulse-form-select" %>
+          <small class="pulse-hint">The LLM model this AI Agent will use for reasoning. Models are defined in <code>config/litellm_config.yaml</code>.</small>
+        </section>
+      <% end %>
+
+      <% if external_enabled %>
+        <section class="pulse-settings-section" data-ai-agent-mode-target="externalOnly" style="<%= both_modes ? 'display: none;' : '' %>">
+          <label class="pulse-checkbox-label">
+            <%= form.check_box :generate_token, checked: true %>
+            Generate an API token for this AI Agent
+          </label>
+          <small class="pulse-hint">Required for the AI Agent to access the API.</small>
+        </section>
+      <% end %>
 
       <% if @current_tenant.feature_enabled?("stripe_billing") %>
         <section class="pulse-settings-section">

--- a/app/views/ai_agents/settings.html.erb
+++ b/app/views/ai_agents/settings.html.erb
@@ -40,7 +40,23 @@
     <% else %>
       <%# Active agent: show full settings %>
 
-      <form action="/ai-agents/<%= @ai_agent.handle %>/settings" method="post" class="pulse-form">
+      <%
+        internal_enabled = @current_tenant.internal_ai_agents_enabled?
+        external_enabled = @current_tenant.external_ai_agents_enabled?
+        both_modes = internal_enabled && external_enabled
+        current_mode = @ai_agent.internal_ai_agent? ? "internal" : "external"
+      %>
+
+      <%# Profile image upload has its own form (multipart), so it must live
+          OUTSIDE the main settings form — nested forms are invalid HTML and
+          would break the image-cropper Stimulus controller's target lookup. %>
+      <section class="pulse-settings-section">
+        <h3>Profile Image</h3>
+        <p class="pulse-hint">Click the image to upload a new one</p>
+        <%= render 'shared/profile_image_upload', resource: @ai_agent, size: 64 %>
+      </section>
+
+      <form id="ai-agent-settings-form" action="/ai-agents/<%= @ai_agent.handle %>/settings" method="post" class="pulse-form" data-controller="ai-agent-mode">
         <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
 
         <section class="pulse-settings-section">
@@ -56,36 +72,126 @@
             <input type="text" id="new_handle" name="new_handle" value="<%= @ai_agent.handle %>" class="pulse-form-input">
             <small class="pulse-hint">The handle is used in URLs and @mentions</small>
           </div>
+
+          <div class="pulse-form-group">
+            <label for="identity_prompt" class="pulse-label">Identity Prompt</label>
+            <textarea id="identity_prompt" name="identity_prompt" rows="6" class="pulse-form-input"><%= @ai_agent.agent_configuration&.dig("identity_prompt") %></textarea>
+            <small class="pulse-hint">This prompt will be shown to the agent on the /whoami page, providing context about their identity and purpose.</small>
+          </div>
         </section>
 
-        <% if @ai_agent.internal_ai_agent? %>
+        <%# Mode is fixed when only one of the two flags is enabled — submit it
+            as a hidden field so the controller still receives it. No visible
+            section in that case (would be an empty header). %>
+        <% unless both_modes || internal_enabled %>
+          <%= hidden_field_tag :mode, current_mode %>
+        <% end %>
+
+        <% if both_modes || internal_enabled %>
           <section class="pulse-settings-section">
-            <h3>Agent Configuration</h3>
+            <h3>Runtime</h3>
 
-            <div class="pulse-form-group">
-              <label for="model" class="pulse-label">Model</label>
-              <select id="model" name="model" class="pulse-form-input">
-                <option value="" <%= @ai_agent.agent_configuration&.dig("model").nil? ? "selected" : "" %>>Default</option>
-                <option value="claude-3-5-sonnet" <%= @ai_agent.agent_configuration&.dig("model") == "claude-3-5-sonnet" ? "selected" : "" %>>Claude 3.5 Sonnet</option>
-                <option value="claude-3-5-haiku" <%= @ai_agent.agent_configuration&.dig("model") == "claude-3-5-haiku" ? "selected" : "" %>>Claude 3.5 Haiku</option>
-                <option value="claude-3-opus" <%= @ai_agent.agent_configuration&.dig("model") == "claude-3-opus" ? "selected" : "" %>>Claude 3 Opus</option>
-              </select>
-              <small class="pulse-hint">The AI model used for this agent's tasks</small>
-            </div>
+            <% if both_modes %>
+              <div class="pulse-form-group">
+                <label class="pulse-label">Mode</label>
+                <small class="pulse-hint" style="margin-bottom: 12px; display: block;">Choose how this AI Agent is powered.</small>
+                <div style="display: flex; flex-direction: column; gap: 12px;">
+                  <label class="pulse-radio-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                    <%= radio_button_tag :mode, "internal", current_mode == "internal", data: { action: "ai-agent-mode#updateVisibility" } %>
+                    <span>
+                      <strong>Internal</strong>
+                      <small class="pulse-hint" style="display: block; margin-top: 2px;">Powered by Harmonic's agent runners. No API access.</small>
+                    </span>
+                  </label>
+                  <label class="pulse-radio-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                    <%= radio_button_tag :mode, "external", current_mode == "external", data: { action: "ai-agent-mode#updateVisibility" } %>
+                    <span>
+                      <strong>External</strong>
+                      <small class="pulse-hint" style="display: block; margin-top: 2px;">Powered by your own infrastructure through the API. Agent skill documents and MCP server are available.</small>
+                    </span>
+                  </label>
+                </div>
+              </div>
+            <% else %>
+              <%= hidden_field_tag :mode, current_mode %>
+            <% end %>
 
-            <div class="pulse-form-group">
-              <label for="identity_prompt" class="pulse-label">Identity Prompt</label>
-              <textarea id="identity_prompt" name="identity_prompt" rows="6" class="pulse-form-input"><%= @ai_agent.agent_configuration&.dig("identity_prompt") %></textarea>
-              <small class="pulse-hint">Custom instructions that define this agent's personality and behavior</small>
-            </div>
+            <% if internal_enabled %>
+              <div class="pulse-form-group" data-ai-agent-mode-target="internalOnly" style="<%= !both_modes || current_mode == 'internal' ? '' : 'display: none;' %>">
+                <label for="model" class="pulse-label">Model</label>
+                <%= select_tag :model, options_for_select(available_llm_models, @ai_agent.agent_configuration&.dig("model") || "default"), class: "pulse-form-input" %>
+                <small class="pulse-hint">The LLM model this AI Agent will use for reasoning.</small>
+              </div>
+            <% end %>
           </section>
         <% end %>
 
-        <section class="pulse-settings-section pulse-action-row">
-          <button type="submit" class="pulse-action-btn pulse-action-btn-primary">Save Settings</button>
-          <a href="/ai-agents/<%= @ai_agent.handle %>" class="pulse-action-btn">Cancel</a>
+        <section class="pulse-settings-section">
+          <h3>Capabilities</h3>
+          <p class="pulse-hint">
+            Check the actions this agent is allowed to perform. Unchecked actions will be blocked.
+          </p>
+
+          <%# Sentinel so an all-unchecked submission still includes a capabilities param —
+              the controller writes [] when present-but-empty, preserving "uncheck all" semantics. %>
+          <%= hidden_field_tag "capabilities[]", "" %>
+
+          <% current_caps = @ai_agent.agent_configuration&.dig("capabilities") %>
+          <% caps_not_configured = current_caps.nil? %>
+
+          <%
+            action_groups = {
+              "Always Allowed" => CapabilityCheck::AI_AGENT_ALWAYS_ALLOWED,
+              "Notes" => %w[create_note update_note confirm_read],
+              "Decisions" => %w[create_decision update_decision_settings vote add_options],
+              "Commitments" => %w[create_commitment update_commitment_settings join_commitment],
+              "Comments" => %w[add_comment],
+              "Pins" => %w[pin_note unpin_note pin_decision unpin_decision pin_commitment unpin_commitment],
+              "Attachments" => %w[add_attachment remove_attachment],
+              "Trustee Grant Responses" => %w[accept_trustee_grant decline_trustee_grant],
+              "Trustee Grant Admin" => %w[create_trustee_grant revoke_trustee_grant],
+            }
+            disabled_by_default = %w[Attachments Trustee\ Grant\ Admin]
+          %>
+
+          <% action_groups.each do |group_name, actions| %>
+            <% is_always_allowed = group_name == "Always Allowed" %>
+            <div style="margin-top: 16px;" data-controller="<%= 'checkbox-group' unless is_always_allowed %>">
+              <div style="font-weight: 500; font-size: 13px; margin-bottom: 8px; color: <%= is_always_allowed ? 'var(--text-muted)' : 'var(--text-primary)' %>; display: flex; align-items: center; gap: 12px;">
+                <span><%= group_name %></span>
+                <% if is_always_allowed %>
+                  <span style="font-weight: normal; font-size: 12px;">(cannot be disabled)</span>
+                <% else %>
+                  <span style="font-weight: normal; font-size: 12px;">
+                    <a href="#" data-action="checkbox-group#checkAll" class="pulse-link">all</a>
+                    /
+                    <a href="#" data-action="checkbox-group#uncheckAll" class="pulse-link">none</a>
+                  </span>
+                <% end %>
+              </div>
+              <div class="pulse-checkbox-group" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 8px;">
+                <% actions.each do |action| %>
+                  <% if is_always_allowed %>
+                    <label class="pulse-checkbox-label" style="display: flex; align-items: center; gap: 8px; cursor: not-allowed; opacity: 0.6;">
+                      <%= check_box_tag nil, action, true, disabled: true, id: "cap_#{action}" %>
+                      <code style="font-size: 12px;"><%= action %></code>
+                    </label>
+                  <% else %>
+                    <% checked = caps_not_configured ? !disabled_by_default.include?(group_name) : current_caps&.include?(action) %>
+                    <label class="pulse-checkbox-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                      <%= check_box_tag "capabilities[]", action, checked, id: "cap_#{action}", data: { checkbox_group_target: "checkbox" } %>
+                      <code style="font-size: 12px;"><%= action %></code>
+                    </label>
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
         </section>
+
       </form>
+
+      <hr style="margin: 32px 0; border: none; border-top: 1px solid var(--color-border-default);">
 
       <% if @ai_agent_collectives.any? %>
         <section class="pulse-settings-section">
@@ -189,6 +295,16 @@
           </p>
         </section>
       <% end %>
+
+      <%# Save button uses HTML5's `form` attribute so it can sit visually at
+          the bottom of the page while still submitting the agent-settings
+          form above. The management sections in between have their own forms
+          (nested forms are invalid HTML), so the Save button must live
+          outside any form. %>
+      <section class="pulse-settings-section pulse-action-row" style="margin-top: 32px;">
+        <button type="submit" form="ai-agent-settings-form" class="pulse-action-btn pulse-action-btn-primary">Save Settings</button>
+        <a href="/ai-agents/<%= @ai_agent.handle %>" class="pulse-action-btn">Cancel</a>
+      </section>
     <% end %>
   </div>
 </article>

--- a/app/views/ai_agents/settings.md.erb
+++ b/app/views/ai_agents/settings.md.erb
@@ -15,12 +15,25 @@
 | Model | `<%= @ai_agent.agent_configuration&.dig("model") || "default" %>` |
 <% end %>
 
-<% if @ai_agent.internal_ai_agent? && @ai_agent.agent_configuration&.dig("identity_prompt").present? %>
+<% if @ai_agent.agent_configuration&.dig("identity_prompt").present? %>
 ## Identity Prompt
 
 ```
 <%= @ai_agent.agent_configuration&.dig("identity_prompt") %>
 ```
+<% end %>
+
+## Capabilities
+
+<% caps = @ai_agent.agent_configuration&.dig("capabilities") %>
+<% if caps.nil? %>
+All grantable actions allowed (no explicit configuration).
+<% elsif caps.empty? %>
+No grantable actions allowed.
+<% else %>
+<% caps.each do |cap| %>
+* `<%= cap %>`
+<% end %>
 <% end %>
 
 <% if @ai_agent_collectives.any? %>

--- a/app/views/ai_agents/show.html.erb
+++ b/app/views/ai_agents/show.html.erb
@@ -92,14 +92,21 @@
       </section>
     <% end %>
 
+    <% active = !@ai_agent.archived? && !@ai_agent.suspended? %>
+    <% show_run_task = active && @ai_agent.internal_ai_agent? && @current_tenant.internal_ai_agents_enabled? %>
+
     <p class="pulse-action-row">
-      <% unless @ai_agent.archived? || @ai_agent.suspended? %>
+      <% if active %>
         <a href="<%= chat_path(@ai_agent.handle) %>" class="pulse-action-btn pulse-action-btn-primary">
           <%= octicon 'comment-discussion' %> Chat
         </a>
+      <% end %>
+      <% if show_run_task %>
         <a href="<%= ai_agent_run_task_path(@ai_agent.handle) %>" class="pulse-action-btn">
           <%= octicon 'play' %> Run Task
         </a>
+      <% end %>
+      <% if active %>
         <a href="/ai-agents/<%= @ai_agent.handle %>/automations" class="pulse-action-btn">
           <%= octicon 'zap' %> Automations
         </a>
@@ -164,51 +171,53 @@
       </section>
     <% end %>
 
-    <% if @recent_runs.any? %>
-      <section class="pulse-settings-section">
-        <h3>Recent Task Runs</h3>
-        <table class="pulse-table">
-          <thead>
-            <tr>
-              <th>Time</th>
-              <th>Status</th>
-              <th>Task</th>
-            </tr>
-          </thead>
-          <tbody>
-            <% @recent_runs.each do |run| %>
+    <% if @ai_agent.internal_ai_agent? %>
+      <% if @recent_runs.any? %>
+        <section class="pulse-settings-section">
+          <h3>Recent Task Runs</h3>
+          <table class="pulse-table">
+            <thead>
               <tr>
-                <td>
-                  <a href="<%= ai_agent_run_path(@ai_agent.handle, run.id) %>" class="pulse-link">
-                    <%= time_ago_in_words(run.created_at) %> ago
-                  </a>
-                </td>
-                <td>
-                  <span class="pulse-badge <%= run.status_badge_class %>">
-                    <% case run.status %>
-                    <% when "completed" %>
-                      <%= run.success ? 'Success' : 'Failed' %>
-                    <% when "running" %>
-                      Running
-                    <% when "queued" %>
-                      Queued
-                    <% else %>
-                      <%= run.status.titleize %>
-                    <% end %>
-                  </span>
-                </td>
-                <td><%= truncate(run.task, length: 60) %></td>
+                <th>Time</th>
+                <th>Status</th>
+                <th>Task</th>
               </tr>
-            <% end %>
-          </tbody>
-        </table>
-        <p><a href="<%= ai_agent_runs_path(@ai_agent.handle) %>" class="pulse-link">View all runs →</a></p>
-      </section>
-    <% else %>
-      <section class="pulse-settings-section">
-        <h3>Recent Task Runs</h3>
-        <p class="pulse-muted">No task runs yet.</p>
-      </section>
+            </thead>
+            <tbody>
+              <% @recent_runs.each do |run| %>
+                <tr>
+                  <td>
+                    <a href="<%= ai_agent_run_path(@ai_agent.handle, run.id) %>" class="pulse-link">
+                      <%= time_ago_in_words(run.created_at) %> ago
+                    </a>
+                  </td>
+                  <td>
+                    <span class="pulse-badge <%= run.status_badge_class %>">
+                      <% case run.status %>
+                      <% when "completed" %>
+                        <%= run.success ? 'Success' : 'Failed' %>
+                      <% when "running" %>
+                        Running
+                      <% when "queued" %>
+                        Queued
+                      <% else %>
+                        <%= run.status.titleize %>
+                      <% end %>
+                    </span>
+                  </td>
+                  <td><%= truncate(run.task, length: 60) %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+          <p><a href="<%= ai_agent_runs_path(@ai_agent.handle) %>" class="pulse-link">View all runs →</a></p>
+        </section>
+      <% else %>
+        <section class="pulse-settings-section">
+          <h3>Recent Task Runs</h3>
+          <p class="pulse-muted">No task runs yet.</p>
+        </section>
+      <% end %>
     <% end %>
   </div>
 </article>

--- a/app/views/ai_agents/show.md.erb
+++ b/app/views/ai_agents/show.md.erb
@@ -45,6 +45,7 @@ No automations configured yet.
 * [Create Automation](/ai-agents/<%= @ai_agent.handle %>/automations/new)
 <% end %>
 
+<% if @ai_agent.internal_ai_agent? %>
 <% if @recent_runs.any? %>
 ## Recent Task Runs
 
@@ -59,6 +60,7 @@ No automations configured yet.
 ## Recent Task Runs
 
 No task runs yet.
+<% end %>
 <% end %>
 
 ## Navigation

--- a/app/views/api_tokens/new.html.erb
+++ b/app/views/api_tokens/new.html.erb
@@ -23,11 +23,21 @@
       <section class="pulse-settings-section">
         <label class="pulse-label">Identity</label>
         <div style="padding: 8px 12px; background-color: var(--bg-tertiary); border: 1px solid var(--border-color); border-radius: 6px; color: var(--text-secondary); font-style: italic;">
-          you
+          <% if @showing_user == @current_user %>
+            you
+          <% elsif @showing_user.ai_agent? %>
+            <%= @showing_user.display_name %> (AI agent)
+          <% else %>
+            <%= @showing_user.display_name %>
+          <% end %>
         </div>
         <p class="pulse-hint" style="margin-top: 8px;">
-          This token will be associated with your account. To create a token for an AI agent, go to
-          <a href="/ai-agents" class="pulse-link">AI Agents</a> and select the agent's settings page.
+          <% if @showing_user == @current_user %>
+            This token will be associated with your account. To create a token for an AI agent, go to
+            <a href="/ai-agents" class="pulse-link">AI Agents</a> and select the agent's settings page.
+          <% else %>
+            This token will be associated with <%= @showing_user.display_name %>. Actions taken through the API using this token will be attributed to <%= @showing_user.display_name %>.
+          <% end %>
         </p>
       </section>
 

--- a/app/views/api_tokens/new.md.erb
+++ b/app/views/api_tokens/new.md.erb
@@ -4,9 +4,13 @@ Create a new API token for **<%= @showing_user.display_name %>**.
 
 ## Identity
 
+<% if @showing_user == @current_user %>
 This token will be associated with **you** (<%= @showing_user.display_name %>).
 
 To create a token for an AI agent, go to [AI Agents](/ai-agents) and select the agent's settings page.
+<% else %>
+This token will be associated with **<%= @showing_user.display_name %>**. Actions taken through the API using this token will be attributed to <%= @showing_user.display_name %>.
+<% end %>
 
 ## Parameters
 

--- a/app/views/layouts/_top_right_menu.html.erb
+++ b/app/views/layouts/_top_right_menu.html.erb
@@ -58,11 +58,11 @@
           <%= octicon 'list-unordered' %>
           <a href="<%= @current_user.path %>/lists">Your lists</a>
         </li>
-        <% if @current_tenant&.ai_agents_enabled? %>
-          <li>
-            <%= octicon 'comment-discussion' %>
-            <a href="/chat">Chat</a>
-          </li>
+        <li>
+          <%= octicon 'comment-discussion' %>
+          <a href="/chat">Chat</a>
+        </li>
+        <% if @current_tenant&.any_ai_agents_enabled? %>
           <li>
             <%= octicon 'command-palette' %>
             <a href="/ai-agents">AI Agents</a>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -49,105 +49,6 @@
         <p class="pulse-form-hint">This is your unique identifier used in URLs and mentions</p>
       </div>
 
-      <% if @settings_user.ai_agent? %>
-        <% current_mode = @settings_user.agent_configuration&.dig("mode") || "external" %>
-        <div data-controller="ai_agent-mode">
-          <div class="pulse-form-section">
-            <label class="pulse-form-label">Mode</label>
-            <p class="pulse-form-hint" style="margin-bottom: 12px;">Choose how this ai_agent is powered.</p>
-            <div style="display: flex; flex-direction: column; gap: 12px;">
-              <label class="pulse-radio-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
-                <%= radio_button_tag :mode, "internal", current_mode == "internal", data: { action: "ai_agent-mode#updateVisibility" } %>
-                <span>
-                  <strong>Internal</strong>
-                  <span class="pulse-form-hint" style="display: block; margin-top: 2px;">Powered by Harmonic's agent runners. No API access.</span>
-                </span>
-              </label>
-              <label class="pulse-radio-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
-                <%= radio_button_tag :mode, "external", current_mode == "external", data: { action: "ai_agent-mode#updateVisibility" } %>
-                <span>
-                  <strong>External</strong>
-                  <span class="pulse-form-hint" style="display: block; margin-top: 2px;">Powered by your own infrastructure through the API. Agent skill documents and MCP server are available.</span>
-                </span>
-              </label>
-            </div>
-          </div>
-
-          <div class="pulse-form-section" data-ai_agent-mode-target="internalOnly" style="<%= current_mode == 'internal' ? '' : 'display: none;' %>">
-            <label class="pulse-form-label" for="model">Model</label>
-            <%= form.select :model, available_llm_models, { selected: @settings_user.agent_configuration&.dig("model") || "default" }, class: 'pulse-select' %>
-            <p class="pulse-form-hint">The LLM model this ai_agent will use for reasoning.</p>
-          </div>
-        </div>
-
-        <div class="pulse-form-section">
-          <label class="pulse-form-label" for="identity_prompt">Identity Prompt</label>
-          <%= form.text_area :identity_prompt, value: @settings_user.agent_configuration&.dig("identity_prompt"), placeholder: 'You are a helpful assistant...', class: 'pulse-textarea', rows: 4 %>
-          <p class="pulse-form-hint">This prompt will be shown to the agent on the /whoami page, providing context about their identity and purpose.</p>
-        </div>
-
-        <div class="pulse-form-section">
-          <label class="pulse-form-label">Capabilities</label>
-          <p class="pulse-form-hint">
-            Check the actions this agent is allowed to perform. Unchecked actions will be blocked.
-          </p>
-
-          <% current_caps = @settings_user.agent_configuration&.dig("capabilities") %>
-          <% caps_not_configured = current_caps.nil? %>
-
-          <%
-            # Group actions by resource type
-            action_groups = {
-              "Always Allowed" => CapabilityCheck::AI_AGENT_ALWAYS_ALLOWED,
-              "Notes" => %w[create_note update_note confirm_read],
-              "Decisions" => %w[create_decision update_decision_settings vote add_options],
-              "Commitments" => %w[create_commitment update_commitment_settings join_commitment],
-              "Comments" => %w[add_comment],
-              "Pins" => %w[pin_note unpin_note pin_decision unpin_decision pin_commitment unpin_commitment],
-              "Attachments" => %w[add_attachment remove_attachment],
-              "Trustee Grant Responses" => %w[accept_trustee_grant decline_trustee_grant],
-              "Trustee Grant Admin" => %w[create_trustee_grant revoke_trustee_grant],
-            }
-            # Groups that are disabled by default for new agents
-            disabled_by_default = %w[Attachments Trustee\ Grant\ Admin]
-          %>
-
-          <% action_groups.each do |group_name, actions| %>
-            <% is_always_allowed = group_name == "Always Allowed" %>
-            <div style="margin-top: 16px;" data-controller="<%= 'checkbox-group' unless is_always_allowed %>">
-              <div style="font-weight: 500; font-size: 13px; margin-bottom: 8px; color: <%= is_always_allowed ? 'var(--text-muted)' : 'var(--text-primary)' %>; display: flex; align-items: center; gap: 12px;">
-                <span><%= group_name %></span>
-                <% if is_always_allowed %>
-                  <span style="font-weight: normal; font-size: 12px;">(cannot be disabled)</span>
-                <% else %>
-                  <span style="font-weight: normal; font-size: 12px;">
-                    <a href="#" data-action="checkbox-group#checkAll" class="pulse-link">all</a>
-                    /
-                    <a href="#" data-action="checkbox-group#uncheckAll" class="pulse-link">none</a>
-                  </span>
-                <% end %>
-              </div>
-              <div class="pulse-checkbox-group" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 8px;">
-                <% actions.each do |action| %>
-                  <% if is_always_allowed %>
-                    <label class="pulse-checkbox-label" style="display: flex; align-items: center; gap: 8px; cursor: not-allowed; opacity: 0.6;">
-                      <%= check_box_tag nil, action, true, disabled: true, id: "cap_#{action}" %>
-                      <code style="font-size: 12px;"><%= action %></code>
-                    </label>
-                  <% else %>
-                    <% checked = caps_not_configured ? !disabled_by_default.include?(group_name) : current_caps&.include?(action) %>
-                    <label class="pulse-checkbox-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
-                      <%= check_box_tag "capabilities[]", action, checked, id: "cap_#{action}", data: { checkbox_group_target: "checkbox" } %>
-                      <code style="font-size: 12px;"><%= action %></code>
-                    </label>
-                  <% end %>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-
       <div class="pulse-form-actions">
         <%= form.submit 'Save Changes', class: 'pulse-action-btn-primary' %>
       </div>
@@ -439,19 +340,5 @@
       <% end %>
     <% end %>
 
-    <% if @settings_user.human? && is_own_settings %>
-      <%# AI Agents Link %>
-      <%= render 'shared/pulse_accordion', title: 'AI Agents' do %>
-        <p class="pulse-form-hint" style="margin-bottom:16px;">
-          AI Agents are virtual identities that you manage. Create agents, configure automations, and manage API tokens from the dedicated AI Agents page.
-        </p>
-        <div class="pulse-form-actions">
-          <a href="/ai-agents" class="pulse-action-btn">
-            <%= octicon 'command-palette', height: 14 %>
-            Manage AI Agents
-          </a>
-        </div>
-      <% end %>
-    <% end %>
   <% end %>
 </article>

--- a/app/views/users/settings.md.erb
+++ b/app/views/users/settings.md.erb
@@ -6,13 +6,6 @@
 
 Name: <%= @settings_user.name %>
 Handle: `<%= @settings_user.handle %>`
-<% if @settings_user.ai_agent? %>
-Type: AI Agent (managed by <%= @settings_user.parent&.display_name || 'Unknown' %>)
-Mode: <%= @settings_user.internal_ai_agent? ? "Internal" : "External" %>
-<% if @settings_user.internal_ai_agent? %>
-Model: `<%= @settings_user.agent_configuration&.dig("model") || "default" %>`
-<% end %>
-<% end %>
 
 <% if is_own_settings && @settings_user.external_oauth_identities.any? %>
 ## Connected Accounts

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -37,9 +37,17 @@ feature_flags:
     default_collective: false
     collective_level: true
 
-  ai_agents:
-    name: "AI Agents Task Runner"
-    description: "Enables the internal AI Agents task runner for executing automated tasks. External agents interacting via the API only need the 'api' flag."
+  internal_ai_agents:
+    name: "Internal AI Agents (Task Runner)"
+    description: "Enables the Harmonic-managed Task Runner for executing internal AI agent runs (the agent-runner service, automation rule dispatch, and Trio's runtime path)."
+    app_enabled: true
+    default_tenant: false
+    default_collective: false
+    collective_level: false
+
+  external_ai_agents:
+    name: "External AI Agents"
+    description: "Allows users to create AI agents that interact with Harmonic via the API using API tokens. Requires the 'api' flag."
     app_enabled: true
     default_tenant: false
     default_collective: false

--- a/db/migrate/20260605000000_split_ai_agents_flag.rb
+++ b/db/migrate/20260605000000_split_ai_agents_flag.rb
@@ -1,0 +1,52 @@
+# Splits the single `ai_agents` feature flag into two independent flags:
+# `internal_ai_agents` (Task Runner) and `external_ai_agents` (API-token
+# agents). Preserves every tenant's current capability set by copying the
+# existing `ai_agents` value (or 'false' default) into both new keys, then
+# deletes the old key.
+#
+# Run-once (not idempotent): the third statement removes the source `ai_agents`
+# key, so a hypothetical second run would COALESCE-default both new flags back
+# to 'false'. Rails' schema_migrations tracking is the correctness story.
+#
+# The `collectives` table cleanup is defensive — `ai_agents` is
+# `collective_level: false` and shouldn't have been settable per-collective,
+# but if any historical write put it there, remove it.
+class SplitAiAgentsFlag < ActiveRecord::Migration[7.2]
+  def up
+    execute <<-SQL
+      UPDATE tenants
+      SET settings = jsonb_set(
+        settings,
+        '{feature_flags,internal_ai_agents}',
+        COALESCE(settings->'feature_flags'->'ai_agents', 'false'::jsonb),
+        true
+      )
+    SQL
+
+    execute <<-SQL
+      UPDATE tenants
+      SET settings = jsonb_set(
+        settings,
+        '{feature_flags,external_ai_agents}',
+        COALESCE(settings->'feature_flags'->'ai_agents', 'false'::jsonb),
+        true
+      )
+    SQL
+
+    execute <<-SQL
+      UPDATE tenants
+      SET settings = settings #- '{feature_flags,ai_agents}'
+      WHERE settings->'feature_flags' ? 'ai_agents'
+    SQL
+
+    execute <<-SQL
+      UPDATE collectives
+      SET settings = settings #- '{feature_flags,ai_agents}'
+      WHERE settings->'feature_flags' ? 'ai_agents'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -9842,6 +9842,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260605000000'),
 ('20260601231650'),
 ('20260601223743'),
 ('20260601205324'),

--- a/test/channels/chat_session_channel_test.rb
+++ b/test/channels/chat_session_channel_test.rb
@@ -4,7 +4,8 @@ require "test_helper"
 class ChatSessionChannelTest < ActionCable::Channel::TestCase
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
 
     @ai_agent = User.create!(

--- a/test/controllers/agent_automations_controller_test.rb
+++ b/test/controllers/agent_automations_controller_test.rb
@@ -3,7 +3,8 @@ require "test_helper"
 class AgentAutomationsControllerTest < ActionDispatch::IntegrationTest
   def setup
     @tenant = @global_tenant
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     @tenant.enable_api!
     @collective = @global_collective
     @collective.enable_api!

--- a/test/controllers/ai_agents_controller_test.rb
+++ b/test/controllers/ai_agents_controller_test.rb
@@ -10,7 +10,8 @@ class AiAgentsControllerTest < ActionDispatch::IntegrationTest
     host! "#{@tenant.subdomain}.#{ENV['HOSTNAME']}"
 
     # Enable AI agents for this tenant
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
 
     # Create an AI agent for tests
     Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
@@ -95,7 +96,8 @@ class AiAgentsControllerTest < ActionDispatch::IntegrationTest
   # === Feature Flag Tests ===
 
   test "index returns forbidden when AI agents feature is disabled" do
-    @tenant.set_feature_flag!("ai_agents", false)
+    @tenant.set_feature_flag!("internal_ai_agents", false)
+    @tenant.set_feature_flag!("external_ai_agents", false)
     sign_in_as(@user, tenant: @tenant)
     get "/ai-agents"
     assert_response :forbidden
@@ -655,7 +657,8 @@ class AiAgentsControllerTest < ActionDispatch::IntegrationTest
     # `system_role: "trio"` would grant billing exemption + workspace-membership
     # + reserved-handle privileges. Only TrioSeeder may assign it; user-supplied
     # params must not.
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     sign_in_as(@user, tenant: @tenant)
 
     assert_difference -> { User.where(user_type: "ai_agent").count }, 1 do
@@ -678,6 +681,356 @@ class AiAgentsControllerTest < ActionDispatch::IntegrationTest
 
     @ai_agent.tenant_users.find_by(tenant: @tenant).reload
     assert_equal @ai_agent_handle, @ai_agent.tenant_users.find_by(tenant: @tenant).handle
+  end
+
+  # === Split-flag scenario tests ===
+
+  test "run_task is reachable when internal_ai_agents is enabled" do
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/run"
+    assert_response :success
+  end
+
+  test "run_task returns 403 when internal_ai_agents is disabled even if external is enabled" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/run"
+    assert_response :forbidden
+  end
+
+  test "run_task returns 404 for an external agent even with internal flag on" do
+    @ai_agent.update!(agent_configuration: { "mode" => "external" })
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/run"
+    assert_response :not_found
+  end
+
+  test "execute_task returns 404 for an external agent" do
+    @ai_agent.update!(agent_configuration: { "mode" => "external" })
+    sign_in_as(@user, tenant: @tenant)
+    post "/ai-agents/#{@ai_agent_handle}/run", params: { task: "x" }
+    assert_response :not_found
+  end
+
+  test "settings is reachable when only external_ai_agents is enabled" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/settings"
+    assert_response :success
+  end
+
+  test "settings is reachable when only internal_ai_agents is enabled" do
+    @tenant.disable_feature_flag!("external_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/settings"
+    assert_response :success
+  end
+
+  test "settings returns 403 when both flags are disabled" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    @tenant.disable_feature_flag!("external_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/settings"
+    assert_response :forbidden
+  end
+
+  test "create with mode=internal is blocked when internal_ai_agents is disabled" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    post "/ai-agents/new/actions/create_ai_agent", params: {
+      name: "Blocked Internal Agent",
+      mode: "internal",
+      confirm_billing: "1",
+    }
+    assert_response :forbidden
+  end
+
+  test "create with mode=external is blocked when external_ai_agents is disabled" do
+    @tenant.disable_feature_flag!("external_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    post "/ai-agents/new/actions/create_ai_agent", params: {
+      name: "Blocked External Agent",
+      mode: "external",
+      confirm_billing: "1",
+    }
+    assert_response :forbidden
+  end
+
+  test "create with missing mode defaults to external and is blocked when external_ai_agents is disabled" do
+    @tenant.disable_feature_flag!("external_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    post "/ai-agents/new/actions/create_ai_agent", params: {
+      name: "Blocked Default-mode Agent",
+      confirm_billing: "1",
+    }
+    assert_response :forbidden
+  end
+
+  test "agent itself can read its own /ai-agents/handle/settings via authorize_parent_or_self" do
+    @tenant.enable_api!
+    token = ApiToken.create!(
+      user: @ai_agent,
+      tenant: @tenant,
+      name: "Self-Read Token",
+      scopes: ApiToken.read_scopes,
+      expires_at: 1.year.from_now,
+    )
+    get "/ai-agents/#{@ai_agent_handle}/settings",
+      headers: {
+        "Authorization" => "Bearer #{token.plaintext_token}",
+        "Accept" => "text/markdown",
+      }
+    assert_response :success
+  end
+
+  test "non-parent, non-self user is 403 on settings" do
+    other_user = create_user(email: "other-#{SecureRandom.hex(4)}@example.com")
+    @tenant.add_user!(other_user)
+    sign_in_as(other_user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/settings"
+    assert_response :forbidden
+  end
+
+  test "agent itself cannot POST update_settings" do
+    token = ApiToken.create!(
+      user: @ai_agent,
+      tenant: @tenant,
+      name: "Self-Write Token",
+      scopes: ApiToken.write_scopes + ApiToken.read_scopes,
+      expires_at: 1.year.from_now,
+    )
+    post "/ai-agents/#{@ai_agent_handle}/settings",
+      params: { name: "Self-renamed" },
+      headers: {
+        "Authorization" => "Bearer #{token.plaintext_token}",
+        "Accept" => "text/markdown",
+      }
+    assert_response :forbidden
+  end
+
+  # === External-only rollout (the production rollout config) ===
+  #
+  # This is the configuration external customers will see first: external AI
+  # agents are enabled, internal (Task Runner) AI agents are not. These tests
+  # exercise the human-facing UX flow end-to-end in that configuration to
+  # catch any place where the UI assumes internal is on.
+
+  test "external-only: index page is reachable and lists existing external agent" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    @ai_agent.update!(agent_configuration: { "mode" => "external" })
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents"
+    assert_response :success
+    assert_includes response.body, @ai_agent.name
+  end
+
+  test "external-only: index empty-state copy mentions API access" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    # Ensure the parent user has no agents in this tenant so the empty state renders.
+    @user.ai_agents.find_each { |a| destroy_user!(a) }
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents"
+    assert_response :success
+    assert_match(/No AI Agents Yet/, response.body)
+    assert_match(/programmatic access to the API/, response.body)
+  end
+
+  test "external-only: per-agent action row hides Run Task/Runs but keeps Settings and Automations" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    @ai_agent.update!(agent_configuration: { "mode" => "external" })
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents"
+    assert_response :success
+    refute_includes response.body, "Run Task"
+    assert_includes response.body, "Settings"
+    assert_includes response.body, "Automations"
+  end
+
+  test "external-only: show page is reachable and hides Run Task button" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    @ai_agent.update!(agent_configuration: { "mode" => "external" })
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}"
+    assert_response :success
+    refute_includes response.body, ">Run Task"
+  end
+
+  test "external-only: new agent form is reachable" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/new"
+    assert_response :success
+  end
+
+  test "external-only: new agent form hides Mode radio and sends hidden mode=external" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/new"
+    assert_response :success
+    refute_match(/radio_button.*mode/, response.body)
+    refute_match(/<label[^>]*>\s*<input[^>]*type="radio"[^>]*name="mode"/, response.body)
+    assert_match(/<input[^>]*type="hidden"[^>]*name="mode"[^>]*value="external"/, response.body)
+  end
+
+  test "create with name that produces an already-taken handle surfaces a friendly error, not a 500" do
+    sign_in_as(@user, tenant: @tenant)
+    existing = create_ai_agent(parent: @user, name: "Collision Target")
+    existing_handle = @tenant.add_user!(existing).handle
+
+    assert_no_difference -> { User.where(user_type: "ai_agent").count } do
+      post "/ai-agents/new/actions/create_ai_agent", params: {
+        name: existing_handle,
+        mode: "external",
+        confirm_billing: "1",
+      }
+    end
+
+    assert_response :redirect, "should redirect back to the form, not 500"
+    assert_match(/handle|already|taken|in use|different name/i, flash[:alert] || flash[:error] || flash[:notice] || "",
+      "flash must explain why creation failed so the user can pick a different name")
+    follow_redirect!
+    # Use a key the layout renders. The layout renders :notice and :alert
+    # (Rails convention). Pre-existing flash[:error] uses in this controller
+    # are a separate UX bug — out of scope here.
+    assert_match(/handle|already|taken|in use|different name/i, response.body,
+      "flash should be visible in the rendered form so the user knows why it failed")
+  end
+
+  test "external-only: admin user creating an agent does NOT get pending_billing_setup even with inactive stripe_customer" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    enable_stripe_billing_flag!(@tenant)
+    @user.update!(app_admin: true)
+    # Pre-existing inactive stripe_customer (e.g. subscription was canceled or never activated)
+    StripeCustomer.create!(billable: @user, stripe_id: "cus_admin_test", active: false)
+
+    sign_in_as(@user, tenant: @tenant)
+    post "/ai-agents/new/actions/create_ai_agent", params: {
+      name: "Admin External Agent",
+      mode: "external",
+      generate_token: "1",
+      confirm_billing: "1",
+    }
+
+    new_agent = @user.ai_agents.find_by(name: "Admin External Agent")
+    assert new_agent
+    refute new_agent.pending_billing_setup?,
+      "admin-created agents should NOT be marked pending_billing_setup just because the admin's stripe_customer happens to be inactive — admins are billing-exempt"
+  end
+
+  test "external-only: regular user with inactive stripe_customer creating an agent DOES get pending_billing_setup" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    enable_stripe_billing_flag!(@tenant)
+    # Clear pre-existing agents so the user passes the early
+    # requires_stripe_billing? redirect (billable_quantity must be 0 going
+    # into the request — otherwise they'd hit the early redirect, not the
+    # pending-flag code path we're testing).
+    @user.ai_agents.find_each { |a| destroy_user!(a) }
+    StripeCustomer.create!(billable: @user, stripe_id: "cus_regular_test", active: false)
+
+    sign_in_as(@user, tenant: @tenant)
+    post "/ai-agents/new/actions/create_ai_agent", params: {
+      name: "Regular User External Agent",
+      mode: "external",
+      generate_token: "1",
+      confirm_billing: "1",
+    }
+
+    new_agent = @user.ai_agents.find_by(name: "Regular User External Agent")
+    assert new_agent
+    assert new_agent.pending_billing_setup?,
+      "non-admin user without an active subscription must have the new agent marked pending so the runner blocks it until billing is set up"
+  end
+
+  test "external-only: external agent creation with generate_token reveals plaintext token in response" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    post "/ai-agents/new/actions/create_ai_agent", params: {
+      name: "External Agent With Token",
+      mode: "external",
+      generate_token: "1",
+      confirm_billing: "1",
+    }
+    assert_response :success, "should render show page directly (not redirect) so the freshly created plaintext token is visible"
+
+    new_agent = @user.ai_agents.find_by(name: "External Agent With Token")
+    assert new_agent
+    assert ApiToken.unscoped.where(user_id: new_agent.id).any?, "token should be persisted"
+
+    # The plaintext is only available on the in-memory ApiToken returned from
+    # the controller request — it's hashed in the DB. So we assert the
+    # response body contains a 40-char hex string (SecureRandom.hex(20))
+    # AND the "save it now" message that this is the only chance to copy it.
+    assert_match(/\b[a-f0-9]{40}\b/, response.body,
+      "plaintext token (40-char hex) must appear in the response — it is hashed at rest and never retrievable")
+    assert_match(/won't be able to see|will not be able to see/i, response.body,
+      "must warn the user this is the only chance to copy the token")
+  end
+
+  test "external-only: external agent creation without generate_token redirects (no token rendered)" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    post "/ai-agents/new/actions/create_ai_agent", params: {
+      name: "External Agent No Token",
+      mode: "external",
+      confirm_billing: "1",
+    }
+    assert_response :redirect
+    new_agent = @user.ai_agents.find_by(name: "External Agent No Token")
+    assert new_agent
+    assert_empty ApiToken.unscoped.where(user_id: new_agent.id)
+  end
+
+  test "external-only: external agent creation succeeds via markdown action" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    assert_difference -> { @user.ai_agents.where(tenant_users: { tenant_id: @tenant.id }).joins(:tenant_users).count }, 1 do
+      post "/ai-agents/new/actions/create_ai_agent", params: {
+        name: "External Only Agent",
+        mode: "external",
+        confirm_billing: "1",
+      }
+    end
+    new_agent = @user.ai_agents.find_by(name: "External Only Agent")
+    assert new_agent
+    assert new_agent.external_ai_agent?, "agent should be external-mode"
+  end
+
+  test "external-only: create with no mode param succeeds (defaults to external)" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    post "/ai-agents/new/actions/create_ai_agent", params: {
+      name: "Default Mode Agent",
+      confirm_billing: "1",
+    }
+    new_agent = @user.ai_agents.find_by(name: "Default Mode Agent")
+    assert new_agent, "agent should be created"
+    assert new_agent.external_ai_agent?, "agent should default to external mode"
+  end
+
+  test "external-only: runs index is gated (no UI surface for runs)" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/runs"
+    assert_response :forbidden
+  end
+
+  test "external-only: any_ai_agents_enabled? is true so top nav AI Agents link renders" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    sign_in_as(@user, tenant: @tenant)
+    get "/"
+    assert_match %r{href="/ai-agents"}, response.body, "Top nav AI Agents link should be visible"
+  end
+
+  test "update_settings accepts capabilities with sentinel and writes []" do
+    sign_in_as(@user, tenant: @tenant)
+    @ai_agent.update!(agent_configuration: { "capabilities" => ["create_note"] })
+    post "/ai-agents/#{@ai_agent_handle}/settings", params: {
+      name: @ai_agent.name,
+      capabilities: [""],
+    }
+    assert_response :redirect
+    @ai_agent.reload
+    assert_equal [], @ai_agent.agent_configuration["capabilities"]
   end
 
   private

--- a/test/controllers/billing_controller_test.rb
+++ b/test/controllers/billing_controller_test.rb
@@ -10,7 +10,8 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
     @user = @global_user
     host! "#{@tenant.subdomain}.#{ENV['HOSTNAME']}"
 
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     enable_stripe_billing_flag!(@tenant)
     # Make @collective paid_tier so @user has a billable resource by default —
     # most tests in this file pre-date the free/paid tier model and assumed a

--- a/test/controllers/chats_controller_test.rb
+++ b/test/controllers/chats_controller_test.rb
@@ -7,7 +7,8 @@ class ChatsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @tenant = @global_tenant
     @user = @global_user
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
     @collective = @tenant.main_collective
 
     @ai_agent = create_ai_agent(parent: @user)

--- a/test/controllers/internal/agent_runner_controller_test.rb
+++ b/test/controllers/internal/agent_runner_controller_test.rb
@@ -6,7 +6,8 @@ class Internal::AgentRunnerControllerTest < ActionDispatch::IntegrationTest
 
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
 
     @ai_agent = create_ai_agent

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -368,6 +368,96 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   # === AiAgent Count Scoping Tests ===
 
+  # === /u/<agent>/settings redirects to /ai-agents/<handle>/settings ===
+  # AI agents have a single canonical settings surface; visits to the
+  # user-settings URL for an agent redirect to the canonical page.
+
+  test "GET /u/<agent>/settings redirects to /ai-agents/<handle>/settings for AI agents" do
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    ai_agent = create_ai_agent(parent: @user, name: "Redirect Test Agent")
+    @tenant.add_user!(ai_agent)
+    handle = ai_agent.tenant_users.find_by(tenant: @tenant).handle
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    sign_in_as(@user, tenant: @tenant)
+    get "/u/#{handle}/settings"
+    assert_redirected_to "/ai-agents/#{handle}/settings"
+  end
+
+  test "GET /u/<agent>/settings.md redirects to /ai-agents/<handle>/settings.md for AI agents" do
+    @tenant.enable_api!
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    ai_agent = create_ai_agent(parent: @user, name: "Redirect MD Test Agent")
+    @tenant.add_user!(ai_agent)
+    handle = ai_agent.tenant_users.find_by(tenant: @tenant).handle
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    api_token = ApiToken.create!(
+      user: @user,
+      tenant: @tenant,
+      name: "Redirect MD Test #{SecureRandom.hex(4)}",
+      scopes: ApiToken.read_scopes,
+    )
+    get "/u/#{handle}/settings",
+      headers: {
+        "Accept" => "text/markdown",
+        "Authorization" => "Bearer #{api_token.plaintext_token}",
+      }
+    assert_response :redirect
+    assert_match %r{/ai-agents/#{handle}/settings}, response.headers["Location"]
+  end
+
+  test "GET /ai-agents/<handle>/settings includes the profile image upload" do
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    ai_agent = create_ai_agent(parent: @user, name: "Profile Image Test Agent")
+    @tenant.add_user!(ai_agent)
+    handle = ai_agent.tenant_users.find_by(tenant: @tenant).handle
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{handle}/settings"
+    assert_response :success
+    assert_match(/Profile Image/i, response.body,
+      "agent settings should include profile image upload — the only thing previously unique to /u/<agent>/settings")
+  end
+
+  test "POST /u/<agent>/settings/profile no longer mutates agent_configuration" do
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    ai_agent = create_ai_agent(parent: @user, name: "Profile POST Test Agent")
+    ai_agent.update!(agent_configuration: { "mode" => "external", "capabilities" => ["create_note"] })
+    @tenant.add_user!(ai_agent)
+    handle = ai_agent.tenant_users.find_by(tenant: @tenant).handle
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    sign_in_as(@user, tenant: @tenant)
+    post "/u/#{handle}/settings/profile", params: {
+      name: "Updated Name",
+      mode: "internal",
+      capabilities: [""],
+      identity_prompt: "ignored",
+    }
+    assert_response :redirect
+    ai_agent.reload
+    assert_equal "Updated Name", ai_agent.name
+    assert_equal "external", ai_agent.agent_configuration["mode"]
+    assert_equal ["create_note"], ai_agent.agent_configuration["capabilities"]
+    assert_nil ai_agent.agent_configuration["identity_prompt"]
+  end
+
   test "ai_agent count only includes ai_agents in current tenant" do
     # Create two ai_agents
     ai_agent1 = create_ai_agent(parent: @user, name: "AiAgent In Tenant")

--- a/test/integration/ai_agent_capability_test.rb
+++ b/test/integration/ai_agent_capability_test.rb
@@ -7,7 +7,8 @@ class AiAgentCapabilityTest < ActionDispatch::IntegrationTest
     @collective = @global_collective
     @collective.enable_api!
     @parent = @global_user
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
 
     @ai_agent = create_ai_agent_for(@parent, "Capability Test AiAgent")
 
@@ -156,7 +157,7 @@ class AiAgentCapabilityTest < ActionDispatch::IntegrationTest
     sign_in_as(@parent, tenant: @tenant)
 
     # Update capabilities via the profile form (POST not PATCH)
-    post "/u/#{@ai_agent.handle}/settings/profile",
+    post "/ai-agents/#{@ai_agent.handle}/settings",
       params: {
         name: @ai_agent.name,
         capabilities: ["create_note", "add_comment", "vote"],
@@ -173,11 +174,13 @@ class AiAgentCapabilityTest < ActionDispatch::IntegrationTest
 
     sign_in_as(@parent, tenant: @tenant)
 
-    # Uncheck all capabilities (no capabilities param sent = empty array saved)
-    post "/u/#{@ai_agent.handle}/settings/profile",
+    # Form submission with all capability checkboxes unchecked.
+    # The form ships a hidden sentinel `capabilities[]=""` so the param is
+    # always present; the controller filters blank values and writes [].
+    post "/ai-agents/#{@ai_agent.handle}/settings",
       params: {
         name: @ai_agent.name,
-        # No capabilities param = all boxes unchecked = empty array
+        capabilities: [""],
       }
 
     assert_response :redirect
@@ -190,7 +193,7 @@ class AiAgentCapabilityTest < ActionDispatch::IntegrationTest
     sign_in_as(@parent, tenant: @tenant)
 
     # Try to set invalid capabilities
-    post "/u/#{@ai_agent.handle}/settings/profile",
+    post "/ai-agents/#{@ai_agent.handle}/settings",
       params: {
         name: @ai_agent.name,
         capabilities: ["create_note", "invalid_action", "create_collective"],

--- a/test/integration/ai_agent_collective_membership_test.rb
+++ b/test/integration/ai_agent_collective_membership_test.rb
@@ -90,7 +90,8 @@ class AiAgentCollectiveMembershipTest < ActionDispatch::IntegrationTest
 
   test "ai_agents index page shows ai_agent collective memberships" do
     # Enable AI agents feature flag and add ai_agent to collective first
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     @collective.add_user!(@ai_agent)
 
     sign_in_as(@parent, tenant: @tenant)
@@ -102,7 +103,8 @@ class AiAgentCollectiveMembershipTest < ActionDispatch::IntegrationTest
 
   test "ai_agents settings page shows available collectives to add agent to" do
     # Enable AI agents feature flag and create another collective where parent has invite permission
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     another_collective = create_collective(tenant: @tenant, created_by: @parent, handle: "another-collective-#{SecureRandom.hex(4)}")
 
     sign_in_as(@parent, tenant: @tenant)
@@ -115,7 +117,8 @@ class AiAgentCollectiveMembershipTest < ActionDispatch::IntegrationTest
 
   test "ai_agents index page shows archived badge for archived ai_agent" do
     # Enable AI agents feature flag and archive the ai_agent
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     @ai_agent.tenant_user = @tenant.tenant_users.find_by(user: @ai_agent)
     @ai_agent.archive!
 

--- a/test/integration/ai_agent_task_run_access_test.rb
+++ b/test/integration/ai_agent_task_run_access_test.rb
@@ -5,7 +5,8 @@ class AiAgentTaskRunAccessTest < ActionDispatch::IntegrationTest
     @tenant = @global_tenant
     @collective = @global_collective
     @parent = @global_user
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
 
     @ai_agent = create_ai_agent_for(@parent, "My AiAgent")
     @other_parent = create_user(name: "Other Parent")

--- a/test/integration/billing_gate_test.rb
+++ b/test/integration/billing_gate_test.rb
@@ -9,7 +9,8 @@ class BillingGateTest < ActionDispatch::IntegrationTest
     @user = @global_user
     host! "#{@tenant.subdomain}.#{ENV['HOSTNAME']}"
 
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     enable_stripe_billing_flag!(@tenant)
     # Make @collective paid_tier so @user has a billable resource and the
     # billing gate has something to fire on. Under the free/paid tier model,

--- a/test/integration/help_pages_test.rb
+++ b/test/integration/help_pages_test.rb
@@ -4,7 +4,8 @@ class HelpPagesTest < ActionDispatch::IntegrationTest
   def setup
     @tenant = @global_tenant
     @tenant.enable_api!
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
     @tenant.enable_feature_flag!("trio")
     @user = @global_user
     @api_token = ApiToken.create!(
@@ -54,7 +55,8 @@ class HelpPagesTest < ActionDispatch::IntegrationTest
 
   test "help index links to automations (always shown, not feature-gated)" do
     @tenant.disable_feature_flag!("api")
-    @tenant.disable_feature_flag!("ai_agents")
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    @tenant.disable_feature_flag!("external_ai_agents")
     get "/help"
     assert_response :success
     assert_includes response.body, "/help/automations"
@@ -108,7 +110,6 @@ class HelpPagesTest < ActionDispatch::IntegrationTest
   GATED_TOPICS = {
     "api" => "api",
     "rest-api" => "api",
-    "agents" => "ai_agents",
     "trio" => "trio",
   }.freeze
 
@@ -138,5 +139,42 @@ class HelpPagesTest < ActionDispatch::IntegrationTest
       assert_response :success
       assert_includes response.body, "/help/#{topic}"
     end
+  end
+
+  test "help agents returns 404 when both ai_agents feature flags are disabled" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    @tenant.disable_feature_flag!("external_ai_agents")
+    get "/help/agents"
+    assert_response :not_found
+  end
+
+  test "help agents renders when only internal_ai_agents flag is enabled" do
+    @tenant.disable_feature_flag!("external_ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    get "/help/agents"
+    assert_response :success
+  end
+
+  test "help agents renders when only external_ai_agents flag is enabled" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
+    get "/help/agents"
+    assert_response :success
+  end
+
+  test "help index hides agents link when both ai_agents feature flags are disabled" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    @tenant.disable_feature_flag!("external_ai_agents")
+    get "/help"
+    assert_response :success
+    refute_includes response.body, "/help/agents"
+  end
+
+  test "help index shows agents link when any ai_agents feature flag is enabled" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
+    get "/help"
+    assert_response :success
+    assert_includes response.body, "/help/agents"
   end
 end

--- a/test/integration/markdown_ui_test.rb
+++ b/test/integration/markdown_ui_test.rb
@@ -4,6 +4,8 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
   def setup
     @tenant = @global_tenant
     @tenant.enable_api!
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
     @collective = @global_collective
     @collective.enable_api!
     @user = @global_user
@@ -1222,7 +1224,7 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
   test "POST create_ai_agent action with generate_token creates ai_agent with token" do
     ai_agent_name = "AiAgent With Token #{SecureRandom.hex(4)}"
     post "/ai-agents/new/actions/create_ai_agent",
-      params: { name: ai_agent_name, generate_token: true }.to_json,
+      params: { name: ai_agent_name, mode: "external", generate_token: true }.to_json,
       headers: @headers
     assert_equal 200, response.status
     assert is_markdown?
@@ -1230,6 +1232,14 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
     new_ai_agent = User.find_by(name: ai_agent_name)
     assert new_ai_agent, "AiAgent should exist"
     assert ApiToken.unscoped.where(user: new_ai_agent).any?, "AiAgent should have an API token"
+
+    # The plaintext token is only available immediately — it's hashed at rest.
+    # The markdown response must include it (and the warning) so the LLM can
+    # capture it for subsequent use.
+    assert_match(/\b[a-f0-9]{40}\b/, response.body,
+      "plaintext token (40-char hex) must appear in the markdown response")
+    assert_match(/won't be able to see|will not be able to see/i, response.body,
+      "must warn that this is the only chance to copy the token")
   ensure
     # Query directly — User#api_tokens relies on Tenant.current_id which is
     # cleared by CurrentAttributes auto-reset after the request.
@@ -2374,7 +2384,8 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
   # AiAgent task run markdown tests
   test "GET ai_agent task run returns markdown and strips JSON from think steps" do
     # Enable ai_agents feature for this tenant
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
 
     # Create a ai_agent
     ai_agent = User.create!(
@@ -2493,7 +2504,8 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
   end
 
   test "GET ai_agent task run markdown surfaces tool_calls and reasoning on think steps" do
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
 
     ai_agent = User.create!(
       name: "Observability Test Agent",

--- a/test/jobs/automation_rule_execution_job_test.rb
+++ b/test/jobs/automation_rule_execution_job_test.rb
@@ -5,7 +5,8 @@ require "test_helper"
 class AutomationRuleExecutionJobTest < ActiveJob::TestCase
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     @ai_agent = create_ai_agent(parent: @user)
     @tenant.add_user!(@ai_agent)
   end

--- a/test/jobs/automation_scheduler_job_test.rb
+++ b/test/jobs/automation_scheduler_job_test.rb
@@ -7,7 +7,8 @@ class AutomationSchedulerJobTest < ActiveSupport::TestCase
 
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     @ai_agent = create_ai_agent(parent: @user)
     @tenant.add_user!(@ai_agent)
 
@@ -293,7 +294,8 @@ class AutomationSchedulerJobTest < ActiveSupport::TestCase
     tenant2.add_user!(user2)
     collective2 = create_collective(tenant: tenant2, created_by: user2)
     collective2.add_user!(user2)
-    tenant2.set_feature_flag!("ai_agents", true)
+    tenant2.set_feature_flag!("internal_ai_agents", true)
+    tenant2.set_feature_flag!("external_ai_agents", true)
     ai_agent2 = create_ai_agent(parent: user2)
     tenant2.add_user!(ai_agent2)
 

--- a/test/jobs/orphaned_task_sweep_job_test.rb
+++ b/test/jobs/orphaned_task_sweep_job_test.rb
@@ -4,7 +4,8 @@ require "test_helper"
 class OrphanedTaskSweepJobTest < ActiveJob::TestCase
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
     @ai_agent = create_ai_agent(parent: @user)
   end

--- a/test/models/agent_session_step_test.rb
+++ b/test/models/agent_session_step_test.rb
@@ -4,7 +4,8 @@ require "test_helper"
 class AgentSessionStepTest < ActiveSupport::TestCase
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
 
     @ai_agent = User.create!(

--- a/test/models/ai_agent_task_run_test.rb
+++ b/test/models/ai_agent_task_run_test.rb
@@ -303,7 +303,8 @@ class AiAgentTaskRunTest < ActiveSupport::TestCase
   end
 
   test "triggered_by_automation? returns true when automation_rule is set" do
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
 
     automation_rule = AutomationRule.create!(
       tenant: @tenant,
@@ -331,7 +332,8 @@ class AiAgentTaskRunTest < ActiveSupport::TestCase
   end
 
   test "create_queued accepts automation_rule parameter" do
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
 
     automation_rule = AutomationRule.create!(
       tenant: @tenant,

--- a/test/models/automation_rule_run_test.rb
+++ b/test/models/automation_rule_run_test.rb
@@ -5,7 +5,8 @@ require "test_helper"
 class AutomationRuleRunTest < ActiveSupport::TestCase
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     @ai_agent = create_ai_agent(parent: @user)
     @tenant.add_user!(@ai_agent)
 

--- a/test/models/chat_message_test.rb
+++ b/test/models/chat_message_test.rb
@@ -4,7 +4,8 @@ require "test_helper"
 class ChatMessageTest < ActiveSupport::TestCase
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
 
     @ai_agent = User.create!(

--- a/test/models/chat_session_test.rb
+++ b/test/models/chat_session_test.rb
@@ -4,7 +4,8 @@ require "test_helper"
 class ChatSessionTest < ActiveSupport::TestCase
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
 
     @ai_agent = User.create!(

--- a/test/services/agent_runner_dispatch_service_test.rb
+++ b/test/services/agent_runner_dispatch_service_test.rb
@@ -6,7 +6,8 @@ class AgentRunnerDispatchServiceTest < ActiveSupport::TestCase
 
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
 
     @ai_agent = create_ai_agent
@@ -209,7 +210,8 @@ class AgentRunnerDispatchServiceTest < ActiveSupport::TestCase
   end
 
   test "skips dispatch when ai_agents not enabled" do
-    @tenant.disable_feature_flag!("ai_agents")
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    @tenant.disable_feature_flag!("external_ai_agents")
 
     redis = Redis.new(url: ENV["REDIS_URL"])
     redis.del("agent_tasks")

--- a/test/services/automation_dispatcher_test.rb
+++ b/test/services/automation_dispatcher_test.rb
@@ -7,7 +7,8 @@ class AutomationDispatcherTest < ActiveSupport::TestCase
 
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     @ai_agent = create_ai_agent(parent: @user)
 
     # Add the AI agent to the tenant and collective
@@ -248,7 +249,8 @@ class AutomationDispatcherTest < ActiveSupport::TestCase
 
     # Create another tenant with its own user, agent, and rules
     other_tenant = Tenant.create!(name: "Other Tenant", subdomain: "other-tenant")
-    other_tenant.set_feature_flag!("ai_agents", true)
+    other_tenant.set_feature_flag!("internal_ai_agents", true)
+    other_tenant.set_feature_flag!("external_ai_agents", true)
     other_user = create_user(name: "Other User")
     other_tenant.add_user!(other_user)
     other_agent = create_ai_agent(parent: other_user, name: "Other Agent")
@@ -710,12 +712,16 @@ class AutomationDispatcherTest < ActiveSupport::TestCase
     AutomationContext.clear_chain!
   end
 
-  test "does not dispatch when ai_agents not enabled for tenant" do
-    @tenant.set_feature_flag!("ai_agents", false)
+  test "dispatches regardless of AI agent flags — gating now happens at trigger_agent execution" do
+    @tenant.set_feature_flag!("internal_ai_agents", false)
+    @tenant.set_feature_flag!("external_ai_agents", false)
     create_rule_without_mention_filter
     event = create_event_with_subject(event_type: "note.created")
 
-    assert_no_difference -> { AutomationRuleRun.count } do
+    # The dispatcher fires the rule. Whether the rule succeeds at executing the
+    # trigger_agent action is enforced by AutomationExecutor and
+    # AgentRunnerDispatchService, not by the dispatcher.
+    assert_difference -> { AutomationRuleRun.count }, 1 do
       AutomationDispatcher.dispatch(event)
     end
   end

--- a/test/services/automation_executor_test.rb
+++ b/test/services/automation_executor_test.rb
@@ -7,7 +7,8 @@ class AutomationExecutorTest < ActiveSupport::TestCase
 
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     @ai_agent = create_ai_agent(parent: @user)
     @tenant.add_user!(@ai_agent)
   end
@@ -679,6 +680,122 @@ class AutomationExecutorTest < ActiveSupport::TestCase
     run.reload
     assert_not_equal "failed", run.status, "system agent should not fail the billing gate: #{run.error_message}"
     assert_equal 1, dispatched.length
+  end
+
+  # === External-only rollout scenario ===
+  # When internal_ai_agents is off but external_ai_agents is on, the Task
+  # Runner shouldn't fire. trigger_agent actions and agent-owned rules must
+  # fail with a clear error rather than silently queueing.
+
+  test "external-only rollout: agent-owned rule fails clearly when internal_ai_agents is disabled" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    rule = create_agent_rule(task: "Run this task")
+    event = create_test_event
+    run = create_automation_run(rule, event)
+
+    dispatched = []
+    AgentRunnerDispatchService.stub :dispatch, ->(tr) { dispatched << tr } do
+      assert_no_difference "AiAgentTaskRun.count" do
+        AutomationExecutor.execute(run)
+      end
+    end
+    assert_equal 0, dispatched.length, "should not dispatch to runner"
+
+    run.reload
+    assert_equal "failed", run.status
+    assert_match(/Internal AI Agents are not enabled/, run.error_message)
+  end
+
+  test "external-only rollout: trigger_agent action fails clearly when internal_ai_agents is disabled" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    target_agent = create_ai_agent(parent: @user, name: "Target Internal Agent")
+    @tenant.add_user!(target_agent)
+
+    rule = AutomationRule.create!(
+      tenant: @tenant,
+      collective: @collective,
+      created_by: @user,
+      name: "External-only trigger_agent test",
+      trigger_type: "event",
+      trigger_config: { "event_type" => "note.created" },
+      actions: [
+        { "type" => "trigger_agent", "agent_id" => target_agent.id, "task" => "Do something" },
+      ],
+      enabled: true,
+    )
+
+    event = create_test_event
+    run = create_automation_run(rule, event)
+
+    assert_no_difference "AiAgentTaskRun.count" do
+      AutomationExecutor.execute(run)
+    end
+
+    run.reload
+    result = run.actions_executed.first["result"]
+    assert_equal "failed", result["status"]
+    assert_match(/Internal AI Agents are not enabled/, result["error"])
+  end
+
+  test "external-only rollout: trigger_agent fails for external-mode target agent even when internal flag is on" do
+    external_target = create_ai_agent(
+      parent: @user,
+      name: "External Target",
+      agent_configuration: { "mode" => "external" },
+    )
+    @tenant.add_user!(external_target)
+
+    rule = AutomationRule.create!(
+      tenant: @tenant,
+      collective: @collective,
+      created_by: @user,
+      name: "External agent target test",
+      trigger_type: "event",
+      trigger_config: { "event_type" => "note.created" },
+      actions: [
+        { "type" => "trigger_agent", "agent_id" => external_target.id, "task" => "Do something" },
+      ],
+      enabled: true,
+    )
+
+    event = create_test_event
+    run = create_automation_run(rule, event)
+
+    assert_no_difference "AiAgentTaskRun.count" do
+      AutomationExecutor.execute(run)
+    end
+
+    run.reload
+    result = run.actions_executed.first["result"]
+    assert_equal "failed", result["status"]
+    assert_match(/external|internal-mode agent/i, result["error"])
+  end
+
+  test "external-only rollout: webhook automations still fire when internal_ai_agents is disabled" do
+    @tenant.disable_feature_flag!("internal_ai_agents")
+    rule = AutomationRule.create!(
+      tenant: @tenant,
+      collective: @collective,
+      created_by: @user,
+      name: "Webhook automation in external-only rollout",
+      trigger_type: "event",
+      trigger_config: { "event_type" => "note.created" },
+      actions: [
+        { "type" => "webhook", "url" => "https://example.invalid/hook", "method" => "POST" },
+      ],
+      enabled: true,
+    )
+    event = create_test_event
+    run = create_automation_run(rule, event)
+
+    AutomationExecutor.execute(run)
+
+    run.reload
+    # The webhook execute path returns "failed" only on actual network errors;
+    # in test it produces a delivery. Either way, the run must not be blocked
+    # by the internal flag.
+    refute_match(/Internal AI Agents are not enabled/, run.error_message.to_s,
+      "webhook automations must not be gated by internal_ai_agents flag")
   end
 
   test "agent rule runs normally when stripe_billing flag disabled" do

--- a/test/services/automation_mention_filter_test.rb
+++ b/test/services/automation_mention_filter_test.rb
@@ -7,7 +7,8 @@ class AutomationMentionFilterTest < ActiveSupport::TestCase
     @tenant = @global_tenant
     @collective = @global_collective
     @user = @global_user
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     Collective.scope_thread_to_collective(
       subdomain: @tenant.subdomain,
       handle: @collective.handle

--- a/test/services/automation_run_lifecycle_test.rb
+++ b/test/services/automation_run_lifecycle_test.rb
@@ -9,7 +9,8 @@ class AutomationRunLifecycleTest < ActiveSupport::TestCase
 
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.set_feature_flag!("ai_agents", true)
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
     @ai_agent = create_ai_agent(parent: @user)
     @tenant.add_user!(@ai_agent)
   end

--- a/test/services/chat_message_presenter_test.rb
+++ b/test/services/chat_message_presenter_test.rb
@@ -4,7 +4,8 @@ require "test_helper"
 class ChatMessagePresenterTest < ActiveSupport::TestCase
   setup do
     @tenant, @collective, @user = create_tenant_collective_user
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
 
     @ai_agent = User.create!(

--- a/test/services/feature_flag_service_test.rb
+++ b/test/services/feature_flag_service_test.rb
@@ -11,7 +11,9 @@ class FeatureFlagServiceTest < ActiveSupport::TestCase
     assert config.key?("api")
     assert config.key?("file_attachments")
     assert config.key?("trio")
-    assert config.key?("ai_agents")
+    assert config.key?("internal_ai_agents")
+    assert config.key?("external_ai_agents")
+    assert_not config.key?("ai_agents"), "old `ai_agents` flag should have been removed"
   end
 
   test "all_flags returns list of flag names" do
@@ -19,7 +21,9 @@ class FeatureFlagServiceTest < ActiveSupport::TestCase
     assert flags.include?("api")
     assert flags.include?("file_attachments")
     assert flags.include?("trio")
-    assert flags.include?("ai_agents")
+    assert flags.include?("internal_ai_agents")
+    assert flags.include?("external_ai_agents")
+    assert_not flags.include?("ai_agents")
   end
 
   test "flag_metadata returns metadata hash for valid flag" do
@@ -150,19 +154,52 @@ class FeatureFlagServiceTest < ActiveSupport::TestCase
     assert_not @collective.trio_enabled?
   end
 
-  test "ai_agents flag is app enabled" do
-    assert FeatureFlagService.app_enabled?("ai_agents")
+  test "internal_ai_agents flag is app enabled" do
+    assert FeatureFlagService.app_enabled?("internal_ai_agents")
   end
 
-  test "ai_agents_enabled? on tenant uses feature flag service" do
-    @tenant.set_feature_flag!("ai_agents", true)
-    assert @tenant.ai_agents_enabled?
-
-    @tenant.set_feature_flag!("ai_agents", false)
-    assert_not @tenant.ai_agents_enabled?
+  test "external_ai_agents flag is app enabled" do
+    assert FeatureFlagService.app_enabled?("external_ai_agents")
   end
 
-  test "ai_agents default is false for tenant" do
-    assert_not FeatureFlagService.default_for_tenant("ai_agents")
+  test "internal_ai_agents_enabled? on tenant uses feature flag service" do
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    assert @tenant.internal_ai_agents_enabled?
+
+    @tenant.set_feature_flag!("internal_ai_agents", false)
+    assert_not @tenant.internal_ai_agents_enabled?
+  end
+
+  test "external_ai_agents_enabled? on tenant uses feature flag service" do
+    @tenant.set_feature_flag!("external_ai_agents", true)
+    assert @tenant.external_ai_agents_enabled?
+
+    @tenant.set_feature_flag!("external_ai_agents", false)
+    assert_not @tenant.external_ai_agents_enabled?
+  end
+
+  test "any_ai_agents_enabled? returns true when either flag is enabled" do
+    @tenant.set_feature_flag!("internal_ai_agents", false)
+    @tenant.set_feature_flag!("external_ai_agents", false)
+    assert_not @tenant.any_ai_agents_enabled?
+
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    assert @tenant.any_ai_agents_enabled?
+
+    @tenant.set_feature_flag!("internal_ai_agents", false)
+    @tenant.set_feature_flag!("external_ai_agents", true)
+    assert @tenant.any_ai_agents_enabled?
+
+    @tenant.set_feature_flag!("internal_ai_agents", true)
+    @tenant.set_feature_flag!("external_ai_agents", true)
+    assert @tenant.any_ai_agents_enabled?
+  end
+
+  test "internal_ai_agents default is false for tenant" do
+    assert_not FeatureFlagService.default_for_tenant("internal_ai_agents")
+  end
+
+  test "external_ai_agents default is false for tenant" do
+    assert_not FeatureFlagService.default_for_tenant("external_ai_agents")
   end
 end

--- a/test/services/stripe_service_test.rb
+++ b/test/services/stripe_service_test.rb
@@ -8,7 +8,8 @@ class StripeServiceTest < ActiveSupport::TestCase
     @tenant, @collective, @user = create_tenant_collective_user
     # Set as main collective so it doesn't count toward billing
     @tenant.update!(main_collective_id: @collective.id)
-    @tenant.enable_feature_flag!("ai_agents")
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    @tenant.enable_feature_flag!("external_ai_agents")
     enable_stripe_billing_flag!(@tenant)
 
     # Set Stripe API key for tests
@@ -330,6 +331,30 @@ class StripeServiceTest < ActiveSupport::TestCase
       body = Rack::Utils.parse_query(req.body)
       body["quantity"] == "2"
     end
+  end
+
+  test "sync_subscription_quantity! does NOT cancel subscription for admin users (their billable_quantity is zero by admin exemption, but they may hold the customer for LLM credit attribution)" do
+    @user.update!(app_admin: true)
+    sc = StripeCustomer.create!(billable: @user, stripe_id: "cus_admin", active: true, stripe_subscription_id: "sub_admin")
+    cancel_stub = stub_request(:delete, "https://api.stripe.com/v1/subscriptions/sub_admin")
+
+    result = StripeService.sync_subscription_quantity!(@user)
+
+    assert result.success, "sync should report success (no-op)"
+    assert_not_requested cancel_stub
+    assert sc.reload.active?, "local StripeCustomer must remain active"
+  end
+
+  test "sync_subscription_quantity! does NOT cancel subscription for sys_admin users either" do
+    @user.update!(sys_admin: true)
+    sc = StripeCustomer.create!(billable: @user, stripe_id: "cus_sysadmin", active: true, stripe_subscription_id: "sub_sysadmin")
+    cancel_stub = stub_request(:delete, "https://api.stripe.com/v1/subscriptions/sub_sysadmin")
+
+    result = StripeService.sync_subscription_quantity!(@user)
+
+    assert result.success
+    assert_not_requested cancel_stub
+    assert sc.reload.active?
   end
 
   test "sync_subscription_quantity! cancels subscription for a billing_exempt user (their billable_quantity is zero)" do


### PR DESCRIPTION
Replace the single ai_agents flag with two independent flags so a tenant can enable external API-based agents without standing up the internal Task Runner (and vice versa):

  - internal_ai_agents: gates the Task Runner — agent-runner dispatch, automation execution (for trigger_agent / agent-owned rules), run UI.
  - external_ai_agents: gates external API-token-based agents — their creation and the agent-management UI.

Migration copies any existing ai_agents value into both new keys so every tenant's capability set is preserved. AutomationDispatcher's flag check is removed (it was gating all rules on AI-agents flag, including webhooks); the gate now lives inside AutomationExecutor where trigger_agent actually dispatches via the runner. System agents (Trio) exempt from both flag and mode checks.

Consolidates the AI-agent settings UI:

  - /ai-agents/<handle>/settings becomes the canonical surface for all agent management (profile image, name, handle, identity prompt, mode, model, capabilities, collective memberships, API tokens).
  - /u/<agent>/settings redirects to the canonical page (HTML and MD).
  - Save button at the bottom of the page via HTML5 form= attribute so the management sections sitting between the form and the button don't break form nesting.
  - UsersController#update_profile drops its vestigial agent-config branches (the documented markdown action is name+new_handle only).
  - authorize_parent split: agents can read their own /ai-agents/<self>/settings; only the parent can write.

Mode-aware controller gates in AiAgentsController:
  - require_any_ai_agents_enabled on shared management actions
  - require_internal_ai_agents_enabled on run_task/runs/cancel_run
  - require_flag_for_create_mode on new/create (resolves effective mode)
  - run_task/execute_task 404 for external agents (closes the pre-existing UX bug where the form would submit, the runner would immediately fail the task, and the user landed on a failed run page)
  - show page hides "Recent Task Runs" for external agents (HTML + MD)

Views updated to parameterize copy across flag combinations and hide internal-only affordances on external-only tenants.

Bonus fixes surfaced while testing:

  - Token render: execute_create_ai_agent rendered show via redirect_to, destroying @token before the show view could display it. Now renders "show" directly when a token was just minted, matching the pattern in ApiTokensController#create.

  - Admin subscription cancellation: sync_subscription_quantity! no-ops for sys_admin/app_admin users. Admins' billable_quantity is always 0 (admin exemption), which previously caused sync to interpret the 0 as "all resources removed" and cancel any subscription they held.

  - Admin agents marked pending: execute_create_ai_agent now uses requires_stripe_billing? to decide pending_billing_setup, matching the early-redirect predicate, so admins' new agents are not spuriously marked pending.

  - Handle collisions: rescue ActiveRecord::RecordNotUnique on execute_create_ai_agent and show a friendly flash[:alert] (was 500). Note: the form has no handle field today; choosing a name whose parameterization collides with an existing handle still produces this error. A handle-availability check on the new-agent form is tracked as follow-up.

  - Invisible flash[:error]: two redirect-to-form sites in AiAgentsController used flash[:error], which the application layout doesn't render. Switched to flash[:alert] so the message displays.

  - Token creation form (api_tokens/new) said "Identity: you" and "This token will be associated with your account" regardless of whether @showing_user was the human or one of their AI agents. Identity badge and hint now branch on @showing_user.