### PR TITLE
Fix N+1 vote query in decision options partial

### DIFF
--- a/app/views/decisions/_options_list_items.html.erb
+++ b/app/views/decisions/_options_list_items.html.erb
@@ -1,3 +1,4 @@
+<% votes_by_option_id = @votes.index_by(&:option_id) %>
 <% @decision.options.order(:created_at).each_with_index do |option, index| %>
   <% if @decision.is_executive? && @decision.can_close?(@current_user) %>
     <%# Executive decision maker: checkbox only (no star) %>
@@ -12,7 +13,7 @@
       <%= markdown_inline(option.title) %>
     </li>
   <% else %>
-    <% vote = @votes.where(option: option).first || Vote.new(accepted: 0) %>
+    <% vote = votes_by_option_id[option.id] || Vote.new(accepted: 0) %>
     <li class="pulse-option-item" data-option-id="<%= option.id %>">
       <input type="hidden" name="votes[<%= index %>][option_title]" value="<%= option.title %>">
       <input type="hidden" name="votes[<%= index %>][accepted]" value="0">

--- a/test/controllers/decisions_controller_test.rb
+++ b/test/controllers/decisions_controller_test.rb
@@ -237,6 +237,55 @@ class DecisionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Option A", option.title
   end
 
+  test "options partial does not N+1 on per-option vote lookups" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    participant = DecisionParticipantManager.new(decision: @decision, user: @user).find_or_create_participant
+    3.times { |i| add_option_with_vote(participant, "Small #{i}") }
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    options_url = "/collectives/#{@collective.handle}/d/#{@decision.truncated_id}/options.html"
+    get options_url # warm caches
+    assert_response :success
+    small_count = count_sql_queries { get options_url }
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    5.times { |i| add_option_with_vote(participant, "Big #{i}") }
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    large_count = count_sql_queries { get options_url }
+
+    # Adding 5 options (each with a vote) must not add a per-option vote query.
+    assert_operator (large_count - small_count), :<, 5,
+      "options partial is N+1 on votes: #{small_count} queries for 3 options, #{large_count} for 8"
+  end
+
+  # Counts user-level SQL queries (skips SCHEMA + TRANSACTION noise).
+  def count_sql_queries(&block)
+    count = 0
+    callback = ->(_name, _start, _finish, _id, payload) do
+      next if payload[:name].to_s =~ /SCHEMA|TRANSACTION/
+      count += 1
+    end
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &block)
+    count
+  end
+
+  def add_option_with_vote(participant, title)
+    option = Option.create!(decision: @decision, decision_participant: participant, title: title)
+    Vote.create!(
+      tenant: @tenant, collective: @collective, decision: @decision,
+      option: option, decision_participant: participant,
+      accepted: 1, preferred: 0,
+    )
+    option
+  end
+
   # === Close Decision Tests ===
 
   test "creator can close decision from show page" do


### PR DESCRIPTION
## Problem

Sentry **issue 7565374452** (`ruby-rails`, production) flags an N+1 in `DecisionsController#options_partial`. The `_options_list_items` partial called:

```erb
<% vote = @votes.where(option: option).first || Vote.new(accepted: 0) %>
```

once per option, so a decision with N options fired N separate `votes` queries. The Sentry span evidence shows **19 such queries, ~58ms / 29% of the transaction**.

## Fix

Load the participant's votes once and index them by `option_id`, then look up in memory:

```erb
<% votes_by_option_id = @votes.index_by(&:option_id) %>
...
<% vote = votes_by_option_id[option.id] || Vote.new(accepted: 0) %>
```

`@votes` is already scoped to the current decision participant (`current_decision_participant.votes`), so this is a single query regardless of option count. Rendered HTML is unchanged.

## Test

Added `test/controllers/decisions_controller_test.rb` → "options partial does not N+1 on per-option vote lookups", which counts `sql.active_record` queries for the `options.html` request and asserts that adding 5 more options does not add per-option vote queries (same query-counting pattern as the existing `user_lists_show_test.rb` N+1 test).

## Verification

⚠️ I can't run the suite locally (no Docker in my env) — relying on CI. Static checks done: traced `@votes` to `current_decision_participant.votes`, confirmed `index_by` semantics match the prior `where(option:).first` lookup, and confirmed the partial's other branches (executive/lottery) don't use `@votes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)