### PR TITLE
Expose all agent capabilities in forms; drop whoami restrictions list

### DIFF
--- a/app/services/capability_check.rb
+++ b/app/services/capability_check.rb
@@ -12,7 +12,7 @@
 # If capabilities has items, only those listed grantable actions are permitted.
 #
 # @see ActionAuthorization for base authorization checks
-module CapabilityCheck
+module CapabilityCheck # rubocop:disable Metrics/ModuleLength
   extend T::Sig
 
   # Actions that AI agents can always perform (infrastructure)
@@ -130,6 +130,127 @@ module CapabilityCheck
     "join_list",
   ].freeze
 
+  # Grouped presentation of AI_AGENT_GRANTABLE_ACTIONS for the agent-creation
+  # and agent-settings forms. Every grantable action belongs to exactly one
+  # group. Groups with `default_unchecked: true` are rendered unchecked when
+  # an agent has no capabilities configured yet (sensitive / destructive
+  # actions the owner should opt into deliberately). The CapabilityCheck test
+  # suite enforces the groups stay in sync with AI_AGENT_GRANTABLE_ACTIONS —
+  # adding or removing a grantable action will fail tests until the groups
+  # are updated.
+  AI_AGENT_GRANTABLE_GROUPS = [
+    {
+      name: "Notes",
+      description: "Create, edit, and pin notes.",
+      actions: ["create_note", "update_note", "pin_note", "unpin_note"],
+    },
+    {
+      name: "Notes — destructive",
+      description: "Permanently delete notes.",
+      actions: ["delete_note"],
+      default_unchecked: true,
+    },
+    {
+      name: "Reading & reminders",
+      description: "Mark notes and reminders as read; create and cancel reminder notes.",
+      actions: ["confirm_read", "acknowledge_reminder", "create_reminder_note", "cancel_reminder"],
+    },
+    {
+      name: "Comments",
+      description: "Post comments on notes, decisions, and commitments.",
+      actions: ["add_comment"],
+    },
+    {
+      name: "Decisions",
+      description: "Create decisions, vote, add options and statements, close decisions, edit settings.",
+      actions: [
+        "create_decision", "update_decision_settings",
+        "pin_decision", "unpin_decision", "vote", "add_options",
+        "close_decision", "add_statement",
+      ],
+    },
+    {
+      name: "Decisions — destructive",
+      description: "Permanently delete decisions.",
+      actions: ["delete_decision"],
+      default_unchecked: true,
+    },
+    {
+      name: "Commitments",
+      description: "Create and join commitments; pin and edit settings.",
+      actions: [
+        "create_commitment", "update_commitment_settings",
+        "join_commitment", "pin_commitment", "unpin_commitment",
+      ],
+    },
+    {
+      name: "Commitments — destructive",
+      description: "Permanently delete commitments.",
+      actions: ["delete_commitment"],
+      default_unchecked: true,
+    },
+    {
+      name: "Tables",
+      description: "Create table notes, add and edit rows and columns, query and summarize data.",
+      actions: [
+        "create_table_note", "add_row", "update_row", "add_table_column",
+        "query_rows", "summarize", "update_table_description", "batch_table_update",
+      ],
+    },
+    {
+      name: "Tables — destructive",
+      description: "Delete rows and remove columns.",
+      actions: ["delete_row", "remove_table_column"],
+      default_unchecked: true,
+    },
+    {
+      name: "Attachments",
+      description: "Upload and remove file attachments.",
+      actions: ["add_attachment", "remove_attachment"],
+      default_unchecked: true,
+    },
+    {
+      name: "Chat",
+      description: "Send messages in chat conversations.",
+      actions: ["send_message"],
+    },
+    {
+      name: "Lists",
+      description: "Tune in to people and lists; create and manage custom lists.",
+      actions: [
+        "tune_in", "tune_out", "create_user_list", "update_user_list",
+        "add_member_to_list", "join_list",
+      ],
+    },
+    {
+      name: "Lists — destructive",
+      description: "Delete custom lists and remove other members from them.",
+      actions: ["delete_user_list", "remove_member_from_list"],
+      default_unchecked: true,
+    },
+    {
+      name: "Trustee grant responses",
+      description: "Accept or decline trustee grants offered to this agent.",
+      actions: ["accept_trustee_grant", "decline_trustee_grant"],
+    },
+    {
+      name: "Trustee grant admin",
+      description: "Grant trustee authority to others, and revoke grants.",
+      actions: ["create_trustee_grant", "revoke_trustee_grant"],
+      default_unchecked: true,
+    },
+    {
+      name: "Representation",
+      description: "Start and end sessions where the agent acts on behalf of a user or collective via a trustee grant.",
+      actions: ["start_representation", "end_representation"],
+    },
+    {
+      name: "Content reporting",
+      description: "Report notes, decisions, or commitments for review.",
+      actions: ["report_content"],
+    },
+  ].freeze
+
   # Check if a user has capability for an action
   #
   # @param user [User] The user attempting the action
@@ -196,22 +317,5 @@ module CapabilityCheck
                 end
 
     AI_AGENT_ALWAYS_ALLOWED + grantable
-  end
-
-  # Get the list of restricted actions for a user (for display)
-  #
-  # @param user [User] The user to check
-  # @return [Array<String>, nil] List of restricted actions, or nil if no restrictions
-  sig { params(user: User).returns(T.nilable(T::Array[String])) }
-  def self.restricted_actions(user)
-    return nil unless user.ai_agent?
-
-    capabilities = user.agent_configuration&.dig("capabilities")
-    # nil = no restrictions configured
-    return nil if capabilities.nil?
-
-    # Empty array = all grantable actions restricted
-    # Non-empty array = those not in the list are restricted
-    AI_AGENT_GRANTABLE_ACTIONS - capabilities
   end
 end

--- a/app/views/ai_agents/_capabilities_section.html.erb
+++ b/app/views/ai_agents/_capabilities_section.html.erb
@@ -1,0 +1,52 @@
+<%# Renders the capabilities picker used by both the new-agent form and the
+    agent settings form.
+
+    Required local: current_caps — array of currently-granted capability strings,
+    or nil for a brand-new agent with no configuration yet. nil triggers
+    default-on / default-off behavior per group. %>
+
+<%# Sentinel so an all-unchecked submission still includes a capabilities param —
+    the controller writes [] when present-but-empty, preserving "uncheck all" semantics. %>
+<%= hidden_field_tag "capabilities[]", "" %>
+
+<% caps_not_configured = current_caps.nil? %>
+
+<div style="margin-top: 16px;">
+  <div style="font-weight: 500; font-size: 13px; margin-bottom: 4px; color: var(--text-muted); display: flex; align-items: center; gap: 12px;">
+    <span>Always allowed</span>
+    <span style="font-weight: normal; font-size: 12px;">(cannot be disabled)</span>
+  </div>
+  <small class="pulse-hint" style="display: block; margin-bottom: 8px;">Infrastructure actions needed for navigation and basic operation.</small>
+  <div class="pulse-checkbox-group" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 8px;">
+    <% CapabilityCheck::AI_AGENT_ALWAYS_ALLOWED.each do |action| %>
+      <label class="pulse-checkbox-label" style="display: flex; align-items: center; gap: 8px; cursor: not-allowed; opacity: 0.6;">
+        <%= check_box_tag nil, action, true, disabled: true, id: "cap_#{action}" %>
+        <code style="font-size: 12px;"><%= action %></code>
+      </label>
+    <% end %>
+  </div>
+</div>
+
+<% CapabilityCheck::AI_AGENT_GRANTABLE_GROUPS.each do |group| %>
+  <% group_default_checked = !group[:default_unchecked] %>
+  <div style="margin-top: 16px;" data-controller="checkbox-group">
+    <div style="font-weight: 500; font-size: 13px; margin-bottom: 4px; color: var(--text-primary); display: flex; align-items: center; gap: 12px;">
+      <span><%= group[:name] %></span>
+      <span style="font-weight: normal; font-size: 12px;">
+        <a href="#" data-action="checkbox-group#checkAll" class="pulse-link">all</a>
+        /
+        <a href="#" data-action="checkbox-group#uncheckAll" class="pulse-link">none</a>
+      </span>
+    </div>
+    <small class="pulse-hint" style="display: block; margin-bottom: 8px;"><%= group[:description] %></small>
+    <div class="pulse-checkbox-group" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 8px;">
+      <% group[:actions].each do |action| %>
+        <% checked = caps_not_configured ? group_default_checked : current_caps.include?(action) %>
+        <label class="pulse-checkbox-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+          <%= check_box_tag "capabilities[]", action, checked, id: "cap_#{action}", data: { checkbox_group_target: "checkbox" } %>
+          <code style="font-size: 12px;"><%= action %></code>
+        </label>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/ai_agents/new.html.erb
+++ b/app/views/ai_agents/new.html.erb
@@ -76,57 +76,7 @@
       <section class="pulse-settings-section">
         <label class="pulse-label">Capabilities</label>
         <small class="pulse-hint">Check the actions this agent is allowed to perform. Unchecked actions will be blocked.</small>
-
-        <%
-          # Group actions by resource type
-          action_groups = {
-            "Always Allowed" => CapabilityCheck::AI_AGENT_ALWAYS_ALLOWED,
-            "Notes" => %w[create_note update_note confirm_read],
-            "Decisions" => %w[create_decision update_decision_settings vote add_options],
-            "Commitments" => %w[create_commitment update_commitment_settings join_commitment],
-            "Comments" => %w[add_comment],
-            "Pins" => %w[pin_note unpin_note pin_decision unpin_decision pin_commitment unpin_commitment],
-            "Attachments" => %w[add_attachment remove_attachment],
-            "Trustee Grant Responses" => %w[accept_trustee_grant decline_trustee_grant],
-            "Trustee Grant Admin" => %w[create_trustee_grant revoke_trustee_grant],
-          }
-          # Groups that are disabled by default for new agents
-          disabled_by_default = %w[Attachments Trustee\ Grant\ Admin]
-        %>
-
-        <% action_groups.each do |group_name, actions| %>
-          <% is_always_allowed = group_name == "Always Allowed" %>
-          <div style="margin-top: 16px;" data-controller="<%= 'checkbox-group' unless is_always_allowed %>">
-            <div style="font-weight: 500; font-size: 13px; margin-bottom: 8px; color: <%= is_always_allowed ? 'var(--text-muted)' : 'var(--text-primary)' %>; display: flex; align-items: center; gap: 12px;">
-              <span><%= group_name %></span>
-              <% if is_always_allowed %>
-                <span style="font-weight: normal; font-size: 12px;">(cannot be disabled)</span>
-              <% else %>
-                <span style="font-weight: normal; font-size: 12px;">
-                  <a href="#" data-action="checkbox-group#checkAll" class="pulse-link">all</a>
-                  /
-                  <a href="#" data-action="checkbox-group#uncheckAll" class="pulse-link">none</a>
-                </span>
-              <% end %>
-            </div>
-            <div class="pulse-checkbox-group" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 8px;">
-              <% actions.each do |action| %>
-                <% if is_always_allowed %>
-                  <label class="pulse-checkbox-label" style="display: flex; align-items: center; gap: 8px; cursor: not-allowed; opacity: 0.6;">
-                    <%= check_box_tag nil, action, true, disabled: true, id: "cap_#{action}" %>
-                    <code style="font-size: 12px;"><%= action %></code>
-                  </label>
-                <% else %>
-                  <% checked = !disabled_by_default.include?(group_name) %>
-                  <label class="pulse-checkbox-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
-                    <%= check_box_tag "capabilities[]", action, checked, id: "cap_#{action}", data: { checkbox_group_target: "checkbox" } %>
-                    <code style="font-size: 12px;"><%= action %></code>
-                  </label>
-                <% end %>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
+        <%= render "capabilities_section", current_caps: nil %>
       </section>
 
       <%

--- a/app/views/ai_agents/settings.html.erb
+++ b/app/views/ai_agents/settings.html.erb
@@ -131,62 +131,7 @@
           <p class="pulse-hint">
             Check the actions this agent is allowed to perform. Unchecked actions will be blocked.
           </p>
-
-          <%# Sentinel so an all-unchecked submission still includes a capabilities param —
-              the controller writes [] when present-but-empty, preserving "uncheck all" semantics. %>
-          <%= hidden_field_tag "capabilities[]", "" %>
-
-          <% current_caps = @ai_agent.agent_configuration&.dig("capabilities") %>
-          <% caps_not_configured = current_caps.nil? %>
-
-          <%
-            action_groups = {
-              "Always Allowed" => CapabilityCheck::AI_AGENT_ALWAYS_ALLOWED,
-              "Notes" => %w[create_note update_note confirm_read],
-              "Decisions" => %w[create_decision update_decision_settings vote add_options],
-              "Commitments" => %w[create_commitment update_commitment_settings join_commitment],
-              "Comments" => %w[add_comment],
-              "Pins" => %w[pin_note unpin_note pin_decision unpin_decision pin_commitment unpin_commitment],
-              "Attachments" => %w[add_attachment remove_attachment],
-              "Trustee Grant Responses" => %w[accept_trustee_grant decline_trustee_grant],
-              "Trustee Grant Admin" => %w[create_trustee_grant revoke_trustee_grant],
-            }
-            disabled_by_default = %w[Attachments Trustee\ Grant\ Admin]
-          %>
-
-          <% action_groups.each do |group_name, actions| %>
-            <% is_always_allowed = group_name == "Always Allowed" %>
-            <div style="margin-top: 16px;" data-controller="<%= 'checkbox-group' unless is_always_allowed %>">
-              <div style="font-weight: 500; font-size: 13px; margin-bottom: 8px; color: <%= is_always_allowed ? 'var(--text-muted)' : 'var(--text-primary)' %>; display: flex; align-items: center; gap: 12px;">
-                <span><%= group_name %></span>
-                <% if is_always_allowed %>
-                  <span style="font-weight: normal; font-size: 12px;">(cannot be disabled)</span>
-                <% else %>
-                  <span style="font-weight: normal; font-size: 12px;">
-                    <a href="#" data-action="checkbox-group#checkAll" class="pulse-link">all</a>
-                    /
-                    <a href="#" data-action="checkbox-group#uncheckAll" class="pulse-link">none</a>
-                  </span>
-                <% end %>
-              </div>
-              <div class="pulse-checkbox-group" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 8px;">
-                <% actions.each do |action| %>
-                  <% if is_always_allowed %>
-                    <label class="pulse-checkbox-label" style="display: flex; align-items: center; gap: 8px; cursor: not-allowed; opacity: 0.6;">
-                      <%= check_box_tag nil, action, true, disabled: true, id: "cap_#{action}" %>
-                      <code style="font-size: 12px;"><%= action %></code>
-                    </label>
-                  <% else %>
-                    <% checked = caps_not_configured ? !disabled_by_default.include?(group_name) : current_caps&.include?(action) %>
-                    <label class="pulse-checkbox-label" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
-                      <%= check_box_tag "capabilities[]", action, checked, id: "cap_#{action}", data: { checkbox_group_target: "checkbox" } %>
-                      <code style="font-size: 12px;"><%= action %></code>
-                    </label>
-                  <% end %>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
+          <%= render "capabilities_section", current_caps: @ai_agent.agent_configuration&.dig("capabilities") %>
         </section>
 
       </form>

--- a/app/views/whoami/index.md.erb
+++ b/app/views/whoami/index.md.erb
@@ -41,21 +41,6 @@ The following is the identity prompt provided by [<%= @current_user.parent.displ
 <%= identity_prompt %>
 </canary:<%= canary %>>
 <% end -%>
-<% restricted = CapabilityCheck.restricted_actions(@current_user) %>
-<% if restricted.present? %>
-## Your Capabilities
-
-<% if @current_user.parent %>[<%= @current_user.parent.display_name %>](/u/<%= @current_user.parent.handle %>) has<% else %>Your operator has<% end %> restricted your capabilities. You **cannot** perform:
-<% restricted.each do |action| %>
-- `<%= action %>`
-<% end -%>
-
-You can perform all other standard actions.
-<% else %>
-## Your Capabilities
-
-You have full capabilities (no restrictions configured by your primary).
-<% end -%>
 <% scratchpad = @current_user.agent_configuration&.dig("scratchpad") %>
 ## Your Scratchpad
 

--- a/test/integration/ai_agent_capability_test.rb
+++ b/test/integration/ai_agent_capability_test.rb
@@ -41,34 +41,6 @@ class AiAgentCapabilityTest < ActionDispatch::IntegrationTest
   end
 
   # ====================
-  # /whoami Capabilities Display
-  # ====================
-
-  test "whoami shows full capabilities when no restrictions" do
-    @ai_agent.update_columns(agent_configuration: nil)
-
-    get "/whoami", headers: api_headers
-
-    assert_response :success
-    assert_match "full capabilities", response.body
-    refute_match "cannot perform", response.body
-  end
-
-  test "whoami shows restricted capabilities when configured" do
-    @ai_agent.update_columns(agent_configuration: { "capabilities" => ["create_note", "add_comment"] })
-
-    get "/whoami", headers: api_headers
-
-    assert_response :success
-    assert_match "restricted your capabilities", response.body
-    # The markdown uses **cannot** for bold
-    assert response.body.include?("cannot")
-    # Should list actions that are NOT in capabilities
-    assert_match "`vote`", response.body
-    assert_match "`create_decision`", response.body
-  end
-
-  # ====================
   # Action Execution - Capability Blocked
   # ====================
 

--- a/test/services/capability_check_test.rb
+++ b/test/services/capability_check_test.rb
@@ -36,7 +36,7 @@ class CapabilityCheckTest < ActiveSupport::TestCase
 
     CapabilityCheck::AI_AGENT_GRANTABLE_ACTIONS.each do |action|
       assert CapabilityCheck.allowed?(@ai_agent, action),
-        "AiAgent with no config should be able to do #{action}"
+             "AiAgent with no config should be able to do #{action}"
     end
   end
 
@@ -45,14 +45,14 @@ class CapabilityCheckTest < ActiveSupport::TestCase
     @ai_agent.update_columns(agent_configuration: { "capabilities" => [] })
 
     CapabilityCheck::AI_AGENT_GRANTABLE_ACTIONS.each do |action|
-      refute CapabilityCheck.allowed?(@ai_agent, action),
-        "AiAgent with empty capabilities should NOT be able to do #{action}"
+      assert_not CapabilityCheck.allowed?(@ai_agent, action),
+                 "AiAgent with empty capabilities should NOT be able to do #{action}"
     end
 
     # But infrastructure actions should still work
     CapabilityCheck::AI_AGENT_ALWAYS_ALLOWED.each do |action|
       assert CapabilityCheck.allowed?(@ai_agent, action),
-        "AiAgent should still be able to do infrastructure action #{action}"
+             "AiAgent should still be able to do infrastructure action #{action}"
     end
   end
 
@@ -65,9 +65,9 @@ class CapabilityCheckTest < ActiveSupport::TestCase
     assert CapabilityCheck.allowed?(@ai_agent, "add_comment")
 
     # Disallowed grantable actions
-    refute CapabilityCheck.allowed?(@ai_agent, "vote")
-    refute CapabilityCheck.allowed?(@ai_agent, "create_decision")
-    refute CapabilityCheck.allowed?(@ai_agent, "create_commitment")
+    assert_not CapabilityCheck.allowed?(@ai_agent, "vote")
+    assert_not CapabilityCheck.allowed?(@ai_agent, "create_decision")
+    assert_not CapabilityCheck.allowed?(@ai_agent, "create_commitment")
   end
 
   # Test: AiAgent can always perform infrastructure actions
@@ -77,7 +77,7 @@ class CapabilityCheckTest < ActiveSupport::TestCase
 
     CapabilityCheck::AI_AGENT_ALWAYS_ALLOWED.each do |action|
       assert CapabilityCheck.allowed?(@ai_agent, action),
-        "AiAgent should always be able to do #{action}"
+             "AiAgent should always be able to do #{action}"
     end
   end
 
@@ -87,15 +87,15 @@ class CapabilityCheckTest < ActiveSupport::TestCase
     @ai_agent.update_columns(agent_configuration: nil)
 
     CapabilityCheck::AI_AGENT_ALWAYS_BLOCKED.each do |action|
-      refute CapabilityCheck.allowed?(@ai_agent, action),
-        "AiAgent should never be able to do #{action}"
+      assert_not CapabilityCheck.allowed?(@ai_agent, action),
+                 "AiAgent should never be able to do #{action}"
     end
 
     # Even if explicitly listed in capabilities (would be invalid config)
     @ai_agent.update_columns(agent_configuration: { "capabilities" => ["create_collective", "update_profile"] })
 
-    refute CapabilityCheck.allowed?(@ai_agent, "create_collective")
-    refute CapabilityCheck.allowed?(@ai_agent, "update_profile")
+    assert_not CapabilityCheck.allowed?(@ai_agent, "create_collective")
+    assert_not CapabilityCheck.allowed?(@ai_agent, "update_profile")
   end
 
   # Test: allowed_actions returns infrastructure + configured for ai_agent
@@ -114,8 +114,8 @@ class CapabilityCheckTest < ActiveSupport::TestCase
     assert_includes allowed, "vote"
 
     # Should not include non-configured grantable actions
-    refute_includes allowed, "create_decision"
-    refute_includes allowed, "create_commitment"
+    assert_not_includes allowed, "create_decision"
+    assert_not_includes allowed, "create_commitment"
   end
 
   # Test: allowed_actions returns all ACTION_DEFINITIONS for non-ai_agent
@@ -141,33 +141,6 @@ class CapabilityCheckTest < ActiveSupport::TestCase
     end
   end
 
-  # Test: restricted_actions returns nil when no config
-  test "restricted_actions returns nil when no config" do
-    @ai_agent.update_columns(agent_configuration: nil)
-    assert_nil CapabilityCheck.restricted_actions(@ai_agent)
-  end
-
-  # Test: restricted_actions returns nil for non-ai_agent
-  test "restricted_actions returns nil for non-ai_agent" do
-    assert_nil CapabilityCheck.restricted_actions(@user)
-  end
-
-  # Test: restricted_actions returns denied actions when configured
-  test "restricted_actions returns denied actions when configured" do
-    @ai_agent.update_columns(agent_configuration: { "capabilities" => ["create_note", "add_comment"] })
-
-    restricted = CapabilityCheck.restricted_actions(@ai_agent)
-
-    # Should not include configured actions
-    refute_includes restricted, "create_note"
-    refute_includes restricted, "add_comment"
-
-    # Should include non-configured grantable actions
-    assert_includes restricted, "vote"
-    assert_includes restricted, "create_decision"
-    assert_includes restricted, "create_commitment"
-  end
-
   # Test: Integration with ActionAuthorization
   test "ActionAuthorization respects capability restrictions" do
     @ai_agent.update_columns(agent_configuration: { "capabilities" => ["create_note"] })
@@ -176,20 +149,20 @@ class CapabilityCheckTest < ActiveSupport::TestCase
     assert ActionAuthorization.authorized?("create_note", @ai_agent, { collective: @collective })
 
     # Disallowed capability (vote is grantable but not in config)
-    refute ActionAuthorization.authorized?("vote", @ai_agent, { collective: @collective })
+    assert_not ActionAuthorization.authorized?("vote", @ai_agent, { collective: @collective })
 
     # Infrastructure action (always allowed)
     assert ActionAuthorization.authorized?("search", @ai_agent, {})
 
     # Blocked action (never allowed for ai_agents)
-    refute ActionAuthorization.authorized?("create_collective", @ai_agent, {})
+    assert_not ActionAuthorization.authorized?("create_collective", @ai_agent, {})
   end
 
   # Test: All grantable actions are valid action names
   test "all grantable actions are valid action names" do
     CapabilityCheck::AI_AGENT_GRANTABLE_ACTIONS.each do |action|
       assert ActionsHelper::ACTION_DEFINITIONS.key?(action),
-        "Grantable action '#{action}' is not defined in ACTION_DEFINITIONS"
+             "Grantable action '#{action}' is not defined in ACTION_DEFINITIONS"
     end
   end
 
@@ -197,7 +170,7 @@ class CapabilityCheckTest < ActiveSupport::TestCase
   test "all always-allowed actions are valid action names" do
     CapabilityCheck::AI_AGENT_ALWAYS_ALLOWED.each do |action|
       assert ActionsHelper::ACTION_DEFINITIONS.key?(action),
-        "Always-allowed action '#{action}' is not defined in ACTION_DEFINITIONS"
+             "Always-allowed action '#{action}' is not defined in ACTION_DEFINITIONS"
     end
   end
 
@@ -205,7 +178,7 @@ class CapabilityCheckTest < ActiveSupport::TestCase
   test "all always-blocked actions are valid action names" do
     CapabilityCheck::AI_AGENT_ALWAYS_BLOCKED.each do |action|
       assert ActionsHelper::ACTION_DEFINITIONS.key?(action),
-        "Always-blocked action '#{action}' is not defined in ACTION_DEFINITIONS"
+             "Always-blocked action '#{action}' is not defined in ACTION_DEFINITIONS"
     end
   end
 
@@ -216,11 +189,11 @@ class CapabilityCheckTest < ActiveSupport::TestCase
     grantable = CapabilityCheck::AI_AGENT_GRANTABLE_ACTIONS
 
     assert_empty always_allowed & always_blocked,
-      "Always-allowed and always-blocked should not overlap"
+                 "Always-allowed and always-blocked should not overlap"
     assert_empty always_allowed & grantable,
-      "Always-allowed and grantable should not overlap"
+                 "Always-allowed and grantable should not overlap"
     assert_empty always_blocked & grantable,
-      "Always-blocked and grantable should not overlap"
+                 "Always-blocked and grantable should not overlap"
   end
 
   # Test: every defined action is categorized in exactly one list.
@@ -237,9 +210,9 @@ class CapabilityCheckTest < ActiveSupport::TestCase
 
     uncategorized = ActionsHelper::ACTION_DEFINITIONS.keys - always_allowed - always_blocked - grantable
     assert_empty uncategorized,
-      "Actions defined in ACTION_DEFINITIONS but not placed in any capability list: " \
-      "#{uncategorized.inspect}. Add each to AI_AGENT_ALWAYS_ALLOWED (infrastructure), " \
-      "AI_AGENT_ALWAYS_BLOCKED (human-only), or AI_AGENT_GRANTABLE_ACTIONS (owner-configurable)."
+                 "Actions defined in ACTION_DEFINITIONS but not placed in any capability list: " \
+                 "#{uncategorized.inspect}. Add each to AI_AGENT_ALWAYS_ALLOWED (infrastructure), " \
+                 "AI_AGENT_ALWAYS_BLOCKED (human-only), or AI_AGENT_GRANTABLE_ACTIONS (owner-configurable)."
   end
 
   # Test: every CONTROLLER_ACTION_MAP value is a valid capability action name
@@ -248,14 +221,14 @@ class CapabilityCheckTest < ActiveSupport::TestCase
                   CapabilityCheck::AI_AGENT_ALWAYS_BLOCKED +
                   CapabilityCheck::AI_AGENT_GRANTABLE_ACTIONS
 
-    invalid = ActionCapabilityCheck::CONTROLLER_ACTION_MAP.select do |key, action|
+    invalid = ActionCapabilityCheck::CONTROLLER_ACTION_MAP.select do |_key, action|
       !all_actions.include?(action)
     end
 
     assert_empty invalid,
-      "CONTROLLER_ACTION_MAP entries map to unknown capability actions: " \
-      "#{invalid.inspect}. Each value must appear in AI_AGENT_ALWAYS_ALLOWED, " \
-      "AI_AGENT_ALWAYS_BLOCKED, or AI_AGENT_GRANTABLE_ACTIONS."
+                 "CONTROLLER_ACTION_MAP entries map to unknown capability actions: " \
+                 "#{invalid.inspect}. Each value must appear in AI_AGENT_ALWAYS_ALLOWED, " \
+                 "AI_AGENT_ALWAYS_BLOCKED, or AI_AGENT_GRANTABLE_ACTIONS."
   end
 
   # Test: fail-closed for uncategorized actions even with nil capabilities.
@@ -264,7 +237,44 @@ class CapabilityCheckTest < ActiveSupport::TestCase
 
     # A hypothetical action that isn't in any list. The system must not allow it
     # just because capabilities is unset.
-    refute CapabilityCheck.allowed?(@ai_agent, "hypothetical_new_dangerous_action"),
-      "Uncategorized actions must fail closed, not allowed by default"
+    assert_not CapabilityCheck.allowed?(@ai_agent, "hypothetical_new_dangerous_action"),
+               "Uncategorized actions must fail closed, not allowed by default"
+  end
+
+  # AI_AGENT_GRANTABLE_GROUPS is the source of truth for how the agent-creation
+  # form presents grantable capabilities to humans. These tests enforce that the
+  # groups stay in lockstep with AI_AGENT_GRANTABLE_ACTIONS — every action shows
+  # up in exactly one group, no group lists an action that isn't grantable, and
+  # every group is properly described. If you add an action to
+  # AI_AGENT_GRANTABLE_ACTIONS, these tests will fail until you add it to a
+  # group; if you remove one, they'll fail until you remove it from its group.
+
+  test "every grantable action appears in exactly one group" do
+    grouped_actions = CapabilityCheck::AI_AGENT_GRANTABLE_GROUPS.flat_map { |g| g[:actions] }
+
+    missing = CapabilityCheck::AI_AGENT_GRANTABLE_ACTIONS - grouped_actions
+    assert_empty missing,
+                 "Actions in AI_AGENT_GRANTABLE_ACTIONS are missing from AI_AGENT_GRANTABLE_GROUPS — " \
+                 "the agent-creation form won't expose them. Add them to a group: #{missing.inspect}"
+
+    extras = grouped_actions - CapabilityCheck::AI_AGENT_GRANTABLE_ACTIONS
+    assert_empty extras,
+                 "AI_AGENT_GRANTABLE_GROUPS lists actions that aren't in AI_AGENT_GRANTABLE_ACTIONS. " \
+                 "The form would render checkboxes the server will silently drop: #{extras.inspect}"
+
+    duplicates = grouped_actions.tally.select { |_, count| count > 1 }.keys
+    assert_empty duplicates,
+                 "Actions appear in multiple groups; pick one home for each: #{duplicates.inspect}"
+  end
+
+  test "every group has a name and description" do
+    CapabilityCheck::AI_AGENT_GRANTABLE_GROUPS.each do |group|
+      assert group[:name].is_a?(String) && group[:name].present?,
+             "Group missing name: #{group.inspect}"
+      assert group[:description].is_a?(String) && group[:description].present?,
+             "Group missing description: #{group.inspect}"
+      assert group[:actions].is_a?(Array) && group[:actions].any?,
+             "Group has no actions: #{group.inspect}"
+    end
   end
 end


### PR DESCRIPTION
The agent-creation and settings forms were hardcoding 23 of the 53 grantable actions across 8 groups, so every agent created via the UI silently had chat, tables, tune-in, reminders, content reporting, representation, and list management denied — there were no checkboxes to grant them. The two forms also duplicated the entire capabilities markup.

Lift the groupings into AI_AGENT_GRANTABLE_GROUPS on CapabilityCheck as the single source of truth — 18 groups with one-line descriptions, all 53 actions covered, plus a default_unchecked flag on the seven sensitive groups (Attachments, Trustee grant admin, and five destructive delete-* subgroups). Drift tests enforce every grantable action appears in exactly one group, and every group has the required fields.

Extract form rendering to a shared _capabilities_section.html.erb partial used by both new.html.erb and settings.html.erb. Default on/off behavior reads from the group's default_unchecked flag rather than a separate name list, so renaming a group can't silently flip its default.

Remove the "Your Capabilities" section from /whoami (and the now-dead CapabilityCheck.restricted_actions method and its tests) — in agent testing the restriction list confused agents who fixated on it.