### PR TITLE
Search: rename `scope:` filter to `visibility:` + fix oversized search-box font (#272, #276)

### DIFF
--- a/app/assets/stylesheets/pulse/_layout.css
+++ b/app/assets/stylesheets/pulse/_layout.css
@@ -112,7 +112,6 @@
   background: transparent;
   padding: 6px 10px 6px 0;
   font-size: 13px;
-  font-family: var(--fontStack-monospace);
   width: 180px;
   min-width: 120px;
   color: var(--color-fg-default);

--- a/app/javascript/controllers/header_search_controller.ts
+++ b/app/javascript/controllers/header_search_controller.ts
@@ -58,7 +58,7 @@ export default class HeaderSearchController extends Controller<HTMLElement> {
 
   /**
    * Build the auto-populated prefix based on context.
-   * `list:<id>` takes precedence on list pages, then `scope:private` for
+   * `list:<id>` takes precedence on list pages, then `visibility:private` for
    * workspaces, then `collective:handle` for collectives.
    */
   private buildPrefix(): string | null {
@@ -67,7 +67,7 @@ export default class HeaderSearchController extends Controller<HTMLElement> {
     }
 
     if (this.workspaceValue) {
-      return "scope:private"
+      return "visibility:private"
     }
 
     const handle = this.collectiveHandleValue

--- a/app/services/search_query.rb
+++ b/app/services/search_query.rb
@@ -91,7 +91,7 @@ class SearchQuery
     min_links max_links min_backlinks max_backlinks min_comments max_comments
     min_readers max_readers min_voters max_voters min_participants max_participants
     after_date before_date
-    scope exclude_scope
+    visibility exclude_visibility
   ].freeze
 
   sig { returns(T::Array[User]) }
@@ -309,13 +309,13 @@ class SearchQuery
   attr_reader :collective
 
   sig { returns(T.nilable(String)) }
-  def scope
-    @params[:scope].presence
+  def visibility
+    @params[:visibility].presence
   end
 
   sig { returns(T.nilable(String)) }
-  def exclude_scope
-    @params[:exclude_scope].presence
+  def exclude_visibility
+    @params[:exclude_visibility].presence
   end
 
   # Options for UI dropdowns
@@ -516,8 +516,8 @@ class SearchQuery
         .where(tenant_id: @tenant.id, collective_type: "private_workspace")
         .pluck(:id)
 
-      # Apply scope filter
-      ids = case scope
+      # Apply visibility filter
+      ids = case visibility
       when "public"
         [main_id].compact
       when "shared"
@@ -528,8 +528,8 @@ class SearchQuery
         member_ids
       end
 
-      # Apply negated scope filter
-      case exclude_scope
+      # Apply negated visibility filter
+      case exclude_visibility
       when "public"
         ids -= [main_id].compact
       when "shared"

--- a/app/services/search_query_parser.rb
+++ b/app/services/search_query_parser.rb
@@ -32,10 +32,10 @@ class SearchQueryParser
   LIST_VALUE_PATTERN = /\A([a-f0-9]{8}|mutuals|tuned_in)\z/
 
   OPERATORS = T.let({
-    # Location scope
+    # Location / visibility
     "collective" => { pattern: COLLECTIVE_HANDLE_PATTERN, multi: false },
     "list" => { pattern: LIST_VALUE_PATTERN, multi: false },
-    "scope" => { values: ["public", "shared", "private"], multi: true },
+    "visibility" => { values: ["public", "shared", "private"], multi: true },
 
     # User filters
     "creator" => { pattern: HANDLE_PATTERN, multi: true },
@@ -83,6 +83,13 @@ class SearchQueryParser
     "type" => { "n" => "note", "d" => "decision", "c" => "commitment" },
     "sort" => { "new" => "newest", "old" => "oldest" },
   }.freeze, T::Hash[String, T::Hash[String, String]])
+
+  # Backward-compatible operator key aliases. `scope:` was renamed to
+  # `visibility:` to match the visibility term used in markdown/MCP actions;
+  # the old key is still accepted so existing links and saved queries keep working.
+  OPERATOR_ALIASES = T.let({
+    "scope" => "visibility",
+  }.freeze, T::Hash[String, String])
 
   # Map DSL sort values to SearchQuery sort_by format
   SORT_MAPPING = T.let({
@@ -165,6 +172,7 @@ class SearchQueryParser
 
       if match_data
         key = T.must(match_data[1]).downcase
+        key = OPERATOR_ALIASES.fetch(key, key)
         value = match_data[2]
 
         if valid_operator?(key, T.must(value))
@@ -311,9 +319,9 @@ class SearchQueryParser
     # List scope — truncated_id or shorthand alias ("mutuals" | "tuned_in").
     params[:list_id_or_alias] = build_collective_param("list")
 
-    # Scope filter (public/shared/private)
-    params[:scope] = build_scope_param
-    params[:exclude_scope] = build_negated_scope_param
+    # Visibility filter (public/shared/private)
+    params[:visibility] = build_visibility_param
+    params[:exclude_visibility] = build_negated_visibility_param
 
     params.compact
   end
@@ -496,32 +504,32 @@ class SearchQueryParser
     T.must(values.last)
   end
 
-  ALL_SCOPES = T.let(%w[public shared private].freeze, T::Array[String])
+  ALL_VISIBILITIES = T.let(%w[public shared private].freeze, T::Array[String])
 
   sig { returns(T.nilable(String)) }
-  def build_scope_param
-    values = (@operators["scope"] || []).uniq
+  def build_visibility_param
+    values = (@operators["visibility"] || []).uniq
     return nil if values.blank?
 
-    # Single scope: use directly
+    # Single visibility: use directly
     return T.must(values.first) if values.length == 1
 
-    # All three scopes: no filter needed
+    # All three visibilities: no filter needed
     return nil if values.length >= 3
 
-    # Two scopes: translate to exclude_scope of the missing one
-    # (handled by build_negated_scope_param)
+    # Two visibilities: translate to exclude_visibility of the missing one
+    # (handled by build_negated_visibility_param)
     nil
   end
 
   sig { returns(T.nilable(String)) }
-  def build_negated_scope_param
-    included = (@operators["scope"] || []).uniq
-    negated = (@negated_operators["scope"] || []).uniq
+  def build_negated_visibility_param
+    included = (@operators["visibility"] || []).uniq
+    negated = (@negated_operators["visibility"] || []).uniq
 
-    # Two included scopes → exclude the missing one
+    # Two included visibilities → exclude the missing one
     if included.length == 2
-      missing = (ALL_SCOPES - included).first
+      missing = (ALL_VISIBILITIES - included).first
       return missing
     end
 

--- a/app/views/help/search.md.erb
+++ b/app/views/help/search.md.erb
@@ -20,7 +20,7 @@ Use operators in your query to filter, sort, and group results.
 
 | Operator | Values | Example |
 |----------|--------|---------|
-| `scope:` | public, shared, private | `scope:shared` |
+| `visibility:` | public, shared, private | `visibility:shared` |
 | `collective:` | collective handle | `collective:my-team` |
 | `list:` | list id, or `mutuals` / `tuned_in` (see [Lists](/help/lists)) | `list:mutuals`, `list:tuned_in`, `list:abc12345` |
 | `type:` | note, decision, commitment | `type:note` |
@@ -69,5 +69,5 @@ Use `min-` and `max-` prefixes with these fields:
 - `creator:@alice sort:newest` — Alice's content, newest first
 - `"project update" type:note after:-7d` — Notes containing "project update" from the last 7 days
 - `collective:my-team group:type` — All content in my-team, grouped by type
-- `scope:private` — Only content in your private workspace
-- `-scope:private` — Everything except your private workspace
+- `visibility:private` — Only content in your private workspace
+- `-visibility:private` — Everything except your private workspace

--- a/test/services/search_query_parser_test.rb
+++ b/test/services/search_query_parser_test.rb
@@ -576,64 +576,77 @@ class SearchQueryParserTest < ActiveSupport::TestCase
     assert_equal "main", result[:collective_handle]
   end
 
-  # scope: operator
+  # visibility: operator
 
-  test "scope:public sets scope" do
-    result = SearchQueryParser.new("scope:public").parse
-    assert_equal "public", result[:scope]
+  test "visibility:public sets visibility" do
+    result = SearchQueryParser.new("visibility:public").parse
+    assert_equal "public", result[:visibility]
   end
 
-  test "scope:private sets scope" do
-    result = SearchQueryParser.new("scope:private").parse
-    assert_equal "private", result[:scope]
+  test "visibility:private sets visibility" do
+    result = SearchQueryParser.new("visibility:private").parse
+    assert_equal "private", result[:visibility]
   end
 
-  test "scope:shared sets scope" do
-    result = SearchQueryParser.new("scope:shared").parse
-    assert_equal "shared", result[:scope]
+  test "visibility:shared sets visibility" do
+    result = SearchQueryParser.new("visibility:shared").parse
+    assert_equal "shared", result[:visibility]
   end
 
-  test "-scope:private sets exclude_scope" do
-    result = SearchQueryParser.new("-scope:private").parse
-    assert_equal "private", result[:exclude_scope]
-    assert_nil result[:scope]
+  test "-visibility:private sets exclude_visibility" do
+    result = SearchQueryParser.new("-visibility:private").parse
+    assert_equal "private", result[:exclude_visibility]
+    assert_nil result[:visibility]
   end
 
-  test "scope:public,shared translates to exclude_scope:private" do
-    result = SearchQueryParser.new("scope:public scope:shared").parse
-    assert_nil result[:scope]
-    assert_equal "private", result[:exclude_scope]
+  test "visibility:public,shared translates to exclude_visibility:private" do
+    result = SearchQueryParser.new("visibility:public visibility:shared").parse
+    assert_nil result[:visibility]
+    assert_equal "private", result[:exclude_visibility]
   end
 
-  test "scope:public,shared comma syntax translates to exclude_scope:private" do
-    result = SearchQueryParser.new("scope:public,shared").parse
-    assert_nil result[:scope]
-    assert_equal "private", result[:exclude_scope]
+  test "visibility:public,shared comma syntax translates to exclude_visibility:private" do
+    result = SearchQueryParser.new("visibility:public,shared").parse
+    assert_nil result[:visibility]
+    assert_equal "private", result[:exclude_visibility]
   end
 
-  test "scope:shared,private translates to exclude_scope:public" do
-    result = SearchQueryParser.new("scope:shared scope:private").parse
-    assert_nil result[:scope]
-    assert_equal "public", result[:exclude_scope]
+  test "visibility:shared,private translates to exclude_visibility:public" do
+    result = SearchQueryParser.new("visibility:shared visibility:private").parse
+    assert_nil result[:visibility]
+    assert_equal "public", result[:exclude_visibility]
   end
 
-  test "scope:public,shared,private means no filter" do
-    result = SearchQueryParser.new("scope:public scope:shared scope:private").parse
-    assert_nil result[:scope]
-    assert_nil result[:exclude_scope]
+  test "visibility:public,shared,private means no filter" do
+    result = SearchQueryParser.new("visibility:public visibility:shared visibility:private").parse
+    assert_nil result[:visibility]
+    assert_nil result[:exclude_visibility]
   end
 
-  test "invalid scope treated as search text" do
-    result = SearchQueryParser.new("scope:invalid").parse
-    assert_equal "scope:invalid", result[:q]
-    assert_nil result[:scope]
+  test "invalid visibility treated as search text" do
+    result = SearchQueryParser.new("visibility:invalid").parse
+    assert_equal "visibility:invalid", result[:q]
+    assert_nil result[:visibility]
   end
 
-  test "scope: operator with other operators" do
-    result = SearchQueryParser.new("budget scope:public type:note").parse
+  test "visibility: operator with other operators" do
+    result = SearchQueryParser.new("budget visibility:public type:note").parse
     assert_equal "budget", result[:q]
-    assert_equal "public", result[:scope]
+    assert_equal "public", result[:visibility]
     assert_equal "note", result[:type]
+  end
+
+  # Backward-compatible `scope:` alias for `visibility:`
+
+  test "scope: alias maps to visibility" do
+    result = SearchQueryParser.new("scope:private").parse
+    assert_equal "private", result[:visibility]
+  end
+
+  test "-scope: alias maps to exclude_visibility" do
+    result = SearchQueryParser.new("-scope:private").parse
+    assert_equal "private", result[:exclude_visibility]
+    assert_nil result[:visibility]
   end
 
   test "invalid collective: value is treated as search text" do

--- a/test/services/search_query_test.rb
+++ b/test/services/search_query_test.rb
@@ -812,9 +812,9 @@ class SearchQueryTest < ActiveSupport::TestCase
     assert_not_includes search.results.pluck(:item_id), @note.id
   end
 
-  # scope: operator tests
+  # visibility: operator tests
 
-  test "scope:public restricts search to main collective only" do
+  test "visibility:public restricts search to main collective only" do
     @tenant.create_main_collective!(created_by: @user)
     main_collective = @tenant.main_collective
     main_collective.add_user!(@user)
@@ -823,7 +823,7 @@ class SearchQueryTest < ActiveSupport::TestCase
 
     search = SearchQuery.new(
       tenant: @tenant, current_user: @user,
-      raw_query: "scope:public cycle:all"
+      raw_query: "visibility:public cycle:all"
     )
 
     result_ids = search.results.pluck(:item_id)
@@ -832,7 +832,7 @@ class SearchQueryTest < ActiveSupport::TestCase
     assert_not_includes result_ids, @note.id
   end
 
-  test "scope:private returns only workspace content" do
+  test "visibility:private returns only workspace content" do
     @tenant.create_main_collective!(created_by: @user)
     main_collective = @tenant.main_collective
     main_collective.add_user!(@user)
@@ -846,7 +846,7 @@ class SearchQueryTest < ActiveSupport::TestCase
 
     search = SearchQuery.new(
       tenant: @tenant, current_user: @user,
-      raw_query: "scope:private cycle:all"
+      raw_query: "visibility:private cycle:all"
     )
 
     result_ids = search.results.pluck(:item_id)
@@ -855,7 +855,7 @@ class SearchQueryTest < ActiveSupport::TestCase
     assert_not_includes result_ids, @note.id
   end
 
-  test "scope:shared returns non-public non-workspace content" do
+  test "visibility:shared returns non-public non-workspace content" do
     @tenant.create_main_collective!(created_by: @user)
     main_collective = @tenant.main_collective
     main_collective.add_user!(@user)
@@ -869,7 +869,7 @@ class SearchQueryTest < ActiveSupport::TestCase
 
     search = SearchQuery.new(
       tenant: @tenant, current_user: @user,
-      raw_query: "scope:shared cycle:all"
+      raw_query: "visibility:shared cycle:all"
     )
 
     result_ids = search.results.pluck(:item_id)
@@ -880,7 +880,7 @@ class SearchQueryTest < ActiveSupport::TestCase
     assert_not_includes result_ids, workspace_note.id
   end
 
-  test "-scope:private excludes workspace content" do
+  test "-visibility:private excludes workspace content" do
     @tenant.create_main_collective!(created_by: @user)
     main_collective = @tenant.main_collective
     main_collective.add_user!(@user)
@@ -894,7 +894,7 @@ class SearchQueryTest < ActiveSupport::TestCase
 
     search = SearchQuery.new(
       tenant: @tenant, current_user: @user,
-      raw_query: "-scope:private cycle:all"
+      raw_query: "-visibility:private cycle:all"
     )
 
     result_ids = search.results.pluck(:item_id)
@@ -905,7 +905,7 @@ class SearchQueryTest < ActiveSupport::TestCase
     assert_not_includes result_ids, workspace_note.id
   end
 
-  test "-scope:public excludes main collective content" do
+  test "-visibility:public excludes main collective content" do
     @tenant.create_main_collective!(created_by: @user)
     main_collective = @tenant.main_collective
     main_collective.add_user!(@user)
@@ -919,7 +919,7 @@ class SearchQueryTest < ActiveSupport::TestCase
 
     search = SearchQuery.new(
       tenant: @tenant, current_user: @user,
-      raw_query: "-scope:public cycle:all"
+      raw_query: "-visibility:public cycle:all"
     )
 
     result_ids = search.results.pluck(:item_id)
@@ -930,7 +930,7 @@ class SearchQueryTest < ActiveSupport::TestCase
     assert_not_includes result_ids, main_note.id
   end
 
-  test "scope:public for unauthenticated user returns main collective results" do
+  test "visibility:public for unauthenticated user returns main collective results" do
     @tenant.create_main_collective!(created_by: @user)
     main_collective = @tenant.main_collective
     main_note = create_note(tenant: @tenant, collective: main_collective, created_by: @user, text: "public unauthenticated content")
@@ -938,7 +938,7 @@ class SearchQueryTest < ActiveSupport::TestCase
 
     search = SearchQuery.new(
       tenant: @tenant, current_user: nil,
-      raw_query: "scope:public cycle:all"
+      raw_query: "visibility:public cycle:all"
     )
 
     result_ids = search.results.pluck(:item_id)


### PR DESCRIPTION
Fixes #272 and #276 in one PR.

## #272 — `scope:` → `visibility:`
Search filters used `scope:` for public/shared/private zones, while markdown actions and MCP context params use `visibility`. Standardized on `visibility`:

- DSL operator `scope:` → `visibility:`
- Internal parser params `:scope`/`:exclude_scope` → `:visibility`/`:exclude_visibility` and `SearchQuery#scope`/`#exclude_scope` → `#visibility`/`#exclude_visibility` (fully internal — these never came from URL params)
- Help docs (`/help/search`) and the header search auto-prefix (`visibility:private` for workspaces) updated

**Backward compatibility:** `scope:` is kept as a hidden operator alias (via a new `OPERATOR_ALIASES` map) so existing bookmarked/saved search URLs keep working. Docs document `visibility:` only. If you'd rather make this a hard cutover with no alias, say so and I'll drop it.

## #276 — search-box font too large
Root cause found via git archaeology: the header search bar (added Jan 29, `0d790ef3`) set `font-family: var(--fontStack-monospace)`, but that variable wasn't defined until Jun 11 (`4f9e0adc`). With the variable undefined and no fallback, the declaration was invalid-at-computed-value-time, so the input inherited the proportional UI font — which looked fine. Once the variable got defined, the input silently switched to the wider monospace font, so typed queries started overflowing the fixed 180px box ("at some point it changed").

Fix: remove the `font-family` line so the input inherits the proportional font again, exactly as it rendered before. Font size stays 13px. This also matches the on-page search input (`.pulse-form-input`, which uses `font-family: inherit`).

## Tests
- Updated `search_query_parser_test.rb` and `search_query_test.rb` to use `visibility:`, and added coverage that the `scope:` alias still maps to `visibility`.

## Verification
Not run locally — this VM can't run the Docker test suite. Relying on CI. CSS/TS changes are visual; I traced the font regression to its commit but did not render it in a browser here.