### PR TITLE
Don't render intra-word underscores as italics (#269)

### DIFF
--- a/app/services/markdown_renderer.rb
+++ b/app/services/markdown_renderer.rb
@@ -20,7 +20,8 @@ class MarkdownRenderer
     ),
     autolink: true,
     tables: true,
-    fenced_code_blocks: true
+    fenced_code_blocks: true,
+    no_intra_emphasis: true # Don't treat intra-word underscores as emphasis (e.g. a_b c_d)
   )
 
   sig { params(content: T.untyped, shift_headers: T::Boolean, display_references: T::Boolean).returns(String) }

--- a/test/services/markdown_renderer_test.rb
+++ b/test/services/markdown_renderer_test.rb
@@ -43,6 +43,22 @@ class MarkdownRendererTest < ActiveSupport::TestCase
     assert html.include?("<em>italic</em>")
   end
 
+  test "render does not treat intra-word underscores as italics" do
+    markdown = "a_b c_d"
+    html = MarkdownRenderer.render(markdown)
+
+    # no_intra_emphasis keeps underscores inside/between words literal
+    assert html.include?("a_b c_d"), "Expected underscores to be preserved literally: #{html}"
+    assert_not html.include?("<em>"), "Expected no <em> tag for intra-word underscores: #{html}"
+  end
+
+  test "render still converts underscore-delimited italics" do
+    markdown = "This is _italic_ text"
+    html = MarkdownRenderer.render(markdown)
+
+    assert html.include?("<em>italic</em>"), "Expected single-underscore emphasis to still render: #{html}"
+  end
+
   test "render converts links" do
     markdown = "[Click here](https://example.com)"
     html = MarkdownRenderer.render(markdown)


### PR DESCRIPTION
Fixes #269.

## Problem

Terms with an underscore in the middle get parsed as italics. Example: `a_b c_d` renders as `a<em>b c</em>d`.

## Root cause

`app/services/markdown_renderer.rb` builds `Redcarpet::Markdown.new` with `autolink`, `tables`, and `fenced_code_blocks` but not `no_intra_emphasis`. That extension exists precisely to stop intra-word underscores from becoming `<em>`.

## Fix

Enable `no_intra_emphasis: true` in the extensions hash. Redcarpet 3.6.0 (already in `Gemfile.lock`) supports it, so no gem upgrade is needed. Single underscores delimiting a word (`_italic_`) still render as italics.

## Tests

Added two cases to `test/services/markdown_renderer_test.rb`:
- `a_b c_d` stays literal with no `<em>` tag
- `_italic_` still renders `<em>italic</em>`

> ⚠️ Unverified by execution: I can't run the Docker test suite from my environment, so the tests are written to existing patterns but not run. Worth a green run in CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)