### PR TITLE
Fire inbox notifications for trustee-authorization lifecycle events

### DIFF
--- a/app/controllers/trustee_grants_controller.rb
+++ b/app/controllers/trustee_grants_controller.rb
@@ -124,29 +124,29 @@ class TrusteeGrantsController < ApplicationController
     # Parse expiration
     expires_at = parse_expires_at(params[:expires_at])
 
-    grant = TrusteeGrant.offer!(
-      tenant: @current_tenant,
-      granting_user: @target_user,
-      trustee_user: trustee,
-      permissions: permissions,
-      collective_scope: collective_scope,
-      expires_at: expires_at
-    )
-
-    if grant.persisted?
-      render_action_success({
-                              action_name: "create_trustee_authorization",
-                              resource: grant,
-                              result: "Trustee authorization request sent to #{trustee.display_name || trustee.handle}",
-                              redirect_to: trustee_grant_show_path(grant),
-                            })
-    else
-      render_action_error({
-                            action_name: "create_trustee_authorization",
-                            resource: nil,
-                            error: grant.errors.full_messages.join(", "),
-                          })
+    begin
+      grant = TrusteeGrant.offer!(
+        tenant: @current_tenant,
+        granting_user: @target_user,
+        trustee_user: trustee,
+        permissions: permissions,
+        collective_scope: collective_scope,
+        expires_at: expires_at
+      )
+    rescue ActiveRecord::RecordInvalid => e
+      return render_action_error({
+                                   action_name: "create_trustee_authorization",
+                                   resource: nil,
+                                   error: e.record.errors.full_messages.join(", "),
+                                 })
     end
+
+    render_action_success({
+                            action_name: "create_trustee_authorization",
+                            resource: grant,
+                            result: "Trustee authorization request sent to #{trustee.display_name || trustee.handle}",
+                            redirect_to: trustee_grant_show_path(grant),
+                          })
   end
 
   # =========================================================================

--- a/app/controllers/trustee_grants_controller.rb
+++ b/app/controllers/trustee_grants_controller.rb
@@ -124,7 +124,7 @@ class TrusteeGrantsController < ApplicationController
     # Parse expiration
     expires_at = parse_expires_at(params[:expires_at])
 
-    grant = TrusteeGrant.new(
+    grant = TrusteeGrant.offer!(
       tenant: @current_tenant,
       granting_user: @target_user,
       trustee_user: trustee,
@@ -133,8 +133,7 @@ class TrusteeGrantsController < ApplicationController
       expires_at: expires_at
     )
 
-    if grant.save
-      NotificationService.notify_trustee_authorization_event!(grant: grant, event: :offered)
+    if grant.persisted?
       render_action_success({
                               action_name: "create_trustee_authorization",
                               resource: grant,

--- a/app/controllers/trustee_grants_controller.rb
+++ b/app/controllers/trustee_grants_controller.rb
@@ -134,7 +134,7 @@ class TrusteeGrantsController < ApplicationController
     )
 
     if grant.save
-      # TODO: Send notification to trustee_user
+      NotificationService.notify_trustee_authorization_event!(grant: grant, event: :offered)
       render_action_success({
                               action_name: "create_trustee_authorization",
                               resource: grant,

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,7 +3,7 @@
 class Notification < ApplicationRecord
   extend T::Sig
 
-  NOTIFICATION_TYPES = %w[mention comment participation system reminder chat_message trio_unavailable tune_in].freeze
+  NOTIFICATION_TYPES = %w[mention comment participation system reminder chat_message trio_unavailable tune_in trustee_authorization].freeze
 
   belongs_to :tenant
   belongs_to :event, optional: true

--- a/app/models/tenant_user.rb
+++ b/app/models/tenant_user.rb
@@ -156,6 +156,9 @@ class TenantUser < ApplicationRecord
     "chat_message" => { "in_app" => true, "email" => false },
     "trio_unavailable" => { "in_app" => true, "email" => false },
     "tune_in" => { "in_app" => true, "email" => false },
+    # Trustee authorization lifecycle (offered/accepted/declined/revoked).
+    # In-app by default, matching most types; users can opt into email.
+    "trustee_authorization" => { "in_app" => true, "email" => false },
   }.freeze, T::Hash[String, T::Hash[String, T::Boolean]])
 
   sig { returns(T::Hash[String, T::Hash[String, T::Boolean]]) }

--- a/app/models/trustee_grant.rb
+++ b/app/models/trustee_grant.rb
@@ -72,15 +72,17 @@ class TrusteeGrant < ApplicationRecord
 
   # Create a pending grant and notify the trustee that they've been offered it.
   # Mirrors accept!/decline!/revoke! so all four lifecycle verbs live on the model,
-  # each owning its own notification. Uses save (not create!) so callers keep the
-  # usual validation-error branch via the returned record's #persisted?.
+  # each owning its own notification. Like the sibling bang verbs (which use update!),
+  # this fails loudly: it raises ActiveRecord::RecordInvalid if the grant is invalid,
+  # so the notification only ever fires for a persisted grant. Callers that want to
+  # render validation errors rather than 500 should rescue RecordInvalid.
   # Note: deliberately NOT an after_create callback — that would fire on every
   # TrusteeGrant.create! (fixtures, the pre-accepted parent-grant path, and the
   # notification tests that create! then notify explicitly), causing double sends.
   sig { params(attributes: T.untyped).returns(TrusteeGrant) }
   def self.offer!(attributes)
-    grant = new(attributes)
-    NotificationService.notify_trustee_authorization_event!(grant: grant, event: :offered) if grant.save
+    grant = create!(attributes)
+    NotificationService.notify_trustee_authorization_event!(grant: grant, event: :offered)
     grant
   end
 

--- a/app/models/trustee_grant.rb
+++ b/app/models/trustee_grant.rb
@@ -70,6 +70,20 @@ class TrusteeGrant < ApplicationRecord
   # STATE TRANSITION METHODS
   # =========================================================================
 
+  # Create a pending grant and notify the trustee that they've been offered it.
+  # Mirrors accept!/decline!/revoke! so all four lifecycle verbs live on the model,
+  # each owning its own notification. Uses save (not create!) so callers keep the
+  # usual validation-error branch via the returned record's #persisted?.
+  # Note: deliberately NOT an after_create callback — that would fire on every
+  # TrusteeGrant.create! (fixtures, the pre-accepted parent-grant path, and the
+  # notification tests that create! then notify explicitly), causing double sends.
+  sig { params(attributes: T.untyped).returns(TrusteeGrant) }
+  def self.offer!(attributes)
+    grant = new(attributes)
+    NotificationService.notify_trustee_authorization_event!(grant: grant, event: :offered) if grant.save
+    grant
+  end
+
   sig { void }
   def accept!
     raise "Cannot accept: not pending" unless pending?

--- a/app/models/trustee_grant.rb
+++ b/app/models/trustee_grant.rb
@@ -75,7 +75,7 @@ class TrusteeGrant < ApplicationRecord
     raise "Cannot accept: not pending" unless pending?
 
     update!(accepted_at: Time.current)
-    # TODO: Send notification to granting_user
+    NotificationService.notify_trustee_authorization_event!(grant: self, event: :accepted)
   end
 
   sig { void }
@@ -83,7 +83,7 @@ class TrusteeGrant < ApplicationRecord
     raise "Cannot decline: not pending" unless pending?
 
     update!(declined_at: Time.current)
-    # TODO: Send notification to granting_user
+    NotificationService.notify_trustee_authorization_event!(grant: self, event: :declined)
   end
 
   sig { void }
@@ -91,7 +91,7 @@ class TrusteeGrant < ApplicationRecord
     raise "Cannot revoke: already revoked or declined" if revoked? || declined?
 
     update!(revoked_at: Time.current)
-    # TODO: Send notification to trustee_user
+    NotificationService.notify_trustee_authorization_event!(grant: self, event: :revoked)
   end
 
   # =========================================================================

--- a/app/models/trustee_grant.rb
+++ b/app/models/trustee_grant.rb
@@ -83,7 +83,6 @@ class TrusteeGrant < ApplicationRecord
     raise "Cannot decline: not pending" unless pending?
 
     update!(declined_at: Time.current)
-    NotificationService.notify_trustee_authorization_event!(grant: self, event: :declined)
   end
 
   sig { void }
@@ -91,7 +90,6 @@ class TrusteeGrant < ApplicationRecord
     raise "Cannot revoke: already revoked or declined" if revoked? || declined?
 
     update!(revoked_at: Time.current)
-    NotificationService.notify_trustee_authorization_event!(grant: self, event: :revoked)
   end
 
   # =========================================================================

--- a/app/models/trustee_grant.rb
+++ b/app/models/trustee_grant.rb
@@ -81,7 +81,7 @@ class TrusteeGrant < ApplicationRecord
   # notification tests that create! then notify explicitly), causing double sends.
   sig { params(attributes: T.untyped).returns(TrusteeGrant) }
   def self.offer!(attributes)
-    grant = create!(attributes)
+    grant = T.cast(create!(attributes), TrusteeGrant)
     NotificationService.notify_trustee_authorization_event!(grant: grant, event: :offered)
     grant
   end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -51,14 +51,21 @@ class NotificationService
   #
   # Unlike most notifications, trustee authorizations are user-relative, not
   # collective-relative — they live under /u/:handle/settings and have no
-  # collective. The Event/EventService path requires a collective_id (NOT NULL),
-  # so we create the in-app notification directly here instead of routing through
-  # EventService.record! + NotificationDispatcher. The trade-off: these do not
-  # fire `notifications.delivered` webhook events (which also require a
-  # collective). In-app inbox + email channels are honored per user preference.
+  # collective. The Event/EventService path used to create most notifications
+  # requires a collective_id (NOT NULL), so we create the in-app notification
+  # directly here instead of routing through EventService.record! +
+  # NotificationDispatcher — the same pattern chat-message notifications use.
   #
-  # event is one of :offered, :accepted, :declined, :revoked. The recipient and
-  # message are derived from the event so call sites stay one-liners.
+  # Like chat, we still fire a `notifications.delivered` event so that user
+  # notification-webhook subscribers (e.g. bridge agents) receive these. That
+  # event needs a collective home; we use the recipient's private workspace —
+  # a per-user collective the recipient is always a member of — mirroring how
+  # chat scopes its delivered event to the chat session's private collective.
+  # See deliver_trustee_notification!.
+  #
+  # event is one of :offered, :accepted, :declined, :revoked. The recipient,
+  # originating actor, and message are derived from the event so call sites
+  # stay one-liners.
   sig { params(grant: TrusteeGrant, event: Symbol).void }
   def self.notify_trustee_authorization_event!(grant:, event:)
     granting = grant.granting_user
@@ -69,15 +76,19 @@ class NotificationService
     case event
     when :offered
       recipient = trustee
+      actor = granting
       title = "#{granting_name} invited you to act on their behalf as a trustee"
     when :accepted
       recipient = granting
+      actor = trustee
       title = "#{trustee_name} accepted your trustee authorization"
     when :declined
       recipient = granting
+      actor = trustee
       title = "#{trustee_name} declined your trustee authorization"
     when :revoked
       recipient = trustee
+      actor = granting
       title = "#{granting_name} revoked your trustee authorization"
     else
       raise ArgumentError, "Unknown trustee authorization event: #{event.inspect}"
@@ -85,7 +96,7 @@ class NotificationService
 
     return if recipient.nil?
 
-    deliver_trustee_notification!(grant: grant, recipient: recipient, title: title)
+    deliver_trustee_notification!(grant: grant, recipient: recipient, actor: actor, title: title)
   end
 
   # Create or update a chat message notification for the recipient.
@@ -247,15 +258,22 @@ class NotificationService
   # Fires `notifications.delivered` for user-notification webhook routing.
   # Skipped for reminder notifications — `ReminderDeliveryJob` fires
   # `reminders.delivered` for those.
+  #
+  # tenant_id/collective_id default to the thread context (the common case for
+  # collective-scoped notifications and chat). Callers whose notification has
+  # no thread collective context — trustee authorizations — pass them
+  # explicitly; EventService.record! drops the event if collective_id is nil.
   sig do
     params(
       notification: Notification,
       recipient: User,
       channels: T::Array[String],
+      tenant_id: T.nilable(String),
+      collective_id: T.nilable(String),
       extra_metadata: T::Hash[String, T.untyped]
     ).void
   end
-  def self.fire_notifications_delivered_event(notification:, recipient:, channels:, extra_metadata: {})
+  def self.fire_notifications_delivered_event(notification:, recipient:, channels:, tenant_id: nil, collective_id: nil, extra_metadata: {})
     return if notification.notification_type == "reminder"
 
     metadata = {
@@ -270,19 +288,27 @@ class NotificationService
       event_type: "notifications.delivered",
       actor: recipient,
       subject: notification,
-      metadata: metadata
+      metadata: metadata,
+      tenant_id: tenant_id,
+      collective_id: collective_id
     )
   rescue StandardError => e
     Rails.logger.error("Failed to fire notifications.delivered event: #{e.message}")
   end
 
   # Creates the trustee-authorization notification + recipient rows directly
-  # (no Event, since trustee grants have no collective). Channels honor the
-  # recipient's per-type preferences, falling back to in-app. A delivery
-  # failure is logged rather than raised so it never breaks the underlying
-  # accept/decline/revoke/offer action, which has already persisted.
-  sig { params(grant: TrusteeGrant, recipient: User, title: String).void }
-  def self.deliver_trustee_notification!(grant:, recipient:, title:)
+  # (no triggering Event, since trustee grants have no collective). Channels
+  # honor the recipient's per-type preferences, falling back to in-app. A
+  # delivery failure is logged rather than raised so it never breaks the
+  # underlying accept/decline/revoke/offer action, which has already persisted.
+  #
+  # After the in-app/email rows are created we fire `notifications.delivered`
+  # so notification-webhook subscribers receive these too (see
+  # fire_notifications_delivered_event). `actor` is the originating party (the
+  # one who offered/accepted/declined/revoked), surfaced to the webhook payload
+  # via `original_actor_id` exactly as the chat-message path does.
+  sig { params(grant: TrusteeGrant, recipient: User, actor: T.nilable(User), title: String).void }
+  def self.deliver_trustee_notification!(grant:, recipient:, actor:, title:)
     tenant = grant.tenant
     return if tenant.nil?
 
@@ -309,6 +335,22 @@ class NotificationService
       )
       NotificationDeliveryJob.perform_later(notification_recipient.id)
     end
+
+    # Route the delivered event through the recipient's private workspace — the
+    # user-relative collective they always belong to — so the webhook dispatcher
+    # (which requires the recipient to be a member of the event's collective)
+    # forwards it. Mirrors chat's use of the chat session's private collective.
+    workspace = Collective.tenant_scoped_only(tenant.id)
+      .find_by(created_by_id: recipient.id, collective_type: "private_workspace")
+
+    fire_notifications_delivered_event(
+      notification: notification,
+      recipient: recipient,
+      channels: channels,
+      tenant_id: tenant.id,
+      collective_id: workspace&.id,
+      extra_metadata: actor ? { "original_actor_id" => actor.id } : {}
+    )
   rescue StandardError => e
     Rails.logger.error("Failed to deliver trustee authorization notification: #{e.message}")
   end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -44,6 +44,50 @@ class NotificationService
     notification
   end
 
+  # Notification type for trustee-authorization lifecycle events.
+  TRUSTEE_NOTIFICATION_TYPE = "trustee_authorization"
+
+  # Notify the affected party of a trustee-authorization lifecycle event.
+  #
+  # Unlike most notifications, trustee authorizations are user-relative, not
+  # collective-relative — they live under /u/:handle/settings and have no
+  # collective. The Event/EventService path requires a collective_id (NOT NULL),
+  # so we create the in-app notification directly here instead of routing through
+  # EventService.record! + NotificationDispatcher. The trade-off: these do not
+  # fire `notifications.delivered` webhook events (which also require a
+  # collective). In-app inbox + email channels are honored per user preference.
+  #
+  # event is one of :offered, :accepted, :declined, :revoked. The recipient and
+  # message are derived from the event so call sites stay one-liners.
+  sig { params(grant: TrusteeGrant, event: Symbol).void }
+  def self.notify_trustee_authorization_event!(grant:, event:)
+    granting = grant.granting_user
+    trustee = grant.trustee_user
+    granting_name = granting&.display_name || granting&.name || "Someone"
+    trustee_name = trustee&.display_name || trustee&.name || "Someone"
+
+    case event
+    when :offered
+      recipient = trustee
+      title = "#{granting_name} invited you to act on their behalf as a trustee"
+    when :accepted
+      recipient = granting
+      title = "#{trustee_name} accepted your trustee authorization"
+    when :declined
+      recipient = granting
+      title = "#{trustee_name} declined your trustee authorization"
+    when :revoked
+      recipient = trustee
+      title = "#{granting_name} revoked your trustee authorization"
+    else
+      raise ArgumentError, "Unknown trustee authorization event: #{event.inspect}"
+    end
+
+    return if recipient.nil?
+
+    deliver_trustee_notification!(grant: grant, recipient: recipient, title: title)
+  end
+
   # Create or update a chat message notification for the recipient.
   # One notification per sender — if an undismissed notification from
   # the same sender already exists, we update its timestamp instead
@@ -232,5 +276,55 @@ class NotificationService
     Rails.logger.error("Failed to fire notifications.delivered event: #{e.message}")
   end
 
-  private_class_method :dismiss_attributes, :notification_ids_for_collective
+  # Creates the trustee-authorization notification + recipient rows directly
+  # (no Event, since trustee grants have no collective). Channels honor the
+  # recipient's per-type preferences, falling back to in-app. A delivery
+  # failure is logged rather than raised so it never breaks the underlying
+  # accept/decline/revoke/offer action, which has already persisted.
+  sig { params(grant: TrusteeGrant, recipient: User, title: String).void }
+  def self.deliver_trustee_notification!(grant:, recipient:, title:)
+    tenant = grant.tenant
+    return if tenant.nil?
+
+    tenant_user = TenantUser.tenant_scoped_only(tenant.id).find_by(user: recipient)
+    channels = tenant_user ? tenant_user.notification_channels_for(TRUSTEE_NOTIFICATION_TYPE) : ["in_app"]
+    return if channels.empty?
+
+    url = trustee_grant_path_for(grant: grant, user: recipient, tenant: tenant)
+
+    notification = Notification.create!(
+      tenant: tenant,
+      notification_type: TRUSTEE_NOTIFICATION_TYPE,
+      title: title,
+      url: url
+    )
+
+    channels.each do |channel|
+      notification_recipient = NotificationRecipient.create!(
+        notification: notification,
+        user: recipient,
+        tenant: tenant,
+        channel: channel,
+        status: "pending"
+      )
+      NotificationDeliveryJob.perform_later(notification_recipient.id)
+    end
+  rescue StandardError => e
+    Rails.logger.error("Failed to deliver trustee authorization notification: #{e.message}")
+  end
+
+  # Builds the recipient-relative show path for a grant. The trustee-grants
+  # controller authorizes by the :handle in the URL, so the link must point at
+  # the recipient's own handle (not always the granting user's) or they'd be
+  # forbidden from opening their own notification.
+  sig { params(grant: TrusteeGrant, user: User, tenant: Tenant).returns(T.nilable(String)) }
+  def self.trustee_grant_path_for(grant:, user:, tenant:)
+    handle = TenantUser.tenant_scoped_only(tenant.id).find_by(user: user)&.handle
+    return nil unless handle
+
+    "/u/#{handle}/settings/trustee-authorizations/#{grant.truncated_id}"
+  end
+
+  private_class_method :dismiss_attributes, :notification_ids_for_collective,
+                       :deliver_trustee_notification!, :trustee_grant_path_for
 end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -63,9 +63,11 @@ class NotificationService
   # chat scopes its delivered event to the chat session's private collective.
   # See deliver_trustee_notification!.
   #
-  # event is one of :offered, :accepted, :declined, :revoked. The recipient,
-  # originating actor, and message are derived from the event so call sites
-  # stay one-liners.
+  # event is one of :offered, :accepted. The recipient, originating actor, and
+  # message are derived from the event so call sites stay one-liners. Declined
+  # and revoked transitions deliberately fire nothing — the acting party
+  # already knows they declined/revoked, and the counterparty learns of it
+  # next time they look rather than via an inbox ping.
   sig { params(grant: TrusteeGrant, event: Symbol).void }
   def self.notify_trustee_authorization_event!(grant:, event:)
     granting = grant.granting_user
@@ -82,14 +84,6 @@ class NotificationService
       recipient = granting
       actor = trustee
       title = "#{trustee_name} accepted your trustee authorization"
-    when :declined
-      recipient = granting
-      actor = trustee
-      title = "#{trustee_name} declined your trustee authorization"
-    when :revoked
-      recipient = trustee
-      actor = granting
-      title = "#{granting_name} revoked your trustee authorization"
     else
       raise ArgumentError, "Unknown trustee authorization event: #{event.inspect}"
     end
@@ -300,12 +294,12 @@ class NotificationService
   # (no triggering Event, since trustee grants have no collective). Channels
   # honor the recipient's per-type preferences, falling back to in-app. A
   # delivery failure is logged rather than raised so it never breaks the
-  # underlying accept/decline/revoke/offer action, which has already persisted.
+  # underlying offer/accept action, which has already persisted.
   #
   # After the in-app/email rows are created we fire `notifications.delivered`
   # so notification-webhook subscribers receive these too (see
   # fire_notifications_delivered_event). `actor` is the originating party (the
-  # one who offered/accepted/declined/revoked), surfaced to the webhook payload
+  # one who offered/accepted), surfaced to the webhook payload
   # via `original_actor_id` exactly as the chat-message path does.
   sig { params(grant: TrusteeGrant, recipient: User, actor: T.nilable(User), title: String).void }
   def self.deliver_trustee_notification!(grant:, recipient:, actor:, title:)

--- a/test/models/trustee_grant_test.rb
+++ b/test/models/trustee_grant_test.rb
@@ -86,6 +86,40 @@ class TrusteeGrantTest < ActiveSupport::TestCase
     assert_not permission.revoked?
   end
 
+  test "offer! creates a pending grant and notifies the trustee as offered" do
+    grant = nil
+    notified = []
+    NotificationService.stub(:notify_trustee_authorization_event!, ->(grant:, event:) { notified << [grant, event] }) do
+      grant = TrusteeGrant.offer!(
+        tenant: @tenant,
+        granting_user: @granting_user,
+        trustee_user: @trustee_user,
+        permissions: { "create_notes" => true },
+      )
+    end
+
+    assert grant.persisted?
+    assert grant.pending?
+    assert_equal [[grant, :offered]], notified
+  end
+
+  test "offer! returns an unsaved record and does not notify when validation fails" do
+    notified = []
+    grant = nil
+    NotificationService.stub(:notify_trustee_authorization_event!, ->(grant:, event:) { notified << [grant, event] }) do
+      grant = TrusteeGrant.offer!(
+        tenant: @tenant,
+        granting_user: @granting_user,
+        trustee_user: @granting_user, # invalid: same as granting user
+        permissions: {},
+      )
+    end
+
+    assert_not grant.persisted?
+    assert_includes grant.errors[:trustee_user], "cannot be the same as the granting user"
+    assert_empty notified
+  end
+
   test "accept! transitions permission from pending to active" do
     permission = TrusteeGrant.create!(
       tenant: @tenant,

--- a/test/models/trustee_grant_test.rb
+++ b/test/models/trustee_grant_test.rb
@@ -103,20 +103,21 @@ class TrusteeGrantTest < ActiveSupport::TestCase
     assert_equal [[grant, :offered]], notified
   end
 
-  test "offer! returns an unsaved record and does not notify when validation fails" do
+  test "offer! raises RecordInvalid and does not notify when validation fails" do
     notified = []
-    grant = nil
+    error = nil
     NotificationService.stub(:notify_trustee_authorization_event!, ->(grant:, event:) { notified << [grant, event] }) do
-      grant = TrusteeGrant.offer!(
-        tenant: @tenant,
-        granting_user: @granting_user,
-        trustee_user: @granting_user, # invalid: same as granting user
-        permissions: {},
-      )
+      error = assert_raises(ActiveRecord::RecordInvalid) do
+        TrusteeGrant.offer!(
+          tenant: @tenant,
+          granting_user: @granting_user,
+          trustee_user: @granting_user, # invalid: same as granting user
+          permissions: {},
+        )
+      end
     end
 
-    assert_not grant.persisted?
-    assert_includes grant.errors[:trustee_user], "cannot be the same as the granting user"
+    assert_includes error.record.errors[:trustee_user], "cannot be the same as the granting user"
     assert_empty notified
   end
 

--- a/test/services/notification_service_trustee_test.rb
+++ b/test/services/notification_service_trustee_test.rb
@@ -1,0 +1,154 @@
+require "test_helper"
+
+# Tests for trustee-authorization lifecycle notifications.
+# These notifications are user-relative (no collective), so they are created
+# directly by NotificationService rather than routed through EventService.
+class NotificationServiceTrusteeTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  def setup
+    @tenant = create_tenant(subdomain: "trustee-notif-#{SecureRandom.hex(4)}")
+    @granting_user = create_user(email: "granting_#{SecureRandom.hex(4)}@example.com", name: "Alice")
+    @trustee_user = create_user(email: "trusted_#{SecureRandom.hex(4)}@example.com", name: "Bob")
+    @granting_tu = @tenant.add_user!(@granting_user, handle: "alice")
+    @trustee_tu = @tenant.add_user!(@trustee_user, handle: "bob")
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+  end
+
+  def build_grant
+    TrusteeGrant.create!(
+      tenant: @tenant,
+      granting_user: @granting_user,
+      trustee_user: @trustee_user,
+      permissions: {},
+    )
+  end
+
+  # =========================================================================
+  # SERVICE-LEVEL ROUTING
+  # =========================================================================
+
+  test "offered notifies the trustee user with their own handle path" do
+    grant = build_grant
+
+    assert_difference ["Notification.count", "NotificationRecipient.count"], 1 do
+      NotificationService.notify_trustee_authorization_event!(grant: grant, event: :offered)
+    end
+
+    notification = Notification.order(:created_at).last
+    assert_equal "trustee_authorization", notification.notification_type
+    assert_equal "/u/bob/settings/trustee-authorizations/#{grant.truncated_id}", notification.url
+    assert_includes notification.title, "act on their behalf"
+
+    recipient = notification.notification_recipients.first
+    assert_equal @trustee_user, recipient.user
+    assert_equal "in_app", recipient.channel
+  end
+
+  test "accepted notifies the granting user with their own handle path" do
+    grant = build_grant
+
+    assert_difference "Notification.count", 1 do
+      NotificationService.notify_trustee_authorization_event!(grant: grant, event: :accepted)
+    end
+
+    notification = Notification.order(:created_at).last
+    assert_equal "/u/alice/settings/trustee-authorizations/#{grant.truncated_id}", notification.url
+    assert_includes notification.title, "accepted your trustee authorization"
+    assert_equal @granting_user, notification.notification_recipients.first.user
+  end
+
+  test "declined notifies the granting user" do
+    grant = build_grant
+
+    NotificationService.notify_trustee_authorization_event!(grant: grant, event: :declined)
+
+    notification = Notification.order(:created_at).last
+    assert_includes notification.title, "declined your trustee authorization"
+    assert_equal @granting_user, notification.notification_recipients.first.user
+  end
+
+  test "revoked notifies the trustee user" do
+    grant = build_grant
+
+    NotificationService.notify_trustee_authorization_event!(grant: grant, event: :revoked)
+
+    notification = Notification.order(:created_at).last
+    assert_includes notification.title, "revoked your trustee authorization"
+    assert_equal @trustee_user, notification.notification_recipients.first.user
+  end
+
+  test "unknown event raises ArgumentError" do
+    grant = build_grant
+    assert_raises(ArgumentError) do
+      NotificationService.notify_trustee_authorization_event!(grant: grant, event: :exploded)
+    end
+  end
+
+  test "honors recipient channel preferences when email is opted into" do
+    grant = build_grant
+    # Opt the trustee into email; both channels should now fan out.
+    @trustee_tu.set_notification_preference!("trustee_authorization", "email", true)
+
+    assert_difference "NotificationRecipient.count", 2 do
+      NotificationService.notify_trustee_authorization_event!(grant: grant, event: :offered)
+    end
+
+    notification = Notification.order(:created_at).last
+    assert_equal ["email", "in_app"], notification.notification_recipients.map(&:channel).sort
+  end
+
+  test "no recipient row created when all channels disabled" do
+    grant = build_grant
+    @trustee_tu.set_notification_preference!("trustee_authorization", "in_app", false)
+
+    assert_no_difference ["Notification.count", "NotificationRecipient.count"] do
+      NotificationService.notify_trustee_authorization_event!(grant: grant, event: :offered)
+    end
+  end
+
+  test "delivery failure is swallowed and does not raise" do
+    grant = build_grant
+    # Force a failure mid-delivery; the underlying action must not blow up.
+    Notification.stub(:create!, ->(*) { raise "boom" }) do
+      assert_nothing_raised do
+        NotificationService.notify_trustee_authorization_event!(grant: grant, event: :offered)
+      end
+    end
+  end
+
+  # =========================================================================
+  # CALL-SITE WIRING (model state transitions)
+  # =========================================================================
+
+  test "accept! sends a notification to the granting user" do
+    grant = build_grant
+
+    assert_difference "Notification.count", 1 do
+      grant.accept!
+    end
+
+    assert_equal @granting_user, Notification.order(:created_at).last.notification_recipients.first.user
+  end
+
+  test "decline! sends a notification to the granting user" do
+    grant = build_grant
+
+    assert_difference "Notification.count", 1 do
+      grant.decline!
+    end
+
+    assert_equal @granting_user, Notification.order(:created_at).last.notification_recipients.first.user
+  end
+
+  test "revoke! sends a notification to the trustee user" do
+    grant = build_grant
+    grant.accept!
+
+    assert_difference "Notification.count", 1 do
+      grant.revoke!
+    end
+
+    assert_equal @trustee_user, Notification.order(:created_at).last.notification_recipients.first.user
+  end
+end

--- a/test/services/notification_service_trustee_test.rb
+++ b/test/services/notification_service_trustee_test.rb
@@ -118,6 +118,54 @@ class NotificationServiceTrusteeTest < ActiveSupport::TestCase
   end
 
   # =========================================================================
+  # notifications.delivered EVENT (webhook routing)
+  # =========================================================================
+
+  def delivered_events
+    Event.tenant_scoped_only(@tenant.id).where(event_type: "notifications.delivered")
+  end
+
+  test "offered fires notifications.delivered scoped to the trustee's private workspace" do
+    grant = build_grant
+    before = delivered_events.count
+
+    NotificationService.notify_trustee_authorization_event!(grant: grant, event: :offered)
+
+    assert_equal before + 1, delivered_events.count
+    delivered = delivered_events.order(:created_at).last
+    # The recipient is the event actor (existing pipeline semantic) and must be
+    # a member of the event's collective for webhook dispatch to forward it.
+    assert_equal @trustee_user.id, delivered.actor_id
+    assert_equal @trustee_user.private_workspace.id, delivered.collective_id
+    # The originating party (granting user) is surfaced for the webhook payload.
+    assert_equal @granting_user.id, delivered.metadata["original_actor_id"]
+    assert_equal "trustee_authorization", delivered.metadata["notification_type"]
+  end
+
+  test "accepted fires notifications.delivered to the granting user with the trustee as actor" do
+    grant = build_grant
+    before = delivered_events.count
+
+    NotificationService.notify_trustee_authorization_event!(grant: grant, event: :accepted)
+
+    assert_equal before + 1, delivered_events.count
+    delivered = delivered_events.order(:created_at).last
+    assert_equal @granting_user.id, delivered.actor_id
+    assert_equal @granting_user.private_workspace.id, delivered.collective_id
+    assert_equal @trustee_user.id, delivered.metadata["original_actor_id"]
+  end
+
+  test "no notifications.delivered event when all channels are disabled" do
+    grant = build_grant
+    @trustee_tu.set_notification_preference!("trustee_authorization", "in_app", false)
+    before = delivered_events.count
+
+    NotificationService.notify_trustee_authorization_event!(grant: grant, event: :offered)
+
+    assert_equal before, delivered_events.count
+  end
+
+  # =========================================================================
   # CALL-SITE WIRING (model state transitions)
   # =========================================================================
 

--- a/test/services/notification_service_trustee_test.rb
+++ b/test/services/notification_service_trustee_test.rb
@@ -58,24 +58,17 @@ class NotificationServiceTrusteeTest < ActiveSupport::TestCase
     assert_equal @granting_user, notification.notification_recipients.first.user
   end
 
-  test "declined notifies the granting user" do
+  # Only :offered and :accepted are notifying events. Declined/revoked are
+  # intentionally not handled — they raise like any other unknown event, and
+  # the model transitions no longer call the service for them.
+  test "declined and revoked are not notifying events" do
     grant = build_grant
 
-    NotificationService.notify_trustee_authorization_event!(grant: grant, event: :declined)
-
-    notification = Notification.order(:created_at).last
-    assert_includes notification.title, "declined your trustee authorization"
-    assert_equal @granting_user, notification.notification_recipients.first.user
-  end
-
-  test "revoked notifies the trustee user" do
-    grant = build_grant
-
-    NotificationService.notify_trustee_authorization_event!(grant: grant, event: :revoked)
-
-    notification = Notification.order(:created_at).last
-    assert_includes notification.title, "revoked your trustee authorization"
-    assert_equal @trustee_user, notification.notification_recipients.first.user
+    [:declined, :revoked].each do |event|
+      assert_raises(ArgumentError) do
+        NotificationService.notify_trustee_authorization_event!(grant: grant, event: event)
+      end
+    end
   end
 
   test "unknown event raises ArgumentError" do
@@ -179,24 +172,20 @@ class NotificationServiceTrusteeTest < ActiveSupport::TestCase
     assert_equal @granting_user, Notification.order(:created_at).last.notification_recipients.first.user
   end
 
-  test "decline! sends a notification to the granting user" do
+  test "decline! fires no notification" do
     grant = build_grant
 
-    assert_difference "Notification.count", 1 do
+    assert_no_difference ["Notification.count", "NotificationRecipient.count"] do
       grant.decline!
     end
-
-    assert_equal @granting_user, Notification.order(:created_at).last.notification_recipients.first.user
   end
 
-  test "revoke! sends a notification to the trustee user" do
+  test "revoke! fires no notification" do
     grant = build_grant
-    grant.accept!
+    grant.accept! # accept! itself notifies; revoke! must add nothing on top.
 
-    assert_difference "Notification.count", 1 do
+    assert_no_difference ["Notification.count", "NotificationRecipient.count"] do
       grant.revoke!
     end
-
-    assert_equal @trustee_user, Notification.order(:created_at).last.notification_recipients.first.user
   end
 end

--- a/test/services/notification_service_trustee_test.rb
+++ b/test/services/notification_service_trustee_test.rb
@@ -110,7 +110,7 @@ class NotificationServiceTrusteeTest < ActiveSupport::TestCase
   test "delivery failure is swallowed and does not raise" do
     grant = build_grant
     # Force a failure mid-delivery; the underlying action must not blow up.
-    Notification.stub(:create!, ->(*) { raise "boom" }) do
+    Notification.stub(:create!, ->(*_) { raise "boom" }) do
       assert_nothing_raised do
         NotificationService.notify_trustee_authorization_event!(grant: grant, event: :offered)
       end


### PR DESCRIPTION
Implements the **trustee-authorization-notifications** plan (the option selected in [decision 324501ae](https://www.harmonic.social/collectives/harmonic-devs/d/324501ae)).

## What

Trustee-authorization lifecycle events had `# TODO: Send notification` markers and fired nothing. The two events where the affected party isn't the one taking the action now reach that party's inbox:

| Event | Recipient | Call site |
|-------|-----------|-----------|
| offered | trustee | `TrusteeGrantsController#execute_create` |
| accepted | granting user | `TrusteeGrant#accept!` |

**`declined` and `revoked` deliberately do not notify** (dropped per review). The party who declines/revokes already knows they did it, and the counterparty sees the change on the grant page rather than via a ping.

Each call site is a one-liner into a new `NotificationService.notify_trustee_authorization_event!(grant:, event:)`.

## Design note

Trustee grants are **user-relative** — they live under `/u/:handle/settings` with no collective. `events.collective_id` is `NOT NULL`, so the usual `EventService.record!` → `NotificationDispatcher` path can't be used here. Instead the notification + recipient rows are created directly, mirroring the existing `notify_chat_message!` path.

Consequences:
- **`notifications.delivered` still fires** so user notification-webhook subscribers (bridge agents) receive these, not just in-app + email. The delivered event needs a collective home and the webhook dispatcher requires the recipient to be a member of it, so the event is routed through the **recipient's private workspace** — the user-relative collective they always belong to — exactly as chat scopes its delivered event to the chat session's private collective. The originating party is passed through `original_actor_id` metadata so the webhook payload resolves an `actor`.
- Notification URLs use the **recipient's** own handle, because the trustee-grants controller authorizes by the `:handle` in the path — linking to the other party's handle would 403 the recipient.
- Delivery is wrapped in a `rescue` so a notification failure never breaks the underlying accept/offer action (which has already persisted).

## Out of scope

Representation-session start/end notifications are **not** included here. They're folded into the `representation-routes-refactor` plan, because that notification should link to the canonical `/representations/{id}` session show page, which that refactor creates and which doesn't exist yet.

## Changes

- `notification.rb` — add `trustee_authorization` to `NOTIFICATION_TYPES`.
- `tenant_user.rb` — add default preference (`in_app` on, `email` off).
- `notification_service.rb` — `notify_trustee_authorization_event!` (+ private `deliver_trustee_notification!` / `trustee_grant_path_for` helpers); `fire_notifications_delivered_event` now accepts explicit `tenant_id`/`collective_id` (defaulting to thread context, preserving existing callers).
- `trustee_grant.rb` / `trustee_grants_controller.rb` — replace the offered/accepted TODOs with dispatch calls.
- `test/services/notification_service_trustee_test.rb` — new tests: recipient routing, handle-relative URLs, channel preferences, unknown-event guard, delivery-failure resilience, `notifications.delivered` scoping to the recipient's private workspace with the originating actor, and call-site wiring through the model state transitions.

## Verification

No schema change / no migration. I **cannot run the Docker-based test suite** in my environment, so CI is the first execution of these tests. I traced callers/schema/preferences statically while writing. Please confirm green CI before merge.
