### PR TITLE
Render table-note cells through the markdown renderer (#279 baseline)

### DIFF
--- a/app/views/notes/_table.html.erb
+++ b/app/views/notes/_table.html.erb
@@ -25,7 +25,7 @@
         <% table.rows.each do |row| %>
           <tr>
             <% table.columns.each do |col| %>
-              <td><%= row[col["name"]] %></td>
+              <td><%= markdown_inline(row[col["name"]]) %></td>
             <% end %>
             <% if @note.user_can_edit_content?(@current_user) %>
               <td>

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -1807,4 +1807,32 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "reminder", note.subtype
     assert_not_nil note.reminder_notification_id
   end
+
+  # === Table note HTML rendering ===
+
+  test "table note HTML view renders markdown links in cells instead of raw text" do
+    sign_in_as(@user, tenant: @tenant)
+
+    note = Note.create!(
+      tenant: @tenant,
+      collective: @collective,
+      created_by: @user,
+      updated_by: @user,
+      subtype: "table",
+      title: "Links table",
+      text: "",
+      table_data: {
+        "description" => "",
+        "columns" => [{ "name" => "Link", "type" => "text" }],
+        "rows" => [{ "_id" => "r1", "Link" => "[Example](https://example.com)" }],
+      },
+    )
+
+    get "/collectives/#{@collective.handle}/n/#{note.truncated_id}"
+    assert_response :success
+
+    # The cell value should be rendered as a clickable link, not raw markdown text
+    assert_match(/<a [^>]*href="https:\/\/example\.com"/, response.body)
+    assert_not_includes response.body, "[Example](https://example.com)"
+  end
 end


### PR DESCRIPTION
Addresses the **baseline improvement** in #279 (the broader spreadsheet-style UX is left as a follow-on).

## Problem

> the baseline improvement is to render the table correctly with the markdown renderer. currently table contents in the html view are just raw text, which is annoying when cells contain links that you want to click on.

In `app/views/notes/_table.html.erb`, the table description is rendered through markdown but cells were plain interpolation (`<td><%= row[col["name"]] %></td>`), so a cell containing `[Example](https://example.com)` displayed as raw markdown text in HTML. The `.md` view already renders cell content as markdown (via `NoteTableFormatter`), so HTML and markdown views disagreed.

## Fix

Run cell values through the existing `markdown_inline` helper. `markdown_inline` strips the `<p>` wrapper, which is appropriate for table cells, and reuses `MarkdownRenderer` (Redcarpet + the same sanitization/link handling used everywhere else). This brings the HTML view to parity with the markdown view.

## No frontend calculations

The issue requires all spreadsheet calculations to happen on the backend. This change is rendering-only; aggregation already lives server-side in `NoteTableService` (`query_rows`, `summarize`). Nothing here introduces client-side computation.

## Tests

Added a controller test in `test/controllers/notes_controller_test.rb`: a table note whose cell contains a markdown link renders a clickable `<a href>` in the HTML view rather than raw `[text](url)`.

> ⚠️ Unverified by execution: I can't run the Docker test suite from my environment, so the test follows existing patterns but hasn't been run. Worth a green CI run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)