### PR TITLE
Polish decision verification UI: constant chainlink icon, gated winner highlight

### DIFF
--- a/app/views/decisions/_results.html.erb
+++ b/app/views/decisions/_results.html.erb
@@ -24,7 +24,8 @@
           </tr>
         <% end %>
         <% ([nil] + @decision.results + [nil]).each_cons(3).with_index do |(prev_result, result, next_result), index| %>
-          <tr class="<%= (index == 0 && @decision.closed?) ? 'pulse-results-winner' : '' %>">
+          <%# Don't highlight the top row until the beacon is drawn — random tiebreakers can still reorder results. %>
+          <tr class="<%= (index == 0 && @decision.closed? && @decision.beacon_drawn?) ? 'pulse-results-winner' : '' %>">
             <td><%= index + 1 %></td>
             <td><%= markdown_inline(result.option_title) %></td>
             <% unless @decision.is_lottery? %>

--- a/app/views/decisions/show.html.erb
+++ b/app/views/decisions/show.html.erb
@@ -262,11 +262,11 @@
   <% if @audit_entry_count && @audit_entry_count > 0 %>
     <div style="margin-top: 8px;">
       <%= link_to "#{@decision.path}/verify", class: 'pulse-body-text-muted' do %>
+        <%# Always show the chainlink icon — the audit chain exists regardless of decision state. %>
+        <%= octicon 'link', height: 14 %>
         <% if @decision.beacon_drawn? %>
-          <%= octicon 'verified', height: 14 %>
           Audit chain: <%= @audit_entry_count %> entries &middot; verified
         <% else %>
-          <%= octicon 'link', height: 14 %>
           Audit chain: <%= @audit_entry_count %> entries &middot; <code style="font-size: 0.85em;"><%= @audit_latest_hash&.slice(0, 8) %>...</code>
         <% end %>
       <% end %>

--- a/test/controllers/decisions_controller_test.rb
+++ b/test/controllers/decisions_controller_test.rb
@@ -1529,6 +1529,48 @@ class DecisionsControllerTest < ActionDispatch::IntegrationTest
     assert_match(/\?\?\?/, response.body)
   end
 
+  test "closed vote decision does not highlight winner row before beacon drawn" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    @decision.update!(subtype: "vote")
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option_a = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    option_b = Option.create!(decision: @decision, decision_participant: participant, title: "Option B")
+    Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: option_a, decision_participant: participant, accepted: 1, preferred: 0)
+    Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: option_b, decision_participant: participant, accepted: 1, preferred: 0)
+    @decision.update!(deadline: 1.hour.ago)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}"
+    assert_response :success
+    # Random tiebreakers can still reorder rows once the beacon resolves, so no row is the final winner yet.
+    assert_no_match(/pulse-results-winner/, response.body)
+  end
+
+  test "closed vote decision highlights winner row once beacon drawn" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    @decision.update!(subtype: "vote")
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option_a = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    option_b = Option.create!(decision: @decision, decision_participant: participant, title: "Option B")
+    Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: option_a, decision_participant: participant, accepted: 1, preferred: 0)
+    Vote.create!(tenant: @tenant, collective: @collective, decision: @decision, option: option_b, decision_participant: participant, accepted: 1, preferred: 0)
+    @decision.update!(deadline: 1.hour.ago, lottery_beacon_round: 999, lottery_beacon_randomness: "abc")
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}"
+    assert_response :success
+    # Beacon is drawn, so the order is final and the top row is the confirmed winner.
+    assert_match(/pulse-results-winner/, response.body)
+  end
+
   test "drawn vote decision shows verify link" do
     sign_in_as(@user, tenant: @tenant)
 
@@ -1606,6 +1648,27 @@ class DecisionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match(/Audit chain:.*verified/, response.body)
     assert_match(/verify/, response.body)
+  end
+
+  test "decision page always shows chainlink audit icon even when beacon drawn" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    @decision.update!(subtype: "vote")
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    option = Option.create!(decision: @decision, decision_participant: participant, title: "Option A")
+    vote = Vote.new(tenant: @tenant, collective: @collective, decision: @decision, option: option, decision_participant: participant, accepted: 1, preferred: 0)
+    DecisionActionService.cast_vote!(decision: @decision, vote: vote, actor: @user)
+    @decision.update!(deadline: 1.hour.ago, lottery_beacon_round: 999, lottery_beacon_randomness: "abc")
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}"
+    assert_response :success
+    # The audit chain icon should be the chainlink regardless of state — never the "verified" badge.
+    assert_match(/octicon-link/, response.body)
+    assert_no_match(/octicon-verified/, response.body)
   end
 
   test "verify page shows audit chain section when entries exist" do


### PR DESCRIPTION
Implements the **decision-verification-ui-polish** plan from `.claude/plans/` — two small, self-contained UI fixes around decision results and the audit chain.

## Changes

**1. Audit-chain link always shows the chainlink icon** (`app/views/decisions/show.html.erb`)
Previously the link swapped to a `verified` octicon once the beacon was drawn. The audit chain exists regardless of decision state, so the icon is now always the `link` (chainlink) octicon; only the trailing text still changes between "verified" and the truncated hash.

**2. Winner row not highlighted before the beacon is drawn** (`app/views/decisions/_results.html.erb`)
The `pulse-results-winner` highlight was applied whenever the decision was `closed?`. Random tiebreakers can still reorder results until the beacon resolves, so the highlight is now also gated on `beacon_drawn?` — the top row isn't presented as the final winner prematurely.

**3. Tests** (`test/controllers/decisions_controller_test.rb`)
Three new controller tests:
- audit icon is always the chainlink (`octicon-link`), never `octicon-verified`
- no `pulse-results-winner` before the beacon is drawn
- `pulse-results-winner` present once the beacon is drawn

## Verification

⚠️ I could **not** run the test suite locally — the repo's tests run inside Docker, which isn't available in my environment. The code and tests follow existing patterns closely, but they're **unverified by execution** and rely on CI. Please confirm CI is green before merging.