### PR TITLE
Unify collective + identity-user handle namespace — handle-unification Goal 2

### DIFF
--- a/app/models/collective.rb
+++ b/app/models/collective.rb
@@ -103,9 +103,15 @@ class Collective < ApplicationRecord
   def self.handle_available?(handle)
     return false if RESERVED_HANDLES.include?(handle.to_s.downcase)
 
-    # `handle` is citext, so this count is case-insensitive: "Foo" is taken
+    # Collective and user handles share one per-tenant namespace (Goal 2 of
+    # handle-model-unification): creating a collective also seeds an identity
+    # user that claims the collective's handle. Treat a handle as available only
+    # when neither a collective nor a user already holds it, so the new
+    # collective's identity user can take the identical handle instead of a
+    # suffixed fallback (@foo-team ↔ /collectives/foo-team stay in sync). Both
+    # columns are citext, so the lookups are case-insensitive: "Foo" is taken
     # once "foo" exists.
-    Collective.where(handle: handle).count == 0
+    !Collective.where(handle: handle).exists? && !TenantUser.where(handle: handle).exists?
   end
 
   sig { void }

--- a/app/models/collective.rb
+++ b/app/models/collective.rb
@@ -14,6 +14,7 @@ class Collective < ApplicationRecord
   belongs_to :trio_user, class_name: "User", optional: true
   before_validation :create_identity_user!
   before_create :set_defaults
+  after_update :sync_identity_user_handle!, if: :saved_change_to_handle?
   tables = ActiveRecord::Base.connection.tables - [
     "tenants", "users", "tenant_users",
     "collectives", "api_tokens", "oauth_identities",
@@ -643,6 +644,10 @@ class Collective < ApplicationRecord
     return if private_workspace?
     return if chat?
     return if identity_user
+    # The identity shares the collective's handle; without one there's nothing
+    # to share, so defer to `handle_is_valid` to surface the blank-handle error
+    # rather than minting an orphan identity user with a placeholder handle.
+    return if handle.blank?
 
     identity = User.create!(
       name: name,
@@ -653,10 +658,29 @@ class Collective < ApplicationRecord
       tenant: tenant,
       user: identity,
       display_name: identity.name,
-      handle: SecureRandom.hex(16)
+      handle: TenantUser.identity_handle_for(tenant_id: T.must(tenant).id, base: T.must(handle))
     )
     self.identity_user = identity
     save!
+  end
+
+  # Keep the identity user's handle in lockstep when the collective is renamed,
+  # so `@new-handle` keeps resolving to the same identity. Suffixes on collision
+  # exactly like creation (excluding the identity's own row from the check).
+  sig { void }
+  def sync_identity_user_handle!
+    return unless identity_user
+    return if handle.blank?
+
+    tenant_user = TenantUser.tenant_scoped_only(T.must(tenant_id)).find_by(user_id: identity_user_id)
+    return unless tenant_user
+
+    desired = TenantUser.identity_handle_for(
+      tenant_id: T.must(tenant_id),
+      base: T.must(handle),
+      except_user_id: identity_user_id,
+    )
+    tenant_user.update!(handle: desired) unless tenant_user.handle.to_s.casecmp?(desired)
   end
 
   sig { params(time_window: ActiveSupport::Duration).returns(ActiveRecord::Relation) }

--- a/app/models/tenant_user.rb
+++ b/app/models/tenant_user.rb
@@ -106,6 +106,27 @@ class TenantUser < ApplicationRecord
   end
   private :generated_default_handle
 
+  # Pick a tenant-unique handle for a collective's identity user, sharing the
+  # collective's own handle so `@foo-team` and `/collectives/foo-team` resolve
+  # to one identity. Case is preserved (`preserve_case: true`) so the identity
+  # displays the case the collective chose. Falls back to a numeric suffix
+  # (`foo-team-XX`) when the desired handle is already held by another user in
+  # the tenant (legacy data where a human grabbed it first) or is a reserved
+  # handle the identity can't claim — matching the suffix policy used for human
+  # handles in `default_handle_for`. `except_user_id` lets a rename skip the
+  # identity's own current row so it isn't treated as a self-collision.
+  sig { params(tenant_id: String, base: String, except_user_id: T.nilable(String)).returns(String) }
+  def self.identity_handle_for(tenant_id:, base:, except_user_id: nil)
+    root = base.to_s.parameterize(preserve_case: true).presence || "collective"
+    scope = tenant_scoped_only(tenant_id)
+    scope = scope.where.not(user_id: except_user_id) if except_user_id.present?
+    candidate = root
+    # Identity users never carry a system_role, so any reserved key is off-limits.
+    candidate = "#{root}-#{SecureRandom.hex(2)}" if RESERVED_HANDLES.key?(root.downcase)
+    candidate = "#{root}-#{SecureRandom.hex(2)}" while scope.exists?(handle: candidate)
+    candidate
+  end
+
   sig { returns(User) }
   def user
     @user ||= super

--- a/db/migrate/20260702010000_backfill_collective_identity_handles.rb
+++ b/db/migrate/20260702010000_backfill_collective_identity_handles.rb
@@ -1,0 +1,62 @@
+# typed: false
+
+# Goal 2 of handle-model-unification: a collective and its identity user now
+# share one handle. Existing identity users were minted with a random hex handle
+# (`SecureRandom.hex(16)`), so backfill each to its collective's handle.
+#
+# Where a collective's handle is already held by another user in the same tenant
+# (legacy data from before the namespaces were unified), the identity user takes
+# a numeric `-XX` suffix instead — the resolution policy chosen for this case.
+# Raw SQL throughout so the backfill is independent of model code/validations and
+# is unaffected by tenant scoping (Tenant.current_id is nil inside migrations).
+class BackfillCollectiveIdentityHandles < ActiveRecord::Migration[7.2]
+  def up
+    rows = exec_query(<<~SQL).to_a
+      SELECT c.tenant_id      AS tenant_id,
+             c.handle::text   AS collective_handle,
+             tu.id            AS tenant_user_id,
+             tu.handle::text  AS current_handle
+      FROM collectives c
+      JOIN tenant_users tu
+        ON tu.user_id = c.identity_user_id
+       AND tu.tenant_id = c.tenant_id
+      WHERE c.identity_user_id IS NOT NULL
+        AND c.handle IS NOT NULL
+    SQL
+
+    rows.each do |row|
+      tenant_id = row["tenant_id"]
+      desired   = row["collective_handle"].to_s
+      next if desired.blank?
+      # handle is citext, so compare case-insensitively: already unified -> skip.
+      next if row["current_handle"].to_s.casecmp?(desired)
+
+      candidate = desired
+      candidate = "#{desired}-#{SecureRandom.hex(2)}" until handle_free?(tenant_id, candidate, row["tenant_user_id"])
+
+      execute(<<~SQL)
+        UPDATE tenant_users
+        SET handle = #{quote(candidate)}, updated_at = now()
+        WHERE id = #{quote(row["tenant_user_id"])}
+      SQL
+    end
+  end
+
+  def down
+    # Irreversible in practice: the original random hex handles are not recorded.
+    # The unified handles remain valid, so rolling back is a no-op rather than an
+    # error that would block `db:rollback` in development.
+  end
+
+  private
+
+  def handle_free?(tenant_id, candidate, exclude_id)
+    exec_query(<<~SQL).rows.empty?
+      SELECT 1 FROM tenant_users
+      WHERE tenant_id = #{quote(tenant_id)}
+        AND handle = #{quote(candidate)}
+        AND id <> #{quote(exclude_id)}
+      LIMIT 1
+    SQL
+  end
+end

--- a/db/migrate/20260702010000_backfill_collective_identity_handles.rb
+++ b/db/migrate/20260702010000_backfill_collective_identity_handles.rb
@@ -4,11 +4,24 @@
 # share one handle. Existing identity users were minted with a random hex handle
 # (`SecureRandom.hex(16)`), so backfill each to its collective's handle.
 #
-# Where a collective's handle is already held by another user in the same tenant
-# (legacy data from before the namespaces were unified), the identity user takes
-# a numeric `-XX` suffix instead — the resolution policy chosen for this case.
-# Raw SQL throughout so the backfill is independent of model code/validations and
-# is unaffected by tenant scoping (Tenant.current_id is nil inside migrations).
+# The desired handle is derived exactly as `TenantUser.identity_handle_for`
+# derives it for live collectives, so this backfill produces the same result a
+# fresh `create_identity_user!` would: the collective handle is run through
+# `parameterize(preserve_case: true)`, and the identity user takes a numeric
+# `-XX` suffix when that handle is already held by another user in the same
+# tenant (legacy data from before the namespaces were unified) OR is reserved.
+# The reserved case is genuinely reachable, not just defensive: collective
+# validation only forbids `Collective::RESERVED_HANDLES` (["main"]), whereas the
+# identity user lives in the `tenant_users` namespace and may not hold a handle
+# in `TenantUser::RESERVED_HANDLES` ({"trio"=>"trio"}). A collective named "trio"
+# is therefore permitted, and without this check the backfill would let its
+# identity user claim the reserved "trio" handle that the runtime path suffixes
+# away (the collision check alone only catches it in tenants that already have a
+# live "trio" tenant_user).
+# Raw SQL is used for the reads/writes so the backfill is independent of model
+# validations/callbacks and tenant scoping (Tenant.current_id is nil inside
+# migrations); the only model reference is the frozen `RESERVED_HANDLES`
+# constant, kept as the single source of truth so the two paths can't diverge.
 class BackfillCollectiveIdentityHandles < ActiveRecord::Migration[7.2]
   def up
     rows = exec_query(<<~SQL).to_a
@@ -26,12 +39,17 @@ class BackfillCollectiveIdentityHandles < ActiveRecord::Migration[7.2]
 
     rows.each do |row|
       tenant_id = row["tenant_id"]
-      desired   = row["collective_handle"].to_s
+      # Mirror TenantUser.identity_handle_for's base derivation, so a backfilled
+      # handle matches what creating the collective today would mint.
+      desired = row["collective_handle"].to_s.parameterize(preserve_case: true)
       next if desired.blank?
       # handle is citext, so compare case-insensitively: already unified -> skip.
       next if row["current_handle"].to_s.casecmp?(desired)
 
       candidate = desired
+      # An identity user can't hold a reserved handle (e.g. "trio"); suffix it
+      # just as identity_handle_for and a live rename would.
+      candidate = "#{desired}-#{SecureRandom.hex(2)}" if TenantUser::RESERVED_HANDLES.key?(desired.downcase)
       candidate = "#{desired}-#{SecureRandom.hex(2)}" until handle_free?(tenant_id, candidate, row["tenant_user_id"])
 
       execute(<<~SQL)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10304,6 +10304,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260702010000'),
 ('20260702000000'),
 ('20260701000000'),
 ('20260629000000'),

--- a/test/models/collective_test.rb
+++ b/test/models/collective_test.rb
@@ -158,6 +158,42 @@ class CollectiveTest < ActiveSupport::TestCase
     assert_equal "collective_identity", collective.identity_user.user_type
   end
 
+  # Goal 2 of handle-model-unification: the identity user shares the collective's
+  # own handle so @foo-team and /collectives/foo-team resolve to one identity.
+  test "identity user shares the collective's handle" do
+    tenant = create_tenant
+    user = create_user
+    collective = Collective.create!(tenant: tenant, created_by: user, name: "Foo Team", handle: "Foo-Team")
+    identity_tu = TenantUser.tenant_scoped_only(tenant.id).find_by(user_id: collective.identity_user_id)
+    assert_equal "Foo-Team", identity_tu.handle
+  end
+
+  test "identity user handle is suffixed when a user already holds the collective handle" do
+    tenant = create_tenant
+    user = create_user
+    TenantUser.create!(tenant: tenant, user: create_user, display_name: "Squatter", handle: "foo-team")
+    collective = Collective.create!(tenant: tenant, created_by: user, name: "Foo Team", handle: "foo-team")
+    identity_tu = TenantUser.tenant_scoped_only(tenant.id).find_by(user_id: collective.identity_user_id)
+    assert_match(/\Afoo-team-[0-9a-f]{4}\z/, identity_tu.handle)
+  end
+
+  test "identity user handle is suffixed when the collective handle is reserved for system agents" do
+    tenant = create_tenant
+    user = create_user
+    collective = Collective.create!(tenant: tenant, created_by: user, name: "Trio", handle: "trio")
+    identity_tu = TenantUser.tenant_scoped_only(tenant.id).find_by(user_id: collective.identity_user_id)
+    assert_match(/\Atrio-[0-9a-f]{4}\z/, identity_tu.handle)
+  end
+
+  test "renaming the collective syncs the identity user handle" do
+    tenant = create_tenant
+    user = create_user
+    collective = Collective.create!(tenant: tenant, created_by: user, name: "Foo Team", handle: "foo-team")
+    collective.update!(handle: "bar-team")
+    identity_tu = TenantUser.tenant_scoped_only(tenant.id).find_by(user_id: collective.identity_user_id)
+    assert_equal "bar-team", identity_tu.handle
+  end
+
   test "Collective#trio_user is nil by default and links to a User when set" do
     tenant = create_tenant
     user = create_user

--- a/test/models/collective_test.rb
+++ b/test/models/collective_test.rb
@@ -145,6 +145,19 @@ class CollectiveTest < ActiveSupport::TestCase
     assert_not Collective.handle_available?("existing-handle")
   end
 
+  test "Collective.handle_available? returns false when a user already holds the handle" do
+    tenant = create_tenant
+    user = create_user
+    TenantUser.create!(tenant: tenant, user: user, display_name: "Squatter", handle: "shared-name")
+
+    # Collective and user handles are one namespace (Goal 2): if a user already
+    # holds "shared-name", the new-collective form must report it as taken so a
+    # collective's identity user gets the identical handle rather than a suffixed
+    # fallback. citext makes the cross-namespace check case-insensitive too.
+    assert_not Collective.handle_available?("shared-name")
+    assert_not Collective.handle_available?("SHARED-NAME"), "cross-namespace check must be case-insensitive"
+  end
+
   test "Collective.create_identity_user! creates an identity user" do
     tenant = create_tenant
     user = create_user


### PR DESCRIPTION
Implements **Goal 2** of `.claude/plans/handle-model-unification.md`. Builds on **#289** (Goal 1, citext), now **merged** — this branch is rebased directly on `main`.

## What changes
Today a collective `foo-team` has an `identity_user` (a `collective_identity` `TenantUser`) minted with a **random hex handle** — two different handles for what users think of as one entity. This makes them share one handle.

- **`TenantUser.identity_handle_for`** — picks a tenant-unique handle from the collective's own handle, case-preserving, falling back to a `-XX` numeric suffix on collision (existing user already holds it, or a reserved handle the identity can't claim).
- **`create_identity_user!`** seeds the identity from the collective handle instead of `SecureRandom.hex(16)`. (Also: returns early on a blank handle rather than minting an orphan identity — the collective fails `handle_is_valid` anyway.)
- **`after_update` sync** keeps the identity handle in lockstep when a collective is renamed.
- **`Collective.handle_available?`** (the `GET /collectives/available` endpoint behind the New Collective form) now checks the **unified namespace** — both `collectives` *and* `tenant_users` — instead of collectives only. See below.
- **Backfill migration** (`20260702010000`) converts existing hex identity handles to the collective handle, raw-SQL so it's independent of model code/tenant scoping. Data-only — no schema change — so its only effect on `db/structure.sql` is the `schema_migrations` entry.

## Handle-availability endpoint
Because collective creation now seeds an identity user from the collective's handle, the availability check has to see the whole namespace. Previously `handle_available?` only asked `Collective.where(handle:)`, so the form reported `foo` as **available** even when a *user* `foo` existed — the collective would then be created with a suffixed identity (`foo-team-XX`), reintroducing exactly the collective≠identity mismatch Goal 2 removes. The check now also consults `tenant_users`, so an "available" handle guarantees the new collective's identity user can take the *identical* handle. Both columns are citext, so the check stays case-insensitive. Suffixing remains the safety net for the API path and backfill; the form just steers humans toward clean handles.

## Collision policy
Per the tracking vote (decision `72345628`, deadline 2026-07-08): **suffix** (my starred pick). Backfill collisions (a human already holds the collective's handle, from before the namespaces were unified) and any going-forward collision both resolve to `foo-team-XX`.

## Cross-namespace uniqueness (plan bullet 3)
Every collective's identity user occupies the collective's handle in the shared `(tenant_id, handle)` `tenant_users` unique index, so a human can no longer register a handle a collective holds. The residual edge — a *new* collective whose handle a human already holds — resolves by suffixing the identity (the human keeps `@handle`), consistent with the suffix policy; the availability endpoint (above) now reports that handle as taken so the form nudges the creator to a clean one.

## Schema
Like #289, `db/structure.sql` is **regenerated by running the migration** (load schema, `db:migrate`, commit the dump), not hand-edited. The migration is timestamped after #289's (`20260702000000`) and `main`'s latest, so the stack applies in order. Post-rebase both `20260702000000` and `20260702010000` are present in `schema_migrations` and the citext extension is in the dump.

## Tests
`test/models/collective_test.rb`: identity shares the handle (case-preserved); suffixing on user collision and on a reserved handle; rename-sync; and `handle_available?` returns false when a *user* already holds the handle (incl. a case-insensitive variant). Plus the existing collective/tenant_user handle suites.

## Verification
Ran locally against the dev Postgres stack: `collective_test` + `tenant_user_test` green (**156 runs, 336 assertions, 0 failures**), `collectives_controller_test` green (111 runs, 367 assertions, 0 failures), and `srb tc` clean. Now that the base is `main`, GitHub CI is running on this PR.
