### PR TITLE
Surface row `_id` in query_rows so existing rows can be updated/deleted (#283)

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -439,7 +439,7 @@ class NotesController < ApplicationController
     markdown = NoteTableFormatter.to_markdown({
       "columns" => table.columns,
       "rows" => result[:rows],
-    })
+    }, include_ids: true)
     render_action_success({
       action_name: "query_rows",
       resource: current_note,

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -414,7 +414,7 @@ class NotesController < ApplicationController
   def execute_add_table_column
     api_helper.add_table_column
     render_action_success({ action_name: "add_table_column", resource: current_note, result: "Column '#{params[:name]}' added." })
-  rescue RuntimeError, ActiveRecord::RecordInvalid => e
+  rescue ArgumentError, RuntimeError, ActiveRecord::RecordInvalid => e
     render_action_error({ action_name: "add_table_column", resource: current_note, error: e.message })
   end
 
@@ -505,7 +505,7 @@ class NotesController < ApplicationController
       format.html { redirect_to current_note.path, notice: "#{operations.length} operations applied." }
       format.md { render_action_success({ action_name: "batch_table_update", resource: current_note, result: "#{operations.length} operations applied." }) }
     end
-  rescue RuntimeError, ActiveRecord::RecordInvalid => e
+  rescue ArgumentError, RuntimeError, ActiveRecord::RecordInvalid => e
     respond_to do |format|
       format.json { render json: { success: false, error: e.message }, status: :unprocessable_entity }
       format.html { redirect_to current_note.path, alert: e.message }

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -133,7 +133,7 @@ class NotesController < ApplicationController
                             resource: note,
                             result: "Table note created.",
                           })
-  rescue RuntimeError, ActiveRecord::RecordInvalid => e
+  rescue ArgumentError, RuntimeError, ActiveRecord::RecordInvalid => e
     render_action_error({
                           action_name: "create_table_note",
                           error: e.message,

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -370,7 +370,7 @@ class NotesController < ApplicationController
     row = api_helper.add_row
     respond_to do |format|
       format.html { redirect_to current_note.path, notice: "Row added." }
-      format.md { render_action_success({ action_name: "add_row", resource: current_note, result: "Row added (id: #{row['_id']})." }) }
+      format.md { render_action_success({ action_name: "add_row", resource: current_note, result: "Row added (id: #{row['_harmonic_row_id']})." }) }
     end
   rescue RuntimeError, ActiveRecord::RecordInvalid => e
     respond_to do |format|
@@ -629,7 +629,7 @@ class NotesController < ApplicationController
       parsed = JSON.parse(params[:initial_rows]) rescue []
       col_names = columns.map { |c| c["name"] }
       initial_rows = parsed.map do |row|
-        r = { "_id" => SecureRandom.hex(4), "_created_by" => @current_user.id, "_created_at" => Time.current.iso8601 }
+        r = { "_harmonic_row_id" => SecureRandom.hex(4), "_harmonic_created_by" => @current_user.id, "_harmonic_created_at" => Time.current.iso8601 }
         col_names.each { |name| r[name] = row[name]&.to_s }
         r
       end

--- a/app/services/actions_helper.rb
+++ b/app/services/actions_helper.rb
@@ -279,7 +279,8 @@ class ActionsHelper
       visibility: :by_collective,
     },
     "query_rows" => {
-      description: "Query rows in this table with optional filtering, sorting, and pagination",
+      description: "Query rows in this table with optional filtering, sorting, and pagination. " \
+        "Results include each row's _harmonic_row_id, the identifier passed as row_id to update_row/delete_row",
       params_string: "(where, order_by, order, limit, offset)",
       params: [
         { name: "where", type: "object", required: false, description: "Filter by column values, e.g. { \"Status\": \"done\" }" },

--- a/app/services/api_helper.rb
+++ b/app/services/api_helper.rb
@@ -335,9 +335,13 @@ class ApiHelper
     end.select { |c| c["name"].present? }
 
     col_names = columns.map { |c| c["name"] }
+    if (reserved = col_names.find { |n| n.to_s.start_with?("_harmonic_") })
+      raise ArgumentError, "Column name '#{reserved}' uses the reserved '_harmonic_' prefix"
+    end
+
     initial_rows = (params[:initial_rows] || []).map do |row|
       row = row.respond_to?(:to_unsafe_h) ? row.to_unsafe_h : row.to_h
-      r = { "_id" => SecureRandom.hex(4), "_created_by" => current_user.id, "_created_at" => Time.current.iso8601 }
+      r = { "_harmonic_row_id" => SecureRandom.hex(4), "_harmonic_created_by" => current_user.id, "_harmonic_created_at" => Time.current.iso8601 }
       col_names.each { |name| r[name] = row[name.to_s]&.to_s || row[name.to_sym]&.to_s }
       r
     end

--- a/app/services/note_table_formatter.rb
+++ b/app/services/note_table_formatter.rb
@@ -3,10 +3,11 @@
 class NoteTableFormatter
   extend T::Sig
 
-  # When `include_ids` is true, an `_id` column is prepended so callers can
-  # discover each row's identifier (needed by update_row / delete_row). This is
-  # opt-in because the human table view and the stored note body should not
-  # expose the internal id; only the machine-facing query_rows action uses it.
+  # When `include_ids` is true, a `_harmonic_row_id` column is prepended so
+  # callers can discover each row's identifier (needed by update_row /
+  # delete_row). This is opt-in because the human table view and the stored note
+  # body should not expose the internal id; only the machine-facing query_rows
+  # action uses it.
   sig { params(table_data: T::Hash[String, T.untyped], include_ids: T::Boolean).returns(String) }
   def self.to_markdown(table_data, include_ids: false)
     parts = []
@@ -20,14 +21,14 @@ class NoteTableFormatter
     return parts.join if columns.empty?
 
     col_names = columns.map { |c| escape_pipe(sanitize(c["name"].to_s)) }
-    col_names.unshift("_id") if include_ids
+    col_names.unshift("_harmonic_row_id") if include_ids
 
     parts << "| #{col_names.join(' | ')} |"
     parts << "| #{col_names.map { |_| '---' }.join(' | ')} |"
 
     rows.each do |row|
       cells = columns.map { |c| escape_pipe(sanitize(row[c["name"]].to_s)) }
-      cells.unshift(escape_pipe(sanitize(row["_id"].to_s))) if include_ids
+      cells.unshift(escape_pipe(sanitize(row["_harmonic_row_id"].to_s))) if include_ids
       parts << "| #{cells.join(' | ')} |"
     end
 

--- a/app/services/note_table_formatter.rb
+++ b/app/services/note_table_formatter.rb
@@ -3,8 +3,12 @@
 class NoteTableFormatter
   extend T::Sig
 
-  sig { params(table_data: T::Hash[String, T.untyped]).returns(String) }
-  def self.to_markdown(table_data)
+  # When `include_ids` is true, an `_id` column is prepended so callers can
+  # discover each row's identifier (needed by update_row / delete_row). This is
+  # opt-in because the human table view and the stored note body should not
+  # expose the internal id; only the machine-facing query_rows action uses it.
+  sig { params(table_data: T::Hash[String, T.untyped], include_ids: T::Boolean).returns(String) }
+  def self.to_markdown(table_data, include_ids: false)
     parts = []
 
     description = table_data["description"]
@@ -16,12 +20,14 @@ class NoteTableFormatter
     return parts.join if columns.empty?
 
     col_names = columns.map { |c| escape_pipe(sanitize(c["name"].to_s)) }
+    col_names.unshift("_id") if include_ids
 
     parts << "| #{col_names.join(' | ')} |"
     parts << "| #{col_names.map { |_| '---' }.join(' | ')} |"
 
     rows.each do |row|
       cells = columns.map { |c| escape_pipe(sanitize(row[c["name"]].to_s)) }
+      cells.unshift(escape_pipe(sanitize(row["_id"].to_s))) if include_ids
       parts << "| #{cells.join(' | ')} |"
     end
 

--- a/app/services/note_table_service.rb
+++ b/app/services/note_table_service.rb
@@ -44,6 +44,10 @@ class NoteTableService
 
   sig { params(name: String, type: String).void }
   def add_column!(name, type)
+    if name.start_with?("_harmonic_")
+      raise "Column name '#{name}' uses the reserved '_harmonic_' prefix"
+    end
+
     new_data = mutable_data
     new_data["columns"] << { "name" => name, "type" => type }
     apply_and_save!(new_data)
@@ -64,9 +68,9 @@ class NoteTableService
   sig { params(values: T::Hash[String, T.untyped], created_by: User).returns(T::Hash[String, T.untyped]) }
   def add_row!(values, created_by:)
     row = {
-      "_id" => SecureRandom.hex(4),
-      "_created_by" => created_by.id,
-      "_created_at" => Time.current.iso8601,
+      "_harmonic_row_id" => SecureRandom.hex(4),
+      "_harmonic_created_by" => created_by.id,
+      "_harmonic_created_at" => Time.current.iso8601,
     }
     column_names.each do |col_name|
       row[col_name] = values[col_name]&.to_s
@@ -81,7 +85,7 @@ class NoteTableService
   sig { params(row_id: String, values: T::Hash[String, T.untyped]).returns(T::Hash[String, T.untyped]) }
   def update_row!(row_id, values)
     new_data = mutable_data
-    row_index = new_data["rows"].index { |r| r["_id"] == row_id }
+    row_index = new_data["rows"].index { |r| r["_harmonic_row_id"] == row_id }
     raise "Row '#{row_id}' not found" unless row_index
 
     row = new_data["rows"][row_index] = new_data["rows"][row_index].dup
@@ -98,7 +102,7 @@ class NoteTableService
   def delete_row!(row_id)
     new_data = mutable_data
     original_count = new_data["rows"].length
-    new_data["rows"] = new_data["rows"].reject { |r| r["_id"] == row_id }
+    new_data["rows"] = new_data["rows"].reject { |r| r["_harmonic_row_id"] == row_id }
     raise "Row '#{row_id}' not found" if new_data["rows"].length == original_count
 
     apply_and_save!(new_data)

--- a/app/services/note_table_service.rb
+++ b/app/services/note_table_service.rb
@@ -37,6 +37,10 @@ class NoteTableService
   def define_columns!(cols)
     raise "Cannot replace columns when rows exist" if rows.any? && columns.any?
 
+    if (reserved = cols.find { |c| c["name"].to_s.start_with?("_harmonic_") })
+      raise ArgumentError, "Column name '#{reserved["name"]}' uses the reserved '_harmonic_' prefix"
+    end
+
     new_data = mutable_data
     new_data["columns"] = cols
     apply_and_save!(new_data)
@@ -45,7 +49,7 @@ class NoteTableService
   sig { params(name: String, type: String).void }
   def add_column!(name, type)
     if name.start_with?("_harmonic_")
-      raise "Column name '#{name}' uses the reserved '_harmonic_' prefix"
+      raise ArgumentError, "Column name '#{name}' uses the reserved '_harmonic_' prefix"
     end
 
     new_data = mutable_data

--- a/app/services/note_table_validator.rb
+++ b/app/services/note_table_validator.rb
@@ -62,8 +62,6 @@ class NoteTableValidator
         errors.add(:table_data, "column name '#{name.truncate(20)}' contains invalid characters (alphanumeric, spaces, underscores only)")
       elsif name.start_with?("_harmonic_")
         errors.add(:table_data, "column name '#{name.truncate(20)}' uses the reserved '_harmonic_' prefix")
-      elsif name.start_with?("_")
-        errors.add(:table_data, "column names cannot start with underscore (reserved for metadata)")
       end
 
       unless VALID_COLUMN_TYPES.include?(col["type"])

--- a/app/services/note_table_validator.rb
+++ b/app/services/note_table_validator.rb
@@ -60,6 +60,8 @@ class NoteTableValidator
         errors.add(:table_data, "column name '#{name.truncate(20)}' exceeds #{MAX_COLUMN_NAME_LENGTH} characters")
       elsif !name.match?(COLUMN_NAME_FORMAT)
         errors.add(:table_data, "column name '#{name.truncate(20)}' contains invalid characters (alphanumeric, spaces, underscores only)")
+      elsif name.start_with?("_harmonic_")
+        errors.add(:table_data, "column name '#{name.truncate(20)}' uses the reserved '_harmonic_' prefix")
       elsif name.start_with?("_")
         errors.add(:table_data, "column names cannot start with underscore (reserved for metadata)")
       end

--- a/app/views/help/table_notes.md.erb
+++ b/app/views/help/table_notes.md.erb
@@ -32,7 +32,7 @@ Each table has an optional **description** field for explaining the table's purp
 | Characters per cell | 1,000 |
 | Total table size | 2 MB |
 
-Column names must be alphanumeric (plus spaces and underscores), unique, and cannot start with an underscore. The `_harmonic_` prefix is reserved for Harmonic's internal bookkeeping fields (row id, creator, timestamp) and cannot be used for a column name.
+Column names must be alphanumeric (plus spaces and underscores) and unique. A leading underscore is allowed (e.g. `_id`, `_source` from a CSV import), with one exception: the `_harmonic_` prefix is reserved for Harmonic's internal bookkeeping fields (row id, creator, timestamp) and cannot be used for a column name.
 
 ## AI Agent Access
 

--- a/app/views/help/table_notes.md.erb
+++ b/app/views/help/table_notes.md.erb
@@ -32,7 +32,7 @@ Each table has an optional **description** field for explaining the table's purp
 | Characters per cell | 1,000 |
 | Total table size | 2 MB |
 
-Column names must be alphanumeric (plus spaces and underscores), unique, and cannot start with an underscore.
+Column names must be alphanumeric (plus spaces and underscores), unique, and cannot start with an underscore. The `_harmonic_` prefix is reserved for Harmonic's internal bookkeeping fields (row id, creator, timestamp) and cannot be used for a column name.
 
 ## AI Agent Access
 
@@ -62,7 +62,7 @@ The `query_rows` action supports:
 - `limit` — Max rows to return (default 20)
 - `offset` — Skip rows for pagination
 
-`query_rows` results include each row's `_id` as the first column. This is how you obtain the `row_id` needed by `update_row` and `delete_row` for rows you did not just add — the rendered table and note body omit `_id`, so query first, then update or delete.
+`query_rows` results include each row's `_harmonic_row_id` as the first column. This is how you obtain the `row_id` needed by `update_row` and `delete_row` for rows you did not just add — the rendered table and note body omit `_harmonic_row_id`, so query first, then update or delete.
 
 ### Aggregation
 

--- a/app/views/help/table_notes.md.erb
+++ b/app/views/help/table_notes.md.erb
@@ -62,6 +62,8 @@ The `query_rows` action supports:
 - `limit` — Max rows to return (default 20)
 - `offset` — Skip rows for pagination
 
+`query_rows` results include each row's `_id` as the first column. This is how you obtain the `row_id` needed by `update_row` and `delete_row` for rows you did not just add — the rendered table and note body omit `_id`, so query first, then update or delete.
+
 ### Aggregation
 
 The `summarize` action computes a value over rows:

--- a/app/views/notes/_table.html.erb
+++ b/app/views/notes/_table.html.erb
@@ -35,7 +35,7 @@
                   style: "display: inline;",
                   data: { turbo_confirm: "Delete this row?" }
                 ) do |f| %>
-                  <%= f.hidden_field :row_id, value: row["_id"] %>
+                  <%= f.hidden_field :row_id, value: row["_harmonic_row_id"] %>
                   <button type="submit" class="pulse-action-btn-secondary" style="padding: 2px 6px;" title="Delete row">
                     <%= octicon 'trash', height: 12 %>
                   </button>

--- a/db/migrate/20260628000000_rename_table_row_internal_fields_to_harmonic_prefix.rb
+++ b/db/migrate/20260628000000_rename_table_row_internal_fields_to_harmonic_prefix.rb
@@ -1,0 +1,67 @@
+# Renames the three internal bookkeeping keys stored on each table-note row from
+# their single-underscore names to the reserved `_harmonic_` namespace:
+#
+#   _id         -> _harmonic_row_id
+#   _created_by -> _harmonic_created_by
+#   _created_at -> _harmonic_created_at
+#
+# The single-underscore prefix is too generic to safely reserve (CSV exports
+# routinely contain columns literally named `_id`). The `_harmonic_` prefix is
+# now reserved instead. PR #283 made `_id` agent-visible for the first time via
+# query_rows, so this is the last moment a clean rename has no external
+# consumers to break.
+#
+# Renaming these keys does not change a note's rendered `text`: the formatter
+# only emits user-defined columns (and, opt-in, the row id), never the raw
+# storage keys — so `update_columns` is sufficient and intentionally skips
+# validations/callbacks, which is the right behavior for a system-job backfill.
+#
+# Idempotent: a row that already carries `_harmonic_row_id` is left untouched,
+# so the migration is safe to re-run and safe to run while old/new code overlap.
+class RenameTableRowInternalFieldsToHarmonicPrefix < ActiveRecord::Migration[7.2]
+  KEY_RENAMES = {
+    "_id" => "_harmonic_row_id",
+    "_created_by" => "_harmonic_created_by",
+    "_created_at" => "_harmonic_created_at",
+  }.freeze
+
+  def up
+    Note.unscoped_for_system_job.where(subtype: "table").find_each do |note|
+      data = note.table_data
+      next unless data.is_a?(Hash)
+
+      rows = data["rows"]
+      next unless rows.is_a?(Array) && rows.any?
+
+      changed = false
+      new_rows = rows.map do |row|
+        next row unless row.is_a?(Hash)
+        next row if row.key?("_harmonic_row_id") # already migrated
+
+        new_row = row.dup
+        KEY_RENAMES.each do |old_key, new_key|
+          next unless new_row.key?(old_key)
+          new_row[new_key] = new_row.delete(old_key)
+          changed = true
+        end
+        new_row
+      end
+
+      next unless changed
+
+      new_data = data.merge("rows" => new_rows)
+      ActiveRecord::Base.transaction do
+        note.update_columns(table_data: new_data)
+      end
+    rescue StandardError => e
+      Rails.logger.warn(
+        "RenameTableRowInternalFieldsToHarmonicPrefix: skipping note #{note.id}: #{e.message}"
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+          "Reversing would conflict with rows legitimately created under the new keys."
+  end
+end

--- a/db/migrate/20260628000000_rename_table_row_internal_fields_to_harmonic_prefix.rb
+++ b/db/migrate/20260628000000_rename_table_row_internal_fields_to_harmonic_prefix.rb
@@ -26,6 +26,8 @@ class RenameTableRowInternalFieldsToHarmonicPrefix < ActiveRecord::Migration[7.2
   }.freeze
 
   def up
+    failed_note_ids = []
+
     Note.unscoped_for_system_job.where(subtype: "table").find_each do |note|
       data = note.table_data
       next unless data.is_a?(Hash)
@@ -50,14 +52,20 @@ class RenameTableRowInternalFieldsToHarmonicPrefix < ActiveRecord::Migration[7.2
       next unless changed
 
       new_data = data.merge("rows" => new_rows)
-      ActiveRecord::Base.transaction do
-        note.update_columns(table_data: new_data)
-      end
+      # update_columns is a single statement and already atomic, so no transaction wrapper.
+      note.update_columns(table_data: new_data)
     rescue StandardError => e
-      Rails.logger.warn(
+      failed_note_ids << note.id
+      Rails.logger.error(
         "RenameTableRowInternalFieldsToHarmonicPrefix: skipping note #{note.id}: #{e.message}"
       )
     end
+
+    return if failed_note_ids.empty?
+
+    # Fail the deploy loud rather than continuing with inconsistently-migrated data.
+    raise "RenameTableRowInternalFieldsToHarmonicPrefix: #{failed_note_ids.length} note(s) failed to migrate; " \
+          "sample ids: #{failed_note_ids.first(10).join(', ')}"
   end
 
   def down

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10171,6 +10171,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260628000000'),
 ('20260626000000'),
 ('20260622000000'),
 ('20260618000000'),

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -753,6 +753,21 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     refute_includes response.body, "pending"
   end
 
+  test "query_rows action exposes each row's _id so it can be updated or deleted" do
+    sign_in_as(@user, tenant: @tenant)
+    note = create_table_note
+    table = NoteTableService.new(note)
+    row = table.add_row!({ "Status" => "done", "Due" => "2026-05-01" }, created_by: @user)
+
+    post "/collectives/#{@collective.handle}/n/#{note.truncated_id}/actions/query_rows",
+      params: {},
+      headers: { "Accept" => "text/markdown" }
+
+    assert_response :success
+    assert_includes response.body, "| _id | Status | Due |"
+    assert_includes response.body, row["_id"], "query_rows must surface the row _id needed by update_row/delete_row"
+  end
+
   test "summarize action returns aggregation result" do
     sign_in_as(@user, tenant: @tenant)
     note = Note.create!(

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -559,6 +559,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
         headers: { "Accept" => "text/markdown" }
     end
 
+    assert_response :unprocessable_entity
     assert_includes response.body, "_harmonic_"
   end
 

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -544,6 +544,24 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 2, note.table_data["columns"].length
   end
 
+  test "create_table_note action rejects a column using the reserved _harmonic_ prefix" do
+    sign_in_as(@user, tenant: @tenant)
+
+    assert_no_difference -> { Note.count } do
+      post "/collectives/#{@collective.handle}/note/actions/create_table_note",
+        params: {
+          title: "Sneaky Table",
+          columns: [
+            { name: "Status", type: "text" },
+            { name: "_harmonic_row_id", type: "text" },
+          ],
+        },
+        headers: { "Accept" => "text/markdown" }
+    end
+
+    assert_includes response.body, "_harmonic_"
+  end
+
   test "create_table_note action appears on note creation page" do
     sign_in_as(@user, tenant: @tenant)
 
@@ -684,7 +702,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     row = table.add_row!({ "Status" => "done", "Due" => "2026-05-01" }, created_by: @user)
 
     post "/collectives/#{@collective.handle}/n/#{note.truncated_id}/actions/delete_row",
-      params: { row_id: row["_id"] }
+      params: { row_id: row["_harmonic_row_id"] }
 
     assert_response :redirect
     assert_redirected_to note.path
@@ -713,7 +731,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     row = table.add_row!({ "Status" => "pending", "Due" => "2026-05-01" }, created_by: @user)
 
     post "/collectives/#{@collective.handle}/n/#{note.truncated_id}/actions/update_row",
-      params: { row_id: row["_id"], values: { "Status" => "done" } },
+      params: { row_id: row["_harmonic_row_id"], values: { "Status" => "done" } },
       headers: { "Accept" => "text/markdown" }
 
     assert_response :success
@@ -728,7 +746,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     row = table.add_row!({ "Status" => "done", "Due" => "2026-05-01" }, created_by: @user)
 
     post "/collectives/#{@collective.handle}/n/#{note.truncated_id}/actions/delete_row",
-      params: { row_id: row["_id"] },
+      params: { row_id: row["_harmonic_row_id"] },
       headers: { "Accept" => "text/markdown" }
 
     assert_response :success
@@ -753,7 +771,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     refute_includes response.body, "pending"
   end
 
-  test "query_rows action exposes each row's _id so it can be updated or deleted" do
+  test "query_rows action exposes each row's _harmonic_row_id so it can be updated or deleted" do
     sign_in_as(@user, tenant: @tenant)
     note = create_table_note
     table = NoteTableService.new(note)
@@ -764,8 +782,8 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
       headers: { "Accept" => "text/markdown" }
 
     assert_response :success
-    assert_includes response.body, "| _id | Status | Due |"
-    assert_includes response.body, row["_id"], "query_rows must surface the row _id needed by update_row/delete_row"
+    assert_includes response.body, "| _harmonic_row_id | Status | Due |"
+    assert_includes response.body, row["_harmonic_row_id"], "query_rows must surface the row _harmonic_row_id needed by update_row/delete_row"
   end
 
   test "summarize action returns aggregation result" do
@@ -1839,7 +1857,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
       table_data: {
         "description" => "",
         "columns" => [{ "name" => "Link", "type" => "text" }],
-        "rows" => [{ "_id" => "r1", "Link" => "[Example](https://example.com)" }],
+        "rows" => [{ "_harmonic_row_id" => "r1", "Link" => "[Example](https://example.com)" }],
       },
     )
 

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -1344,23 +1344,22 @@ class NoteTest < ActiveSupport::TestCase
     assert(note.errors[:table_data].any? { |e| e.include?("unique") })
   end
 
-  test "table note rejects column names starting with underscore" do
+  test "table note allows column names starting with underscore (only _harmonic_ is reserved)" do
     note = Note.new(
       tenant_id: Tenant.current_id,
       collective_id: Collective.current_id,
       created_by: @global_user,
       updated_by: @global_user,
       subtype: "table",
-      title: "Reserved column",
+      title: "Underscore column",
       text: "",
       table_data: {
-        "columns" => [{ "name" => "_id", "type" => "text" }],
+        "columns" => [{ "name" => "_id", "type" => "text" }, { "name" => "_source", "type" => "text" }],
         "rows" => [],
       }
     )
 
-    assert_not note.valid?
-    assert(note.errors[:table_data].any? { |e| e.include?("underscore") })
+    assert note.valid?, note.errors.full_messages.to_sentence
   end
 
   test "table note rejects column names using the reserved _harmonic_ prefix" do

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -1345,11 +1345,15 @@ class NoteTest < ActiveSupport::TestCase
   end
 
   test "table note allows column names starting with underscore (only _harmonic_ is reserved)" do
+    tenant = create_tenant
+    user = create_user
+    collective = create_collective(tenant: tenant, created_by: user)
+
     note = Note.new(
-      tenant_id: Tenant.current_id,
-      collective_id: Collective.current_id,
-      created_by: @global_user,
-      updated_by: @global_user,
+      tenant: tenant,
+      collective: collective,
+      created_by: user,
+      updated_by: user,
       subtype: "table",
       title: "Underscore column",
       text: "",

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -1363,6 +1363,25 @@ class NoteTest < ActiveSupport::TestCase
     assert(note.errors[:table_data].any? { |e| e.include?("underscore") })
   end
 
+  test "table note rejects column names using the reserved _harmonic_ prefix" do
+    note = Note.new(
+      tenant_id: Tenant.current_id,
+      collective_id: Collective.current_id,
+      created_by: @global_user,
+      updated_by: @global_user,
+      subtype: "table",
+      title: "Reserved prefix",
+      text: "",
+      table_data: {
+        "columns" => [{ "name" => "_harmonic_row_id", "type" => "text" }],
+        "rows" => [],
+      }
+    )
+
+    assert_not note.valid?
+    assert(note.errors[:table_data].any? { |e| e.include?("_harmonic_") })
+  end
+
   test "table note rejects column names with special characters" do
     note = Note.new(
       tenant_id: Tenant.current_id,
@@ -1412,7 +1431,7 @@ class NoteTest < ActiveSupport::TestCase
       text: "",
       table_data: {
         "columns" => [{ "name" => "Data", "type" => "text" }],
-        "rows" => [{ "_id" => "abc1", "Data" => "x" * 1001 }],
+        "rows" => [{ "_harmonic_row_id" => "abc1", "Data" => "x" * 1001 }],
       }
     )
 

--- a/test/services/api_helper_test.rb
+++ b/test/services/api_helper_test.rb
@@ -509,7 +509,7 @@ class ApiHelperTest < ActiveSupport::TestCase
 
     row = helper.add_row
 
-    assert row["_id"].present?
+    assert row["_harmonic_row_id"].present?
     assert_equal "done", row["Status"]
     assert_equal "42", row["Amount"]
     assert_equal 1, note.reload.table_data["rows"].length
@@ -520,7 +520,7 @@ class ApiHelperTest < ActiveSupport::TestCase
     table = NoteTableService.new(note)
     row = table.add_row!({ "Status" => "pending", "Amount" => "10" }, created_by: @user)
 
-    helper = table_api_helper(note, params: { row_id: row["_id"], values: { "Status" => "done" } })
+    helper = table_api_helper(note, params: { row_id: row["_harmonic_row_id"], values: { "Status" => "done" } })
     updated = helper.update_row
 
     assert_equal "done", updated["Status"]
@@ -532,7 +532,7 @@ class ApiHelperTest < ActiveSupport::TestCase
     table = NoteTableService.new(note)
     row = table.add_row!({ "Status" => "done", "Amount" => "10" }, created_by: @user)
 
-    helper = table_api_helper(note, params: { row_id: row["_id"] })
+    helper = table_api_helper(note, params: { row_id: row["_harmonic_row_id"] })
     helper.delete_row
 
     assert_equal 0, note.reload.table_data["rows"].length
@@ -647,7 +647,7 @@ class ApiHelperTest < ActiveSupport::TestCase
     )
 
     row = helper.add_row
-    assert row["_id"].present?
+    assert row["_harmonic_row_id"].present?
   end
 
   test "add_table_column requires resource owner" do

--- a/test/services/note_table_formatter_test.rb
+++ b/test/services/note_table_formatter_test.rb
@@ -8,8 +8,8 @@ class NoteTableFormatterTest < ActiveSupport::TestCase
         { "name" => "Due", "type" => "date" },
       ],
       "rows" => [
-        { "_id" => "abc1", "Status" => "done", "Due" => "2026-04-20" },
-        { "_id" => "def2", "Status" => "in_progress", "Due" => "2026-04-28" },
+        { "_harmonic_row_id" => "abc1", "Status" => "done", "Due" => "2026-04-20" },
+        { "_harmonic_row_id" => "def2", "Status" => "in_progress", "Due" => "2026-04-28" },
       ],
     }
 
@@ -21,40 +21,40 @@ class NoteTableFormatterTest < ActiveSupport::TestCase
     assert_includes result, "| in_progress | 2026-04-28 |"
   end
 
-  test "omits _id column by default" do
+  test "omits _harmonic_row_id column by default" do
     table_data = {
       "columns" => [{ "name" => "Status", "type" => "text" }],
-      "rows" => [{ "_id" => "abc1", "Status" => "done" }],
+      "rows" => [{ "_harmonic_row_id" => "abc1", "Status" => "done" }],
     }
 
     result = NoteTableFormatter.to_markdown(table_data)
 
     assert_includes result, "| Status |"
-    refute_includes result, "_id"
+    refute_includes result, "_harmonic_row_id"
     refute_includes result, "abc1"
   end
 
-  test "prepends _id column when include_ids is true" do
+  test "prepends _harmonic_row_id column when include_ids is true" do
     table_data = {
       "columns" => [
         { "name" => "Status", "type" => "text" },
         { "name" => "Due", "type" => "date" },
       ],
       "rows" => [
-        { "_id" => "abc1", "Status" => "done", "Due" => "2026-04-20" },
-        { "_id" => "def2", "Status" => "in_progress", "Due" => "2026-04-28" },
+        { "_harmonic_row_id" => "abc1", "Status" => "done", "Due" => "2026-04-20" },
+        { "_harmonic_row_id" => "def2", "Status" => "in_progress", "Due" => "2026-04-28" },
       ],
     }
 
     result = NoteTableFormatter.to_markdown(table_data, include_ids: true)
 
-    assert_includes result, "| _id | Status | Due |"
+    assert_includes result, "| _harmonic_row_id | Status | Due |"
     assert_includes result, "| --- | --- | --- |"
     assert_includes result, "| abc1 | done | 2026-04-20 |"
     assert_includes result, "| def2 | in_progress | 2026-04-28 |"
   end
 
-  test "renders blank _id cell when a row has no _id and include_ids is true" do
+  test "renders blank _harmonic_row_id cell when a row has no id and include_ids is true" do
     table_data = {
       "columns" => [{ "name" => "Status", "type" => "text" }],
       "rows" => [{ "Status" => "done" }],
@@ -62,7 +62,7 @@ class NoteTableFormatterTest < ActiveSupport::TestCase
 
     result = NoteTableFormatter.to_markdown(table_data, include_ids: true)
 
-    assert_includes result, "| _id | Status |"
+    assert_includes result, "| _harmonic_row_id | Status |"
     assert_includes result, "|  | done |"
   end
 
@@ -70,7 +70,7 @@ class NoteTableFormatterTest < ActiveSupport::TestCase
     table_data = {
       "description" => "Task tracker for Q2.",
       "columns" => [{ "name" => "Task", "type" => "text" }],
-      "rows" => [{ "_id" => "abc1", "Task" => "Ship it" }],
+      "rows" => [{ "_harmonic_row_id" => "abc1", "Task" => "Ship it" }],
     }
 
     result = NoteTableFormatter.to_markdown(table_data)
@@ -99,7 +99,7 @@ class NoteTableFormatterTest < ActiveSupport::TestCase
   test "escapes pipe characters in cell values" do
     table_data = {
       "columns" => [{ "name" => "Value", "type" => "text" }],
-      "rows" => [{ "_id" => "abc1", "Value" => "a|b|c" }],
+      "rows" => [{ "_harmonic_row_id" => "abc1", "Value" => "a|b|c" }],
     }
 
     result = NoteTableFormatter.to_markdown(table_data)
@@ -128,7 +128,7 @@ class NoteTableFormatterTest < ActiveSupport::TestCase
         { "name" => "A", "type" => "text" },
         { "name" => "B", "type" => "text" },
       ],
-      "rows" => [{ "_id" => "abc1", "A" => "hello", "B" => nil }],
+      "rows" => [{ "_harmonic_row_id" => "abc1", "A" => "hello", "B" => nil }],
     }
 
     result = NoteTableFormatter.to_markdown(table_data)
@@ -138,7 +138,7 @@ class NoteTableFormatterTest < ActiveSupport::TestCase
   test "handles empty string cell values" do
     table_data = {
       "columns" => [{ "name" => "A", "type" => "text" }],
-      "rows" => [{ "_id" => "abc1", "A" => "" }],
+      "rows" => [{ "_harmonic_row_id" => "abc1", "A" => "" }],
     }
 
     result = NoteTableFormatter.to_markdown(table_data)
@@ -148,7 +148,7 @@ class NoteTableFormatterTest < ActiveSupport::TestCase
   test "strips null bytes from values" do
     table_data = {
       "columns" => [{ "name" => "A", "type" => "text" }],
-      "rows" => [{ "_id" => "abc1", "A" => "hello\x00world" }],
+      "rows" => [{ "_harmonic_row_id" => "abc1", "A" => "hello\x00world" }],
     }
 
     result = NoteTableFormatter.to_markdown(table_data)
@@ -159,7 +159,7 @@ class NoteTableFormatterTest < ActiveSupport::TestCase
   test "strips control characters from values" do
     table_data = {
       "columns" => [{ "name" => "A", "type" => "text" }],
-      "rows" => [{ "_id" => "abc1", "A" => "hello\x01\x02world" }],
+      "rows" => [{ "_harmonic_row_id" => "abc1", "A" => "hello\x01\x02world" }],
     }
 
     result = NoteTableFormatter.to_markdown(table_data)
@@ -169,7 +169,7 @@ class NoteTableFormatterTest < ActiveSupport::TestCase
   test "preserves script tags as literal text (sanitized by Redcarpet on render)" do
     table_data = {
       "columns" => [{ "name" => "Content", "type" => "text" }],
-      "rows" => [{ "_id" => "abc1", "Content" => "<script>alert('xss')</script>" }],
+      "rows" => [{ "_harmonic_row_id" => "abc1", "Content" => "<script>alert('xss')</script>" }],
     }
 
     result = NoteTableFormatter.to_markdown(table_data)
@@ -179,7 +179,7 @@ class NoteTableFormatterTest < ActiveSupport::TestCase
   test "preserves markdown syntax in cell values" do
     table_data = {
       "columns" => [{ "name" => "Note", "type" => "text" }],
-      "rows" => [{ "_id" => "abc1", "Note" => "**bold** and [link](http://example.com)" }],
+      "rows" => [{ "_harmonic_row_id" => "abc1", "Note" => "**bold** and [link](http://example.com)" }],
     }
 
     result = NoteTableFormatter.to_markdown(table_data)

--- a/test/services/note_table_formatter_test.rb
+++ b/test/services/note_table_formatter_test.rb
@@ -21,6 +21,51 @@ class NoteTableFormatterTest < ActiveSupport::TestCase
     assert_includes result, "| in_progress | 2026-04-28 |"
   end
 
+  test "omits _id column by default" do
+    table_data = {
+      "columns" => [{ "name" => "Status", "type" => "text" }],
+      "rows" => [{ "_id" => "abc1", "Status" => "done" }],
+    }
+
+    result = NoteTableFormatter.to_markdown(table_data)
+
+    assert_includes result, "| Status |"
+    refute_includes result, "_id"
+    refute_includes result, "abc1"
+  end
+
+  test "prepends _id column when include_ids is true" do
+    table_data = {
+      "columns" => [
+        { "name" => "Status", "type" => "text" },
+        { "name" => "Due", "type" => "date" },
+      ],
+      "rows" => [
+        { "_id" => "abc1", "Status" => "done", "Due" => "2026-04-20" },
+        { "_id" => "def2", "Status" => "in_progress", "Due" => "2026-04-28" },
+      ],
+    }
+
+    result = NoteTableFormatter.to_markdown(table_data, include_ids: true)
+
+    assert_includes result, "| _id | Status | Due |"
+    assert_includes result, "| --- | --- | --- |"
+    assert_includes result, "| abc1 | done | 2026-04-20 |"
+    assert_includes result, "| def2 | in_progress | 2026-04-28 |"
+  end
+
+  test "renders blank _id cell when a row has no _id and include_ids is true" do
+    table_data = {
+      "columns" => [{ "name" => "Status", "type" => "text" }],
+      "rows" => [{ "Status" => "done" }],
+    }
+
+    result = NoteTableFormatter.to_markdown(table_data, include_ids: true)
+
+    assert_includes result, "| _id | Status |"
+    assert_includes result, "|  | done |"
+  end
+
   test "prepends description before table" do
     table_data = {
       "description" => "Task tracker for Q2.",

--- a/test/services/note_table_service_test.rb
+++ b/test/services/note_table_service_test.rb
@@ -153,6 +153,17 @@ class NoteTableServiceTest < ActiveSupport::TestCase
     assert_equal 2, table.columns.length
   end
 
+  test "add_column! allows a leading underscore that is not the _harmonic_ prefix" do
+    note = create_table_note
+    table = NoteTableService.new(note)
+
+    table.add_column!("_source", "text")
+
+    assert_includes table.column_names, "_source"
+    assert_equal 3, table.columns.length
+    assert note.valid?, note.errors.full_messages.to_sentence
+  end
+
   test "remove_column! removes column and its values" do
     note = create_table_note
     table = NoteTableService.new(note)

--- a/test/services/note_table_service_test.rb
+++ b/test/services/note_table_service_test.rb
@@ -146,11 +146,21 @@ class NoteTableServiceTest < ActiveSupport::TestCase
     note = create_table_note
     table = NoteTableService.new(note)
 
-    error = assert_raises(RuntimeError) do
+    error = assert_raises(ArgumentError) do
       table.add_column!("_harmonic_sneaky", "text")
     end
     assert_includes error.message, "_harmonic_"
     assert_equal 2, table.columns.length
+  end
+
+  test "define_columns! rejects a column using the reserved _harmonic_ prefix" do
+    note = create_table_note
+    table = NoteTableService.new(note)
+
+    error = assert_raises(ArgumentError) do
+      table.define_columns!([{ "name" => "_harmonic_row_id", "type" => "text" }])
+    end
+    assert_includes error.message, "_harmonic_"
   end
 
   test "add_column! allows a leading underscore that is not the _harmonic_ prefix" do

--- a/test/services/note_table_service_test.rb
+++ b/test/services/note_table_service_test.rb
@@ -58,7 +58,7 @@ class NoteTableServiceTest < ActiveSupport::TestCase
     row = table.add_row!({ "Status" => "done", "Due" => "2026-04-20" }, created_by: note.created_by)
 
     assert_equal 1, table.rows.length
-    assert row["_id"].present?
+    assert row["_harmonic_row_id"].present?
     assert_equal "done", row["Status"]
     assert_includes note.text, "done"
     assert_includes note.text, "2026-04-20"
@@ -69,7 +69,7 @@ class NoteTableServiceTest < ActiveSupport::TestCase
     table = NoteTableService.new(note)
     row = table.add_row!({ "Status" => "pending", "Due" => "2026-04-20" }, created_by: note.created_by)
 
-    updated = table.update_row!(row["_id"], { "Status" => "done" })
+    updated = table.update_row!(row["_harmonic_row_id"], { "Status" => "done" })
 
     assert_equal "done", updated["Status"]
     assert_equal "2026-04-20", updated["Due"]
@@ -90,7 +90,7 @@ class NoteTableServiceTest < ActiveSupport::TestCase
     table = NoteTableService.new(note)
     row = table.add_row!({ "Status" => "done", "Due" => "2026-04-20" }, created_by: note.created_by)
 
-    table.delete_row!(row["_id"])
+    table.delete_row!(row["_harmonic_row_id"])
 
     assert_equal 0, table.rows.length
     refute_includes note.text, "done"
@@ -140,6 +140,17 @@ class NoteTableServiceTest < ActiveSupport::TestCase
     assert_equal 3, table.columns.length
     assert_includes table.column_names, "Priority"
     assert_includes note.text, "Priority"
+  end
+
+  test "add_column! rejects a column using the reserved _harmonic_ prefix" do
+    note = create_table_note
+    table = NoteTableService.new(note)
+
+    error = assert_raises(RuntimeError) do
+      table.add_column!("_harmonic_sneaky", "text")
+    end
+    assert_includes error.message, "_harmonic_"
+    assert_equal 2, table.columns.length
   end
 
   test "remove_column! removes column and its values" do


### PR DESCRIPTION
Fixes #283.

## Problem

Table-note rows have a server-generated `_id` that both `update_row` and `delete_row` require, but it was only ever surfaced **once** — in the `add_row` success message. The note body and human table view render through `NoteTableFormatter.to_markdown`, which emits only the user-defined columns, and `execute_query_rows` reused that same formatter — so the `_id` of any existing row was undiscoverable. An agent or member could **add** rows but could not **update** or **delete** any row it hadn't just created, which breaks the shared-table-stays-current premise of table notes.

## Fix

- `NoteTableFormatter.to_markdown` gains an opt-in `include_ids:` keyword (default `false`) that prepends an `_id` column to the header and each data row.
- `execute_query_rows` renders with `include_ids: true`.

`query_rows` is the machine-facing row-discovery action, so this is the natural place to expose the id. The human table view and the stored note body are untouched (they keep the default `false`), so there's no UI clutter and no change to persisted note text. Flow is now: `query_rows` → read `_id` → `update_row` / `delete_row`.

Also documents this in the table-notes help doc.

## Tests

- Formatter: `_id` omitted by default; prepended (header + separator + cells) when `include_ids: true`; blank `_id` cell handled when a row lacks one.
- Controller: `query_rows` action response includes the `| _id | … |` header and the actual row id.

## Verification

⚠️ Written to existing patterns but **not executed** — this environment has no Docker/Ruby runtime, so I could not run the suite or RuboCop/Sorbet locally. Needs a green CI run before merge.
