### PR TITLE
Fix flaky collective import test event-order assertion

### DIFF
--- a/test/services/collective_import_service_test.rb
+++ b/test/services/collective_import_service_test.rb
@@ -333,7 +333,7 @@ class CollectiveImportServiceTest < ActiveSupport::TestCase
     note = Note.where(collective_id: imported_collective.id).first
     events = NoteHistoryEvent.where(note_id: note.id)
     assert events.count >= 1
-    assert_equal "create", events.first.event_type
+    assert events.exists?(event_type: "create")
   end
 
   test "sets record_counts on data_import" do


### PR DESCRIPTION
The "imports note history events" test asserted that the first imported NoteHistoryEvent's event_type was "create". Since the auto-confirm change, source notes now have two events (create + read_confirmation) inserted microseconds apart in the same after_create block, so their created_at values tie at PostgreSQL's microsecond resolution and the secondary order falls back to UUID, which is random. The test's intent — that events were imported — is preserved by checking existence of a "create" event rather than position.