### PR TITLE
Don't email AI agents at their placeholder addresses (#294)

### DIFF
--- a/app/jobs/notification_delivery_job.rb
+++ b/app/jobs/notification_delivery_job.rb
@@ -33,8 +33,12 @@ class NotificationDeliveryJob < TenantScopedJob
   sig { params(recipient: NotificationRecipient).void }
   def deliver_email(recipient)
     user = recipient.user
-    # Skip email delivery for users without email addresses
-    return recipient.mark_delivered! if user.nil? || user.email.blank?
+    # Skip email delivery for users without a routable address. Non-human users
+    # (ai_agent, collective_identity) carry a syntactically valid but unroutable
+    # placeholder address (e.g. "<uuid>@not-a-real-email.com"), so a blank check
+    # alone lets them through. Guarding on human? covers existing DB rows without
+    # a backfill — this is the load-bearing layer.
+    return recipient.mark_delivered! if user.nil? || !user.human? || user.email.blank?
 
     NotificationMailer.notification_email(recipient).deliver_now
     recipient.mark_delivered!

--- a/app/models/tenant_user.rb
+++ b/app/models/tenant_user.rb
@@ -196,7 +196,11 @@ class TenantUser < ApplicationRecord
     prefs = notification_preferences[notification_type] || DEFAULT_NOTIFICATION_PREFERENCES[notification_type] || {}
     channels = []
     channels << "in_app" if prefs["in_app"]
-    channels << "email" if prefs["email"]
+    # Non-human users (ai_agent, collective_identity) have no routable email
+    # address, so never return the email channel for them regardless of stored
+    # prefs. Keeps every caller (dispatcher, reminder service, trustee path)
+    # honest and avoids creating an email NotificationRecipient that can't deliver.
+    channels << "email" if prefs["email"] && user.human?
     channels
   end
 
@@ -237,6 +241,11 @@ class TenantUser < ApplicationRecord
       channels.each do |channel, enabled|
         next unless NOTIFICATION_CHANNELS.include?(channel)
 
+        # Non-human users can never carry a stored email:true — the markdown
+        # action surface accepts arbitrary payloads and the simple-mode form
+        # omits the email column, so coerce it to false at write time to keep
+        # persisted state clean.
+        enabled = false if channel == "email" && !user.human?
         T.must(current[type])[channel] = enabled
       end
     end

--- a/test/jobs/notification_delivery_job_test.rb
+++ b/test/jobs/notification_delivery_job_test.rb
@@ -82,6 +82,38 @@ class NotificationDeliveryJobTest < ActiveSupport::TestCase
     assert_equal "delivered", recipient.status
   end
 
+  test "perform does NOT send email to non-human recipient but marks delivered" do
+    tenant, collective, parent = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+
+    agent = create_ai_agent(parent: parent)
+
+    event = Event.create!(tenant: tenant, collective: collective, event_type: "note.created")
+    notification = Notification.create!(
+      tenant: tenant,
+      event: event,
+      notification_type: "mention",
+      title: "Test Email Notification",
+      body: "This is a test notification body",
+      url: "/n/test123",
+    )
+
+    recipient = NotificationRecipient.create!(
+      notification: notification,
+      user: agent,
+      channel: "email",
+      status: "pending",
+    )
+
+    initial_count = ActionMailer::Base.deliveries.size
+    NotificationDeliveryJob.perform_now(recipient.id)
+
+    assert_equal initial_count, ActionMailer::Base.deliveries.size, "agent's fake address must not receive mail"
+    recipient.reload
+    assert_equal "delivered", recipient.status
+    assert recipient.delivered_at.present?
+  end
+
   test "perform does nothing if recipient not found" do
     # Should not raise an error
     assert_nothing_raised do

--- a/test/models/tenant_user_test.rb
+++ b/test/models/tenant_user_test.rb
@@ -36,7 +36,7 @@ class TenantUserTest < ActiveSupport::TestCase
     tenant, collective, parent = create_tenant_collective_user
     Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
     agent = create_ai_agent(parent: parent)
-    agent_tenant_user = agent.tenant_user
+    agent_tenant_user = tenant.add_user!(agent)
 
     # Force email on in stored prefs; the channel must still be filtered out.
     agent_tenant_user.update_notification_preferences!("mention" => { "in_app" => true, "email" => true })
@@ -50,7 +50,7 @@ class TenantUserTest < ActiveSupport::TestCase
     tenant, collective, parent = create_tenant_collective_user
     Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
     agent = create_ai_agent(parent: parent)
-    agent_tenant_user = agent.tenant_user
+    agent_tenant_user = tenant.add_user!(agent)
 
     agent_tenant_user.update_notification_preferences!("mention" => { "email" => true })
 

--- a/test/models/tenant_user_test.rb
+++ b/test/models/tenant_user_test.rb
@@ -32,6 +32,32 @@ class TenantUserTest < ActiveSupport::TestCase
     assert prefs["system"]["email"]
   end
 
+  test "notification_channels_for never returns email for a non-human user" do
+    tenant, collective, parent = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    agent = create_ai_agent(parent: parent)
+    agent_tenant_user = agent.tenant_user
+
+    # Force email on in stored prefs; the channel must still be filtered out.
+    agent_tenant_user.update_notification_preferences!("mention" => { "in_app" => true, "email" => true })
+
+    channels = agent_tenant_user.notification_channels_for("mention")
+    assert_includes channels, "in_app"
+    refute_includes channels, "email", "agents have no routable address — email channel must be dropped"
+  end
+
+  test "update_notification_preferences! coerces email to false for a non-human user" do
+    tenant, collective, parent = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    agent = create_ai_agent(parent: parent)
+    agent_tenant_user = agent.tenant_user
+
+    agent_tenant_user.update_notification_preferences!("mention" => { "email" => true })
+
+    refute agent_tenant_user.notification_preferences["mention"]["email"],
+      "agents must never persist a stored email:true"
+  end
+
   test "notification_channels_for returns correct channels based on defaults" do
     tenant, _collective, user = create_tenant_collective_user
     tenant_user = user.tenant_user


### PR DESCRIPTION
Fixes #294.

## Problem

AI agents (and collective identities) are minted with a syntactically valid but **unroutable** placeholder email (`<uuid>@not-a-real-email.com`) to satisfy `User` validations. The notification path never branched on `user.human?`, so every event whose preferences include the `email` channel attempted a real SMTP send to that junk address. No settings change is required to trigger it — it's the default state.

## Fix — three layers, red-green TDD each

1. **`NotificationDeliveryJob#deliver_email`** — skip the mailer and `mark_delivered!` when the recipient is not human. This is the load-bearing layer: it covers existing DB rows with no backfill.
2. **`TenantUser#notification_channels_for`** — drop `"email"` for non-human users regardless of stored prefs, so no email `NotificationRecipient` is ever created (efficiency win) and every caller (dispatcher, reminder service, trustee path) stays honest.
3. **`TenantUser#update_notification_preferences!`** — coerce `email: true` → `false` for non-human users at write time, keeping persisted state clean against the markdown action surface and the simple-mode form.

The placeholder address itself is unchanged — it's load-bearing for `User` validation, per the issue.

## Tests

- `notification_delivery_job_test.rb`: ai_agent recipient on the `email` channel → no mailer fires, recipient still marked `delivered`.
- `tenant_user_test.rb`: agent with stored `mention/email:true` → `notification_channels_for("mention")` returns `["in_app"]`; `update_notification_preferences!` stores `email:false`.

## Verification

⚠️ **Not run locally** — this environment has no Docker, and the repo's test/lint/sorbet all run inside Docker containers. Tests written red-green by construction but unexecuted; please run `./scripts/run-tests.sh` (or the two changed test files) + `srb tc` + `rubocop` in CI.

First of the six PRs from the [issue-triage decision](https://www.harmonic.social/collectives/harmonic-devs/d/8c5e35bb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)