### PR TITLE
Fix comment notification links highlighting the wrong comment (#292)

### DIFF
--- a/app/javascript/controllers/comment_thread_controller.test.ts
+++ b/app/javascript/controllers/comment_thread_controller.test.ts
@@ -73,6 +73,78 @@ describe("CommentThreadController", () => {
   afterEach(() => {
     application.stop()
     vi.restoreAllMocks()
+    window.history.replaceState({}, "", "/")
+  })
+
+  describe("highlightCommentFromUrl", () => {
+    // Reconnect a fresh controller after pointing the URL at a comment, since
+    // the shared beforeEach already connected with a comment_id-less URL.
+    const reconnect = (): void => {
+      application.stop()
+      application = Application.start()
+      application.register("comment-thread", CommentThreadController)
+    }
+
+    beforeEach(() => {
+      vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(() => {})
+    })
+
+    it("highlights the targeted comment and clears the comment_id param", async () => {
+      window.history.replaceState({}, "", "/test-resource?comment_id=def456")
+      reconnect()
+
+      const target = document.getElementById("n-def456") as HTMLElement
+      await vi.waitFor(() => {
+        expect(target.classList.contains("pulse-comment-highlighted")).toBe(true)
+      })
+
+      // The collapsed replies group containing the target is expanded.
+      expect(document.getElementById("replies-abc123")?.hidden).toBe(false)
+      // The param is dropped so reconnects won't re-highlight.
+      expect(window.location.search).toBe("")
+    })
+
+    it("preserves other query params and the hash when clearing comment_id", async () => {
+      window.history.replaceState({}, "", "/test-resource?foo=bar&comment_id=def456#section")
+      reconnect()
+
+      const target = document.getElementById("n-def456") as HTMLElement
+      await vi.waitFor(() => {
+        expect(target.classList.contains("pulse-comment-highlighted")).toBe(true)
+      })
+
+      expect(window.location.search).toBe("?foo=bar")
+      expect(window.location.hash).toBe("#section")
+    })
+
+    it("does not re-highlight when the controller reconnects after a reply", async () => {
+      window.history.replaceState({}, "", "/test-resource?comment_id=def456")
+      reconnect()
+
+      const target = document.getElementById("n-def456") as HTMLElement
+      await vi.waitFor(() => {
+        expect(target.classList.contains("pulse-comment-highlighted")).toBe(true)
+      })
+
+      // Simulate the post-reply refresh: clear the visual highlight and
+      // reconnect a fresh controller (as replaceWith does in the real flow).
+      target.classList.remove("pulse-comment-highlighted")
+      reconnect()
+
+      await new Promise((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve))
+      )
+      expect(target.classList.contains("pulse-comment-highlighted")).toBe(false)
+    })
+
+    it("does nothing when comment_id is absent", async () => {
+      window.history.replaceState({}, "", "/test-resource")
+      reconnect()
+
+      await new Promise((resolve) => requestAnimationFrame(resolve))
+      const highlighted = document.querySelector(".pulse-comment-highlighted")
+      expect(highlighted).toBeNull()
+    })
   })
 
   describe("toggleReplies", () => {

--- a/app/javascript/controllers/comment_thread_controller.test.ts
+++ b/app/javascript/controllers/comment_thread_controller.test.ts
@@ -86,7 +86,9 @@ describe("CommentThreadController", () => {
     }
 
     beforeEach(() => {
-      vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(() => {})
+      // jsdom doesn't implement scrollIntoView, so define a no-op stub the
+      // highlight path can call.
+      Element.prototype.scrollIntoView = vi.fn()
     })
 
     it("highlights the targeted comment and clears the comment_id param", async () => {

--- a/app/javascript/controllers/comment_thread_controller.ts
+++ b/app/javascript/controllers/comment_thread_controller.ts
@@ -47,6 +47,22 @@ export default class CommentThreadController extends Controller {
       target.scrollIntoView({ behavior: "smooth", block: "center" })
       target.classList.add("pulse-comment-highlighted")
     })
+
+    // Drop the `?comment_id=` param now that we've highlighted. Replying refreshes
+    // the comments list, which reconnects this controller; without clearing the
+    // param, every reply would re-run the highlight animation on the original
+    // comment.
+    this.clearCommentIdParam()
+  }
+
+  private clearCommentIdParam(): void {
+    const url = new URL(window.location.href)
+    if (!url.searchParams.has("comment_id")) return
+
+    url.searchParams.delete("comment_id")
+    const query = url.searchParams.toString()
+    const newUrl = `${url.pathname}${query ? `?${query}` : ""}${url.hash}`
+    window.history.replaceState(window.history.state, "", newUrl)
   }
 
   private async refreshCommentsList(): Promise<void> {

--- a/app/services/notification_dispatcher.rb
+++ b/app/services/notification_dispatcher.rb
@@ -141,7 +141,9 @@ class NotificationDispatcher
       notification_type: "comment",
       title: "#{actor_name} replied to your #{content_type}",
       body: comment.text.to_s.truncate(200),
-      url: get_path(commentable)
+      # Link to the reply itself (so `?comment_id=` highlights the new reply),
+      # not the comment being replied to.
+      url: get_path(comment)
     )
   end
 

--- a/test/services/notification_dispatcher_test.rb
+++ b/test/services/notification_dispatcher_test.rb
@@ -484,6 +484,45 @@ class NotificationDispatcherTest < ActiveSupport::TestCase
     assert_equal decision_owner.id, recipient.user_id
   end
 
+  test "reply notification url highlights the reply, not the comment being replied to" do
+    tenant, collective, author = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+
+    replier = create_user(email: "nested-replier@example.com", name: "Nested Replier")
+    tenant.add_user!(replier)
+    collective.add_user!(replier)
+
+    # author posts a note, then a first comment on it
+    note = create_note(tenant: tenant, collective: collective, created_by: author, text: "Root note")
+    first_comment = create_note(
+      tenant: tenant,
+      collective: collective,
+      created_by: author,
+      text: "First comment",
+      subtype: "comment",
+      commentable: note
+    )
+
+    # replier replies to the first comment
+    reply = create_note(
+      tenant: tenant,
+      collective: collective,
+      created_by: replier,
+      text: "A reply to the first comment",
+      subtype: "comment",
+      commentable: first_comment
+    )
+
+    event = Event.where(event_type: "comment.created", subject: reply).last
+    notification = Notification.where(event: event, notification_type: "comment").last
+    assert_not_nil notification, "Expected a reply notification for the first comment's author"
+
+    # The link must land on the reply itself, not the comment being replied to.
+    assert_equal reply.display_path, notification.url
+    assert_includes notification.url, "comment_id=#{reply.truncated_id}"
+    assert_not_includes notification.url, "comment_id=#{first_comment.truncated_id}"
+  end
+
   # NOTE: AI agent task triggering tests have been moved to AutomationDispatcherTest
   # since agent triggering is now handled by the automation system via AutomationDispatcher
   # instead of the hardcoded triggers that were previously in NotificationDispatcher.


### PR DESCRIPTION
Fixes #292.

## Problem
Two issues, both reported in #292:

1. **Reply notifications highlighted the wrong comment.** `handle_reply_notification` built the link from `get_path(commentable)` — the comment being *replied to* — so the `?comment_id=` param highlighted the parent comment instead of the new reply.
2. **The highlight re-triggered on every reply.** The `comment-thread` Stimulus controller reads `?comment_id=` on connect and highlights it. Submitting a reply refreshes the comments list (`replaceWith` on `.pulse-comments-list`), which reconnects the controller — so with the param still in the URL, each reply re-ran the highlight animation on the original comment.

## Fix
- `notification_dispatcher.rb`: link reply notifications to the reply itself (`get_path(comment)`), so `?comment_id=` targets the new reply. This also makes the link land on the reply when the commentable is a top-level note/decision.
- `comment_thread_controller.ts`: after the initial highlight, drop the `?comment_id=` param via `history.replaceState` (preserving any other query params and the hash). Reconnects then no-op.

## Tests
- `notification_dispatcher_test.rb`: nested reply → notification url highlights the reply, not the comment being replied to.
- `comment_thread_controller.test.ts`: highlights + clears the param, preserves other params/hash, and does not re-highlight on reconnect.

## Verification
Not run locally — Docker isn't available on this VM and the frontend deps aren't installed, so I relied on tracing callers and the existing test patterns. Relying on CI for the actual run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)