### PR TITLE
Clean up stray "studio" references (#278)

### DIFF
--- a/lib/tasks/e2e.rake
+++ b/lib/tasks/e2e.rake
@@ -43,11 +43,11 @@ namespace :e2e do
       puts "Added user to tenant: #{tenant_subdomain}"
     end
 
-    # Add to main studio
+    # Add to main collective
     if tenant.main_collective
       unless tenant.main_collective.collective_members.exists?(user: user)
         tenant.main_collective.add_user!(user)
-        puts "Added user to main studio: #{tenant.main_collective.name}"
+        puts "Added user to main collective: #{tenant.main_collective.name}"
       end
     end
 

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -745,8 +745,8 @@ class NoteTest < ActiveSupport::TestCase
     tenant2 = create_tenant(subdomain: "tenant2-#{SecureRandom.hex(4)}")
     user = create_user
 
-    collective1 = create_collective(tenant: tenant1, created_by: user, handle: "studio1-#{SecureRandom.hex(4)}")
-    collective2 = create_collective(tenant: tenant2, created_by: user, handle: "studio2-#{SecureRandom.hex(4)}")
+    collective1 = create_collective(tenant: tenant1, created_by: user, handle: "collective1-#{SecureRandom.hex(4)}")
+    collective2 = create_collective(tenant: tenant2, created_by: user, handle: "collective2-#{SecureRandom.hex(4)}")
 
     note = Note.create!(
       tenant: tenant1,


### PR DESCRIPTION
Fixes #278.

Collectives used to be called "studios". A case-insensitive sweep of the live code surface turned up only a couple of genuinely-stray references (most "studio" hits are historical migrations/docs, or belong to the separate `studio`→`superagent` rename).

## Changes

- **`lib/tasks/e2e.rake`** — the e2e setup task's comment and `puts` output said "main studio"; updated to "main collective".
- **`test/models/note_test.rb`** — the tenant-isolation test used collective handles `"studio1-…"` / `"studio2-…"` (while the local variables were already `collective1` / `collective2`); renamed to `"collective1-…"` / `"collective2-…"`.

## Deliberately left untouched

- **`app/models/tenant.rb:179`** reads `settings["default_studio_settings"]` as an **intentional backward-compatibility fallback** (`default_collective_settings || default_studio_settings || {}`) for tenants that may still store the old settings key. Dropping it is a data-migration decision, not a stray-reference cleanup, so it's out of scope for this PR. Flagging it here for a follow-up if/when we confirm no tenant still uses the old key.
- **Historical migrations** (including `20260115044701_rename_studio_to_superagent.rb`) and **CHANGELOG** audit-trail lines are kept as-is as a historical record.

> ⚠️ Unverified by execution: I can't run the Docker test suite from my environment. These are string/comment-only changes plus a test-fixture handle rename, so risk is low, but worth a green CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)