### PR TITLE
Markdown preview (Write/Preview toggle) (#258)

### DIFF
--- a/app/assets/stylesheets/pulse.css
+++ b/app/assets/stylesheets/pulse.css
@@ -7,6 +7,7 @@
  *= require pulse/_base
  *= require pulse/_layout
  *= require pulse/_components
+ *= require pulse/_markdown_editor
  *= require pulse/_sidebar
  *= require pulse/_feed
  *= require pulse/_heartbeat

--- a/app/assets/stylesheets/pulse/_markdown_editor.css
+++ b/app/assets/stylesheets/pulse/_markdown_editor.css
@@ -1,49 +1,136 @@
 /*
  * Markdown editor: GitHub-style Write / Preview toggle for text-entry forms.
+ *
+ * The whole editor reads as one widget: a single outer border wraps the tab
+ * strip and the input area, focus moves to the wrapper, and the active tab
+ * "lifts" by removing its bottom border so it visually merges with the content
+ * below. Inner textareas (.pulse-form-textarea, .pulse-form-input) drop their
+ * own border/background — the wrapper provides them.
+ *
+ * Corners are square (no border-radius) to match the rest of the Pulse UI.
+ *
  * Colors use the shared --color-* tokens from root_variables.css.
  */
 
 .pulse-md-editor {
   width: 100%;
+  border: 1px solid var(--color-border-default);
+  background: var(--color-canvas-default);
+}
+
+.pulse-md-editor:focus-within {
+  border-color: var(--color-accent-fg);
 }
 
 .pulse-md-tabs {
   display: flex;
-  gap: 4px;
-  margin-bottom: 6px;
+  gap: 0;
+  padding: 0;
+  margin: 0;
+  background: var(--color-canvas-subtle);
+  border-bottom: 1px solid var(--color-border-default);
 }
 
 .pulse-md-tab {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 4px 10px;
+  padding: 6px 12px;
+  margin-bottom: -1px; /* overlap the strip's bottom border so the active tab can "eat" it */
   font-size: 0.85rem;
   line-height: 1;
   color: var(--color-fg-muted);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: var(--border-radius-lg);
   cursor: pointer;
+}
+
+/* Pull every tab up by 1px so its top border lies on top of the wrapper's
+   border — when any tab is active, its top border merges with the wrapper's
+   top edge. The first tab also pulls left by 1px so it merges with the
+   wrapper's left edge at the top-left corner. */
+.pulse-md-tab {
+  margin-top: -1px;
+}
+
+.pulse-md-tab:first-child {
+  margin-left: -1px;
 }
 
 .pulse-md-tab:hover {
   color: var(--color-fg-default);
-  background: var(--color-canvas-subtle);
 }
 
 .pulse-md-tab.is-active {
   color: var(--color-fg-default);
-  background: var(--color-canvas-subtle);
+  background: var(--color-canvas-default);
   border-color: var(--color-border-default);
+  border-bottom-color: var(--color-canvas-default);
+}
+
+/* When the editor wrapper picks up focus, the active tab's top border (and
+   the leftmost tab's left border) must follow — they sit on top of the
+   wrapper's border and would otherwise show as gray seams inside the blue
+   outline. The active tab's right border stays gray (internal divider) and
+   the bottom stays canvas-default (eats the strip divider). */
+.pulse-md-editor:focus-within .pulse-md-tab.is-active {
+  border-top-color: var(--color-accent-fg);
+}
+
+.pulse-md-editor:focus-within .pulse-md-tab.is-active:first-child {
+  border-left-color: var(--color-accent-fg);
+}
+
+/* Inner inputs and the preview pane sit flush inside the wrapper — the
+   wrapper provides the border, radius, and focus highlight, so we strip
+   theirs to avoid double borders. */
+.pulse-md-editor .pulse-form-textarea,
+.pulse-md-editor .pulse-form-input,
+.pulse-md-editor .pulse-md-preview {
+  border: none;
+  border-radius: 0;
+  background: transparent;
+}
+
+.pulse-md-editor .pulse-form-textarea:focus,
+.pulse-md-editor .pulse-form-input:focus {
+  outline: none;
+  border: none;
 }
 
 .pulse-md-preview {
-  min-height: 6em;
   padding: 8px 12px;
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--border-radius-lg);
-  background: var(--color-canvas-default);
+}
+
+/* Stack the input area and the preview pane in the same grid cell so the
+   cell sizes to the taller of the two — toggling tabs cannot change the
+   editor's height. The hidden pane stays in layout via visibility:hidden so
+   it still contributes its natural size to the cell. */
+.pulse-md-stack {
+  display: grid;
+}
+
+.pulse-md-stack > * {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+/* Both panes (and the textarea inside the mention container, when present)
+   grow to fill the grid cell, so the visible pane always covers the editor's
+   full content area — even when the cell grew because the OTHER pane
+   demanded more room. min-height (not height) so the item's intrinsic size
+   still contributes to cell sizing in the first place. */
+.pulse-md-stack > textarea,
+.pulse-md-stack > .pulse-md-preview,
+.pulse-md-stack > .mention-autocomplete-container,
+.pulse-md-stack > .mention-autocomplete-container > textarea {
+  min-height: 100%;
+}
+
+.pulse-md-stack [hidden] {
+  display: revert !important;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .pulse-md-empty {

--- a/app/assets/stylesheets/pulse/_markdown_editor.css
+++ b/app/assets/stylesheets/pulse/_markdown_editor.css
@@ -1,0 +1,53 @@
+/*
+ * Markdown editor: GitHub-style Write / Preview toggle for text-entry forms.
+ * Colors use the shared --color-* tokens from root_variables.css.
+ */
+
+.pulse-md-editor {
+  width: 100%;
+}
+
+.pulse-md-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.pulse-md-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  font-size: 0.85rem;
+  line-height: 1;
+  color: var(--color-fg-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--border-radius-lg);
+  cursor: pointer;
+}
+
+.pulse-md-tab:hover {
+  color: var(--color-fg-default);
+  background: var(--color-canvas-subtle);
+}
+
+.pulse-md-tab.is-active {
+  color: var(--color-fg-default);
+  background: var(--color-canvas-subtle);
+  border-color: var(--color-border-default);
+}
+
+.pulse-md-preview {
+  min-height: 6em;
+  padding: 8px 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--border-radius-lg);
+  background: var(--color-canvas-default);
+}
+
+.pulse-md-empty {
+  color: var(--color-fg-muted);
+  font-style: italic;
+  margin: 0;
+}

--- a/app/controllers/markdown_previews_controller.rb
+++ b/app/controllers/markdown_previews_controller.rb
@@ -12,23 +12,31 @@ class MarkdownPreviewsController < ApplicationController
 
   def create
     text = params[:text].to_s
+    inline = params[:inline].to_s == "true"
 
     if text.length > MAX_PREVIEW_LENGTH
-      render html: helpers.tag.p("Too much text to preview.", class: "pulse-md-empty"), status: :unprocessable_entity
+      render html: empty_message("Too much text to preview.", inline:), status: :unprocessable_entity
       return
     end
 
     if text.strip.empty?
-      render html: helpers.tag.p("Nothing to preview.", class: "pulse-md-empty")
+      render html: empty_message("Nothing to preview.", inline:)
       return
     end
 
-    inline = params[:inline].to_s == "true"
     rendered = inline ? helpers.markdown_inline(text) : helpers.markdown(text)
     render html: rendered
   end
 
   private
+
+  # Placeholder shown when there's nothing (or too much) to render. Inline
+  # consumers (e.g. comments) get a span so it sits in their inline-styled pane;
+  # block consumers get a paragraph.
+  def empty_message(text, inline:)
+    tag_name = inline ? :span : :p
+    helpers.tag.public_send(tag_name, text, class: "pulse-md-empty")
+  end
 
   # No single resource backs this endpoint.
   def current_resource_model

--- a/app/controllers/markdown_previews_controller.rb
+++ b/app/controllers/markdown_previews_controller.rb
@@ -1,0 +1,37 @@
+# typed: false
+# frozen_string_literal: true
+
+# Renders a markdown preview for text-entry forms, so users can see how their
+# markdown will render before posting it. The rendering goes through the same
+# MarkdownRenderer used to display posted content, so the preview matches the
+# final result (including sanitization and reference linking).
+class MarkdownPreviewsController < ApplicationController
+  # Cap the amount of text we render in a single preview request. This is well
+  # above any real note/comment length and exists only to bound work per request.
+  MAX_PREVIEW_LENGTH = 100_000
+
+  def create
+    text = params[:text].to_s
+
+    if text.length > MAX_PREVIEW_LENGTH
+      render html: helpers.tag.p("Too much text to preview.", class: "pulse-md-empty"), status: :unprocessable_entity
+      return
+    end
+
+    if text.strip.empty?
+      render html: helpers.tag.p("Nothing to preview.", class: "pulse-md-empty")
+      return
+    end
+
+    inline = params[:inline].to_s == "true"
+    rendered = inline ? helpers.markdown_inline(text) : helpers.markdown(text)
+    render html: rendered
+  end
+
+  private
+
+  # No single resource backs this endpoint.
+  def current_resource_model
+    nil
+  end
+end

--- a/app/javascript/controllers/comments_controller.test.ts
+++ b/app/javascript/controllers/comments_controller.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { Application } from "@hotwired/stimulus"
 import CommentsController from "./comments_controller"
+import MarkdownPreviewController from "./markdown_preview_controller"
 
 describe("CommentsController", () => {
   let application: Application
@@ -202,6 +203,64 @@ describe("CommentsController", () => {
       expect(consoleSpy).toHaveBeenCalled()
       // Button should be re-enabled after error
       expect(submitButton.disabled).toBe(false)
+    })
+  })
+
+  it("resets the markdown editor to Write mode after a successful submit", async () => {
+    document.body.innerHTML = `
+      <div class="pulse-comments-section"
+           data-controller="comments"
+           data-comments-refresh-url-value="/test-resource/comments.html">
+        <div class="pulse-comments-list" data-comments-target="list"></div>
+        <form data-comments-target="form"
+              action="/test-resource/comments"
+              method="post"
+              data-action="submit->comments#submit">
+          <div class="pulse-md-editor"
+               data-controller="markdown-preview"
+               data-markdown-preview-url-value="/markdown/preview">
+            <button type="button" data-markdown-preview-target="writeTab"
+                    data-action="markdown-preview#showWrite">Write</button>
+            <button type="button" data-markdown-preview-target="previewTab"
+                    data-action="markdown-preview#showPreview">Preview</button>
+            <textarea name="text" data-comments-target="textarea"
+                      data-markdown-preview-target="input"></textarea>
+            <div data-markdown-preview-target="preview" hidden></div>
+          </div>
+          <button type="submit" data-comments-target="submitButton">Add Comment</button>
+        </form>
+      </div>
+    `
+    application.register("markdown-preview", MarkdownPreviewController)
+
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement
+    const pane = document.querySelector("[data-markdown-preview-target='preview']") as HTMLElement
+
+    // Let both controllers connect (connect() puts the editor in Write mode).
+    await vi.waitFor(() => expect(textarea.hidden).toBe(false))
+
+    // Simulate the user having submitted from the Preview tab.
+    textarea.hidden = true
+    pane.hidden = false
+
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ success: true }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('<div class="pulse-comments-list"></div>'),
+      })
+    vi.stubGlobal("fetch", mockFetch)
+
+    textarea.value = "Hello"
+    document.querySelector("form")!.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true })
+    )
+
+    // After a successful submit the editor is back in Write mode.
+    await vi.waitFor(() => {
+      expect(textarea.hidden).toBe(false)
+      expect(pane.hidden).toBe(true)
     })
   })
 

--- a/app/javascript/controllers/comments_controller.ts
+++ b/app/javascript/controllers/comments_controller.ts
@@ -56,6 +56,11 @@ export default class CommentsController extends Controller {
           this.textareaTarget.value = ""
         }
 
+        // If the user submitted from the Preview tab, the markdown editor is
+        // still showing the (now stale) rendered HTML with the textarea hidden.
+        // Reset it to Write mode so the next comment opens ready to type.
+        this.resetPreviewToWrite()
+
         // Refresh the comments list
         await this.refreshComments()
       } else {
@@ -141,6 +146,18 @@ export default class CommentsController extends Controller {
         }
       }
     })
+  }
+
+  // Return the markdown editor (if any) to Write mode after a submit, so a
+  // comment sent from the Preview tab doesn't leave stale rendered HTML behind.
+  private resetPreviewToWrite(): void {
+    const editor = this.element.querySelector('[data-controller~="markdown-preview"]')
+    if (!editor) return
+    const controller = this.application.getControllerForElementAndIdentifier(
+      editor,
+      "markdown-preview"
+    ) as { showWrite?: () => void } | null
+    controller?.showWrite?.()
   }
 
   private showLoadingState(): void {

--- a/app/javascript/controllers/index.ts
+++ b/app/javascript/controllers/index.ts
@@ -41,6 +41,7 @@ import LightboxController from "./lightbox_controller"
 import LogoutController from "./logout_controller"
 import MemberSelectController from "./member_select_controller"
 import MentionAutocompleteController from "./mention_autocomplete_controller"
+import MarkdownPreviewController from "./markdown_preview_controller"
 import MetricController from "./metric_controller"
 import MoreButtonController from "./more_button_controller"
 import NavController from "./nav_controller"
@@ -115,6 +116,7 @@ application.register("list-form", ListFormController)
 application.register("logout", LogoutController)
 application.register("member-select", MemberSelectController)
 application.register("mention-autocomplete", MentionAutocompleteController)
+application.register("markdown-preview", MarkdownPreviewController)
 application.register("metric", MetricController)
 application.register("more-button", MoreButtonController)
 application.register("nav", NavController)

--- a/app/javascript/controllers/markdown_preview_controller.test.ts
+++ b/app/javascript/controllers/markdown_preview_controller.test.ts
@@ -76,7 +76,9 @@ describe("MarkdownPreviewController", () => {
     expect(mockFetch.mock.calls[0][0]).toContain("/markdown/preview")
     expect(mockFetch.mock.calls[0][1].method).toBe("POST")
     expect(mockFetch.mock.calls[0][1].headers["X-CSRF-Token"]).toBe("test-csrf-token")
-    expect(mockFetch.mock.calls[0][1].body).toContain("text=%2A%2Abold%2A%2A")
+    // URLSearchParams' form-urlencoded serializer leaves "*" unencoded (it is in
+    // the unreserved "*-._" set), so the body is "text=**bold**", not "%2A%2A...".
+    expect(mockFetch.mock.calls[0][1].body).toContain("text=**bold**")
   })
 
   it("does not fetch when the textarea is empty", async () => {

--- a/app/javascript/controllers/markdown_preview_controller.test.ts
+++ b/app/javascript/controllers/markdown_preview_controller.test.ts
@@ -126,6 +126,35 @@ describe("MarkdownPreviewController", () => {
     })
   })
 
+  it("ignores a stale preview response once a newer request supersedes it", async () => {
+    // First request hangs; we resolve it by hand after the second one lands.
+    let resolveFirst: (value: { ok: boolean; text: () => Promise<string> }) => void
+    const firstResponse = new Promise<{ ok: boolean; text: () => Promise<string> }>((resolve) => {
+      resolveFirst = resolve
+    })
+    const mockFetch = vi
+      .fn()
+      .mockImplementationOnce(() => firstResponse)
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve("<p>NEW</p>") })
+    vi.stubGlobal("fetch", mockFetch)
+
+    const { preview, textarea, pane } = els()
+
+    textarea.value = "first"
+    preview.click() // request 1 — left pending
+    textarea.value = "second"
+    preview.click() // request 2 — resolves first
+
+    await vi.waitFor(() => expect(pane.innerHTML).toContain("NEW"))
+
+    // Resolve the older request last; it must not overwrite the newer result.
+    resolveFirst!({ ok: true, text: () => Promise.resolve("<p>OLD</p>") })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(pane.innerHTML).toContain("NEW")
+    expect(pane.innerHTML).not.toContain("OLD")
+  })
+
   it("sends inline=true when configured", async () => {
     const editor = document.querySelector(".pulse-md-editor") as HTMLElement
     editor.setAttribute("data-markdown-preview-inline-value", "true")

--- a/app/javascript/controllers/markdown_preview_controller.test.ts
+++ b/app/javascript/controllers/markdown_preview_controller.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import MarkdownPreviewController from "./markdown_preview_controller"
+
+describe("MarkdownPreviewController", () => {
+  let application: Application
+
+  beforeEach(() => {
+    document.head.innerHTML = `<meta name="csrf-token" content="test-csrf-token">`
+
+    document.body.innerHTML = `
+      <div class="pulse-md-editor"
+           data-controller="markdown-preview"
+           data-markdown-preview-url-value="/markdown/preview"
+           data-markdown-preview-inline-value="false">
+        <div class="pulse-md-tabs">
+          <button type="button" class="pulse-md-tab is-active"
+                  data-markdown-preview-target="writeTab"
+                  data-action="markdown-preview#showWrite">Write</button>
+          <button type="button" class="pulse-md-tab"
+                  data-markdown-preview-target="previewTab"
+                  data-action="markdown-preview#showPreview">Preview</button>
+        </div>
+        <textarea data-markdown-preview-target="input"></textarea>
+        <div class="markdown-body pulse-md-preview" data-markdown-preview-target="preview" hidden></div>
+      </div>
+    `
+
+    application = Application.start()
+    application.register("markdown-preview", MarkdownPreviewController)
+  })
+
+  afterEach(() => {
+    application.stop()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  const els = () => ({
+    write: document.querySelector("[data-markdown-preview-target='writeTab']") as HTMLElement,
+    preview: document.querySelector("[data-markdown-preview-target='previewTab']") as HTMLElement,
+    textarea: document.querySelector("textarea") as HTMLTextAreaElement,
+    pane: document.querySelector("[data-markdown-preview-target='preview']") as HTMLElement,
+  })
+
+  it("starts in write mode with the textarea visible", async () => {
+    await vi.waitFor(() => {
+      const { textarea, pane } = els()
+      expect(textarea.hidden).toBe(false)
+      expect(pane.hidden).toBe(true)
+    })
+  })
+
+  it("fetches and shows rendered HTML when Preview is clicked", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("<p><strong>bold</strong></p>"),
+    })
+    vi.stubGlobal("fetch", mockFetch)
+
+    const { write, preview, textarea, pane } = els()
+    textarea.value = "**bold**"
+    preview.click()
+
+    await vi.waitFor(() => {
+      expect(pane.innerHTML).toContain("<strong>bold</strong>")
+    })
+
+    // textarea hidden, preview shown, tabs reflect active state
+    expect(textarea.hidden).toBe(true)
+    expect(pane.hidden).toBe(false)
+    expect(preview.classList.contains("is-active")).toBe(true)
+    expect(write.classList.contains("is-active")).toBe(false)
+
+    // POSTed the text with the CSRF token
+    expect(mockFetch.mock.calls[0][0]).toContain("/markdown/preview")
+    expect(mockFetch.mock.calls[0][1].method).toBe("POST")
+    expect(mockFetch.mock.calls[0][1].headers["X-CSRF-Token"]).toBe("test-csrf-token")
+    expect(mockFetch.mock.calls[0][1].body).toContain("text=%2A%2Abold%2A%2A")
+  })
+
+  it("does not fetch when the textarea is empty", async () => {
+    const mockFetch = vi.fn()
+    vi.stubGlobal("fetch", mockFetch)
+
+    const { preview, pane } = els()
+    preview.click()
+
+    await vi.waitFor(() => {
+      expect(pane.innerHTML).toContain("Nothing to preview")
+    })
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it("returns to write mode and restores the textarea", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("<p>hi</p>"),
+    })
+    vi.stubGlobal("fetch", mockFetch)
+
+    const { write, preview, textarea, pane } = els()
+    textarea.value = "hi"
+    preview.click()
+    await vi.waitFor(() => expect(pane.hidden).toBe(false))
+
+    write.click()
+    expect(textarea.hidden).toBe(false)
+    expect(pane.hidden).toBe(true)
+    expect(write.classList.contains("is-active")).toBe(true)
+    expect(preview.classList.contains("is-active")).toBe(false)
+  })
+
+  it("shows an error message when the request fails", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false })
+    vi.stubGlobal("fetch", mockFetch)
+
+    const { preview, textarea, pane } = els()
+    textarea.value = "**bold**"
+    preview.click()
+
+    await vi.waitFor(() => {
+      expect(pane.innerHTML).toContain("Couldn't load preview")
+    })
+  })
+
+  it("sends inline=true when configured", async () => {
+    const editor = document.querySelector(".pulse-md-editor") as HTMLElement
+    editor.setAttribute("data-markdown-preview-inline-value", "true")
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("<strong>x</strong>"),
+    })
+    vi.stubGlobal("fetch", mockFetch)
+
+    // Re-query after attribute change; controller value updates in place.
+    const { preview, textarea } = els()
+    textarea.value = "**x**"
+    preview.click()
+
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalled())
+    expect(mockFetch.mock.calls[0][1].body).toContain("inline=true")
+  })
+})

--- a/app/javascript/controllers/markdown_preview_controller.ts
+++ b/app/javascript/controllers/markdown_preview_controller.ts
@@ -66,10 +66,16 @@ export default class MarkdownPreviewController extends Controller {
 
     const text = this.inputTarget.value
     if (text.trim() === "") {
+      this.previewTarget.style.minHeight = ""
       this.previewTarget.innerHTML = `<p class="pulse-md-empty">Nothing to preview.</p>`
       return
     }
 
+    // Pin the preview at its current rendered height so swapping innerHTML to
+    // the tiny "Loading…" placeholder doesn't shrink the grid cell. The final
+    // response resets this so the new content determines the editor's height.
+    const heldHeight = this.previewTarget.offsetHeight
+    if (heldHeight > 0) this.previewTarget.style.minHeight = `${heldHeight}px`
     this.previewTarget.innerHTML = `<p class="pulse-md-empty">Loading preview…</p>`
 
     const requestId = ++this.previewRequestId
@@ -94,10 +100,12 @@ export default class MarkdownPreviewController extends Controller {
 
       // A newer request started while we were awaiting — drop this stale result.
       if (requestId !== this.previewRequestId) return
+      this.previewTarget.style.minHeight = ""
       this.previewTarget.innerHTML = html
     } catch (error) {
       if (requestId !== this.previewRequestId) return
       console.error("Error loading markdown preview:", error)
+      this.previewTarget.style.minHeight = ""
       this.previewTarget.innerHTML = `<p class="pulse-md-empty">Couldn't load preview.</p>`
     }
   }

--- a/app/javascript/controllers/markdown_preview_controller.ts
+++ b/app/javascript/controllers/markdown_preview_controller.ts
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import { getCsrfToken } from "../utils/csrf"
+import { fetchWithCsrf } from "../utils/csrf"
 
 /**
  * Adds a GitHub-style Write / Preview toggle to a markdown text field.
@@ -40,6 +40,11 @@ export default class MarkdownPreviewController extends Controller {
   declare urlValue: string
   declare inlineValue: boolean
 
+  // Monotonic id stamped on each preview request. Only the most recent request
+  // is allowed to write to the pane, so a slow response can't overwrite a newer
+  // one (e.g. rapid Preview → Write → edit → Preview clicks).
+  private previewRequestId = 0
+
   connect(): void {
     this.showWrite()
   }
@@ -67,27 +72,31 @@ export default class MarkdownPreviewController extends Controller {
 
     this.previewTarget.innerHTML = `<p class="pulse-md-empty">Loading preview…</p>`
 
+    const requestId = ++this.previewRequestId
+
     try {
       const body = new URLSearchParams()
       body.set("text", text)
       if (this.inlineValue) body.set("inline", "true")
 
-      const response = await fetch(this.urlValue, {
+      const response = await fetchWithCsrf(this.urlValue, {
         method: "POST",
         headers: {
-          "X-CSRF-Token": getCsrfToken(),
           "Content-Type": "application/x-www-form-urlencoded",
           Accept: "text/html",
         },
         body: body.toString(),
       })
 
-      if (response.ok) {
-        this.previewTarget.innerHTML = await response.text()
-      } else {
-        this.previewTarget.innerHTML = `<p class="pulse-md-empty">Couldn't load preview.</p>`
-      }
+      const html = response.ok
+        ? await response.text()
+        : `<p class="pulse-md-empty">Couldn't load preview.</p>`
+
+      // A newer request started while we were awaiting — drop this stale result.
+      if (requestId !== this.previewRequestId) return
+      this.previewTarget.innerHTML = html
     } catch (error) {
+      if (requestId !== this.previewRequestId) return
       console.error("Error loading markdown preview:", error)
       this.previewTarget.innerHTML = `<p class="pulse-md-empty">Couldn't load preview.</p>`
     }

--- a/app/javascript/controllers/markdown_preview_controller.ts
+++ b/app/javascript/controllers/markdown_preview_controller.ts
@@ -1,0 +1,106 @@
+import { Controller } from "@hotwired/stimulus"
+import { getCsrfToken } from "../utils/csrf"
+
+/**
+ * Adds a GitHub-style Write / Preview toggle to a markdown text field.
+ *
+ * The preview is rendered server-side (via the same MarkdownRenderer used to
+ * display posted content), so what you see in the preview matches what gets
+ * posted — including sanitization and reference linking.
+ *
+ * Expected markup:
+ *   <div data-controller="markdown-preview"
+ *        data-markdown-preview-url-value="/markdown/preview"
+ *        data-markdown-preview-inline-value="false">
+ *     <div class="markdown-preview-tabs">
+ *       <button type="button" data-markdown-preview-target="writeTab"
+ *               data-action="markdown-preview#showWrite">Write</button>
+ *       <button type="button" data-markdown-preview-target="previewTab"
+ *               data-action="markdown-preview#showPreview">Preview</button>
+ *     </div>
+ *     <textarea data-markdown-preview-target="input"></textarea>
+ *     <div class="markdown-body markdown-preview-pane" data-markdown-preview-target="preview" hidden></div>
+ *   </div>
+ */
+export default class MarkdownPreviewController extends Controller {
+  static targets = ["input", "preview", "writeTab", "previewTab"]
+  static values = {
+    url: String,
+    inline: { type: Boolean, default: false },
+  }
+
+  declare readonly inputTarget: HTMLTextAreaElement
+  declare readonly previewTarget: HTMLElement
+  declare readonly writeTabTarget: HTMLElement
+  declare readonly previewTabTarget: HTMLElement
+  declare readonly hasInputTarget: boolean
+  declare readonly hasPreviewTarget: boolean
+  declare readonly hasWriteTabTarget: boolean
+  declare readonly hasPreviewTabTarget: boolean
+  declare urlValue: string
+  declare inlineValue: boolean
+
+  connect(): void {
+    this.showWrite()
+  }
+
+  showWrite(event?: Event): void {
+    event?.preventDefault()
+    if (this.hasInputTarget) this.inputTarget.hidden = false
+    if (this.hasPreviewTarget) this.previewTarget.hidden = true
+    this.setActiveTab(this.hasWriteTabTarget ? this.writeTabTarget : null)
+  }
+
+  async showPreview(event?: Event): Promise<void> {
+    event?.preventDefault()
+    if (!this.hasPreviewTarget || !this.hasInputTarget) return
+
+    if (this.hasInputTarget) this.inputTarget.hidden = true
+    this.previewTarget.hidden = false
+    this.setActiveTab(this.hasPreviewTabTarget ? this.previewTabTarget : null)
+
+    const text = this.inputTarget.value
+    if (text.trim() === "") {
+      this.previewTarget.innerHTML = `<p class="pulse-md-empty">Nothing to preview.</p>`
+      return
+    }
+
+    this.previewTarget.innerHTML = `<p class="pulse-md-empty">Loading preview…</p>`
+
+    try {
+      const body = new URLSearchParams()
+      body.set("text", text)
+      if (this.inlineValue) body.set("inline", "true")
+
+      const response = await fetch(this.urlValue, {
+        method: "POST",
+        headers: {
+          "X-CSRF-Token": getCsrfToken(),
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "text/html",
+        },
+        body: body.toString(),
+      })
+
+      if (response.ok) {
+        this.previewTarget.innerHTML = await response.text()
+      } else {
+        this.previewTarget.innerHTML = `<p class="pulse-md-empty">Couldn't load preview.</p>`
+      }
+    } catch (error) {
+      console.error("Error loading markdown preview:", error)
+      this.previewTarget.innerHTML = `<p class="pulse-md-empty">Couldn't load preview.</p>`
+    }
+  }
+
+  private setActiveTab(active: HTMLElement | null): void {
+    const tabs: HTMLElement[] = []
+    if (this.hasWriteTabTarget) tabs.push(this.writeTabTarget)
+    if (this.hasPreviewTabTarget) tabs.push(this.previewTabTarget)
+    for (const tab of tabs) {
+      const isActive = tab === active
+      tab.classList.toggle("is-active", isActive)
+      tab.setAttribute("aria-selected", isActive ? "true" : "false")
+    }
+  }
+}

--- a/app/views/commitments/new.html.erb
+++ b/app/views/commitments/new.html.erb
@@ -45,14 +45,10 @@
 
     <div class="pulse-form-group">
       <label class="pulse-form-label">Description <span class="pulse-form-label-optional">(optional)</span></label>
-      <div class="mention-autocomplete-container" data-controller="mention-autocomplete" data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
-        <%= form.text_area :description,
+      <%= render 'shared/markdown_editor', form: form, field: :description,
             placeholder: description_placeholder,
-            class: "pulse-form-textarea",
             rows: 4,
-            data: { mention_autocomplete_target: "input" } %>
-        <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
-      </div>
+            textarea_class: "pulse-form-textarea" %>
     </div>
 
     <%= render 'shared/multi_file_select', form: form %>

--- a/app/views/commitments/settings.html.erb
+++ b/app/views/commitments/settings.html.erb
@@ -31,10 +31,10 @@
 
       <section class="pulse-settings-section">
         <label for="description" class="pulse-label">Description</label>
-        <div class="mention-autocomplete-container" data-controller="mention-autocomplete" data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
-          <%= form.text_area :description, placeholder: @current_collective.private_workspace? ? 'Description (markdown supported)' : 'Description (markdown supported, use @ to mention users)', value: @commitment.description, class: "pulse-form-input", data: { mention_autocomplete_target: "input" } %>
-          <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
-        </div>
+        <%= render 'shared/markdown_editor', form: form, field: :description,
+              placeholder: @current_collective.private_workspace? ? 'Description (markdown supported)' : 'Description (markdown supported, use @ to mention users)',
+              value: @commitment.description,
+              textarea_class: "pulse-form-input" %>
       </section>
 
       <section class="pulse-settings-section">

--- a/app/views/decisions/new.html.erb
+++ b/app/views/decisions/new.html.erb
@@ -48,15 +48,11 @@
 
     <div class="pulse-form-group">
       <label class="pulse-form-label">Description <span class="pulse-form-label-optional">(optional)</span></label>
-      <div class="mention-autocomplete-container" data-controller="mention-autocomplete" data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
-        <%= form.text_area :description,
+      <%= render 'shared/markdown_editor', form: form, field: :description,
             placeholder: @current_collective.private_workspace? ? "Add context or background for this decision..." : "Add context or background for this decision... (use @ to mention users)",
             value: @decision.description,
-            class: "pulse-form-textarea",
             rows: 4,
-            data: { mention_autocomplete_target: "input" } %>
-        <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
-      </div>
+            textarea_class: "pulse-form-textarea" %>
     </div>
 
     <%= render 'shared/multi_file_select', form: form %>

--- a/app/views/decisions/settings.html.erb
+++ b/app/views/decisions/settings.html.erb
@@ -24,10 +24,10 @@
 
       <section class="pulse-settings-section">
         <label for="description" class="pulse-label">Description</label>
-        <div class="mention-autocomplete-container" data-controller="mention-autocomplete" data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
-          <%= form.text_area :description, placeholder: @current_collective.private_workspace? ? 'Description (optional)' : 'Description (optional, use @ to mention users)', value: @decision.description, class: "pulse-form-input", data: { mention_autocomplete_target: "input" } %>
-          <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
-        </div>
+        <%= render 'shared/markdown_editor', form: form, field: :description,
+              placeholder: @current_collective.private_workspace? ? 'Description (optional)' : 'Description (optional, use @ to mention users)',
+              value: @decision.description,
+              textarea_class: "pulse-form-input" %>
       </section>
 
       <% unless @decision.closed? %>

--- a/app/views/notes/edit.html.erb
+++ b/app/views/notes/edit.html.erb
@@ -20,16 +20,12 @@
     <%= form_with(url: "#{@note.path}/edit", method: :post, class: "pulse-form") do |form| %>
       <div class="pulse-form-group">
         <label class="pulse-form-label">Content</label>
-        <div class="mention-autocomplete-container" data-controller="mention-autocomplete" data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
-          <%= form.text_area :text,
+        <%= render 'shared/markdown_editor', form: form, field: :text,
               placeholder: @note.is_reminder? ? "What should you be reminded about?" : (@current_collective.private_workspace? ? "Write your note here..." : "Write your note here... (use @ to mention users)"),
-              value: @note.text,
-              class: "pulse-form-textarea",
-              rows: @note.is_reminder? ? 4 : 12,
               required: true,
-              data: { mention_autocomplete_target: "input" } %>
-          <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
-        </div>
+              value: @note.text,
+              rows: @note.is_reminder? ? 4 : 12,
+              textarea_class: "pulse-form-textarea" %>
         <% if @note.is_reminder? %>
           <p class="pulse-form-hint">You and anyone @mentioned will be notified when this reminder fires.</p>
         <% else %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -20,17 +20,13 @@
     <div data-note-subtype-target="postFields"<%= ' style="display: none;"'.html_safe if @subtype != 'post' %>>
       <div class="pulse-form-group">
         <label class="pulse-form-label">Text</label>
-        <div class="mention-autocomplete-container" data-controller="mention-autocomplete" data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
-          <%= form.text_area :text,
+        <%= render 'shared/markdown_editor', form: form, field: :text,
               placeholder: @current_collective.private_workspace? ? "Write your note here..." : "Write your note here... (use @ to mention users)",
               autofocus: true,
-              value: @note.text,
-              class: "pulse-form-textarea",
-              rows: 8,
               required: true,
-              data: { mention_autocomplete_target: "input" } %>
-          <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
-        </div>
+              value: @note.text,
+              rows: 8,
+              textarea_class: "pulse-form-textarea" %>
       </div>
       <%= render 'shared/note_media_uploader', pending: true %>
     </div>
@@ -38,16 +34,13 @@
     <div data-note-subtype-target="reminderFields"<%= ' style="display: none;"'.html_safe unless @subtype == 'reminder' %>>
       <div class="pulse-form-group">
         <label class="pulse-form-label">Text</label>
-        <div class="mention-autocomplete-container" data-controller="mention-autocomplete" data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
-          <%= form.text_area :text,
+        <%= render 'shared/markdown_editor', form: form, field: :text,
               placeholder: "What should you be reminded about?",
-              value: @note.text,
-              class: "pulse-form-textarea",
-              rows: 4,
               required: true,
-              data: { mention_autocomplete_target: "input", note_subtype_target: "reminderTextInput" } %>
-          <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
-        </div>
+              value: @note.text,
+              rows: 4,
+              textarea_class: "pulse-form-textarea",
+              extra_data: { note_subtype_target: "reminderTextInput" } %>
         <p class="pulse-form-hint">You and anyone @mentioned will be notified when this reminder fires.</p>
       </div>
       <div class="pulse-form-group">

--- a/app/views/shared/_markdown_editor.html.erb
+++ b/app/views/shared/_markdown_editor.html.erb
@@ -5,20 +5,25 @@
     form  - the form builder
 
   Optional locals:
-    field            - field name (default :text)
-    placeholder      - textarea placeholder
-    autofocus        - boolean (default false)
-    rows             - textarea rows
-    textarea_class   - CSS class for the textarea
-    textarea_style   - inline style for the textarea
-    inline           - render preview with inline markdown (strips outer <p>); default false
-    mention          - wrap the textarea in a mention-autocomplete container; default true
+    field                   - field name (default :text)
+    value                   - explicit textarea value (for url-bound forms that prefill)
+    placeholder             - textarea placeholder
+    autofocus               - boolean (default false)
+    required                - boolean (default false)
+    rows                    - textarea rows
+    textarea_class          - CSS class for the textarea
+    textarea_style          - inline style for the textarea
+    extra_data              - extra data-* attributes merged into the textarea
+    inline                  - render preview with inline markdown (strips outer <p>); default false
+    mention                 - wrap the textarea in a mention-autocomplete container; default true
+    mention_container_class - extra classes for the mention-autocomplete container
 %>
 <% field        = local_assigns.fetch(:field, :text) %>
 <% inline       = local_assigns.fetch(:inline, false) %>
 <% mention      = local_assigns.fetch(:mention, true) && @current_collective.present? %>
 <% textarea_data = { markdown_preview_target: "input" } %>
 <% textarea_data[:mention_autocomplete_target] = "input" if mention %>
+<% textarea_data.merge!(local_assigns.fetch(:extra_data, {})) %>
 
 <div class="pulse-md-editor" data-controller="markdown-preview"
      data-markdown-preview-url-value="<%= markdown_preview_path %>"
@@ -36,6 +41,8 @@
     <%= form.text_area field,
           placeholder: local_assigns[:placeholder],
           autofocus: local_assigns.fetch(:autofocus, false),
+          required: local_assigns.fetch(:required, false),
+          value: local_assigns[:value],
           rows: local_assigns[:rows],
           class: local_assigns[:textarea_class],
           style: local_assigns[:textarea_style],
@@ -43,7 +50,7 @@
   <% end %>
 
   <% if mention %>
-    <div class="mention-autocomplete-container" data-controller="mention-autocomplete"
+    <div class="mention-autocomplete-container <%= local_assigns[:mention_container_class] %>" data-controller="mention-autocomplete"
          data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
       <%= textarea %>
       <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>

--- a/app/views/shared/_markdown_editor.html.erb
+++ b/app/views/shared/_markdown_editor.html.erb
@@ -1,0 +1,56 @@
+<%#
+  Reusable markdown text field with a GitHub-style Write / Preview toggle.
+
+  Required locals:
+    form  - the form builder
+
+  Optional locals:
+    field            - field name (default :text)
+    placeholder      - textarea placeholder
+    autofocus        - boolean (default false)
+    rows             - textarea rows
+    textarea_class   - CSS class for the textarea
+    textarea_style   - inline style for the textarea
+    inline           - render preview with inline markdown (strips outer <p>); default false
+    mention          - wrap the textarea in a mention-autocomplete container; default true
+%>
+<% field        = local_assigns.fetch(:field, :text) %>
+<% inline       = local_assigns.fetch(:inline, false) %>
+<% mention      = local_assigns.fetch(:mention, true) && @current_collective.present? %>
+<% textarea_data = { markdown_preview_target: "input" } %>
+<% textarea_data[:mention_autocomplete_target] = "input" if mention %>
+
+<div class="pulse-md-editor" data-controller="markdown-preview"
+     data-markdown-preview-url-value="<%= markdown_preview_path %>"
+     data-markdown-preview-inline-value="<%= inline %>">
+  <div class="pulse-md-tabs" role="tablist">
+    <button type="button" class="pulse-md-tab is-active" role="tab" aria-selected="true"
+            data-markdown-preview-target="writeTab"
+            data-action="markdown-preview#showWrite"><%= octicon 'pencil', height: 14 %> Write</button>
+    <button type="button" class="pulse-md-tab" role="tab" aria-selected="false"
+            data-markdown-preview-target="previewTab"
+            data-action="markdown-preview#showPreview"><%= octicon 'eye', height: 14 %> Preview</button>
+  </div>
+
+  <% textarea = capture do %>
+    <%= form.text_area field,
+          placeholder: local_assigns[:placeholder],
+          autofocus: local_assigns.fetch(:autofocus, false),
+          rows: local_assigns[:rows],
+          class: local_assigns[:textarea_class],
+          style: local_assigns[:textarea_style],
+          data: textarea_data %>
+  <% end %>
+
+  <% if mention %>
+    <div class="mention-autocomplete-container" data-controller="mention-autocomplete"
+         data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
+      <%= textarea %>
+      <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
+    </div>
+  <% else %>
+    <%= textarea %>
+  <% end %>
+
+  <div class="markdown-body pulse-md-preview" data-markdown-preview-target="preview" hidden></div>
+</div>

--- a/app/views/shared/_markdown_editor.html.erb
+++ b/app/views/shared/_markdown_editor.html.erb
@@ -31,10 +31,10 @@
   <div class="pulse-md-tabs" role="tablist">
     <button type="button" class="pulse-md-tab is-active" role="tab" aria-selected="true"
             data-markdown-preview-target="writeTab"
-            data-action="markdown-preview#showWrite"><%= octicon 'pencil', height: 14 %> Write</button>
+            data-action="markdown-preview#showWrite">Write</button>
     <button type="button" class="pulse-md-tab" role="tab" aria-selected="false"
             data-markdown-preview-target="previewTab"
-            data-action="markdown-preview#showPreview"><%= octicon 'eye', height: 14 %> Preview</button>
+            data-action="markdown-preview#showPreview">Preview</button>
   </div>
 
   <% textarea = capture do %>
@@ -49,15 +49,22 @@
           data: textarea_data %>
   <% end %>
 
-  <% if mention %>
-    <div class="mention-autocomplete-container <%= local_assigns[:mention_container_class] %>" data-controller="mention-autocomplete"
-         data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
+  <%# Stack the input area and the preview pane in the same grid cell so the
+      cell's height is the max of both — switching tabs never changes the
+      editor's height (it can only grow if the preview content needs more
+      space). The hidden one stays in layout via the [hidden] CSS override
+      below; visibility:hidden keeps its footprint without showing it. %>
+  <div class="pulse-md-stack">
+    <% if mention %>
+      <div class="mention-autocomplete-container <%= local_assigns[:mention_container_class] %>" data-controller="mention-autocomplete"
+           data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
+        <%= textarea %>
+        <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
+      </div>
+    <% else %>
       <%= textarea %>
-      <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
-    </div>
-  <% else %>
-    <%= textarea %>
-  <% end %>
+    <% end %>
 
-  <div class="markdown-body pulse-md-preview" data-markdown-preview-target="preview" hidden></div>
+    <div class="markdown-body pulse-md-preview" data-markdown-preview-target="preview" hidden></div>
+  </div>
 </div>

--- a/app/views/shared/_new_note.html.erb
+++ b/app/views/shared/_new_note.html.erb
@@ -1,8 +1,8 @@
 <%= form_with url: "#{@current_collective.path}/note" do |form| %>
-  <div class="mention-autocomplete-container" data-controller="mention-autocomplete" data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
-    <%= form.text_area :text, placeholder: @current_collective.private_workspace? ? "Note" : "Note (use @ to mention users)", autofocus: true, style: 'height:6em;width:100%;background:none;border:none;', data: { mention_autocomplete_target: "input" } %>
-    <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
-  </div>
+  <%= render 'shared/markdown_editor', form: form,
+        placeholder: @current_collective.private_workspace? ? "Note" : "Note (use @ to mention users)",
+        autofocus: true,
+        textarea_style: 'height:6em;width:100%;background:none;border:none;' %>
   <%= render 'shared/multi_file_select', form: form %>
   <%= form.submit 'Post' %>
   <span>

--- a/app/views/shared/_pulse_comments.html.erb
+++ b/app/views/shared/_pulse_comments.html.erb
@@ -22,23 +22,11 @@
   <% elsif @current_user %>
     <div class="pulse-comment-form">
       <%= form_with url: "#{commentable.path}/comments", method: :post, local: true, class: "pulse-new-comment-form", data: { comments_target: "form", action: "submit->comments#submit", turbo: "false" } do |form| %>
-        <div class="pulse-md-editor" data-controller="markdown-preview"
-             data-markdown-preview-url-value="<%= markdown_preview_path %>"
-             data-markdown-preview-inline-value="true">
-          <div class="pulse-md-tabs" role="tablist">
-            <button type="button" class="pulse-md-tab is-active" role="tab" aria-selected="true"
-                    data-markdown-preview-target="writeTab"
-                    data-action="markdown-preview#showWrite"><%= octicon 'pencil', height: 14 %> Write</button>
-            <button type="button" class="pulse-md-tab" role="tab" aria-selected="false"
-                    data-markdown-preview-target="previewTab"
-                    data-action="markdown-preview#showPreview"><%= octicon 'eye', height: 14 %> Preview</button>
-          </div>
-          <div class="pulse-form-group mention-autocomplete-container" data-controller="mention-autocomplete" data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
-            <%= form.text_area :text, placeholder: @current_collective.private_workspace? ? "Add a comment..." : "Add a comment (use @ to mention users)...", rows: 3, class: "pulse-form-textarea", data: { mention_autocomplete_target: "input", comments_target: "textarea", markdown_preview_target: "input" } %>
-            <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
-          </div>
-          <div class="markdown-body pulse-md-preview" data-markdown-preview-target="preview" hidden></div>
-        </div>
+        <%= render 'shared/markdown_editor', form: form, field: :text, inline: true, rows: 3,
+              textarea_class: "pulse-form-textarea",
+              mention_container_class: "pulse-form-group",
+              extra_data: { comments_target: "textarea" },
+              placeholder: @current_collective.private_workspace? ? "Add a comment..." : "Add a comment (use @ to mention users)..." %>
         <div class="pulse-form-actions">
           <%= form.submit "Add Comment", class: "pulse-feed-action-btn", data: { comments_target: "submitButton" } %>
         </div>

--- a/app/views/shared/_pulse_comments.html.erb
+++ b/app/views/shared/_pulse_comments.html.erb
@@ -22,9 +22,22 @@
   <% elsif @current_user %>
     <div class="pulse-comment-form">
       <%= form_with url: "#{commentable.path}/comments", method: :post, local: true, class: "pulse-new-comment-form", data: { comments_target: "form", action: "submit->comments#submit", turbo: "false" } do |form| %>
-        <div class="pulse-form-group mention-autocomplete-container" data-controller="mention-autocomplete" data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
-          <%= form.text_area :text, placeholder: @current_collective.private_workspace? ? "Add a comment..." : "Add a comment (use @ to mention users)...", rows: 3, class: "pulse-form-textarea", data: { mention_autocomplete_target: "input", comments_target: "textarea" } %>
-          <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
+        <div class="pulse-md-editor" data-controller="markdown-preview"
+             data-markdown-preview-url-value="<%= markdown_preview_path %>"
+             data-markdown-preview-inline-value="true">
+          <div class="pulse-md-tabs" role="tablist">
+            <button type="button" class="pulse-md-tab is-active" role="tab" aria-selected="true"
+                    data-markdown-preview-target="writeTab"
+                    data-action="markdown-preview#showWrite"><%= octicon 'pencil', height: 14 %> Write</button>
+            <button type="button" class="pulse-md-tab" role="tab" aria-selected="false"
+                    data-markdown-preview-target="previewTab"
+                    data-action="markdown-preview#showPreview"><%= octicon 'eye', height: 14 %> Preview</button>
+          </div>
+          <div class="pulse-form-group mention-autocomplete-container" data-controller="mention-autocomplete" data-mention-autocomplete-collective-path-value="<%= @current_collective.path %>">
+            <%= form.text_area :text, placeholder: @current_collective.private_workspace? ? "Add a comment..." : "Add a comment (use @ to mention users)...", rows: 3, class: "pulse-form-textarea", data: { mention_autocomplete_target: "input", comments_target: "textarea", markdown_preview_target: "input" } %>
+            <div data-mention-autocomplete-target="dropdown" class="mention-dropdown"></div>
+          </div>
+          <div class="markdown-body pulse-md-preview" data-markdown-preview-target="preview" hidden></div>
         </div>
         <div class="pulse-form-actions">
           <%= form.submit "Add Comment", class: "pulse-feed-action-btn", data: { comments_target: "submitButton" } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -298,6 +298,10 @@ Rails.application.routes.draw do
   # not via execute_action — so no /search/actions/* routes.
   get 'search' => 'search#show'
 
+  # Renders a markdown preview for text-entry forms (notes, comments, etc.).
+  # Tenant-level: not tied to a specific collective or resource.
+  post 'markdown/preview' => 'markdown_previews#create', as: 'markdown_preview'
+
   # ============================================================
   # ADMIN ROUTES
   # ============================================================

--- a/test/controllers/markdown_previews_controller_test.rb
+++ b/test/controllers/markdown_previews_controller_test.rb
@@ -44,6 +44,21 @@ class MarkdownPreviewsControllerTest < ActionDispatch::IntegrationTest
     assert_includes @response.body, "Too much text"
   end
 
+  test "inline fallback renders an inline span rather than a block paragraph" do
+    sign_in_as(@user, tenant: @tenant)
+    post "/markdown/preview", params: { text: "a" * (MarkdownPreviewsController::MAX_PREVIEW_LENGTH + 1), inline: "true" }
+    assert_response :unprocessable_entity
+    assert_includes @response.body, "<span"
+    assert_not_includes @response.body, "<p"
+  end
+
+  test "block fallback renders a paragraph when not inline" do
+    sign_in_as(@user, tenant: @tenant)
+    post "/markdown/preview", params: { text: "a" * (MarkdownPreviewsController::MAX_PREVIEW_LENGTH + 1) }
+    assert_response :unprocessable_entity
+    assert_includes @response.body, "<p"
+  end
+
   test "requires authentication" do
     post "/markdown/preview", params: { text: "hi" }
     assert_response :redirect

--- a/test/controllers/markdown_previews_controller_test.rb
+++ b/test/controllers/markdown_previews_controller_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MarkdownPreviewsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @tenant = @global_tenant
+    @user = @global_user
+    host! "#{@tenant.subdomain}.#{ENV['HOSTNAME']}"
+  end
+
+  test "renders markdown to sanitized HTML for an authenticated user" do
+    sign_in_as(@user, tenant: @tenant)
+    post "/markdown/preview", params: { text: "# Hello\n\n**bold**" }
+    assert_response :success
+    assert_includes @response.body, "<strong>bold</strong>"
+  end
+
+  test "strips dangerous markup via the shared renderer" do
+    sign_in_as(@user, tenant: @tenant)
+    post "/markdown/preview", params: { text: "<script>alert(1)</script> hi" }
+    assert_response :success
+    assert_not_includes @response.body, "<script>"
+  end
+
+  test "returns a placeholder when text is blank" do
+    sign_in_as(@user, tenant: @tenant)
+    post "/markdown/preview", params: { text: "   " }
+    assert_response :success
+    assert_includes @response.body, "Nothing to preview"
+  end
+
+  test "inline mode strips the wrapping paragraph" do
+    sign_in_as(@user, tenant: @tenant)
+    post "/markdown/preview", params: { text: "just text", inline: "true" }
+    assert_response :success
+    assert_not_includes @response.body, "<p>"
+  end
+
+  test "rejects text over the length cap" do
+    sign_in_as(@user, tenant: @tenant)
+    post "/markdown/preview", params: { text: "a" * (MarkdownPreviewsController::MAX_PREVIEW_LENGTH + 1) }
+    assert_response :unprocessable_entity
+    assert_includes @response.body, "Too much text"
+  end
+
+  test "requires authentication" do
+    post "/markdown/preview", params: { text: "hi" }
+    assert_response :redirect
+  end
+end


### PR DESCRIPTION
Closes #258.

## What

Adds a GitHub-style **Write / Preview** toggle to markdown text fields, so you can see how your markdown will render before posting it.

The preview is rendered **server-side** through the same `MarkdownRenderer` used to display posted content, so what you see matches the final result — including HTML sanitization, Harmonic reference linking, and header shifting. A purely client-side renderer (e.g. marked.js) would diverge from these behaviors.

## How

- **`POST /markdown/preview`** (`MarkdownPreviewsController`) — auth-required, length-capped (100k chars), returns the rendered HTML fragment. Supports `inline=true` for comment-style rendering (`markdown_inline`).
- **`markdown-preview` Stimulus controller** — Write/Preview tabs; on Preview it POSTs the textarea contents (with CSRF token) and swaps the returned HTML into a `markdown-body` pane; handles empty/loading/error states.
- **`shared/_markdown_editor` partial** — reusable tabbed editor that coexists with the existing `mention-autocomplete` controller on the same textarea.
- Wired into the **new-note form** and the **Pulse comment form** (the two primary markdown surfaces). Other textareas can adopt the partial incrementally.
- **CSS** in `pulse/_markdown_editor.css`, `pulse-`-prefixed, using shared `--color-*` tokens.

## Tests

- `markdown_preview_controller.test.ts` — write/preview toggle, fetch + CSRF, empty/error states, inline flag.
- `markdown_previews_controller_test.rb` — rendering, sanitization, blank placeholder, inline mode, length cap, auth required.

## Verification

I can't run the Docker-based test suite or the app from my environment, so I verified statically: traced the existing renderer/helpers, matched Stimulus value/target and fetch/CSRF conventions from sibling controllers, and confirmed the new Pulse CSS passes `check-style-guide.sh`. **CI is the first real run of the test suite** — I'll watch it and fix any failures on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)