### PR TITLE
Agent runner mcp migration

### DIFF
--- a/agent-runner/src/core/MarkdownFrontmatter.ts
+++ b/agent-runner/src/core/MarkdownFrontmatter.ts
@@ -1,0 +1,72 @@
+/**
+ * Parsers for YAML-flavored frontmatter that Rails' markdown layout wraps
+ * every page response in. Used by McpClient to extract per-page action lists
+ * and the server-resolved path from a `fetch_page` result.
+ *
+ * These are deliberately small grep-and-slice parsers rather than a full YAML
+ * implementation — the frontmatter shape we emit is fixed and predictable, so
+ * a real parser would be over-engineered (and would force a runtime dep).
+ */
+
+/**
+ * Parse available action names from the markdown response's YAML frontmatter.
+ * Matches Ruby MarkdownUiService.parse_frontmatter + actions extraction.
+ *
+ * The Rails markdown layout wraps every response in frontmatter:
+ *   ---
+ *   actions:
+ *     - name: create_note
+ *       description: Create a note
+ *       ...
+ *   ---
+ */
+export function parseAvailableActions(content: string): readonly string[] {
+  // Must start with "---\n" (matches Ruby: content.start_with?("---\n"))
+  if (!content.startsWith("---\n")) return [];
+
+  // Find closing "---\n" after position 4 (matches Ruby: content.index("\n---\n", 4))
+  const endIndex = content.indexOf("\n---\n", 4);
+  if (endIndex === -1) return [];
+
+  const frontmatter = content.slice(4, endIndex);
+
+  // Parse action names from the YAML frontmatter.
+  // We don't use a full YAML parser — just extract "- name: <value>" lines
+  // within the "actions:" block.
+  const actionsMatch = /^actions:\s*$/m.exec(frontmatter);
+  if (actionsMatch === null) return [];
+
+  const actionsBlock = frontmatter.slice(actionsMatch.index + actionsMatch[0].length);
+  const names: string[] = [];
+
+  for (const line of actionsBlock.split("\n")) {
+    // Stop if we hit a non-indented line (next top-level YAML key)
+    if (line.length > 0 && !line.startsWith(" ") && !line.startsWith("\t")) break;
+
+    // Match only top-level action items (2-space indent: "  - name: value")
+    // Skip deeper nested "name:" like params (6+ spaces)
+    const nameMatch = /^  - name:\s*(.+)$/.exec(line);
+    if (nameMatch?.[1] !== undefined) {
+      const name = nameMatch[1].trim();
+      if (name !== "") names.push(name);
+    }
+  }
+
+  return names;
+}
+
+/**
+ * Extract a `path: …` value from a markdown response's YAML frontmatter.
+ * Used to resolve the path the server actually landed on (the server follows
+ * redirects internally; we don't see hop-by-hop).
+ *
+ * Returns null if there's no frontmatter or no `path:` line in it.
+ */
+export function parseResolvedPath(content: string): string | null {
+  if (!content.startsWith("---\n")) return null;
+  const endIndex = content.indexOf("\n---\n", 4);
+  if (endIndex === -1) return null;
+  const frontmatter = content.slice(4, endIndex);
+  const match = /^path:\s*(.+)$/m.exec(frontmatter);
+  return match?.[1]?.trim() ?? null;
+}

--- a/agent-runner/src/core/StepBuilder.ts
+++ b/agent-runner/src/core/StepBuilder.ts
@@ -8,21 +8,24 @@ export interface StepRecord {
   readonly type: string;
   readonly detail: Record<string, unknown>;
   readonly timestamp: string;
+  /** McpToolCallLog id from _meta.harmonic.tool_call_log_id on the MCP response. Null for loop-internal step types. */
+  readonly mcp_tool_call_log_id?: string | null;
 }
 
 /**
- * Build a navigate step record.
- * Matches Ruby: add_step("navigate", { path:, resolved_path:, content_preview:, available_actions:, error: })
+ * Build a fetch_page step record (formerly "navigate" before the agent-runner
+ * migrated to /mcp; the underlying behavior is the same — read a page).
  */
-export function navigateStep(detail: {
+export function fetchPageStep(detail: {
   readonly path: string;
   readonly resolvedPath: string;
   readonly contentPreview: string;
   readonly availableActions: readonly string[];
   readonly error: string | null;
+  readonly mcp_tool_call_log_id: string | null;
 }, timestamp: Date): StepRecord {
   return {
-    type: "navigate",
+    type: "fetch_page",
     detail: {
       path: detail.path,
       resolved_path: detail.resolvedPath,
@@ -31,22 +34,24 @@ export function navigateStep(detail: {
       error: detail.error,
     },
     timestamp: timestamp.toISOString(),
+    mcp_tool_call_log_id: detail.mcp_tool_call_log_id,
   };
 }
 
 /**
- * Build an execute step record.
- * Matches Ruby: add_step("execute", { action:, params:, success:, content_preview:, error: })
+ * Build an execute_action step record (formerly "execute" before the
+ * agent-runner migrated to /mcp; same behavior — invoke a Harmonic action).
  */
-export function executeStep(detail: {
+export function executeActionStep(detail: {
   readonly action: string;
   readonly params: Record<string, unknown>;
   readonly success: boolean;
   readonly contentPreview: string | null;
   readonly error: string | null;
+  readonly mcp_tool_call_log_id: string | null;
 }, timestamp: Date): StepRecord {
   return {
-    type: "execute",
+    type: "execute_action",
     detail: {
       action: detail.action,
       params: detail.params,
@@ -55,6 +60,7 @@ export function executeStep(detail: {
       error: detail.error,
     },
     timestamp: timestamp.toISOString(),
+    mcp_tool_call_log_id: detail.mcp_tool_call_log_id,
   };
 }
 

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -7,6 +7,7 @@ import { Effect, Layer, pipe } from "effect";
 import { Config, ConfigLive } from "./config/Config.js";
 import { LLMClientLive } from "./services/LLMClient.js";
 import { HarmonicClientLive } from "./services/HarmonicClient.js";
+import { McpClientLive } from "./services/McpClient.js";
 import { TaskReporterLive } from "./services/TaskReporter.js";
 import { TaskQueueLive } from "./services/TaskQueue.js";
 import { AgentLockLive } from "./services/AgentLock.js";
@@ -292,6 +293,7 @@ const RailsHttpProvided = RailsHttpLive.pipe(Layer.provide(ConfigLive));
 const ServiceLayer = Layer.mergeAll(
   LLMClientLive,
   HarmonicClientLive,
+  McpClientLive,
   TaskReporterLive,
   TaskQueueLive,
   AgentLockLive,

--- a/agent-runner/src/services/AgentLoop.ts
+++ b/agent-runner/src/services/AgentLoop.ts
@@ -32,8 +32,8 @@ import { parseToolCalls } from "../core/ActionParser.js";
 import { RESPOND_TO_HUMAN_TOOL, buildChatSystemPrompt } from "../core/AgentContext.js";
 import { extractCanary, checkLeakage } from "../core/LeakageDetector.js";
 import {
-  navigateStep,
-  executeStep,
+  fetchPageStep,
+  executeActionStep,
   thinkStep,
   doneStep,
   errorStep,
@@ -144,6 +144,7 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
               content: "",
               availableActions: [] as readonly string[],
               resolvedPath: path,
+              mcpToolCallLogId: null,
               _error: err.message,
             }),
           ),
@@ -156,12 +157,13 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
           ? `Error fetching ${path}: ${navError}`
           : result.content;
 
-        yield* addStep(navigateStep({
+        yield* addStep(fetchPageStep({
           path,
           resolvedPath: result.resolvedPath,
           contentPreview: result.content,
           availableActions: [...result.availableActions],
           error: navError,
+          mcp_tool_call_log_id: result.mcpToolCallLogId,
         }, new Date()));
 
         return result;
@@ -182,7 +184,7 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
           retryBudget,
         ).pipe(
           Effect.catchAll((err) =>
-            Effect.succeed({ content: "", success: false, _error: err.message }),
+            Effect.succeed({ content: "", success: false, mcpToolCallLogId: null, _error: err.message }),
           ),
         );
 
@@ -190,12 +192,13 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
           ? (result as { _error: string })._error
           : (result.success ? null : result.content);
 
-        yield* addStep(executeStep({
+        yield* addStep(executeActionStep({
           action: actionName,
           params,
           success: result.success,
           contentPreview: result.content,
           error: execError,
+          mcp_tool_call_log_id: result.mcpToolCallLogId,
         }, new Date()));
 
         if (result.success) {

--- a/agent-runner/src/services/AgentLoop.ts
+++ b/agent-runner/src/services/AgentLoop.ts
@@ -14,6 +14,7 @@ import { Effect, pipe } from "effect";
 import { LLMClient } from "./LLMClient.js";
 import { HarmonicClient } from "./HarmonicClient.js";
 import { TaskReporter } from "./TaskReporter.js";
+import { createRetryBudget } from "./Retry.js";
 import { Config } from "../config/Config.js";
 import { log } from "./Logger.js";
 import { decryptToken } from "./TokenCrypto.js";
@@ -109,6 +110,10 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
     let lastActionResult: string | null = null;
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
+    // Per-task budget for cumulative Retry-After backoff. Shared across all
+    // navigate/executeAction calls in this run; a sustained-throttle scenario
+    // can't blow past the budget into the task's wall-clock limit.
+    const retryBudget = createRetryBudget();
     const isChatTurn = task.mode === "chat_turn";
     const tools = isChatTurn
       ? [...getToolDefinitions(), RESPOND_TO_HUMAN_TOOL]
@@ -131,7 +136,7 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
     // on a step so the loop can continue.
     const fetchPage = (path: string) =>
       Effect.gen(function* () {
-        const result = yield* harmonic.navigate(path, token, subdomain).pipe(
+        const result = yield* harmonic.navigate(path, token, subdomain, retryBudget).pipe(
           Effect.catchAll((err) =>
             Effect.succeed({
               content: "",
@@ -172,6 +177,7 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
           params,
           token,
           subdomain,
+          retryBudget,
         ).pipe(
           Effect.catchAll((err) =>
             Effect.succeed({ content: "", success: false, _error: err.message }),

--- a/agent-runner/src/services/AgentLoop.ts
+++ b/agent-runner/src/services/AgentLoop.ts
@@ -13,6 +13,7 @@
 import { Effect, pipe } from "effect";
 import { LLMClient } from "./LLMClient.js";
 import { HarmonicClient } from "./HarmonicClient.js";
+import { McpClient } from "./McpClient.js";
 import { TaskReporter } from "./TaskReporter.js";
 import { createRetryBudget } from "./Retry.js";
 import { Config } from "../config/Config.js";
@@ -69,10 +70,11 @@ export type TaskOutcome = { readonly outcome: "completed" | "failed" | "cancelle
  * Run a single agent task to completion.
  * Returns the outcome so the caller can track stats.
  */
-export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LLMClient | HarmonicClient | TaskReporter | Config> =>
+export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LLMClient | HarmonicClient | McpClient | TaskReporter | Config> =>
   Effect.gen(function* () {
     const llm = yield* LLMClient;
     const harmonic = yield* HarmonicClient;
+    const mcp = yield* McpClient;
     const reporter = yield* TaskReporter;
     const config = yield* Config;
     const subdomain = task.tenantSubdomain;
@@ -131,12 +133,12 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
         );
       });
 
-    // Helper: fetch a page. HarmonicClient.navigate catches HTTP errors and
-    // surfaces them as HarmonicApiError; we catch that and record the error
-    // on a step so the loop can continue.
+    // Helper: fetch a page. McpClient.fetchPage catches transport and
+    // tool-level errors and surfaces them as HarmonicApiError; we catch that
+    // and record the error on a step so the loop can continue.
     const fetchPage = (path: string) =>
       Effect.gen(function* () {
-        const result = yield* harmonic.navigate(path, token, subdomain, retryBudget).pipe(
+        const result = yield* mcp.fetchPage(path, token, subdomain, retryBudget).pipe(
           Effect.catchAll((err) =>
             Effect.succeed({
               content: "",
@@ -171,7 +173,7 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
     // guesses wrong. That body is surfaced verbatim in the tool result.
     const executeAction = (path: string, actionName: string, params: Record<string, unknown>) =>
       Effect.gen(function* () {
-        const result = yield* harmonic.executeAction(
+        const result = yield* mcp.executeAction(
           path,
           actionName,
           params,

--- a/agent-runner/src/services/HarmonicClient.ts
+++ b/agent-runner/src/services/HarmonicClient.ts
@@ -21,6 +21,7 @@ import { HarmonicApiError } from "../errors/Errors.js";
 import { Config } from "../config/Config.js";
 import { buildHeaders } from "./HmacSigner.js";
 import { RailsHttp } from "./RailsHttp.js";
+import { withRetryAfter, type RetryBudget } from "./Retry.js";
 
 export interface NavigateResult {
   readonly content: string;
@@ -49,13 +50,14 @@ export interface ChatHistoryResponse {
 }
 
 export interface HarmonicClientService {
-  readonly navigate: (path: string, token: string, subdomain: string) => Effect.Effect<NavigateResult, HarmonicApiError>;
+  readonly navigate: (path: string, token: string, subdomain: string, retryBudget: RetryBudget) => Effect.Effect<NavigateResult, HarmonicApiError>;
   readonly executeAction: (
     path: string,
     action: string,
     params: Record<string, unknown> | undefined,
     token: string,
     subdomain: string,
+    retryBudget: RetryBudget,
   ) => Effect.Effect<ActionResult, HarmonicApiError>;
   readonly fetchChatHistory: (chatSessionId: string, subdomain: string) => Effect.Effect<ChatHistoryResponse, HarmonicApiError>;
 }
@@ -115,14 +117,14 @@ export const HarmonicClientLive = Layer.effect(
     const railsHttp = yield* RailsHttp;
     const config = yield* Config;
 
-    const navigate: HarmonicClientService["navigate"] = (path, token, subdomain) =>
+    const navigate: HarmonicClientService["navigate"] = (path, token, subdomain, retryBudget) =>
       Effect.tryPromise({
         try: async () => {
           let currentPath = path;
           const maxRedirects = 5;
 
           for (let i = 0; i <= maxRedirects; i++) {
-            const response = await railsHttp.request({
+            const response = await withRetryAfter(retryBudget, () => railsHttp.request({
               method: "GET",
               subdomain,
               path: currentPath,
@@ -132,7 +134,7 @@ export const HarmonicClientLive = Layer.effect(
                 "Authorization": `Bearer ${token}`,
               },
               timeoutMs: 30_000,
-            });
+            }));
 
             // Follow redirects (3xx with Location header)
             if (response.statusCode >= 300 && response.statusCode < 400) {
@@ -166,7 +168,7 @@ export const HarmonicClientLive = Layer.effect(
           }),
       });
 
-    const executeAction: HarmonicClientService["executeAction"] = (path, action, params, token, subdomain) =>
+    const executeAction: HarmonicClientService["executeAction"] = (path, action, params, token, subdomain, retryBudget) =>
       Effect.tryPromise({
         try: async () => {
           // Strip the query string before appending `/actions/<name>` —
@@ -174,7 +176,7 @@ export const HarmonicClientLive = Layer.effect(
           // action URLs are on the bare resource path.
           const basePath = path.split("?")[0] ?? path;
           const actionPath = `${basePath}/actions/${action}`;
-          const response = await railsHttp.request({
+          const response = await withRetryAfter(retryBudget, () => railsHttp.request({
             method: "POST",
             subdomain,
             path: actionPath,
@@ -186,7 +188,7 @@ export const HarmonicClientLive = Layer.effect(
             },
             body: params !== undefined ? JSON.stringify(params) : "{}",
             timeoutMs: 30_000,
-          });
+          }));
 
           const content = await response.text();
           return {

--- a/agent-runner/src/services/HarmonicClient.ts
+++ b/agent-runner/src/services/HarmonicClient.ts
@@ -1,19 +1,14 @@
 /**
- * HTTP client for Harmonic Rails markdown API — Effect service.
- * Handles navigate (GET with Accept: text/markdown) and execute_action (POST).
+ * HMAC-authenticated Harmonic Rails client — Effect service.
  *
- * Agent requests go through ApplicationController like any external API client:
- * - URL is built with the tenant subdomain so Rails sees the right Host header
- * - TCP is routed to the Rails container via the RailsHttp dispatcher
- *   (see RailsHttp.ts for the full explanation of why the URL and TCP target
- *    are separated)
- * - Bearer token authenticates the agent as a user
- * - Subject to normal capability checks, API authorization, etc.
+ * Holds runner ↔ Rails calls that aren't agent-acting and therefore don't go
+ * through /mcp. Today that's just fetchChatHistory: the runner fetches prior
+ * messages from /internal/agent-runner/chat/{session_id}/history when
+ * preparing the system prompt for a chat turn. The agent itself never
+ * invokes this — it's runner-side setup.
  *
- * X-Forwarded-Proto: https is set to prevent Rails' force_ssl from redirecting.
- * This is safe in production because the reverse proxy (Caddy) overwrites
- * X-Forwarded-Proto before forwarding to Rails, so external clients cannot
- * set this header to bypass SSL.
+ * Agent-acting calls (fetch_page, execute_action) live on McpClient and use
+ * the public /mcp endpoint with Bearer auth.
  */
 
 import { Context, Effect, Layer } from "effect";
@@ -21,18 +16,6 @@ import { HarmonicApiError } from "../errors/Errors.js";
 import { Config } from "../config/Config.js";
 import { buildHeaders } from "./HmacSigner.js";
 import { RailsHttp } from "./RailsHttp.js";
-import { withRetryAfter, type RetryBudget } from "./Retry.js";
-
-export interface NavigateResult {
-  readonly content: string;
-  readonly availableActions: readonly string[];
-  readonly resolvedPath: string;
-}
-
-export interface ActionResult {
-  readonly content: string;
-  readonly success: boolean;
-}
 
 export interface ChatHistoryMessage {
   readonly content: string;
@@ -50,158 +33,16 @@ export interface ChatHistoryResponse {
 }
 
 export interface HarmonicClientService {
-  readonly navigate: (path: string, token: string, subdomain: string, retryBudget: RetryBudget) => Effect.Effect<NavigateResult, HarmonicApiError>;
-  readonly executeAction: (
-    path: string,
-    action: string,
-    params: Record<string, unknown> | undefined,
-    token: string,
-    subdomain: string,
-    retryBudget: RetryBudget,
-  ) => Effect.Effect<ActionResult, HarmonicApiError>;
   readonly fetchChatHistory: (chatSessionId: string, subdomain: string) => Effect.Effect<ChatHistoryResponse, HarmonicApiError>;
 }
 
 export class HarmonicClient extends Context.Tag("HarmonicClient")<HarmonicClient, HarmonicClientService>() {}
-
-/**
- * Parse available actions from YAML frontmatter in the markdown response.
- * Matches Ruby MarkdownUiService.parse_frontmatter + actions extraction.
- *
- * The Rails markdown layout wraps every response in frontmatter:
- * ---
- * actions:
- *   - name: create_note
- *     description: Create a note
- *     ...
- * ---
- */
-export function parseAvailableActions(content: string): readonly string[] {
-  // Must start with "---\n" (matches Ruby: content.start_with?("---\n"))
-  if (!content.startsWith("---\n")) return [];
-
-  // Find closing "---\n" after position 4 (matches Ruby: content.index("\n---\n", 4))
-  const endIndex = content.indexOf("\n---\n", 4);
-  if (endIndex === -1) return [];
-
-  const frontmatter = content.slice(4, endIndex);
-
-  // Parse action names from the YAML frontmatter.
-  // We don't use a full YAML parser — just extract "- name: <value>" lines
-  // within the "actions:" block.
-  const actionsMatch = /^actions:\s*$/m.exec(frontmatter);
-  if (actionsMatch === null) return [];
-
-  const actionsBlock = frontmatter.slice(actionsMatch.index + actionsMatch[0].length);
-  const names: string[] = [];
-
-  for (const line of actionsBlock.split("\n")) {
-    // Stop if we hit a non-indented line (next top-level YAML key)
-    if (line.length > 0 && !line.startsWith(" ") && !line.startsWith("\t")) break;
-
-    // Match only top-level action items (2-space indent: "  - name: value")
-    // Skip deeper nested "name:" like params (6+ spaces)
-    const nameMatch = /^  - name:\s*(.+)$/.exec(line);
-    if (nameMatch?.[1] !== undefined) {
-      const name = nameMatch[1].trim();
-      if (name !== "") names.push(name);
-    }
-  }
-
-  return names;
-}
 
 export const HarmonicClientLive = Layer.effect(
   HarmonicClient,
   Effect.gen(function* () {
     const railsHttp = yield* RailsHttp;
     const config = yield* Config;
-
-    const navigate: HarmonicClientService["navigate"] = (path, token, subdomain, retryBudget) =>
-      Effect.tryPromise({
-        try: async () => {
-          let currentPath = path;
-          const maxRedirects = 5;
-
-          for (let i = 0; i <= maxRedirects; i++) {
-            const response = await withRetryAfter(retryBudget, () => railsHttp.request({
-              method: "GET",
-              subdomain,
-              path: currentPath,
-              headers: {
-                "X-Forwarded-Proto": "https",
-                "Accept": "text/markdown",
-                "Authorization": `Bearer ${token}`,
-              },
-              timeoutMs: 30_000,
-            }));
-
-            // Follow redirects (3xx with Location header)
-            if (response.statusCode >= 300 && response.statusCode < 400) {
-              const location = response.headers["location"];
-              if (typeof location === "string") {
-                // Drain the redirect response body to release the socket
-                await response.text();
-                currentPath = location.startsWith("http")
-                  ? new URL(location).pathname
-                  : location;
-                continue;
-              }
-              // 3xx without Location — fall through to error handling
-            }
-
-            const content = await response.text();
-            if (response.statusCode < 200 || response.statusCode >= 300) {
-              throw new Error(`Navigate to ${currentPath} failed: HTTP ${response.statusCode} - ${content.slice(0, 500)}`);
-            }
-
-            const availableActions = parseAvailableActions(content);
-            return { content, availableActions, resolvedPath: currentPath };
-          }
-
-          throw new Error(`Navigate to ${path} failed: too many redirects`);
-        },
-        catch: (error) =>
-          new HarmonicApiError({
-            message: error instanceof Error ? error.message : String(error),
-            path,
-          }),
-      });
-
-    const executeAction: HarmonicClientService["executeAction"] = (path, action, params, token, subdomain, retryBudget) =>
-      Effect.tryPromise({
-        try: async () => {
-          // Strip the query string before appending `/actions/<name>` —
-          // the agent's currentPath can include `?comment_id=…`, but
-          // action URLs are on the bare resource path.
-          const basePath = path.split("?")[0] ?? path;
-          const actionPath = `${basePath}/actions/${action}`;
-          const response = await withRetryAfter(retryBudget, () => railsHttp.request({
-            method: "POST",
-            subdomain,
-            path: actionPath,
-            headers: {
-              "X-Forwarded-Proto": "https",
-              "Content-Type": "application/json",
-              "Accept": "text/markdown",
-              "Authorization": `Bearer ${token}`,
-            },
-            body: params !== undefined ? JSON.stringify(params) : "{}",
-            timeoutMs: 30_000,
-          }));
-
-          const content = await response.text();
-          return {
-            content,
-            success: response.statusCode >= 200 && response.statusCode < 300,
-          };
-        },
-        catch: (error) =>
-          new HarmonicApiError({
-            message: error instanceof Error ? error.message : String(error),
-            path: `${(path.split("?")[0] ?? path)}/actions/${action}`,
-          }),
-      });
 
     const fetchChatHistory: HarmonicClientService["fetchChatHistory"] = (chatSessionId, subdomain) => {
       const path = `/internal/agent-runner/chat/${chatSessionId}/history`;
@@ -232,6 +73,6 @@ export const HarmonicClientLive = Layer.effect(
       });
     };
 
-    return { navigate, executeAction, fetchChatHistory };
+    return { fetchChatHistory };
   }),
 );

--- a/agent-runner/src/services/McpClient.ts
+++ b/agent-runner/src/services/McpClient.ts
@@ -26,7 +26,7 @@ import { Context, Effect, Layer } from "effect";
 import { HarmonicApiError } from "../errors/Errors.js";
 import { RailsHttp, type RailsResponse } from "./RailsHttp.js";
 import { withRetryAfter, type RetryBudget } from "./Retry.js";
-import { parseAvailableActions } from "./HarmonicClient.js";
+import { parseAvailableActions, parseResolvedPath } from "../core/MarkdownFrontmatter.js";
 
 const MCP_PROTOCOL_VERSION = "2025-11-25";
 
@@ -71,22 +71,6 @@ interface JsonRpcResponse {
     readonly _meta?: { readonly harmonic?: { readonly tool_call_log_id?: string } };
   };
   readonly error?: { readonly code: number; readonly message: string; readonly data?: unknown };
-}
-
-/**
- * Extract a `path: …` value from a Rails markdown response's YAML
- * frontmatter. Used to resolve the path the server actually landed on
- * (the server follows redirects internally; we don't see hop-by-hop).
- *
- * Returns null if there's no frontmatter or no `path:` line in it.
- */
-export function parseResolvedPath(content: string): string | null {
-  if (!content.startsWith("---\n")) return null;
-  const endIndex = content.indexOf("\n---\n", 4);
-  if (endIndex === -1) return null;
-  const frontmatter = content.slice(4, endIndex);
-  const match = /^path:\s*(.+)$/m.exec(frontmatter);
-  return match?.[1]?.trim() ?? null;
 }
 
 export const McpClientLive = Layer.effect(
@@ -161,9 +145,13 @@ export const McpClientLive = Layer.effect(
           }
           const content = extractResultText(rpc);
           const isError = rpc.result?.isError ?? false;
+          // fetchPage throws on tool error (executeAction returns success: false
+          // instead) because fetchPage's downstream contract includes
+          // `availableActions` and `resolvedPath` parsed from the markdown
+          // frontmatter — those fields don't exist on a 4xx body. Throwing keeps
+          // the loop on the error-recording path rather than handing back a
+          // structurally-incomplete result.
           if (isError) {
-            // The tool result wrapped an error; surface as a HarmonicApiError so
-            // the loop records it on a step and continues.
             throw new Error(`fetch_page tool error: ${content.slice(0, 500)}`);
           }
           return {

--- a/agent-runner/src/services/McpClient.ts
+++ b/agent-runner/src/services/McpClient.ts
@@ -1,0 +1,208 @@
+/**
+ * MCP (Model Context Protocol) client for agent-acting calls — Effect service.
+ *
+ * Speaks the JSON-RPC 2.0 envelope for the 2025-11-25 revision of the
+ * Streamable HTTP transport. Each call is a stateless one-shot `POST /mcp`
+ * with `Authorization: Bearer …` and `MCP-Protocol-Version: 2025-11-25`. No
+ * `initialize` handshake, no `MCP-Session-Id` — matches the hosted endpoint's
+ * stateless design.
+ *
+ * Replaces HarmonicClient.navigate / executeAction. HarmonicClient survives
+ * with only fetchChatHistory, which pulls chat-session context the runner
+ * uses to build the LLM prompt; it stays on the HMAC `/internal/...` path
+ * because it isn't a tool the agent invokes.
+ *
+ * Why no @modelcontextprotocol/sdk
+ * --------------------------------
+ * The SDK is built around long-lived stateful client sessions with SSE
+ * resumption. Our use case is the opposite: one-shot stateless calls
+ * authenticated by Bearer per request. The JSON-RPC envelope is small and
+ * fully under our control (we wrote both sides). A dependency-free
+ * implementation keeps the call site shape obvious and avoids the SDK's
+ * session-management ceremony.
+ */
+
+import { Context, Effect, Layer } from "effect";
+import { HarmonicApiError } from "../errors/Errors.js";
+import { RailsHttp, type RailsResponse } from "./RailsHttp.js";
+import { withRetryAfter, type RetryBudget } from "./Retry.js";
+import { parseAvailableActions } from "./HarmonicClient.js";
+
+const MCP_PROTOCOL_VERSION = "2025-11-25";
+
+export interface FetchPageResult {
+  readonly content: string;
+  readonly availableActions: readonly string[];
+  readonly resolvedPath: string;
+  readonly mcpToolCallLogId: string | null;
+}
+
+export interface ExecuteActionResult {
+  readonly content: string;
+  readonly success: boolean;
+  readonly mcpToolCallLogId: string | null;
+}
+
+export interface McpClientService {
+  readonly fetchPage: (
+    path: string,
+    token: string,
+    subdomain: string,
+    retryBudget: RetryBudget,
+  ) => Effect.Effect<FetchPageResult, HarmonicApiError>;
+  readonly executeAction: (
+    path: string,
+    action: string,
+    params: Record<string, unknown> | undefined,
+    token: string,
+    subdomain: string,
+    retryBudget: RetryBudget,
+  ) => Effect.Effect<ExecuteActionResult, HarmonicApiError>;
+}
+
+export class McpClient extends Context.Tag("McpClient")<McpClient, McpClientService>() {}
+
+interface JsonRpcResponse {
+  readonly jsonrpc: string;
+  readonly id?: number | string | null;
+  readonly result?: {
+    readonly content?: ReadonlyArray<{ readonly type: string; readonly text?: string }>;
+    readonly isError?: boolean;
+    readonly _meta?: { readonly harmonic?: { readonly tool_call_log_id?: string } };
+  };
+  readonly error?: { readonly code: number; readonly message: string; readonly data?: unknown };
+}
+
+/**
+ * Extract a `path: …` value from a Rails markdown response's YAML
+ * frontmatter. Used to resolve the path the server actually landed on
+ * (the server follows redirects internally; we don't see hop-by-hop).
+ *
+ * Returns null if there's no frontmatter or no `path:` line in it.
+ */
+export function parseResolvedPath(content: string): string | null {
+  if (!content.startsWith("---\n")) return null;
+  const endIndex = content.indexOf("\n---\n", 4);
+  if (endIndex === -1) return null;
+  const frontmatter = content.slice(4, endIndex);
+  const match = /^path:\s*(.+)$/m.exec(frontmatter);
+  return match?.[1]?.trim() ?? null;
+}
+
+export const McpClientLive = Layer.effect(
+  McpClient,
+  Effect.gen(function* () {
+    const railsHttp = yield* RailsHttp;
+
+    let requestIdCounter = 0;
+    const nextId = (): number => ++requestIdCounter;
+
+    const post = async (
+      subdomain: string,
+      token: string,
+      body: object,
+      retryBudget: RetryBudget,
+    ): Promise<RailsResponse> => withRetryAfter(retryBudget, () => railsHttp.request({
+      method: "POST",
+      subdomain,
+      path: "/mcp",
+      headers: {
+        "X-Forwarded-Proto": "https",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Authorization": `Bearer ${token}`,
+        "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+      },
+      body: JSON.stringify(body),
+      timeoutMs: 30_000,
+    }));
+
+    const callTool = async (
+      name: string,
+      args: Record<string, unknown>,
+      token: string,
+      subdomain: string,
+      retryBudget: RetryBudget,
+    ): Promise<JsonRpcResponse> => {
+      const envelope = {
+        jsonrpc: "2.0",
+        id: nextId(),
+        method: "tools/call",
+        params: { name, arguments: args },
+      };
+      const response = await post(subdomain, token, envelope, retryBudget);
+      const text = await response.text();
+      if (response.statusCode === 401) {
+        throw new Error(`MCP call unauthorized (token revoked or expired)`);
+      }
+      if (response.statusCode === 429) {
+        throw new Error(`MCP call rate-limited after backoff: ${text.slice(0, 200)}`);
+      }
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw new Error(`MCP call failed: HTTP ${response.statusCode} - ${text.slice(0, 500)}`);
+      }
+      return JSON.parse(text) as JsonRpcResponse;
+    };
+
+    const extractResultText = (rpc: JsonRpcResponse): string => {
+      const first = rpc.result?.content?.[0];
+      return first?.text ?? "";
+    };
+
+    const extractLogId = (rpc: JsonRpcResponse): string | null =>
+      rpc.result?._meta?.harmonic?.tool_call_log_id ?? null;
+
+    const fetchPage: McpClientService["fetchPage"] = (path, token, subdomain, retryBudget) =>
+      Effect.tryPromise({
+        try: async () => {
+          const rpc = await callTool("fetch_page", { path }, token, subdomain, retryBudget);
+          if (rpc.error !== undefined) {
+            throw new Error(`fetch_page JSON-RPC error: ${rpc.error.message}`);
+          }
+          const content = extractResultText(rpc);
+          const isError = rpc.result?.isError ?? false;
+          if (isError) {
+            // The tool result wrapped an error; surface as a HarmonicApiError so
+            // the loop records it on a step and continues.
+            throw new Error(`fetch_page tool error: ${content.slice(0, 500)}`);
+          }
+          return {
+            content,
+            availableActions: parseAvailableActions(content),
+            resolvedPath: parseResolvedPath(content) ?? path,
+            mcpToolCallLogId: extractLogId(rpc),
+          };
+        },
+        catch: (error) =>
+          new HarmonicApiError({
+            message: error instanceof Error ? error.message : String(error),
+            path,
+          }),
+      });
+
+    const executeAction: McpClientService["executeAction"] = (path, action, params, token, subdomain, retryBudget) =>
+      Effect.tryPromise({
+        try: async () => {
+          const args = { path, action, ...(params !== undefined ? { params } : {}) };
+          const rpc = await callTool("execute_action", args, token, subdomain, retryBudget);
+          if (rpc.error !== undefined) {
+            throw new Error(`execute_action JSON-RPC error: ${rpc.error.message}`);
+          }
+          const content = extractResultText(rpc);
+          const isError = rpc.result?.isError ?? false;
+          return {
+            content,
+            success: !isError,
+            mcpToolCallLogId: extractLogId(rpc),
+          };
+        },
+        catch: (error) =>
+          new HarmonicApiError({
+            message: error instanceof Error ? error.message : String(error),
+            path: `${path}/actions/${action}`,
+          }),
+      });
+
+    return { fetchPage, executeAction };
+  }),
+);

--- a/agent-runner/src/services/Retry.ts
+++ b/agent-runner/src/services/Retry.ts
@@ -1,0 +1,88 @@
+/**
+ * Retry-After backoff for Harmonic API requests.
+ *
+ * The hosted MCP endpoint (and other rate-limited Harmonic endpoints) return
+ * HTTP 429 with a `Retry-After` header (integer seconds) when one of the
+ * four layered rate-limit scopes (per-token burst/sustained, per-principal,
+ * per-tenant aggregate) is breached. A well-behaved client respects the
+ * Retry-After delay rather than expecting elevated limits.
+ *
+ * Policy
+ * ------
+ * - On 429 with a positive integer Retry-After: sleep for that duration,
+ *   retry the same request ONCE. If the retry also 429s, surface that
+ *   response to the caller (which forwards it to the LLM as a tool error).
+ * - Per-task backoff budget caps cumulative sleep time. If the requested
+ *   Retry-After exceeds the remaining budget, don't sleep — return the 429
+ *   immediately. Prevents a sustained-throttle scenario from blowing past
+ *   the task's wall-clock budget.
+ * - Non-429 responses pass through unchanged.
+ * - Missing / malformed Retry-After is treated as "don't retry" (no sleep,
+ *   return the 429). Conservative: better to surface than to guess a delay.
+ *
+ * Defaults
+ * --------
+ * Per-task budget defaults to 60 seconds. This is a coarse first cut —
+ * tune by observing real 429+backoff events logged by the runner.
+ */
+
+const DEFAULT_BUDGET_MS = 60_000;
+
+export interface RetryBudget {
+  remainingMs: number;
+}
+
+export function createRetryBudget(totalMs: number = DEFAULT_BUDGET_MS): RetryBudget {
+  return { remainingMs: totalMs };
+}
+
+interface RetryableResponse {
+  readonly statusCode: number;
+  readonly headers: Record<string, string | string[] | undefined>;
+  readonly text: () => Promise<string>;
+}
+
+/**
+ * Wrap a request-producing thunk with Retry-After 429 handling.
+ *
+ * The `drainBody` callback is invoked on a 429 BEFORE retrying so the
+ * underlying socket can be released. Required because undici streams the
+ * body and an unread response holds the socket open.
+ */
+export async function withRetryAfter<T extends RetryableResponse>(
+  budget: RetryBudget,
+  request: () => Promise<T>,
+  sleep: (ms: number) => Promise<void> = defaultSleep,
+): Promise<T> {
+  const first = await request();
+  if (first.statusCode !== 429) return first;
+
+  const retryAfterSec = parseRetryAfterSeconds(first.headers["retry-after"]);
+  if (retryAfterSec === null) return first;
+
+  const sleepMs = retryAfterSec * 1000;
+  if (sleepMs > budget.remainingMs) return first;
+
+  // Drain the body of the rejected response so undici can free the socket
+  // before the retry request opens a new one.
+  try {
+    await first.text();
+  } catch {
+    // Body already consumed or transport-level error — proceed regardless.
+  }
+
+  budget.remainingMs -= sleepMs;
+  await sleep(sleepMs);
+  return await request();
+}
+
+function parseRetryAfterSeconds(header: string | string[] | undefined): number | null {
+  if (typeof header !== "string") return null;
+  const n = parseInt(header, 10);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/agent-runner/test/core/MarkdownFrontmatter.test.ts
+++ b/agent-runner/test/core/MarkdownFrontmatter.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { parseAvailableActions, parseResolvedPath } from "../../src/core/MarkdownFrontmatter.js";
+
+describe("parseAvailableActions", () => {
+  it("parses action names from YAML frontmatter", () => {
+    const content = `---
+app: Harmonic
+host: test.harmonic.local
+path: /collectives/team
+actions:
+  - name: create_note
+    description: Create a new note
+    path: /collectives/team/actions/create_note
+    params:
+      - name: body
+        type: string
+        required: true
+  - name: vote
+    description: Cast a vote
+    path: /collectives/team/actions/vote
+---
+nav: | [Home](/) |
+
+# Team Collective
+`;
+    const actions = parseAvailableActions(content);
+    expect(actions).toEqual(["create_note", "vote"]);
+  });
+
+  it("returns empty array when no frontmatter", () => {
+    const content = "# Just a page\n\nSome content here.";
+    expect(parseAvailableActions(content)).toEqual([]);
+  });
+
+  it("returns empty array for empty content", () => {
+    expect(parseAvailableActions("")).toEqual([]);
+  });
+
+  it("returns empty array when frontmatter has no actions", () => {
+    const content = `---
+app: Harmonic
+host: test.harmonic.local
+path: /whoami
+---
+# About You
+`;
+    expect(parseAvailableActions(content)).toEqual([]);
+  });
+
+  it("handles frontmatter with single action", () => {
+    const content = `---
+actions:
+  - name: send_heartbeat
+    description: Send heartbeat
+---
+# Page
+`;
+    const actions = parseAvailableActions(content);
+    expect(actions).toEqual(["send_heartbeat"]);
+  });
+
+  it("ignores actions without name field", () => {
+    const content = `---
+actions:
+  - name: valid_action
+    description: Valid
+  - description: No name field
+  - name: another_valid
+    description: Also valid
+---
+# Page
+`;
+    const actions = parseAvailableActions(content);
+    expect(actions).toEqual(["valid_action", "another_valid"]);
+  });
+
+  it("handles malformed YAML gracefully", () => {
+    const content = `---
+actions: [not valid yaml
+---
+# Page
+`;
+    // Should not throw, return empty
+    expect(parseAvailableActions(content)).toEqual([]);
+  });
+
+  it("does not confuse horizontal rules for frontmatter", () => {
+    const content = `# Page Title
+
+Some content
+
+---
+
+More content after rule
+`;
+    expect(parseAvailableActions(content)).toEqual([]);
+  });
+});
+
+describe("parseResolvedPath", () => {
+  it("extracts path from frontmatter", () => {
+    expect(parseResolvedPath("---\npath: /foo/bar\n---\n# Body")).toBe("/foo/bar");
+  });
+
+  it("returns null when content has no frontmatter", () => {
+    expect(parseResolvedPath("# Plain markdown")).toBeNull();
+  });
+
+  it("returns null when frontmatter has no path line", () => {
+    expect(parseResolvedPath("---\napp: Harmonic\n---\n# Body")).toBeNull();
+  });
+});

--- a/agent-runner/test/core/StepBuilder.test.ts
+++ b/agent-runner/test/core/StepBuilder.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
-  navigateStep,
-  executeStep,
+  fetchPageStep,
+  executeActionStep,
   thinkStep,
   errorStep,
   securityWarningStep,
@@ -13,17 +13,18 @@ import {
 describe("StepBuilder", () => {
   const timestamp = new Date("2026-04-13T10:00:00Z");
 
-  describe("navigateStep", () => {
-    it("builds navigate step with rich detail matching Ruby", () => {
-      const step = navigateStep({
+  describe("fetchPageStep", () => {
+    it("builds fetch_page step with rich detail and surfaces mcp_tool_call_log_id", () => {
+      const step = fetchPageStep({
         path: "/notifications",
         resolvedPath: "/notifications",
         contentPreview: "# Notifications\n\nYou have 3 unread.",
         availableActions: ["mark_read", "dismiss"],
         error: null,
+        mcp_tool_call_log_id: "log-uuid-1",
       }, timestamp);
 
-      expect(step.type).toBe("navigate");
+      expect(step.type).toBe("fetch_page");
       expect(step.detail).toEqual({
         path: "/notifications",
         resolved_path: "/notifications",
@@ -32,32 +33,36 @@ describe("StepBuilder", () => {
         error: null,
       });
       expect(step.timestamp).toBe("2026-04-13T10:00:00.000Z");
+      expect(step.mcp_tool_call_log_id).toBe("log-uuid-1");
     });
 
-    it("includes error when navigation fails", () => {
-      const step = navigateStep({
+    it("includes error when fetch fails and leaves mcp_tool_call_log_id null", () => {
+      const step = fetchPageStep({
         path: "/bad-path",
         resolvedPath: "/bad-path",
         contentPreview: "",
         availableActions: [],
         error: "Not found",
+        mcp_tool_call_log_id: null,
       }, timestamp);
 
       expect(step.detail["error"]).toBe("Not found");
+      expect(step.mcp_tool_call_log_id).toBeNull();
     });
   });
 
-  describe("executeStep", () => {
-    it("builds execute step with rich detail matching Ruby", () => {
-      const step = executeStep({
+  describe("executeActionStep", () => {
+    it("builds execute_action step with rich detail and surfaces mcp_tool_call_log_id", () => {
+      const step = executeActionStep({
         action: "create_note",
         params: { body: "Hello" },
         success: true,
         contentPreview: "Note created successfully",
         error: null,
+        mcp_tool_call_log_id: "log-uuid-2",
       }, timestamp);
 
-      expect(step.type).toBe("execute");
+      expect(step.type).toBe("execute_action");
       expect(step.detail).toEqual({
         action: "create_note",
         params: { body: "Hello" },
@@ -65,20 +70,23 @@ describe("StepBuilder", () => {
         content_preview: "Note created successfully",
         error: null,
       });
+      expect(step.mcp_tool_call_log_id).toBe("log-uuid-2");
     });
 
-    it("builds failed execute step", () => {
-      const step = executeStep({
+    it("builds failed execute_action step", () => {
+      const step = executeActionStep({
         action: "delete_note",
         params: {},
         success: false,
         contentPreview: null,
         error: "Invalid action 'delete_note'. Available actions: create_note, vote",
+        mcp_tool_call_log_id: null,
       }, timestamp);
 
       expect(step.detail["success"]).toBe(false);
       expect(step.detail["content_preview"]).toBeNull();
       expect(step.detail["error"]).toContain("Invalid action");
+      expect(step.mcp_tool_call_log_id).toBeNull();
     });
   });
 

--- a/agent-runner/test/services/AgentLoop.test.ts
+++ b/agent-runner/test/services/AgentLoop.test.ts
@@ -274,7 +274,7 @@ describe("AgentLoop", () => {
     const state = createMockState();
     await runWithMocks(makeTask(), state, [makeLLMResponse()]);
 
-    const navStep = state.stepsCalled.find((s) => s.type === "navigate");
+    const navStep = state.stepsCalled.find((s) => s.type === "fetch_page");
     expect(navStep).toBeDefined();
     expect(navStep?.detail["path"]).toBe("/whoami");
     expect(navStep?.detail["available_actions"]).toEqual(["update_scratchpad"]);
@@ -322,7 +322,7 @@ describe("AgentLoop", () => {
     );
 
     expect(state.navigatePaths).toContain("/notifications");
-    const navSteps = state.stepsCalled.filter((s) => s.type === "navigate");
+    const navSteps = state.stepsCalled.filter((s) => s.type === "fetch_page");
     expect(navSteps.length).toBe(2); // /whoami + /notifications
   });
 
@@ -348,7 +348,7 @@ describe("AgentLoop", () => {
     );
 
     expect(state.executeActions).toContain("create_note");
-    const execSteps = state.stepsCalled.filter((s) => s.type === "execute");
+    const execSteps = state.stepsCalled.filter((s) => s.type === "execute_action");
     expect(execSteps.length).toBe(1);
     expect(execSteps[0]?.detail["success"]).toBe(true);
   });
@@ -378,7 +378,7 @@ describe("AgentLoop", () => {
 
     // The action IS sent to Rails — no client-side gate.
     expect(state.executeActions).toContain("delete_everything");
-    const execSteps = state.stepsCalled.filter((s) => s.type === "execute");
+    const execSteps = state.stepsCalled.filter((s) => s.type === "execute_action");
     expect(execSteps.length).toBe(1);
     expect(execSteps[0]?.detail["success"]).toBe(false);
   });
@@ -403,7 +403,7 @@ describe("AgentLoop", () => {
 
     expect(state.executeActions).toContain("create_note");
     expect(state.executeActionPaths).toContain("/collectives/team/note");
-    const execSteps = state.stepsCalled.filter((s) => s.type === "execute");
+    const execSteps = state.stepsCalled.filter((s) => s.type === "execute_action");
     expect(execSteps[0]?.detail["success"]).toBe(true);
   });
 
@@ -644,9 +644,9 @@ describe("AgentLoop", () => {
 
     const stepTypes = state.stepsCalled.map((s) => s.type);
     // Expected order: navigate(/whoami), think, execute, think, done, scratchpad_update
-    expect(stepTypes[0]).toBe("navigate");   // /whoami
+    expect(stepTypes[0]).toBe("fetch_page");   // /whoami
     expect(stepTypes[1]).toBe("think");      // first LLM call
-    expect(stepTypes[2]).toBe("execute");    // create_note
+    expect(stepTypes[2]).toBe("execute_action");    // create_note
     expect(stepTypes[3]).toBe("think");      // second LLM call
     expect(stepTypes[4]).toBe("done");       // task done
     expect(stepTypes[5]).toBe("scratchpad_update"); // scratchpad
@@ -699,9 +699,9 @@ describe("AgentLoop", () => {
 
     expect(state.navigatePaths).toContain("/notifications");
     expect(state.executeActions).toContain("mark_read");
-    const navSteps = state.stepsCalled.filter((s) => s.type === "navigate");
+    const navSteps = state.stepsCalled.filter((s) => s.type === "fetch_page");
     expect(navSteps.length).toBe(2); // /whoami + /notifications
-    const execSteps = state.stepsCalled.filter((s) => s.type === "execute");
+    const execSteps = state.stepsCalled.filter((s) => s.type === "execute_action");
     expect(execSteps.length).toBe(1);
   });
 
@@ -761,9 +761,9 @@ describe("AgentLoop", () => {
     // Steps are reported incrementally via the step endpoint
     expect(state.stepsCalled.length).toBeGreaterThanOrEqual(4); // navigate, think, execute, think, done, scratchpad
     const stepTypes = state.stepsCalled.map((s) => s.type);
-    expect(stepTypes).toContain("navigate");
+    expect(stepTypes).toContain("fetch_page");
     expect(stepTypes).toContain("think");
-    expect(stepTypes).toContain("execute");
+    expect(stepTypes).toContain("execute_action");
     expect(stepTypes).toContain("done");
   });
 
@@ -834,7 +834,7 @@ describe("AgentLoop", () => {
     expect(state.failCalled).toBe(false);
     expect(state.completeCalled).toBe(true);
     // A navigate step should have been recorded with the error
-    const navSteps = state.stepsCalled.filter((s) => s.type === "navigate");
+    const navSteps = state.stepsCalled.filter((s) => s.type === "fetch_page");
     const brokenNav = navSteps.find((s) => s.detail["path"] === "/broken-page");
     expect(brokenNav).toBeDefined();
     expect(brokenNav?.detail["error"]).toContain("Connection refused");
@@ -908,7 +908,7 @@ describe("AgentLoop", () => {
     // resolved path from the page frontmatter and supplies it explicitly.
     // What still matters: the navigate step records the resolved path so
     // the LLM can see it.
-    const navSteps = state.stepsCalled.filter((s) => s.type === "navigate");
+    const navSteps = state.stepsCalled.filter((s) => s.type === "fetch_page");
     const workspaceNav = navSteps.find((s) => s.detail["path"] === "/workspace");
     expect(workspaceNav).toBeDefined();
     expect(workspaceNav!.detail["resolved_path"]).toBe("/workspace/abc123");

--- a/agent-runner/test/services/AgentLoop.test.ts
+++ b/agent-runner/test/services/AgentLoop.test.ts
@@ -190,8 +190,6 @@ function buildTestLayers(
     },
   });
   const HarmonicClientTest = Layer.succeed(HarmonicClient, {
-    navigate: () => Effect.fail(new HarmonicApiError({ message: "HarmonicClient.navigate is deprecated; use McpClient.fetchPage", path: "" })),
-    executeAction: () => Effect.fail(new HarmonicApiError({ message: "HarmonicClient.executeAction is deprecated; use McpClient.executeAction", path: "" })),
     fetchChatHistory: () => {
       const messages = (options?.chatHistory ?? []).map((m) => ({
         role: m.role,

--- a/agent-runner/test/services/AgentLoop.test.ts
+++ b/agent-runner/test/services/AgentLoop.test.ts
@@ -4,6 +4,7 @@ import { runTask } from "../../src/services/AgentLoop.js";
 import { LLMClient } from "../../src/services/LLMClient.js";
 import type { LLMResponse } from "../../src/services/LLMClient.js";
 import { HarmonicClient } from "../../src/services/HarmonicClient.js";
+import { McpClient } from "../../src/services/McpClient.js";
 import { TaskReporter } from "../../src/services/TaskReporter.js";
 import { Config } from "../../src/config/Config.js";
 import { LLMError, HarmonicApiError } from "../../src/errors/Errors.js";
@@ -163,22 +164,34 @@ function buildTestLayers(
 
   const navErrors = options?.navigateErrors ?? {};
   const defaultNavigate = { content: WHOAMI_CONTENT, availableActions: ["update_scratchpad"] as readonly string[] };
-  const HarmonicClientTest = Layer.succeed(HarmonicClient, {
-    navigate: (path: string) => {
+  // fetchPage/executeAction live on McpClient. HarmonicClient retains only
+  // fetchChatHistory, which the runner uses to build the LLM prompt and
+  // stays on the HMAC /internal/... path.
+  const McpClientTest = Layer.succeed(McpClient, {
+    fetchPage: (path: string) => {
       state.navigatePaths.push(path);
       if (navErrors[path] !== undefined) {
         return Effect.fail(new HarmonicApiError({ message: navErrors[path], path }));
       }
       const result = (options?.navigateResults ?? navigateResults)?.[path] ?? defaultNavigate;
       const resolvedPath: string = (result as { resolvedPath?: string }).resolvedPath ?? path;
-      return Effect.succeed({ content: result.content, availableActions: result.availableActions, resolvedPath });
+      return Effect.succeed({
+        content: result.content,
+        availableActions: result.availableActions,
+        resolvedPath,
+        mcpToolCallLogId: null,
+      });
     },
     executeAction: (path: string, action: string, _params: Record<string, unknown> | undefined) => {
       state.executeActions.push(action);
       state.executeActionPaths.push(path);
       const result = (options?.executeResults ?? executeResults)?.[action] ?? { content: "Action completed", success: true };
-      return Effect.succeed(result);
+      return Effect.succeed({ content: result.content, success: result.success, mcpToolCallLogId: null });
     },
+  });
+  const HarmonicClientTest = Layer.succeed(HarmonicClient, {
+    navigate: () => Effect.fail(new HarmonicApiError({ message: "HarmonicClient.navigate is deprecated; use McpClient.fetchPage", path: "" })),
+    executeAction: () => Effect.fail(new HarmonicApiError({ message: "HarmonicClient.executeAction is deprecated; use McpClient.executeAction", path: "" })),
     fetchChatHistory: () => {
       const messages = (options?.chatHistory ?? []).map((m) => ({
         role: m.role,
@@ -221,7 +234,7 @@ function buildTestLayers(
     },
   });
 
-  return Layer.mergeAll(ConfigTest, LLMClientTest, HarmonicClientTest, TaskReporterTest);
+  return Layer.mergeAll(ConfigTest, LLMClientTest, HarmonicClientTest, McpClientTest, TaskReporterTest);
 }
 
 function runWithMocks(

--- a/agent-runner/test/services/HarmonicClient.test.ts
+++ b/agent-runner/test/services/HarmonicClient.test.ts
@@ -1,21 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { Effect, Layer, Exit } from "effect";
-import { HarmonicClient, HarmonicClientLive, parseAvailableActions, type NavigateResult } from "../../src/services/HarmonicClient.js";
-import { RailsHttp } from "../../src/services/RailsHttp.js";
-import type { RailsRequestOptions, RailsResponse } from "../../src/services/RailsHttp.js";
+import { HarmonicClient, HarmonicClientLive, type ChatHistoryResponse } from "../../src/services/HarmonicClient.js";
+import { RailsHttp, type RailsRequestOptions, type RailsResponse } from "../../src/services/RailsHttp.js";
 import { Config } from "../../src/config/Config.js";
-import { createRetryBudget } from "../../src/services/Retry.js";
 import type { HarmonicApiError } from "../../src/errors/Errors.js";
-
-// --- Test helpers for navigate ---
-
-function makeResponse(statusCode: number, body: string, headers: Record<string, string> = {}): RailsResponse {
-  return {
-    statusCode,
-    headers,
-    text: async () => body,
-  };
-}
 
 const TEST_CONFIG = {
   harmonicInternalUrl: "http://web:3000",
@@ -32,314 +20,71 @@ const TEST_CONFIG = {
   streamMaxLen: 1000,
 };
 
-function buildTestLayer(requestHandler: (opts: RailsRequestOptions) => RailsResponse) {
+function makeResponse(statusCode: number, body: string): RailsResponse {
+  return { statusCode, headers: {}, text: async () => body };
+}
+
+function runFetchChatHistory(handler: (opts: RailsRequestOptions) => RailsResponse): Promise<Exit.Exit<ChatHistoryResponse, HarmonicApiError>> {
   const RailsHttpTest = Layer.succeed(RailsHttp, {
-    request: async (opts: RailsRequestOptions) => requestHandler(opts),
+    request: async (opts: RailsRequestOptions) => handler(opts),
   });
   const ConfigTest = Layer.succeed(Config, TEST_CONFIG);
-  return HarmonicClientLive.pipe(Layer.provide(Layer.merge(RailsHttpTest, ConfigTest)));
-}
+  const layer = HarmonicClientLive.pipe(Layer.provide(Layer.merge(RailsHttpTest, ConfigTest)));
 
-function runNavigate(
-  requestHandler: (opts: RailsRequestOptions) => RailsResponse,
-  path: string,
-): Promise<Exit.Exit<NavigateResult, HarmonicApiError>> {
-  const layer = buildTestLayer(requestHandler);
   const program = Effect.gen(function* () {
     const client = yield* HarmonicClient;
-    return yield* client.navigate(path, "test-token", "app", createRetryBudget());
+    return yield* client.fetchChatHistory("session-abc", "app");
   });
   return Effect.runPromiseExit(program.pipe(Effect.provide(layer)));
 }
 
-function runExecuteAction(
-  requestHandler: (opts: RailsRequestOptions) => RailsResponse,
-  path: string,
-  action: string,
-  params: Record<string, unknown> = {},
-): Promise<Exit.Exit<{ content: string; success: boolean }, HarmonicApiError>> {
-  const layer = buildTestLayer(requestHandler);
-  const program = Effect.gen(function* () {
-    const client = yield* HarmonicClient;
-    return yield* client.executeAction(path, action, params, "test-token", "app", createRetryBudget());
-  });
-  return Effect.runPromiseExit(program.pipe(Effect.provide(layer)));
-}
-
-describe("executeAction URL construction", () => {
-  it("strips ?query string from path before appending /actions/<name>", async () => {
-    let observedPath = "";
+describe("HarmonicClient.fetchChatHistory", () => {
+  it("hits the HMAC /internal chat-history path with the chat session id", async () => {
+    let observedOpts: RailsRequestOptions | undefined;
     const handler = (opts: RailsRequestOptions) => {
-      observedPath = opts.path;
-      return makeResponse(200, "Comment added");
+      observedOpts = opts;
+      return makeResponse(200, JSON.stringify({ messages: [], current_state: {} }));
     };
-
-    const exit = await runExecuteAction(handler, "/d/abc?comment_id=xyz", "add_comment", { text: "hi" });
+    const exit = await runFetchChatHistory(handler);
 
     expect(Exit.isSuccess(exit)).toBe(true);
-    expect(observedPath).toBe("/d/abc/actions/add_comment");
+    expect(observedOpts?.method).toBe("GET");
+    expect(observedOpts?.path).toBe("/internal/agent-runner/chat/session-abc/history");
+    expect(observedOpts?.subdomain).toBe("app");
+    // HMAC headers from buildHeaders: X-Internal-Signature + X-Internal-Timestamp
+    expect(observedOpts?.headers?.["X-Internal-Signature"]).toBeDefined();
+    expect(observedOpts?.headers?.["X-Internal-Timestamp"]).toBeDefined();
   });
 
-  it("works correctly when path has no query string", async () => {
-    let observedPath = "";
-    const handler = (opts: RailsRequestOptions) => {
-      observedPath = opts.path;
-      return makeResponse(200, "OK");
-    };
-
-    await runExecuteAction(handler, "/d/abc", "vote", { option_title: "yes" });
-
-    expect(observedPath).toBe("/d/abc/actions/vote");
-  });
-});
-
-describe("navigate redirect following", () => {
-  it("follows a single redirect", async () => {
-    const requests: string[] = [];
-    const result = await runNavigate((opts) => {
-      requests.push(opts.path);
-      if (opts.path === "/workspace") {
-        return makeResponse(302, "", { location: "/workspace/abc123" });
-      }
-      return makeResponse(200, "# Workspace\n\nContent here.");
-    }, "/workspace");
-
-    expect(Exit.isSuccess(result)).toBe(true);
-    if (Exit.isSuccess(result)) {
-      expect(result.value.content).toContain("# Workspace");
-      expect(result.value.resolvedPath).toBe("/workspace/abc123");
-    }
-    expect(requests).toEqual(["/workspace", "/workspace/abc123"]);
-  });
-
-  it("follows multiple redirects", async () => {
-    const requests: string[] = [];
-    const result = await runNavigate((opts) => {
-      requests.push(opts.path);
-      if (opts.path === "/a") return makeResponse(301, "", { location: "/b" });
-      if (opts.path === "/b") return makeResponse(302, "", { location: "/c" });
-      return makeResponse(200, "# Final page");
-    }, "/a");
-
-    expect(Exit.isSuccess(result)).toBe(true);
-    if (Exit.isSuccess(result)) {
-      expect(result.value.content).toContain("# Final page");
-      expect(result.value.resolvedPath).toBe("/c");
-    }
-    expect(requests).toEqual(["/a", "/b", "/c"]);
-  });
-
-  it("handles absolute URL in Location header", async () => {
-    const requests: string[] = [];
-    const result = await runNavigate((opts) => {
-      requests.push(opts.path);
-      if (opts.path === "/workspace") {
-        return makeResponse(302, "", { location: "https://app.harmonic.local/workspace/abc123" });
-      }
-      return makeResponse(200, "# Workspace");
-    }, "/workspace");
-
-    expect(Exit.isSuccess(result)).toBe(true);
-    expect(requests).toEqual(["/workspace", "/workspace/abc123"]);
-  });
-
-  it("fails after too many redirects", async () => {
-    const result = await runNavigate((opts) => {
-      const n = parseInt(opts.path.slice(1)) || 0;
-      return makeResponse(302, "", { location: `/${n + 1}` });
-    }, "/0");
-
-    expect(Exit.isFailure(result)).toBe(true);
-    if (Exit.isFailure(result)) {
-      const error = result.cause;
-      expect(String(error)).toContain("too many redirects");
-    }
-  });
-
-  it("returns success directly when no redirect", async () => {
-    const result = await runNavigate(() => {
-      return makeResponse(200, "---\nactions:\n  - name: create_note\n---\n# Page");
-    }, "/collectives/team");
-
-    expect(Exit.isSuccess(result)).toBe(true);
-    if (Exit.isSuccess(result)) {
-      expect(result.value.content).toContain("# Page");
-      expect(result.value.availableActions).toEqual(["create_note"]);
-      expect(result.value.resolvedPath).toBe("/collectives/team");
-    }
-  });
-
-  it("fails on non-redirect error status", async () => {
-    const result = await runNavigate(() => {
-      return makeResponse(404, "Not Found");
-    }, "/nonexistent");
-
-    expect(Exit.isFailure(result)).toBe(true);
-  });
-
-  it("fails on 3xx without Location header", async () => {
-    const result = await runNavigate(() => {
-      return makeResponse(302, "Redirecting...");
-    }, "/bad-redirect");
-
-    expect(Exit.isFailure(result)).toBe(true);
-    if (Exit.isFailure(result)) {
-      expect(String(result.cause)).toContain("302");
-    }
-  });
-
-  it("resolvedPath equals original path when no redirect", async () => {
-    const result = await runNavigate(() => {
-      return makeResponse(200, "# Direct page");
-    }, "/direct");
-
-    expect(Exit.isSuccess(result)).toBe(true);
-    if (Exit.isSuccess(result)) {
-      expect(result.value.resolvedPath).toBe("/direct");
-    }
-  });
-});
-
-describe("parseAvailableActions", () => {
-  it("parses action names from YAML frontmatter", () => {
-    const content = `---
-app: Harmonic
-host: test.harmonic.local
-path: /collectives/team
-actions:
-  - name: create_note
-    description: Create a new note
-    path: /collectives/team/actions/create_note
-    params:
-      - name: body
-        type: string
-        required: true
-  - name: vote
-    description: Cast a vote
-    path: /collectives/team/actions/vote
----
-nav: | [Home](/) |
-
-# Team Collective
-`;
-    const actions = parseAvailableActions(content);
-    expect(actions).toEqual(["create_note", "vote"]);
-  });
-
-  it("returns empty array when no frontmatter", () => {
-    const content = "# Just a page\n\nSome content here.";
-    expect(parseAvailableActions(content)).toEqual([]);
-  });
-
-  it("returns empty array for empty content", () => {
-    expect(parseAvailableActions("")).toEqual([]);
-  });
-
-  it("returns empty array when frontmatter has no actions", () => {
-    const content = `---
-app: Harmonic
-host: test.harmonic.local
-path: /whoami
----
-# About You
-`;
-    expect(parseAvailableActions(content)).toEqual([]);
-  });
-
-  it("handles frontmatter with single action", () => {
-    const content = `---
-actions:
-  - name: send_heartbeat
-    description: Send heartbeat
----
-# Page
-`;
-    const actions = parseAvailableActions(content);
-    expect(actions).toEqual(["send_heartbeat"]);
-  });
-
-  it("ignores actions without name field", () => {
-    const content = `---
-actions:
-  - name: valid_action
-    description: Valid
-  - description: No name field
-  - name: another_valid
-    description: Also valid
----
-# Page
-`;
-    const actions = parseAvailableActions(content);
-    expect(actions).toEqual(["valid_action", "another_valid"]);
-  });
-
-  it("handles malformed YAML gracefully", () => {
-    const content = `---
-actions: [not valid yaml
----
-# Page
-`;
-    // Should not throw, return empty
-    expect(parseAvailableActions(content)).toEqual([]);
-  });
-
-  it("does not confuse horizontal rules for frontmatter", () => {
-    const content = `# Page Title
-
-Some content
-
----
-
-More content after rule
-`;
-    expect(parseAvailableActions(content)).toEqual([]);
-  });
-});
-
-describe("navigate Retry-After backoff", () => {
-  it("retries once on 429 with Retry-After and surfaces the eventual 200", async () => {
-    const calls: number[] = [];
-    let i = 0;
-    const RailsHttpTest = Layer.succeed(RailsHttp, {
-      request: async (opts: RailsRequestOptions) => {
-        calls.push(opts.method === "GET" ? 1 : 0);
-        if (i++ === 0) {
-          return { statusCode: 429, headers: { "retry-after": "0" }, text: async () => "" };
-        }
-        return makeResponse(200, "# Hello");
-      },
+  it("parses the response into messages + current_state", async () => {
+    const body = JSON.stringify({
+      messages: [
+        { content: "hi", role: "user", timestamp: "2026-06-15T10:00:00Z" },
+        { content: "hello back", role: "assistant", timestamp: "2026-06-15T10:00:01Z" },
+      ],
+      current_state: { current_path: "/collectives/foo" },
     });
-    const ConfigTest = Layer.succeed(Config, TEST_CONFIG);
-    const layer = HarmonicClientLive.pipe(Layer.provide(Layer.merge(RailsHttpTest, ConfigTest)));
-
-    const program = Effect.gen(function* () {
-      const client = yield* HarmonicClient;
-      return yield* client.navigate("/whoami", "tok", "app", createRetryBudget());
-    });
-    const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(layer)));
+    const exit = await runFetchChatHistory(() => makeResponse(200, body));
 
     expect(Exit.isSuccess(exit)).toBe(true);
     if (Exit.isSuccess(exit)) {
-      expect(exit.value.content).toContain("# Hello");
+      expect(exit.value.messages).toHaveLength(2);
+      expect(exit.value.messages[0]?.role).toBe("user");
+      expect(exit.value.current_state.current_path).toBe("/collectives/foo");
     }
-    expect(calls.length).toBe(2);
   });
 
-  it("surfaces a HarmonicApiError when 429 retry also 429s", async () => {
-    const RailsHttpTest = Layer.succeed(RailsHttp, {
-      request: async (_opts: RailsRequestOptions) => {
-        return { statusCode: 429, headers: { "retry-after": "0" }, text: async () => "rate limited" };
-      },
-    });
-    const ConfigTest = Layer.succeed(Config, TEST_CONFIG);
-    const layer = HarmonicClientLive.pipe(Layer.provide(Layer.merge(RailsHttpTest, ConfigTest)));
+  it("surfaces non-2xx HTTP responses as HarmonicApiError", async () => {
+    const exit = await runFetchChatHistory(() => makeResponse(500, "Internal Server Error"));
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const dump = JSON.stringify(exit.cause);
+      expect(dump).toMatch(/HTTP 500/);
+    }
+  });
 
-    const program = Effect.gen(function* () {
-      const client = yield* HarmonicClient;
-      return yield* client.navigate("/whoami", "tok", "app", createRetryBudget());
-    });
-    const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(layer)));
-
+  it("surfaces malformed JSON as HarmonicApiError", async () => {
+    const exit = await runFetchChatHistory(() => makeResponse(200, "not json at all"));
     expect(Exit.isFailure(exit)).toBe(true);
   });
 });

--- a/agent-runner/test/services/HarmonicClient.test.ts
+++ b/agent-runner/test/services/HarmonicClient.test.ts
@@ -4,6 +4,7 @@ import { HarmonicClient, HarmonicClientLive, parseAvailableActions, type Navigat
 import { RailsHttp } from "../../src/services/RailsHttp.js";
 import type { RailsRequestOptions, RailsResponse } from "../../src/services/RailsHttp.js";
 import { Config } from "../../src/config/Config.js";
+import { createRetryBudget } from "../../src/services/Retry.js";
 import type { HarmonicApiError } from "../../src/errors/Errors.js";
 
 // --- Test helpers for navigate ---
@@ -46,7 +47,7 @@ function runNavigate(
   const layer = buildTestLayer(requestHandler);
   const program = Effect.gen(function* () {
     const client = yield* HarmonicClient;
-    return yield* client.navigate(path, "test-token", "app");
+    return yield* client.navigate(path, "test-token", "app", createRetryBudget());
   });
   return Effect.runPromiseExit(program.pipe(Effect.provide(layer)));
 }
@@ -60,7 +61,7 @@ function runExecuteAction(
   const layer = buildTestLayer(requestHandler);
   const program = Effect.gen(function* () {
     const client = yield* HarmonicClient;
-    return yield* client.executeAction(path, action, params, "test-token", "app");
+    return yield* client.executeAction(path, action, params, "test-token", "app", createRetryBudget());
   });
   return Effect.runPromiseExit(program.pipe(Effect.provide(layer)));
 }
@@ -292,5 +293,53 @@ Some content
 More content after rule
 `;
     expect(parseAvailableActions(content)).toEqual([]);
+  });
+});
+
+describe("navigate Retry-After backoff", () => {
+  it("retries once on 429 with Retry-After and surfaces the eventual 200", async () => {
+    const calls: number[] = [];
+    let i = 0;
+    const RailsHttpTest = Layer.succeed(RailsHttp, {
+      request: async (opts: RailsRequestOptions) => {
+        calls.push(opts.method === "GET" ? 1 : 0);
+        if (i++ === 0) {
+          return { statusCode: 429, headers: { "retry-after": "0" }, text: async () => "" };
+        }
+        return makeResponse(200, "# Hello");
+      },
+    });
+    const ConfigTest = Layer.succeed(Config, TEST_CONFIG);
+    const layer = HarmonicClientLive.pipe(Layer.provide(Layer.merge(RailsHttpTest, ConfigTest)));
+
+    const program = Effect.gen(function* () {
+      const client = yield* HarmonicClient;
+      return yield* client.navigate("/whoami", "tok", "app", createRetryBudget());
+    });
+    const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(layer)));
+
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) {
+      expect(exit.value.content).toContain("# Hello");
+    }
+    expect(calls.length).toBe(2);
+  });
+
+  it("surfaces a HarmonicApiError when 429 retry also 429s", async () => {
+    const RailsHttpTest = Layer.succeed(RailsHttp, {
+      request: async (_opts: RailsRequestOptions) => {
+        return { statusCode: 429, headers: { "retry-after": "0" }, text: async () => "rate limited" };
+      },
+    });
+    const ConfigTest = Layer.succeed(Config, TEST_CONFIG);
+    const layer = HarmonicClientLive.pipe(Layer.provide(Layer.merge(RailsHttpTest, ConfigTest)));
+
+    const program = Effect.gen(function* () {
+      const client = yield* HarmonicClient;
+      return yield* client.navigate("/whoami", "tok", "app", createRetryBudget());
+    });
+    const exit = await Effect.runPromiseExit(program.pipe(Effect.provide(layer)));
+
+    expect(Exit.isFailure(exit)).toBe(true);
   });
 });

--- a/agent-runner/test/services/McpClient.test.ts
+++ b/agent-runner/test/services/McpClient.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from "vitest";
+import { Effect, Layer, Exit } from "effect";
+import {
+  McpClient,
+  McpClientLive,
+  parseResolvedPath,
+  type FetchPageResult,
+  type ExecuteActionResult,
+} from "../../src/services/McpClient.js";
+import { RailsHttp, type RailsRequestOptions, type RailsResponse } from "../../src/services/RailsHttp.js";
+import { Config } from "../../src/config/Config.js";
+import { createRetryBudget } from "../../src/services/Retry.js";
+import type { HarmonicApiError } from "../../src/errors/Errors.js";
+
+const TEST_CONFIG = {
+  harmonicInternalUrl: "http://web:3000",
+  harmonicHostname: "harmonic.local",
+  agentRunnerSecret: "test-secret",
+  redisUrl: "redis://localhost:6379",
+  llmBaseUrl: "http://localhost:4000",
+  llmGatewayMode: "litellm" as const,
+  stripeGatewayKey: undefined,
+  streamName: "agent_tasks",
+  consumerGroup: "agent_runners",
+  consumerName: "test",
+  maxConcurrentTasks: 1,
+  streamMaxLen: 1000,
+};
+
+function makeResponse(statusCode: number, body: string, headers: Record<string, string> = {}): RailsResponse {
+  return { statusCode, headers, text: async () => body };
+}
+
+function makeMcpEnvelope(opts: {
+  content?: string;
+  isError?: boolean;
+  toolCallLogId?: string;
+  errorMessage?: string;
+}): string {
+  if (opts.errorMessage !== undefined) {
+    return JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      error: { code: -32601, message: opts.errorMessage },
+    });
+  }
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      content: [{ type: "text", text: opts.content ?? "" }],
+      isError: opts.isError ?? false,
+      _meta: opts.toolCallLogId !== undefined
+        ? { harmonic: { tool_call_log_id: opts.toolCallLogId } }
+        : undefined,
+    },
+  });
+}
+
+function buildLayer(handler: (opts: RailsRequestOptions) => RailsResponse) {
+  const RailsHttpTest = Layer.succeed(RailsHttp, {
+    request: async (opts: RailsRequestOptions) => handler(opts),
+  });
+  const ConfigTest = Layer.succeed(Config, TEST_CONFIG);
+  return McpClientLive.pipe(Layer.provide(Layer.merge(RailsHttpTest, ConfigTest)));
+}
+
+function runFetchPage(handler: (opts: RailsRequestOptions) => RailsResponse, path: string): Promise<Exit.Exit<FetchPageResult, HarmonicApiError>> {
+  const program = Effect.gen(function* () {
+    const client = yield* McpClient;
+    return yield* client.fetchPage(path, "tok", "app", createRetryBudget());
+  });
+  return Effect.runPromiseExit(program.pipe(Effect.provide(buildLayer(handler))));
+}
+
+function runExecuteAction(
+  handler: (opts: RailsRequestOptions) => RailsResponse,
+  path: string,
+  action: string,
+  params: Record<string, unknown> = {},
+): Promise<Exit.Exit<ExecuteActionResult, HarmonicApiError>> {
+  const program = Effect.gen(function* () {
+    const client = yield* McpClient;
+    return yield* client.executeAction(path, action, params, "tok", "app", createRetryBudget());
+  });
+  return Effect.runPromiseExit(program.pipe(Effect.provide(buildLayer(handler))));
+}
+
+const MARKDOWN_PAGE = `---
+app: Harmonic
+path: /whoami
+title: Who Am I?
+actions:
+  - name: update_scratchpad
+    description: Update your scratchpad
+---
+# Body content here
+`;
+
+describe("McpClient.fetchPage", () => {
+  it("returns markdown content with parsed availableActions and resolvedPath from frontmatter", async () => {
+    const handler = (opts: RailsRequestOptions) => {
+      expect(opts.method).toBe("POST");
+      expect(opts.path).toBe("/mcp");
+      expect(opts.headers?.["Authorization"]).toBe("Bearer tok");
+      expect(opts.headers?.["MCP-Protocol-Version"]).toBe("2025-11-25");
+      const payload = JSON.parse(opts.body ?? "{}");
+      expect(payload.method).toBe("tools/call");
+      expect(payload.params.name).toBe("fetch_page");
+      expect(payload.params.arguments.path).toBe("/whoami");
+      return makeResponse(200, makeMcpEnvelope({
+        content: MARKDOWN_PAGE,
+        toolCallLogId: "log-abc",
+      }));
+    };
+    const exit = await runFetchPage(handler, "/whoami");
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) {
+      expect(exit.value.content).toBe(MARKDOWN_PAGE);
+      expect(exit.value.availableActions).toEqual(["update_scratchpad"]);
+      expect(exit.value.resolvedPath).toBe("/whoami");
+      expect(exit.value.mcpToolCallLogId).toBe("log-abc");
+    }
+  });
+
+  it("falls back to the requested path when frontmatter has no path: line", async () => {
+    const noPath = "---\napp: Harmonic\n---\n# Hi";
+    const handler = () => makeResponse(200, makeMcpEnvelope({ content: noPath }));
+    const exit = await runFetchPage(handler, "/requested");
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) {
+      expect(exit.value.resolvedPath).toBe("/requested");
+    }
+  });
+
+  it("surfaces JSON-RPC errors as HarmonicApiError", async () => {
+    const handler = () => makeResponse(200, makeMcpEnvelope({ errorMessage: "Method not found" }));
+    const exit = await runFetchPage(handler, "/whoami");
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+
+  it("surfaces 401 (revoked token) as HarmonicApiError", async () => {
+    const handler = () => makeResponse(401, "Unauthorized");
+    const exit = await runFetchPage(handler, "/whoami");
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const message = JSON.stringify(exit.cause);
+      expect(message).toMatch(/unauthorized/i);
+    }
+  });
+
+  it("surfaces tool isError envelope as HarmonicApiError", async () => {
+    const handler = () => makeResponse(200, makeMcpEnvelope({
+      content: "Not found",
+      isError: true,
+    }));
+    const exit = await runFetchPage(handler, "/whoami");
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+});
+
+describe("McpClient.executeAction", () => {
+  it("forwards path/action/params and returns markdown body with success=true", async () => {
+    const handler = (opts: RailsRequestOptions) => {
+      const payload = JSON.parse(opts.body ?? "{}");
+      expect(payload.params.name).toBe("execute_action");
+      expect(payload.params.arguments).toEqual({ path: "/c/foo/note", action: "create_note", params: { text: "hello" } });
+      return makeResponse(200, makeMcpEnvelope({
+        content: "## Action Success",
+        toolCallLogId: "log-xyz",
+      }));
+    };
+    const exit = await runExecuteAction(handler, "/c/foo/note", "create_note", { text: "hello" });
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) {
+      expect(exit.value.success).toBe(true);
+      expect(exit.value.content).toBe("## Action Success");
+      expect(exit.value.mcpToolCallLogId).toBe("log-xyz");
+    }
+  });
+
+  it("returns success=false when result envelope has isError: true (tool-level failure)", async () => {
+    const handler = () => makeResponse(200, makeMcpEnvelope({
+      content: "Validation failed: text can't be blank",
+      isError: true,
+    }));
+    const exit = await runExecuteAction(handler, "/c/foo/note", "create_note", {});
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) {
+      expect(exit.value.success).toBe(false);
+      expect(exit.value.content).toMatch(/Validation failed/);
+    }
+  });
+
+  it("omits params from arguments when undefined", async () => {
+    let captured: Record<string, unknown> | undefined;
+    const handler = (opts: RailsRequestOptions) => {
+      captured = JSON.parse(opts.body ?? "{}").params.arguments;
+      return makeResponse(200, makeMcpEnvelope({ content: "ok" }));
+    };
+    await runExecuteAction(handler, "/x", "noop");
+    expect(captured).toEqual({ path: "/x", action: "noop", params: {} });
+  });
+
+  it("surfaces 429 after exhausted retry as HarmonicApiError", async () => {
+    // Both initial and retry return 429 → withRetryAfter surfaces the 429
+    // and the catch path wraps it as HarmonicApiError.
+    const handler = () => ({
+      statusCode: 429,
+      headers: { "retry-after": "0" } as Record<string, string>,
+      text: async () => "rate limited",
+    });
+    const exit = await runExecuteAction(handler, "/x", "noop");
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+});
+
+describe("parseResolvedPath", () => {
+  it("extracts path from frontmatter", () => {
+    expect(parseResolvedPath("---\npath: /foo/bar\n---\n# Body")).toBe("/foo/bar");
+  });
+  it("returns null when content has no frontmatter", () => {
+    expect(parseResolvedPath("# Plain markdown")).toBeNull();
+  });
+  it("returns null when frontmatter has no path line", () => {
+    expect(parseResolvedPath("---\napp: Harmonic\n---\n# Body")).toBeNull();
+  });
+});

--- a/agent-runner/test/services/McpClient.test.ts
+++ b/agent-runner/test/services/McpClient.test.ts
@@ -3,7 +3,6 @@ import { Effect, Layer, Exit } from "effect";
 import {
   McpClient,
   McpClientLive,
-  parseResolvedPath,
   type FetchPageResult,
   type ExecuteActionResult,
 } from "../../src/services/McpClient.js";
@@ -215,14 +214,3 @@ describe("McpClient.executeAction", () => {
   });
 });
 
-describe("parseResolvedPath", () => {
-  it("extracts path from frontmatter", () => {
-    expect(parseResolvedPath("---\npath: /foo/bar\n---\n# Body")).toBe("/foo/bar");
-  });
-  it("returns null when content has no frontmatter", () => {
-    expect(parseResolvedPath("# Plain markdown")).toBeNull();
-  });
-  it("returns null when frontmatter has no path line", () => {
-    expect(parseResolvedPath("---\napp: Harmonic\n---\n# Body")).toBeNull();
-  });
-});

--- a/agent-runner/test/services/Retry.test.ts
+++ b/agent-runner/test/services/Retry.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { withRetryAfter, createRetryBudget, type RetryBudget } from "../../src/services/Retry.js";
+
+interface FakeResponse {
+  statusCode: number;
+  headers: Record<string, string | string[] | undefined>;
+  bodyDrained: boolean;
+  text: () => Promise<string>;
+}
+
+function makeResponse(statusCode: number, headers: Record<string, string> = {}): FakeResponse {
+  const resp: FakeResponse = {
+    statusCode,
+    headers,
+    bodyDrained: false,
+    text: async () => {
+      resp.bodyDrained = true;
+      return "";
+    },
+  };
+  return resp;
+}
+
+function spy(): { calls: number; sleeps: number[]; sleep: (ms: number) => Promise<void> } {
+  const sleeps: number[] = [];
+  return {
+    calls: 0,
+    sleeps,
+    sleep: async (ms: number) => {
+      sleeps.push(ms);
+    },
+  };
+}
+
+describe("withRetryAfter", () => {
+  it("passes a non-429 response through unchanged without sleeping", async () => {
+    const budget: RetryBudget = createRetryBudget();
+    const startBudget = budget.remainingMs;
+    const s = spy();
+    let calls = 0;
+    const result = await withRetryAfter(budget, async () => {
+      calls += 1;
+      return makeResponse(200);
+    }, s.sleep);
+
+    expect(result.statusCode).toBe(200);
+    expect(calls).toBe(1);
+    expect(s.sleeps).toEqual([]);
+    expect(budget.remainingMs).toBe(startBudget);
+  });
+
+  it("retries once on 429 with Retry-After, returns the retry result on success", async () => {
+    const budget: RetryBudget = createRetryBudget(60_000);
+    const s = spy();
+    const responses = [makeResponse(429, { "retry-after": "2" }), makeResponse(200)];
+    let i = 0;
+    const result = await withRetryAfter(budget, async () => {
+      return responses[i++]!;
+    }, s.sleep);
+
+    expect(result.statusCode).toBe(200);
+    expect(i).toBe(2);
+    expect(s.sleeps).toEqual([2000]);
+    expect(budget.remainingMs).toBe(60_000 - 2000);
+    expect(responses[0]!.bodyDrained).toBe(true);
+  });
+
+  it("returns the second 429 if the retry also 429s (caller surfaces to LLM)", async () => {
+    const budget: RetryBudget = createRetryBudget(60_000);
+    const s = spy();
+    const responses = [
+      makeResponse(429, { "retry-after": "1" }),
+      makeResponse(429, { "retry-after": "1" }),
+    ];
+    let i = 0;
+    const result = await withRetryAfter(budget, async () => {
+      return responses[i++]!;
+    }, s.sleep);
+
+    expect(result.statusCode).toBe(429);
+    expect(i).toBe(2);
+    expect(s.sleeps).toEqual([1000]);
+  });
+
+  it("returns 429 immediately if Retry-After exceeds remaining budget (no sleep, no retry)", async () => {
+    const budget: RetryBudget = { remainingMs: 500 }; // 0.5s remaining
+    const s = spy();
+    let calls = 0;
+    const result = await withRetryAfter(budget, async () => {
+      calls += 1;
+      return makeResponse(429, { "retry-after": "10" }); // wants 10s
+    }, s.sleep);
+
+    expect(result.statusCode).toBe(429);
+    expect(calls).toBe(1);
+    expect(s.sleeps).toEqual([]);
+    expect(budget.remainingMs).toBe(500);
+  });
+
+  it("treats missing Retry-After as no-retry (returns the 429)", async () => {
+    const budget: RetryBudget = createRetryBudget();
+    const s = spy();
+    let calls = 0;
+    const result = await withRetryAfter(budget, async () => {
+      calls += 1;
+      return makeResponse(429); // no Retry-After header
+    }, s.sleep);
+
+    expect(result.statusCode).toBe(429);
+    expect(calls).toBe(1);
+    expect(s.sleeps).toEqual([]);
+  });
+
+  it("treats malformed Retry-After as no-retry", async () => {
+    const budget: RetryBudget = createRetryBudget();
+    const s = spy();
+    let calls = 0;
+    const result = await withRetryAfter(budget, async () => {
+      calls += 1;
+      return makeResponse(429, { "retry-after": "not-a-number" });
+    }, s.sleep);
+
+    expect(result.statusCode).toBe(429);
+    expect(calls).toBe(1);
+    expect(s.sleeps).toEqual([]);
+  });
+
+  it("budget depletes across multiple retried calls within a task", async () => {
+    const budget: RetryBudget = createRetryBudget(5_000); // 5s
+    const s = spy();
+
+    // First call: 429+1s → success after 1s sleep. Budget: 5s → 4s.
+    let i = 0;
+    const r1 = await withRetryAfter(budget, async () => {
+      const resp = [makeResponse(429, { "retry-after": "1" }), makeResponse(200)][i++]!;
+      return resp;
+    }, s.sleep);
+    expect(r1.statusCode).toBe(200);
+    expect(budget.remainingMs).toBe(4_000);
+
+    // Second call: 429+3s → success after 3s sleep. Budget: 4s → 1s.
+    let j = 0;
+    const r2 = await withRetryAfter(budget, async () => {
+      const resp = [makeResponse(429, { "retry-after": "3" }), makeResponse(200)][j++]!;
+      return resp;
+    }, s.sleep);
+    expect(r2.statusCode).toBe(200);
+    expect(budget.remainingMs).toBe(1_000);
+
+    // Third call: 429+2s requested but only 1s left → return 429 immediately.
+    let k = 0;
+    const r3 = await withRetryAfter(budget, async () => {
+      k += 1;
+      return makeResponse(429, { "retry-after": "2" });
+    }, s.sleep);
+    expect(r3.statusCode).toBe(429);
+    expect(k).toBe(1);
+    expect(budget.remainingMs).toBe(1_000);
+
+    expect(s.sleeps).toEqual([1_000, 3_000]);
+  });
+});

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -314,10 +314,10 @@ class ChatsController < ApplicationController
 
   def format_activity_text(step)
     case step.step_type
-    when "navigate"
+    when "fetch_page", "navigate"
       path = step.detail&.dig("path")
       "Navigating to #{path}" if path.present?
-    when "execute"
+    when "execute_action", "execute"
       action = step.detail&.dig("action")
       "Executing #{action}" if action.present?
     end
@@ -380,7 +380,7 @@ class ChatsController < ApplicationController
       first_think_position = latest_turn.agent_session_steps.where(step_type: "think").minimum(:position)
       if first_think_position
         latest_activity_step = latest_turn.agent_session_steps
-          .where(step_type: ["navigate", "execute"])
+          .where(step_type: AgentSessionStep::TOOL_CALL_STEP_TYPES)
           .where("position > ?", first_think_position)
           .order(position: :desc)
           .first

--- a/app/controllers/internal/agent_runner_controller.rb
+++ b/app/controllers/internal/agent_runner_controller.rb
@@ -44,6 +44,12 @@ module Internal
       steps.each do |s|
         step_type = s[:type]
         timestamp = s[:timestamp].present? ? Time.parse(s[:timestamp]) : Time.current
+        mcp_tool_call_log_id = s[:mcp_tool_call_log_id]
+
+        if mcp_tool_call_log_id.present? && !mcp_log_belongs_to_task_run?(mcp_tool_call_log_id, task_run)
+          render json: { error: "mcp_tool_call_log_id does not belong to this task run" }, status: :unprocessable_entity
+          return
+        end
 
         # Message steps are stored as ChatMessage records, not AgentSessionSteps
         if step_type == "message"
@@ -68,6 +74,7 @@ module Internal
             detail: s[:detail] || {},
             created_at: timestamp,
             sender_id: s[:sender_id],
+            mcp_tool_call_log_id: mcp_tool_call_log_id,
           )
           step_offset += 1
 
@@ -314,6 +321,15 @@ module Internal
       task_run = AiAgentTaskRun.find_by(id: params[:id])
       raise TaskRunNotFound unless task_run
       task_run
+    end
+
+    # Validate that the McpToolCallLog the runner is claiming this step
+    # corresponds to actually belongs to the current task run. Defense in
+    # depth: prevents a misbehaving runner from cross-linking steps to
+    # unrelated log rows.
+    sig { params(log_id: T.untyped, task_run: AiAgentTaskRun).returns(T::Boolean) }
+    def mcp_log_belongs_to_task_run?(log_id, task_run)
+      McpToolCallLog.where(id: log_id, ai_agent_task_run_id: task_run.id).exists?
     end
 
     sig { params(_exception: StandardError).void }

--- a/app/controllers/internal/agent_runner_controller.rb
+++ b/app/controllers/internal/agent_runner_controller.rb
@@ -78,7 +78,7 @@ module Internal
           )
           step_offset += 1
 
-          if step_type == "navigate" || step_type == "execute"
+          if AgentSessionStep::TOOL_CALL_STEP_TYPES.include?(step_type)
             broadcast_chat_activity(task_run, step_record)
           end
         end
@@ -155,9 +155,9 @@ module Internal
       msg_scope = msg_scope.where("created_at >= ?", cutoff_timestamp) if cutoff_timestamp
       chat_msgs = msg_scope.to_a
 
-      # Load action steps (navigate/execute from AgentSessionStep) for interleaving
+      # Load tool-call steps for interleaving.
       action_scope = AgentSessionStep
-        .where(ai_agent_task_run_id: task_run_ids, step_type: %w[navigate execute])
+        .where(ai_agent_task_run_id: task_run_ids, step_type: AgentSessionStep::TOOL_CALL_STEP_TYPES)
         .order(:created_at, :position)
       action_scope = action_scope.where("created_at >= ?", cutoff_timestamp) if cutoff_timestamp
       action_steps = action_scope.to_a
@@ -190,10 +190,10 @@ module Internal
           }
         when :action
           case item.step_type
-          when "navigate"
+          when "fetch_page", "navigate"
             path = item.detail&.dig("path")
             action_buffer << "navigated to #{path}" if path.present?
-          when "execute"
+          when "execute_action", "execute"
             action_name = item.detail&.dig("action")
             success = item.detail&.dig("success")
             action_buffer << "#{action_name} (#{success ? "success" : "failed"})" if action_name.present?
@@ -408,10 +408,10 @@ module Internal
       return unless task_run.agent_session_steps.where(step_type: "think").exists?
 
       text = case step_record.step_type
-      when "navigate"
+      when "fetch_page", "navigate"
         path = step_record.detail&.dig("path")
         "Navigating to #{path}" if path.present?
-      when "execute"
+      when "execute_action", "execute"
         action = step_record.detail&.dig("action")
         "Executing #{action}" if action.present?
       end

--- a/app/controllers/mcp/endpoint_controller.rb
+++ b/app/controllers/mcp/endpoint_controller.rb
@@ -499,7 +499,8 @@ module Mcp
         arguments: redact_args_for_log(name, args),
         status: "pending",
         duration_ms: 0,
-        request_id: request.request_id
+        request_id: request.request_id,
+        ai_agent_task_run_id: task_run_context_id,
       )
       Current.mcp_tool_call_log_id = log.id
 
@@ -513,6 +514,36 @@ module Mcp
                  end
       duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round
       log.update!(status: tool_call_status(name, envelope), duration_ms: duration_ms)
+      stamp_log_meta(envelope, log)
+    end
+
+    # Returns the current token's context_id when context is an AiAgentTaskRun
+    # (set when AgentRunnerDispatchService issued the ephemeral token); nil
+    # otherwise (external clients, internal tokens not bound to a task run).
+    def task_run_context_id
+      return nil unless @current_token&.context_type == "AiAgentTaskRun"
+
+      @current_token.context_id
+    end
+
+    # Surface the log row id on the JSON-RPC response via _meta so the
+    # agent-runner (Step E of the migration) can plumb it into AgentSessionStep
+    # rows for a deep-link from the steps timeline to the raw call record.
+    #
+    # Only stamps on `result` envelopes. JSON-RPC's error object spec (and the
+    # MCP spec) define _meta on results but not on errors; the controller's
+    # error paths (INVALID_PARAMS, METHOD_NOT_FOUND, etc.) early-return before
+    # the log row is created and never flow through here, so result-only is
+    # both correct and sufficient.
+    def stamp_log_meta(envelope, log)
+      return envelope unless envelope.is_a?(Hash)
+
+      result = envelope[:result]
+      return envelope unless result.is_a?(Hash)
+
+      meta = (result[:_meta] ||= {})
+      harmonic = (meta[:harmonic] ||= {})
+      harmonic[:tool_call_log_id] = log.id
       envelope
     end
 

--- a/app/controllers/mcp/endpoint_controller.rb
+++ b/app/controllers/mcp/endpoint_controller.rb
@@ -527,8 +527,8 @@ module Mcp
     end
 
     # Surface the log row id on the JSON-RPC response via _meta so the
-    # agent-runner (Step E of the migration) can plumb it into AgentSessionStep
-    # rows for a deep-link from the steps timeline to the raw call record.
+    # agent-runner can plumb it into AgentSessionStep rows, enabling a
+    # deep-link from the steps timeline to the raw call record.
     #
     # Only stamps on `result` envelopes. JSON-RPC's error object spec (and the
     # MCP spec) define _meta on results but not on errors; the controller's

--- a/app/models/agent_session_step.rb
+++ b/app/models/agent_session_step.rb
@@ -3,9 +3,14 @@
 class AgentSessionStep < ApplicationRecord
   extend T::Sig
 
-  STEP_TYPES = [
-    "navigate", "think", "execute", "done", "error", "security_warning", "scratchpad_update", "scratchpad_update_failed",
-  ].freeze
+  # "fetch_page" and "execute_action" are the current step types for tool
+  # calls; "navigate" and "execute" are retained so legacy rows (written
+  # before the agent-runner switched to /mcp) still validate on read.
+  TOOL_CALL_STEP_TYPES = ["fetch_page", "execute_action", "navigate", "execute"].freeze
+
+  STEP_TYPES = (TOOL_CALL_STEP_TYPES + [
+    "think", "done", "error", "security_warning", "scratchpad_update", "scratchpad_update_failed",
+  ]).freeze
 
   belongs_to :tenant
   belongs_to :ai_agent_task_run

--- a/app/models/agent_session_step.rb
+++ b/app/models/agent_session_step.rb
@@ -10,6 +10,10 @@ class AgentSessionStep < ApplicationRecord
   belongs_to :tenant
   belongs_to :ai_agent_task_run
   belongs_to :sender, class_name: "User", optional: true
+  # Set for tool-call step types (fetch_page, execute_action; legacy:
+  # navigate, execute) when the runner is calling /mcp. Null for loop-internal
+  # step types and for pre-runner-migration rows.
+  belongs_to :mcp_tool_call_log, optional: true
 
   validates :position, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :step_type, presence: true, inclusion: { in: STEP_TYPES }

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -183,9 +183,17 @@ class ApiToken < ApplicationRecord
       tenant: Tenant,
       context: T.any(AiAgentTaskRun, AutomationRuleRun),
       expires_in: ActiveSupport::Duration,
+      mcp_only: T::Boolean,
     ).returns(ApiToken)
   end
-  def self.create_internal_token(user:, tenant:, context:, expires_in: 1.hour)
+  # `mcp_only:` is an explicit opt-in by the caller. AgentRunnerDispatchService
+  # passes true because all agent-acting calls go through /mcp via the
+  # agent-runner's McpClient (locking the token to /mcp closes the audit-bypass
+  # hole where a leaked token could be used directly without producing an
+  # McpToolCallLog row). AutomationInternalActionService leaves it false
+  # because automations dispatch via MarkdownUiService against the direct
+  # action endpoints, not /mcp.
+  def self.create_internal_token(user:, tenant:, context:, expires_in: 1.hour, mcp_only: false)
     token = new(
       user: user,
       tenant: tenant,
@@ -194,9 +202,7 @@ class ApiToken < ApplicationRecord
       name: "Internal Agent Token",
       expires_at: Time.current + expires_in,
       context: context,
-      # false because AgentRunnerDispatchService hands these tokens to a
-      # separate Node.js process that calls Rails directly, not via /mcp.
-      mcp_only: false,
+      mcp_only: mcp_only,
     )
     # Set the allow flag to bypass the validation - only this method can create internal tokens
     token.allow_internal_token = true

--- a/app/models/mcp_tool_call_log.rb
+++ b/app/models/mcp_tool_call_log.rb
@@ -21,6 +21,11 @@ class McpToolCallLog < ApplicationRecord
   belongs_to :tenant
   belongs_to :user
   belongs_to :api_token
+  # Set when the token's polymorphic context is an AiAgentTaskRun — i.e. the
+  # call came from an internal agent runner ephemeral token (or, post-runner-
+  # migration, from any internal agent routing through /mcp). Null for
+  # external MCP clients (Claude Desktop / Code / Cursor / etc.).
+  belongs_to :ai_agent_task_run, optional: true
 
   has_many :mcp_tool_call_resources, dependent: :destroy
 

--- a/app/models/mcp_tool_call_resource.rb
+++ b/app/models/mcp_tool_call_resource.rb
@@ -6,8 +6,9 @@
 # McpToolCallLog row representing the call that touched it. Companion
 # to McpToolCallLog at the per-resource grain.
 #
-# Coexists with AiAgentTaskRunResource during the agent-runner migration
-# dual-write window. See .claude/plans/mcp-resource-attribution.md.
+# Coexists with AiAgentTaskRunResource during the dual-write window —
+# external MCP callers only populate this table; requests with an
+# AiAgentTaskRun context populate both.
 class McpToolCallResource < ApplicationRecord
   extend T::Sig
 

--- a/app/services/agent_runner_dispatch_service.rb
+++ b/app/services/agent_runner_dispatch_service.rb
@@ -81,11 +81,16 @@ class AgentRunnerDispatchService
     # Create ephemeral token linked to task run.
     # Extended TTL (4 hours) because the token is created at dispatch time,
     # not execution time — the task may sit in the queue before agent-runner picks it up.
+    # mcp_only: true locks the token to /mcp. All agent-acting calls from the
+    # runner go through McpClient → /mcp, so this closes the audit-bypass hole
+    # where a leaked token could be used against direct REST/markdown
+    # endpoints without producing an McpToolCallLog row.
     token = ApiToken.create_internal_token(
       user: ai_agent,
       tenant: tenant,
       context: @task_run,
       expires_in: 4.hours,
+      mcp_only: true,
     )
 
     # Publish to Redis Stream with encrypted token

--- a/app/views/ai_agents/show_run.md.erb
+++ b/app/views/ai_agents/show_run.md.erb
@@ -27,13 +27,13 @@
 <% @task_run.agent_session_steps.each_with_index do |step_record, index| -%>
 <% step = step_record.to_step_hash.with_indifferent_access -%>
 <% detail = step[:detail].is_a?(Hash) ? step[:detail].with_indifferent_access : {} -%>
-### Step <%= index + 1 %>: <%= step[:type].upcase %>
+### Step <%= index + 1 %>: <%= step[:type].upcase.tr("_", " ") %>
 
 *<%= Time.parse(step[:timestamp]).strftime("%H:%M:%S") %>*
 
 <% case step[:type] -%>
-<% when "navigate" -%>
-Navigated to: `<%= detail[:path] %>`
+<% when "fetch_page", "navigate" -%>
+Viewed page: `<%= detail[:path] %>`
 <% if detail[:available_actions]&.any? -%>
 
 Available actions: <%= detail[:available_actions].join(", ") %>
@@ -50,7 +50,7 @@ Available actions: <%= detail[:available_actions].join(", ") %>
 </details>
 <% end -%>
 
-<% when "execute" -%>
+<% when "execute_action", "execute" -%>
 Executed: `<%= detail[:action] %>` - <%= detail[:success] ? 'Success' : 'Failed' %>
 <% if detail[:params].present? && detail[:params].any? -%>
 

--- a/app/views/shared/_task_run_steps_timeline.html.erb
+++ b/app/views/shared/_task_run_steps_timeline.html.erb
@@ -9,9 +9,9 @@
       <div class="pulse-feed-item-header">
         <div class="pulse-feed-item-type">
           <% case step[:type] %>
-          <% when "navigate" %>
+          <% when "fetch_page", "navigate" %>
             <%= octicon 'arrow-right', height: 14 %>
-          <% when "execute" %>
+          <% when "execute_action", "execute" %>
             <%= octicon 'play', height: 14 %>
           <% when "think" %>
             <%= octicon 'light-bulb', height: 14 %>
@@ -30,7 +30,7 @@
           <% else %>
             <%= octicon 'dot', height: 14 %>
           <% end %>
-          <%= step[:type].upcase %>
+          <%= step[:type].upcase.tr("_", " ") %>
         </div>
         <div class="pulse-feed-item-meta">
           <span>Step <%= index + 1 %></span>
@@ -42,9 +42,9 @@
       <div class="pulse-feed-item-body">
         <% detail = step[:detail].is_a?(Hash) ? step[:detail].with_indifferent_access : {} %>
         <% case step[:type] %>
-        <% when "navigate" %>
+        <% when "fetch_page", "navigate" %>
           <div class="pulse-feed-item-title">
-            Navigated to: <code class="pulse-code"><%= detail[:path] %></code>
+            Viewed page: <code class="pulse-code"><%= detail[:path] %></code>
           </div>
           <% if detail[:available_actions]&.any? %>
             <p class="pulse-muted" style="margin: 8px 0 0 0;">
@@ -63,7 +63,7 @@
             </details>
           <% end %>
 
-        <% when "execute" %>
+        <% when "execute_action", "execute" %>
           <div class="pulse-feed-item-title">
             Executed: <code class="pulse-code"><%= detail[:action] %></code>
             <% if detail[:success] %>

--- a/app/views/system_admin/show_task_run.md.erb
+++ b/app/views/system_admin/show_task_run.md.erb
@@ -39,10 +39,10 @@
 <% @task_run.agent_session_steps.each_with_index do |step_record, index| -%>
 <% step = step_record.to_step_hash.with_indifferent_access -%>
 <% detail = step[:detail].is_a?(Hash) ? step[:detail].with_indifferent_access : {} -%>
-### Step <%= index + 1 %>: <%= step[:type].upcase %> (<%= Time.parse(step[:timestamp]).strftime("%H:%M:%S") %>)
+### Step <%= index + 1 %>: <%= step[:type].upcase.tr("_", " ") %> (<%= Time.parse(step[:timestamp]).strftime("%H:%M:%S") %>)
 
 <% case step[:type] -%>
-<% when "navigate" -%>
+<% when "fetch_page", "navigate" -%>
 Path: `<%= detail[:path] %>`
 <% if !redacted && detail[:content_preview].present? -%>
 
@@ -50,7 +50,7 @@ Path: `<%= detail[:path] %>`
 <%= detail[:content_preview] %>
 ```
 <% end -%>
-<% when "execute" -%>
+<% when "execute_action", "execute" -%>
 Action: `<%= detail[:action] %>` — <%= detail[:success] ? "success" : "failed" %>
 <% if detail[:error].present? -%>
 Error: <%= detail[:error] %>

--- a/db/migrate/20260615120000_add_ai_agent_task_run_id_to_mcp_tool_call_logs.rb
+++ b/db/migrate/20260615120000_add_ai_agent_task_run_id_to_mcp_tool_call_logs.rb
@@ -1,0 +1,38 @@
+class AddAiAgentTaskRunIdToMcpToolCallLogs < ActiveRecord::Migration[7.2]
+  def up
+    unless column_exists?(:mcp_tool_call_logs, :ai_agent_task_run_id)
+      add_column :mcp_tool_call_logs, :ai_agent_task_run_id, :uuid, null: true
+    end
+
+    # Drop any pre-existing FK on this column (may have been added by an earlier
+    # iteration of this migration without on_delete: :nullify) so we can
+    # recreate it with the audit-trail-correct cascade.
+    if foreign_key_exists?(:mcp_tool_call_logs, column: :ai_agent_task_run_id)
+      remove_foreign_key :mcp_tool_call_logs, column: :ai_agent_task_run_id
+    end
+    add_foreign_key :mcp_tool_call_logs, :ai_agent_task_runs,
+                    column: :ai_agent_task_run_id, on_delete: :nullify
+
+    # Compound index supports the most common query shape:
+    # "what tool calls happened during task run X, in order?"
+    unless index_exists?(:mcp_tool_call_logs, [:ai_agent_task_run_id, :created_at],
+                        name: "idx_mcp_logs_on_task_run_and_created_at")
+      add_index :mcp_tool_call_logs, [:ai_agent_task_run_id, :created_at],
+                where: "ai_agent_task_run_id IS NOT NULL",
+                name: "idx_mcp_logs_on_task_run_and_created_at"
+    end
+  end
+
+  def down
+    if index_exists?(:mcp_tool_call_logs, [:ai_agent_task_run_id, :created_at],
+                    name: "idx_mcp_logs_on_task_run_and_created_at")
+      remove_index :mcp_tool_call_logs, name: "idx_mcp_logs_on_task_run_and_created_at"
+    end
+    if foreign_key_exists?(:mcp_tool_call_logs, column: :ai_agent_task_run_id)
+      remove_foreign_key :mcp_tool_call_logs, column: :ai_agent_task_run_id
+    end
+    if column_exists?(:mcp_tool_call_logs, :ai_agent_task_run_id)
+      remove_column :mcp_tool_call_logs, :ai_agent_task_run_id
+    end
+  end
+end

--- a/db/migrate/20260615130000_add_mcp_tool_call_log_id_to_agent_session_steps.rb
+++ b/db/migrate/20260615130000_add_mcp_tool_call_log_id_to_agent_session_steps.rb
@@ -1,0 +1,20 @@
+class AddMcpToolCallLogIdToAgentSessionSteps < ActiveRecord::Migration[7.2]
+  def change
+    # Optional link from an agent_session_step to the McpToolCallLog row
+    # representing the underlying MCP tool call. Populated by the agent-runner
+    # from the _meta.harmonic.tool_call_log_id field on the MCP response, so
+    # the steps timeline can deep-link to the raw call record.
+    #
+    # Pre-runner-migration step rows leave this null. Loop-internal step
+    # types (think, done, error, security_warning, scratchpad_update*) also
+    # leave it null because they don't correspond to a tool call.
+    #
+    # on_delete: :nullify so a step row survives audit-log retention pruning
+    # (eventual partition+archive) with a broken link rather than vanishing.
+    add_reference :agent_session_steps, :mcp_tool_call_log,
+                  type: :uuid,
+                  null: true,
+                  foreign_key: { on_delete: :nullify },
+                  index: { where: "mcp_tool_call_log_id IS NOT NULL", name: "idx_session_steps_on_mcp_log" }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -153,7 +153,8 @@ CREATE TABLE public.agent_session_steps (
     sender_id uuid,
     detail jsonb DEFAULT '{}'::jsonb NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    tenant_id uuid NOT NULL
+    tenant_id uuid NOT NULL,
+    mcp_tool_call_log_id uuid
 );
 
 
@@ -3317,6 +3318,13 @@ CREATE INDEX idx_search_index_type ON ONLY public.search_index USING btree (tena
 --
 
 CREATE UNIQUE INDEX idx_search_index_unique_item ON ONLY public.search_index USING btree (tenant_id, item_type, item_id);
+
+
+--
+-- Name: idx_session_steps_on_mcp_log; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_session_steps_on_mcp_log ON public.agent_session_steps USING btree (mcp_tool_call_log_id) WHERE (mcp_tool_call_log_id IS NOT NULL);
 
 
 --
@@ -9450,6 +9458,14 @@ ALTER TABLE ONLY public.automation_rules
 
 
 --
+-- Name: agent_session_steps fk_rails_92776c0c45; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.agent_session_steps
+    ADD CONSTRAINT fk_rails_92776c0c45 FOREIGN KEY (mcp_tool_call_log_id) REFERENCES public.mcp_tool_call_logs(id) ON DELETE SET NULL;
+
+
+--
 -- Name: note_history_events fk_rails_927b722124; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10040,6 +10056,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260615130000'),
 ('20260615120000'),
 ('20260615000000'),
 ('20260614120000'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -825,7 +825,8 @@ CREATE TABLE public.mcp_tool_call_logs (
     duration_ms integer NOT NULL,
     request_id character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    ai_agent_task_run_id uuid
 );
 
 
@@ -3155,6 +3156,13 @@ CREATE INDEX idx_audit_entries_decision ON public.decision_audit_entries USING b
 --
 
 CREATE UNIQUE INDEX idx_audit_entries_decision_sequence ON public.decision_audit_entries USING btree (decision_id, sequence_number);
+
+
+--
+-- Name: idx_mcp_logs_on_task_run_and_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_mcp_logs_on_task_run_and_created_at ON public.mcp_tool_call_logs USING btree (ai_agent_task_run_id, created_at) WHERE (ai_agent_task_run_id IS NOT NULL);
 
 
 --
@@ -9170,6 +9178,14 @@ ALTER TABLE ONLY public.note_history_events
 
 
 --
+-- Name: mcp_tool_call_logs fk_rails_60cc7f713b; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.mcp_tool_call_logs
+    ADD CONSTRAINT fk_rails_60cc7f713b FOREIGN KEY (ai_agent_task_run_id) REFERENCES public.ai_agent_task_runs(id) ON DELETE SET NULL;
+
+
+--
 -- Name: chat_messages fk_rails_6223514182; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10024,6 +10040,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260615120000'),
 ('20260615000000'),
 ('20260614120000'),
 ('20260614000000'),

--- a/sorbet/rbi/dsl/agent_session_step.rbi
+++ b/sorbet/rbi/dsl/agent_session_step.rbi
@@ -181,6 +181,7 @@ class AgentSessionStep
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         block: T.proc.params(object: ::AgentSessionStep).void
       ).void
@@ -191,10 +192,11 @@ class AgentSessionStep
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol
       ).returns(T::Enumerator[::AgentSessionStep])
     end
-    def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
+    def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
 
     sig do
       params(
@@ -202,6 +204,7 @@ class AgentSessionStep
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         block: T.proc.params(object: T::Array[::AgentSessionStep]).void
       ).void
@@ -212,10 +215,11 @@ class AgentSessionStep
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol
       ).returns(T::Enumerator[T::Enumerator[::AgentSessionStep]])
     end
-    def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
+    def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
 
     sig do
       params(
@@ -297,6 +301,7 @@ class AgentSessionStep
         finish: T.untyped,
         load: T.untyped,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         use_ranges: T.untyped,
         block: T.proc.params(object: PrivateRelation).void
@@ -309,11 +314,12 @@ class AgentSessionStep
         finish: T.untyped,
         load: T.untyped,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         use_ranges: T.untyped
       ).returns(::ActiveRecord::Batches::BatchEnumerator)
     end
-    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, use_ranges: nil, &block); end
+    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, cursor: primary_key, order: :asc, use_ranges: nil, &block); end
 
     sig { params(record: T.untyped).returns(T::Boolean) }
     def include?(record); end
@@ -425,6 +431,9 @@ class AgentSessionStep
     sig { params(args: T.untyped, blk: T.untyped).returns(::AiAgentTaskRun) }
     def build_ai_agent_task_run(*args, &blk); end
 
+    sig { params(args: T.untyped, blk: T.untyped).returns(::McpToolCallLog) }
+    def build_mcp_tool_call_log(*args, &blk); end
+
     sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
     def build_sender(*args, &blk); end
 
@@ -436,6 +445,12 @@ class AgentSessionStep
 
     sig { params(args: T.untyped, blk: T.untyped).returns(::AiAgentTaskRun) }
     def create_ai_agent_task_run!(*args, &blk); end
+
+    sig { params(args: T.untyped, blk: T.untyped).returns(::McpToolCallLog) }
+    def create_mcp_tool_call_log(*args, &blk); end
+
+    sig { params(args: T.untyped, blk: T.untyped).returns(::McpToolCallLog) }
+    def create_mcp_tool_call_log!(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
     def create_sender(*args, &blk); end
@@ -449,8 +464,23 @@ class AgentSessionStep
     sig { params(args: T.untyped, blk: T.untyped).returns(::Tenant) }
     def create_tenant!(*args, &blk); end
 
+    sig { returns(T.nilable(::McpToolCallLog)) }
+    def mcp_tool_call_log; end
+
+    sig { params(value: T.nilable(::McpToolCallLog)).void }
+    def mcp_tool_call_log=(value); end
+
+    sig { returns(T::Boolean) }
+    def mcp_tool_call_log_changed?; end
+
+    sig { returns(T::Boolean) }
+    def mcp_tool_call_log_previously_changed?; end
+
     sig { returns(T.nilable(::AiAgentTaskRun)) }
     def reload_ai_agent_task_run; end
+
+    sig { returns(T.nilable(::McpToolCallLog)) }
+    def reload_mcp_tool_call_log; end
 
     sig { returns(T.nilable(::User)) }
     def reload_sender; end
@@ -460,6 +490,9 @@ class AgentSessionStep
 
     sig { void }
     def reset_ai_agent_task_run; end
+
+    sig { void }
+    def reset_mcp_tool_call_log; end
 
     sig { void }
     def reset_sender; end
@@ -564,9 +597,6 @@ class AgentSessionStep
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
     def merge(*args, &blk); end
-
-    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
-    def messages(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
     def none(*args, &blk); end
@@ -873,6 +903,51 @@ class AgentSessionStep
     sig { void }
     def id_will_change!; end
 
+    sig { returns(T.nilable(::String)) }
+    def mcp_tool_call_log_id; end
+
+    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+    def mcp_tool_call_log_id=(value); end
+
+    sig { returns(T::Boolean) }
+    def mcp_tool_call_log_id?; end
+
+    sig { returns(T.nilable(::String)) }
+    def mcp_tool_call_log_id_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def mcp_tool_call_log_id_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def mcp_tool_call_log_id_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def mcp_tool_call_log_id_change; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def mcp_tool_call_log_id_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def mcp_tool_call_log_id_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def mcp_tool_call_log_id_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def mcp_tool_call_log_id_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def mcp_tool_call_log_id_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def mcp_tool_call_log_id_previously_was; end
+
+    sig { returns(T.nilable(::String)) }
+    def mcp_tool_call_log_id_was; end
+
+    sig { void }
+    def mcp_tool_call_log_id_will_change!; end
+
     sig { returns(::Integer) }
     def position; end
 
@@ -934,6 +1009,9 @@ class AgentSessionStep
     def restore_id_value!; end
 
     sig { void }
+    def restore_mcp_tool_call_log_id!; end
+
+    sig { void }
     def restore_position!; end
 
     sig { void }
@@ -974,6 +1052,12 @@ class AgentSessionStep
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_id_value?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def saved_change_to_mcp_tool_call_log_id; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_mcp_tool_call_log_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([::Integer, ::Integer])) }
     def saved_change_to_position; end
@@ -1150,6 +1234,9 @@ class AgentSessionStep
     def will_save_change_to_id_value?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_mcp_tool_call_log_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_position?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
@@ -1234,9 +1321,6 @@ class AgentSessionStep
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
     def merge(*args, &blk); end
-
-    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
-    def messages(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
     def none(*args, &blk); end

--- a/sorbet/rbi/dsl/mcp_tool_call_log.rbi
+++ b/sorbet/rbi/dsl/mcp_tool_call_log.rbi
@@ -416,6 +416,18 @@ class McpToolCallLog
   end
 
   module GeneratedAssociationMethods
+    sig { returns(T.nilable(::AiAgentTaskRun)) }
+    def ai_agent_task_run; end
+
+    sig { params(value: T.nilable(::AiAgentTaskRun)).void }
+    def ai_agent_task_run=(value); end
+
+    sig { returns(T::Boolean) }
+    def ai_agent_task_run_changed?; end
+
+    sig { returns(T::Boolean) }
+    def ai_agent_task_run_previously_changed?; end
+
     sig { returns(T.nilable(::ApiToken)) }
     def api_token; end
 
@@ -428,6 +440,9 @@ class McpToolCallLog
     sig { returns(T::Boolean) }
     def api_token_previously_changed?; end
 
+    sig { params(args: T.untyped, blk: T.untyped).returns(::AiAgentTaskRun) }
+    def build_ai_agent_task_run(*args, &blk); end
+
     sig { params(args: T.untyped, blk: T.untyped).returns(::ApiToken) }
     def build_api_token(*args, &blk); end
 
@@ -436,6 +451,12 @@ class McpToolCallLog
 
     sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
     def build_user(*args, &blk); end
+
+    sig { params(args: T.untyped, blk: T.untyped).returns(::AiAgentTaskRun) }
+    def create_ai_agent_task_run(*args, &blk); end
+
+    sig { params(args: T.untyped, blk: T.untyped).returns(::AiAgentTaskRun) }
+    def create_ai_agent_task_run!(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(::ApiToken) }
     def create_api_token(*args, &blk); end
@@ -469,6 +490,9 @@ class McpToolCallLog
     sig { params(value: T::Enumerable[::McpToolCallResource]).void }
     def mcp_tool_call_resources=(value); end
 
+    sig { returns(T.nilable(::AiAgentTaskRun)) }
+    def reload_ai_agent_task_run; end
+
     sig { returns(T.nilable(::ApiToken)) }
     def reload_api_token; end
 
@@ -477,6 +501,9 @@ class McpToolCallLog
 
     sig { returns(T.nilable(::User)) }
     def reload_user; end
+
+    sig { void }
+    def reset_ai_agent_task_run; end
 
     sig { void }
     def reset_api_token; end
@@ -662,6 +689,51 @@ class McpToolCallLog
   end
 
   module GeneratedAttributeMethods
+    sig { returns(T.nilable(::String)) }
+    def ai_agent_task_run_id; end
+
+    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+    def ai_agent_task_run_id=(value); end
+
+    sig { returns(T::Boolean) }
+    def ai_agent_task_run_id?; end
+
+    sig { returns(T.nilable(::String)) }
+    def ai_agent_task_run_id_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def ai_agent_task_run_id_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def ai_agent_task_run_id_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def ai_agent_task_run_id_change; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def ai_agent_task_run_id_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def ai_agent_task_run_id_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def ai_agent_task_run_id_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def ai_agent_task_run_id_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def ai_agent_task_run_id_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def ai_agent_task_run_id_previously_was; end
+
+    sig { returns(T.nilable(::String)) }
+    def ai_agent_task_run_id_was; end
+
+    sig { void }
+    def ai_agent_task_run_id_will_change!; end
+
     sig { returns(::String) }
     def api_token_id; end
 
@@ -978,6 +1050,9 @@ class McpToolCallLog
     def request_id_will_change!; end
 
     sig { void }
+    def restore_ai_agent_task_run_id!; end
+
+    sig { void }
     def restore_api_token_id!; end
 
     sig { void }
@@ -1012,6 +1087,12 @@ class McpToolCallLog
 
     sig { void }
     def restore_user_id!; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def saved_change_to_ai_agent_task_run_id; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_ai_agent_task_run_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([::String, ::String])) }
     def saved_change_to_api_token_id; end
@@ -1309,6 +1390,9 @@ class McpToolCallLog
 
     sig { void }
     def user_id_will_change!; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_ai_agent_task_run_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_api_token_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/test/controllers/internal/agent_runner_controller_test.rb
+++ b/test/controllers/internal/agent_runner_controller_test.rb
@@ -129,6 +129,21 @@ class Internal::AgentRunnerControllerTest < ActionDispatch::IntegrationTest
     assert_equal({ "path" => "/notifications" }, step_row.detail)
   end
 
+  test "step accepts new tool-call step types (fetch_page, execute_action)" do
+    @task_run.update!(status: "running", started_at: Time.current)
+    body = {
+      steps: [
+        { type: "fetch_page", detail: { path: "/whoami" }, timestamp: Time.current.iso8601 },
+        { type: "execute_action", detail: { action: "create_note", success: true }, timestamp: Time.current.iso8601 },
+      ],
+    }.to_json
+    post step_url, params: body, headers: signed_headers(body)
+    assert_response :success
+    assert_equal 2, @task_run.agent_session_steps.count
+    types = @task_run.agent_session_steps.pluck(:step_type).sort
+    assert_equal ["execute_action", "fetch_page"], types
+  end
+
   test "step populates mcp_tool_call_log_id when provided in payload" do
     @ai_agent.update!(agent_configuration: { "mode" => "internal" })
     @task_run.update!(status: "running", started_at: Time.current)
@@ -141,7 +156,7 @@ class Internal::AgentRunnerControllerTest < ActionDispatch::IntegrationTest
 
     body = {
       steps: [
-        { type: "navigate", detail: { path: "/whoami" }, timestamp: Time.current.iso8601, mcp_tool_call_log_id: log.id },
+        { type: "fetch_page", detail: { path: "/whoami" }, timestamp: Time.current.iso8601, mcp_tool_call_log_id: log.id },
       ],
     }.to_json
 

--- a/test/controllers/internal/agent_runner_controller_test.rb
+++ b/test/controllers/internal/agent_runner_controller_test.rb
@@ -129,6 +129,72 @@ class Internal::AgentRunnerControllerTest < ActionDispatch::IntegrationTest
     assert_equal({ "path" => "/notifications" }, step_row.detail)
   end
 
+  test "step populates mcp_tool_call_log_id when provided in payload" do
+    @ai_agent.update!(agent_configuration: { "mode" => "internal" })
+    @task_run.update!(status: "running", started_at: Time.current)
+    api_token = ApiToken.create_internal_token(user: @ai_agent, tenant: @tenant, context: @task_run)
+    log = McpToolCallLog.create!(
+      tenant: @tenant, user: @ai_agent, api_token: api_token,
+      tool_name: "fetch_page", arguments: {}, status: "ok", duration_ms: 5,
+      ai_agent_task_run: @task_run,
+    )
+
+    body = {
+      steps: [
+        { type: "navigate", detail: { path: "/whoami" }, timestamp: Time.current.iso8601, mcp_tool_call_log_id: log.id },
+      ],
+    }.to_json
+
+    post step_url, params: body, headers: signed_headers(body)
+    assert_response :success
+
+    step_row = @task_run.agent_session_steps.first
+    assert_equal log.id, step_row.mcp_tool_call_log_id
+  end
+
+  test "step leaves mcp_tool_call_log_id null when omitted (loop-internal types like think)" do
+    @task_run.update!(status: "running", started_at: Time.current)
+
+    body = {
+      steps: [
+        { type: "think", detail: { thought: "considering" }, timestamp: Time.current.iso8601 },
+      ],
+    }.to_json
+
+    post step_url, params: body, headers: signed_headers(body)
+    assert_response :success
+
+    step_row = @task_run.agent_session_steps.first
+    assert_nil step_row.mcp_tool_call_log_id
+  end
+
+  test "step rejects mcp_tool_call_log_id from a different task run" do
+    @ai_agent.update!(agent_configuration: { "mode" => "internal" })
+    @task_run.update!(status: "running", started_at: Time.current)
+
+    # Log row belonging to a different task run in the same tenant.
+    other_run = AiAgentTaskRun.create!(
+      tenant: @tenant, ai_agent: @ai_agent, initiated_by: @user,
+      task: "other", max_steps: 5, status: "running"
+    )
+    other_token = ApiToken.create_internal_token(user: @ai_agent, tenant: @tenant, context: other_run)
+    foreign_log = McpToolCallLog.create!(
+      tenant: @tenant, user: @ai_agent, api_token: other_token,
+      tool_name: "fetch_page", arguments: {}, status: "ok", duration_ms: 5,
+      ai_agent_task_run: other_run,
+    )
+
+    body = {
+      steps: [
+        { type: "navigate", detail: { path: "/whoami" }, timestamp: Time.current.iso8601, mcp_tool_call_log_id: foreign_log.id },
+      ],
+    }.to_json
+
+    post step_url, params: body, headers: signed_headers(body)
+    assert_response :unprocessable_entity
+    assert_equal 0, @task_run.agent_session_steps.count
+  end
+
   test "step assigns sequential positions across multiple calls" do
     @task_run.update!(status: "running", started_at: Time.current)
 

--- a/test/controllers/mcp/endpoint_controller_test.rb
+++ b/test/controllers/mcp/endpoint_controller_test.rb
@@ -1554,4 +1554,64 @@ class Mcp::EndpointControllerTest < ActionDispatch::IntegrationTest # rubocop:di
                    })
     end
   end
+
+  # ====================
+  # Task-run linkage and _meta exposure (Step B)
+  #
+  # When the calling token has a polymorphic context of AiAgentTaskRun
+  # (i.e. it's an internal agent-runner ephemeral token), the log row gets
+  # ai_agent_task_run_id stamped. Every tools/call response also carries
+  # _meta.harmonic.tool_call_log_id so the agent-runner can plumb it into
+  # AgentSessionStep rows for deep-linking.
+  # ====================
+
+  test "tools/call response includes _meta.harmonic.tool_call_log_id on success" do
+    post_jsonrpc({
+                   jsonrpc: "2.0", id: 900, method: "tools/call",
+                   params: { name: "fetch_page", arguments: { path: "/whoami" } },
+                 })
+
+    body = response.parsed_body
+    log = McpToolCallLog.order(:created_at).last
+    assert_equal log.id, body.dig("result", "_meta", "harmonic", "tool_call_log_id")
+  end
+
+  test "tools/call response includes _meta.harmonic.tool_call_log_id on unknown tool" do
+    post_jsonrpc({
+                   jsonrpc: "2.0", id: 901, method: "tools/call",
+                   params: { name: "no_such_tool", arguments: {} },
+                 })
+
+    body = response.parsed_body
+    log = McpToolCallLog.order(:created_at).last
+    assert_equal "unknown_tool", log.status
+    assert_equal log.id, body.dig("result", "_meta", "harmonic", "tool_call_log_id")
+  end
+
+  test "log row stamps ai_agent_task_run_id when token context is an AiAgentTaskRun" do
+    task_run = AiAgentTaskRun.create!(
+      tenant: @tenant, ai_agent: @agent, initiated_by: @user,
+      task: "test", max_steps: 5, status: "running"
+    )
+    @api_token.update!(context: task_run)
+
+    post_jsonrpc({
+                   jsonrpc: "2.0", id: 902, method: "tools/call",
+                   params: { name: "fetch_page", arguments: { path: "/whoami" } },
+                 })
+
+    log = McpToolCallLog.order(:created_at).last
+    assert_equal task_run.id, log.ai_agent_task_run_id
+  end
+
+  test "log row leaves ai_agent_task_run_id null when token has no task-run context" do
+    # @api_token from setup has no context — represents an external client.
+    post_jsonrpc({
+                   jsonrpc: "2.0", id: 903, method: "tools/call",
+                   params: { name: "fetch_page", arguments: { path: "/whoami" } },
+                 })
+
+    log = McpToolCallLog.order(:created_at).last
+    assert_nil log.ai_agent_task_run_id
+  end
 end

--- a/test/integration/api_token_mcp_only_test.rb
+++ b/test/integration/api_token_mcp_only_test.rb
@@ -131,7 +131,11 @@ class ApiTokenMcpOnlyTest < ActionDispatch::IntegrationTest
   # ====================
 
   test "ApiToken.create_internal_token defaults mcp_only=false" do
-    # Agent runner uses these tokens for direct HTTPS calls, not via /mcp.
+    # The default is conservative; the security boundary is enforced at the
+    # call site. AgentRunnerDispatchService passes mcp_only: true explicitly
+    # because its tokens flow through /mcp via the runner's McpClient;
+    # AutomationInternalActionService omits the kwarg because automations
+    # dispatch via MarkdownUiService against direct action endpoints.
     task_run = AiAgentTaskRun.create!(
       tenant: @tenant,
       ai_agent: @ai_agent,
@@ -140,6 +144,19 @@ class ApiTokenMcpOnlyTest < ActionDispatch::IntegrationTest
     )
     token = ApiToken.create_internal_token(user: @ai_agent, tenant: @tenant, context: task_run)
     refute token.mcp_only?
+  end
+
+  test "ApiToken.create_internal_token accepts mcp_only: true opt-in" do
+    task_run = AiAgentTaskRun.create!(
+      tenant: @tenant,
+      ai_agent: @ai_agent,
+      initiated_by: @parent,
+      task: "test",
+    )
+    token = ApiToken.create_internal_token(
+      user: @ai_agent, tenant: @tenant, context: task_run, mcp_only: true,
+    )
+    assert token.mcp_only?
   end
 
   test "human tokens default mcp_only=false" do

--- a/test/models/mcp_tool_call_log_test.rb
+++ b/test/models/mcp_tool_call_log_test.rb
@@ -100,4 +100,26 @@ class McpToolCallLogTest < ActiveSupport::TestCase
     assert_equal 1, McpToolCallLog.count
     assert_equal @tenant.id, McpToolCallLog.first.tenant_id
   end
+
+  test "ai_agent_task_run_id is optional and nil by default" do
+    log = McpToolCallLog.create!(
+      tenant: @tenant, user: @agent, api_token: @token,
+      tool_name: "fetch_page", arguments: {}, status: "ok", duration_ms: 1
+    )
+    assert_nil log.ai_agent_task_run_id
+    assert_nil log.ai_agent_task_run
+  end
+
+  test "ai_agent_task_run can be associated" do
+    task_run = AiAgentTaskRun.create!(
+      tenant: @tenant, ai_agent: @agent, initiated_by: @user,
+      task: "test", max_steps: 5, status: "running"
+    )
+    log = McpToolCallLog.create!(
+      tenant: @tenant, user: @agent, api_token: @token,
+      tool_name: "fetch_page", arguments: {}, status: "ok", duration_ms: 1,
+      ai_agent_task_run: task_run
+    )
+    assert_equal task_run, log.ai_agent_task_run
+  end
 end


### PR DESCRIPTION
## Summary

Migrates the internal agent-runner from direct REST calls against Rails to the hosted `/mcp` endpoint. After this lands, internal and external agents share the same tool surface, every internal-agent action lands in `McpToolCallLog` linked to its parent `AiAgentTaskRun`, and a deep-link chain (task run → call → resources/steps) connects what used to be three disjoint records.

Builds on the resource-attribution layer shipped in PR #239 (Branch 1). The dual-write semantics that branch set up activate automatically as soon as this branch's runner migration starts producing internal MCP calls.

## What ships

### Rails — audit-chain plumbing

- **`McpToolCallLog.ai_agent_task_run_id`** — nullable FK. Populated from `current_token.context_id` when the token's polymorphic context is `AiAgentTaskRun`. Internal-agent calls always set it; external clients leave it `NULL`. `on_delete: :nullify` so log rows survive task-run deletion with a broken link (audit-trail semantics).
- **MCP `tools/call` response gains `_meta.harmonic.tool_call_log_id`** on every `result` envelope — spec-compliant per JSON-RPC, harmless to external clients.
- **`AgentSessionStep.mcp_tool_call_log_id`** — nullable FK so the human's task-run UI can deep-link a step row to the raw `McpToolCallLog`. Populated by the runner from the `_meta` field on each MCP response. Cross-task-run references rejected at the step endpoint (defense-in-depth against a misbehaving runner cross-linking step rows to log rows from a different task run).

### Agent-runner — transport migration

- **New `McpClient`** ([agent-runner/src/services/McpClient.ts](agent-runner/src/services/McpClient.ts)) replaces `HarmonicClient.navigate` / `executeAction`. Stateless one-shot `POST /mcp` per call with `Authorization: Bearer …` and `MCP-Protocol-Version: 2025-11-25`. No session handshake, no `MCP-Session-Id` — matches the hosted endpoint's stateless design.
- **No dependency on `@modelcontextprotocol/sdk`.** The SDK is built around long-lived stateful sessions with SSE resumption; we want the opposite. A small hand-rolled JSON-RPC envelope keeps call sites obvious.
- **`HarmonicClient` slimmed to just `fetchChatHistory`** — the only remaining HMAC-authenticated runner ↔ Rails call (used to build LLM prompt context, not an agent tool). 500+ lines of dead transport code dropped.
- **`Retry-After` backoff** ([Retry.ts](agent-runner/src/services/Retry.ts)) — on 429 with a parseable `Retry-After`, sleep capped by a per-task `RetryBudget` (default 60s), retry once. Budget exhausted → return the 429 immediately. Surfaces to the LLM as a tool error if the retry also 429s. Wraps both fetch-page and execute-action transports.
- **Step type rename** in `StepBuilder.ts`: `navigate → fetch_page`, `execute → execute_action`. The six loop-internal step types (`think`, `done`, `error`, `security_warning`, `scratchpad_update`, `scratchpad_update_failed`) stay — they aren't tool calls. Legacy strings preserved on existing rows.
- **Frontmatter parsers extracted** into `core/MarkdownFrontmatter.ts` — `parseAvailableActions` and `parseResolvedPath` live alongside other data parsers in `core/` rather than inside a transport module.

### Rails — security lockdown

- **`mcp_only: true` is now an explicit opt-in at `create_internal_token`** call sites, defaulting to `false`. `AgentRunnerDispatchService` passes `true`; `AutomationInternalActionService` omits the kwarg (automations dispatch via `MarkdownUiService` against direct action endpoints, not `/mcp` — `mcp_only` should mean what it says).
- Result: every newly-issued agent-runner ephemeral token is locked to `/mcp`. A leaked token can no longer be used to call `/collectives/.../actions/...` directly and produce no `McpToolCallLog` row. Closes the audit-bypass hole.

### View — task-run timeline

- **`show_run` views** ([_task_run_steps_timeline.html.erb](app/views/shared/_task_run_steps_timeline.html.erb), [show_run.md.erb](app/views/ai_agents/show_run.md.erb), [system_admin/show_task_run.md.erb](app/views/system_admin/show_task_run.md.erb)) render `fetch_page` and `execute_action` step types alongside legacy `navigate`/`execute` — single `case` branches handle both. Display labels use `tr("_", " ")` so the new types read as "FETCH PAGE" / "EXECUTE ACTION" rather than the underscored enum.
- User-facing label changed from "Navigated to" → "Viewed page" in the steps timeline (per UX preference).
- New `AgentSessionStep::TOOL_CALL_STEP_TYPES` constant — single source of truth for the four tool-call step types (legacy + new). Replaces four ad-hoc inline lists across controllers/views.

## Verified end-to-end

Dogfooded against a chat-turn task run with internal agent Hermes2:

- ✓ Task run completed (5 steps, 6.1s, `chat_turn` mode)
- ✓ `McpToolCallLog.ai_agent_task_run_id` populated (Step B)
- ✓ `AgentSessionStep.mcp_tool_call_log_id` linked from step to log row (Step B')
- ✓ Runner routed through `/mcp` — log row exists, only possible if McpClient hit the endpoint
- ✓ New step type strings (`fetch_page`, not `navigate`)
- ✓ `mcp_only: true` token worked — call succeeded against `/mcp`, the only path the locked-down token can take
- ✓ Step types rendered correctly in the task-run UI

The `execute_action` + `McpToolCallResource` dual-write path is verified at the unit-test level (Rails endpoint + Internal step endpoint + AgentLoop integration tests) and was dogfooded for external MCP in PR #239. Wasn't exercised end-to-end here because Hermes2 chose not to create a note (scratchpad-induced hesitation, not a real capability gap).

## Test coverage

- **203 agent-runner tests** (Vitest) — McpClient happy paths + 429/auth error handling, Retry budget exhaustion, StepBuilder type emission with log-id propagation, AgentLoop integration with mocked McpClient, slimmed HarmonicClient with new `fetchChatHistory` coverage
- **Rails endpoint tests** — `_meta` injection on success + error envelopes, FK populated when token has `AiAgentTaskRun` context, FK null otherwise, defensive null handling for non-`AiAgentTaskRun` context types
- **Internal step endpoint tests** — happy path with `mcp_tool_call_log_id`, null when omitted, cross-task-run reference rejected (422)
- **`mcp_only` integration tests** — default false at `create_internal_token`, explicit `mcp_only: true` opt-in accepted, validation unchanged (only AI agents)
- **Cross-tenant regression** locked in from PR #239 — `McpToolCallLog`'s tenant-scoped default scope + `belongs_to` validation reject cross-tenant log_id references

## Migration concerns

- **Hard dependency on `/mcp`**: after this lands, every newly-dispatched internal agent task can ONLY use `/mcp`. If `/mcp` has a Rails-side outage, internal agents fail their actions — no direct-call fallback. The trade-off is intentional (audit integrity), and the internal HMAC endpoints (preflight/claim/step/complete/scratchpad) are unaffected because they use HMAC, not Bearer.
- **`McpToolCallLog::STATUSES` gained `"pending"`** — represents the in-flight state during dispatch. Operator dashboards filtering on terminal statuses might temporarily miss in-flight calls (~50–2000ms window). Side benefit: orphaned `pending` rows older than N seconds become a useful signal for processes killed mid-dispatch, which Phase 1's post-dispatch-only log write silently dropped.

## Out of scope

- **`AiAgentTaskRunResource` deprecation** — the dual-write coexistence layer continues until the next branch ([agent-runner-mcp-migration.md](.claude/plans/agent-runner-mcp-migration.md) Step H), once the migration soaks.
- **Phase 2 principal-review UI** for per-call detail browsing — the deep-link substrate is in place (`mcp_tool_call_log_id` on `AgentSessionStep`); the click-through detail page lands separately.
- **External-agent per-resource backlinks** in `AuthorComponent` / `CommentComponent` — Phase 2 detail page is the target; this branch keeps the existing `AiAgentTaskRunResource`-based link working for internal agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
