### PR TITLE
Fix #286: edit table rows in place in the HTML UI

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -385,9 +385,15 @@ class NotesController < ApplicationController
 
   def execute_update_row
     api_helper.update_row
-    render_action_success({ action_name: "update_row", resource: current_note, result: "Row updated." })
+    respond_to do |format|
+      format.html { redirect_to current_note.path, notice: "Row updated." }
+      format.md { render_action_success({ action_name: "update_row", resource: current_note, result: "Row updated." }) }
+    end
   rescue RuntimeError, ActiveRecord::RecordInvalid => e
-    render_action_error({ action_name: "update_row", resource: current_note, error: e.message })
+    respond_to do |format|
+      format.html { redirect_to current_note.path, alert: e.message }
+      format.md { render_action_error({ action_name: "update_row", resource: current_note, error: e.message }) }
+    end
   end
 
   def describe_delete_row

--- a/app/javascript/controllers/index.ts
+++ b/app/javascript/controllers/index.ts
@@ -80,6 +80,7 @@ import CommitmentSubtypeController from "./commitment_subtype_controller"
 import DecisionSubtypeController from "./decision_subtype_controller"
 import DialogController from "./dialog_controller"
 import TabsController from "./tabs_controller"
+import TableRowEditController from "./table_row_edit_controller"
 import WebhookTestController from "./webhook_test_controller"
 
 // Register all controllers
@@ -152,6 +153,7 @@ application.register("kebab-menu", KebabMenuController)
 application.register("summary-toggle", SummaryToggleController)
 application.register("dialog", DialogController)
 application.register("tabs", TabsController)
+application.register("table-row-edit", TableRowEditController)
 application.register("webhook-test", WebhookTestController)
 
 export { application }

--- a/app/javascript/controllers/table_row_edit_controller.test.ts
+++ b/app/javascript/controllers/table_row_edit_controller.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import TableRowEditController from "./table_row_edit_controller"
+
+describe("TableRowEditController", () => {
+  let application: Application
+
+  beforeEach(() => {
+    application = Application.start()
+    application.register("table-row-edit", TableRowEditController)
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+    vi.restoreAllMocks()
+  })
+
+  function mount() {
+    document.body.innerHTML = `
+      <table><tbody>
+        <tr data-controller="table-row-edit">
+          <td>
+            <span data-table-row-edit-target="display">pending</span>
+            <input data-table-row-edit-target="input" name="values[Status]" value="pending" hidden>
+          </td>
+          <td>
+            <button data-table-row-edit-target="editButton" data-action="table-row-edit#edit">Edit</button>
+            <button data-table-row-edit-target="saveButton" type="submit" form="update-row-x" hidden>Save</button>
+            <button data-table-row-edit-target="cancelButton" data-action="table-row-edit#cancel" hidden>Cancel</button>
+            <button data-table-row-edit-target="deleteButton">Delete</button>
+          </td>
+        </tr>
+      </tbody></table>
+    `
+  }
+
+  const el = (sel: string) => document.querySelector(sel) as HTMLElement
+  const display = () => el("[data-table-row-edit-target='display']")
+  const input = () => el("[data-table-row-edit-target='input']") as HTMLInputElement
+  const editBtn = () => el("[data-table-row-edit-target='editButton']") as HTMLButtonElement
+  const saveBtn = () => el("[data-table-row-edit-target='saveButton']")
+  const cancelBtn = () => el("[data-table-row-edit-target='cancelButton']") as HTMLButtonElement
+  const deleteBtn = () => el("[data-table-row-edit-target='deleteButton']")
+
+  it("starts in display mode: inputs and save/cancel hidden, display and edit/delete shown", async () => {
+    mount()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(display().hidden).toBe(false)
+    expect(input().hidden).toBe(true)
+    expect(editBtn().hidden).toBe(false)
+    expect(deleteBtn().hidden).toBe(false)
+    expect(saveBtn().hidden).toBe(true)
+    expect(cancelBtn().hidden).toBe(true)
+  })
+
+  it("Edit reveals inputs and save/cancel, hides display and edit/delete", async () => {
+    mount()
+    await new Promise((r) => setTimeout(r, 0))
+    editBtn().click()
+    expect(display().hidden).toBe(true)
+    expect(input().hidden).toBe(false)
+    expect(editBtn().hidden).toBe(true)
+    expect(deleteBtn().hidden).toBe(true)
+    expect(saveBtn().hidden).toBe(false)
+    expect(cancelBtn().hidden).toBe(false)
+  })
+
+  it("Cancel restores display mode and discards edits", async () => {
+    mount()
+    await new Promise((r) => setTimeout(r, 0))
+    editBtn().click()
+    input().value = "edited but abandoned"
+    cancelBtn().click()
+    expect(input().value).toBe("pending") // reset to server-rendered value
+    expect(display().hidden).toBe(false)
+    expect(input().hidden).toBe(true)
+    expect(saveBtn().hidden).toBe(true)
+    expect(editBtn().hidden).toBe(false)
+  })
+})

--- a/app/javascript/controllers/table_row_edit_controller.ts
+++ b/app/javascript/controllers/table_row_edit_controller.ts
@@ -1,0 +1,46 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Toggles a table-note row between its read-only display and an inline edit
+// form (issue #286). Each editable <tr> has this controller. The row's cell
+// inputs are associated (via the HTML `form=` attribute) with a hidden
+// update_row form rendered after the table, so pressing Save submits that
+// form through Turbo — no fetch needed. Cancel restores the original values.
+export default class extends Controller {
+  static targets = [
+    "display",
+    "input",
+    "editButton",
+    "saveButton",
+    "cancelButton",
+    "deleteButton",
+  ]
+
+  declare readonly displayTargets: HTMLElement[]
+  declare readonly inputTargets: HTMLInputElement[]
+  declare readonly editButtonTargets: HTMLElement[]
+  declare readonly saveButtonTargets: HTMLElement[]
+  declare readonly cancelButtonTargets: HTMLElement[]
+  declare readonly deleteButtonTargets: HTMLElement[]
+
+  edit(): void {
+    this.setEditing(true)
+    this.inputTargets[0]?.focus()
+  }
+
+  cancel(): void {
+    // Discard edits — reset each input to its server-rendered value.
+    this.inputTargets.forEach((input) => {
+      input.value = input.defaultValue
+    })
+    this.setEditing(false)
+  }
+
+  private setEditing(editing: boolean): void {
+    this.displayTargets.forEach((el) => (el.hidden = editing))
+    this.inputTargets.forEach((el) => (el.hidden = !editing))
+    this.editButtonTargets.forEach((el) => (el.hidden = editing))
+    this.deleteButtonTargets.forEach((el) => (el.hidden = editing))
+    this.saveButtonTargets.forEach((el) => (el.hidden = !editing))
+    this.cancelButtonTargets.forEach((el) => (el.hidden = !editing))
+  }
+}

--- a/app/views/notes/_table.html.erb
+++ b/app/views/notes/_table.html.erb
@@ -22,31 +22,59 @@
         </tr>
       </thead>
       <tbody>
+        <% can_edit = @note.user_can_edit_content?(@current_user) %>
         <% table.rows.each do |row| %>
-          <tr>
-            <% table.columns.each do |col| %>
-              <td><%= markdown_inline(row[col["name"]]) %></td>
-            <% end %>
-            <% if @note.user_can_edit_content?(@current_user) %>
-              <td>
+          <% if can_edit %>
+            <% row_id = row["_harmonic_row_id"] %>
+            <% update_form_id = "update-row-#{row_id}" %>
+            <tr data-controller="table-row-edit">
+              <% table.columns.each do |col| %>
+                <td>
+                  <span data-table-row-edit-target="display"><%= markdown_inline(row[col["name"]]) %></span>
+                  <%= text_field_tag "values[#{col["name"]}]", row[col["name"]],
+                        form: update_form_id, hidden: true, class: "pulse-form-input",
+                        style: "width: 100%; min-width: 80px;",
+                        data: { "table-row-edit-target": "input" } %>
+                </td>
+              <% end %>
+              <td style="white-space: nowrap;">
+                <button type="button" class="pulse-action-btn-secondary" style="padding: 2px 6px;" title="Edit row"
+                        data-table-row-edit-target="editButton" data-action="table-row-edit#edit">
+                  <%= octicon 'pencil', height: 12 %>
+                </button>
+                <button type="submit" form="<%= update_form_id %>" class="pulse-action-btn" style="padding: 2px 6px;" title="Save row"
+                        hidden data-table-row-edit-target="saveButton">
+                  <%= octicon 'check', height: 12 %>
+                </button>
+                <button type="button" class="pulse-action-btn-secondary" style="padding: 2px 6px;" title="Cancel edit"
+                        hidden data-table-row-edit-target="cancelButton" data-action="table-row-edit#cancel">
+                  <%= octicon 'x', height: 12 %>
+                </button>
                 <%= form_with(
                   url: "#{@note.path}/actions/delete_row",
                   method: :post,
                   style: "display: inline;",
                   data: { turbo_confirm: "Delete this row?" }
                 ) do |f| %>
-                  <%= f.hidden_field :row_id, value: row["_harmonic_row_id"] %>
-                  <button type="submit" class="pulse-action-btn-secondary" style="padding: 2px 6px;" title="Delete row">
+                  <%= f.hidden_field :row_id, value: row_id %>
+                  <button type="submit" class="pulse-action-btn-secondary" style="padding: 2px 6px;" title="Delete row"
+                          data-table-row-edit-target="deleteButton">
                     <%= octicon 'trash', height: 12 %>
                   </button>
                 <% end %>
               </td>
-            <% end %>
-          </tr>
+            </tr>
+          <% else %>
+            <tr>
+              <% table.columns.each do |col| %>
+                <td><%= markdown_inline(row[col["name"]]) %></td>
+              <% end %>
+            </tr>
+          <% end %>
         <% end %>
         <% if table.rows.empty? %>
           <tr>
-            <td colspan="<%= table.columns.length + (@note.user_can_edit_content?(@current_user) ? 1 : 0) %>" style="text-align: center; color: var(--color-fg-muted); padding: 24px;">
+            <td colspan="<%= table.columns.length + (can_edit ? 1 : 0) %>" style="text-align: center; color: var(--color-fg-muted); padding: 24px;">
               No rows yet. Add a row to get started.
             </td>
           </tr>
@@ -61,6 +89,15 @@
 </div>
 
 <% if @note.user_can_edit_content?(@current_user) && table.columns.any? %>
+  <%# One hidden update_row form per row. The row's cell inputs are linked to it
+      via the HTML `form=` attribute, so Save submits it through Turbo (#286).
+      Forms live here, outside <table>, since a <form> can't sit between rows. %>
+  <% table.rows.each do |row| %>
+    <%= form_with(url: "#{@note.path}/actions/update_row", method: :post, id: "update-row-#{row["_harmonic_row_id"]}") do |f| %>
+      <%= f.hidden_field :row_id, value: row["_harmonic_row_id"] %>
+    <% end %>
+  <% end %>
+
   <div style="padding: 12px 16px;">
     <%= form_with(url: "#{@note.path}/actions/add_row", method: :post, class: "pulse-form") do |f| %>
       <div style="display: flex; gap: 8px; align-items: end; flex-wrap: wrap;">

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -711,6 +711,58 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 0, note.table_data["rows"].length
   end
 
+  # #286: rows could be created and deleted in the HTML UI, but not updated.
+  test "update_row via HTML form redirects back to note and updates the row" do
+    sign_in_as(@user, tenant: @tenant)
+    note = create_table_note
+    table = NoteTableService.new(note)
+    row = table.add_row!({ "Status" => "pending", "Due" => "2026-05-01" }, created_by: @user)
+
+    post "/collectives/#{@collective.handle}/n/#{note.truncated_id}/actions/update_row",
+      params: { row_id: row["_harmonic_row_id"], values: { "Status" => "done", "Due" => "2026-06-01" } }
+
+    assert_response :redirect
+    assert_redirected_to note.path
+    note.reload
+    updated = note.table_data["rows"].first
+    assert_equal "done", updated["Status"]
+    assert_equal "2026-06-01", updated["Due"]
+  end
+
+  test "update_row via HTML form on a missing row redirects with an alert" do
+    sign_in_as(@user, tenant: @tenant)
+    note = create_table_note
+
+    post "/collectives/#{@collective.handle}/n/#{note.truncated_id}/actions/update_row",
+      params: { row_id: "nonexistent", values: { "Status" => "done" } }
+
+    assert_response :redirect
+    assert_redirected_to note.path
+    assert_match(/not found/i, flash[:alert])
+  end
+
+  # #286: the HTML table renders an in-place edit affordance — per-row inputs
+  # wired (via the form= attribute) to a hidden update_row form — for a member
+  # who can edit the content.
+  test "table show page renders per-row edit inputs and an update_row form for an editor" do
+    sign_in_as(@user, tenant: @tenant)
+    note = create_table_note
+    table = NoteTableService.new(note)
+    row = table.add_row!({ "Status" => "pending", "Due" => "2026-05-01" }, created_by: @user)
+    form_id = "update-row-#{row["_harmonic_row_id"]}"
+
+    get note.path
+
+    assert_response :success
+    assert_select "form##{form_id}[action='#{note.path}/actions/update_row']"
+    assert_select "tr[data-controller='table-row-edit']"
+    # One editable cell input per column (Status, Due), each wired to the row's
+    # hidden update form via the HTML form= attribute.
+    assert_select "input[form='#{form_id}']", count: 2
+    assert_select "button[data-table-row-edit-target='editButton']"
+    assert_select "button[type='submit'][form='#{form_id}']"
+  end
+
   test "add_row action adds a row to table note" do
     sign_in_as(@user, tenant: @tenant)
     note = create_table_note

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -1917,8 +1917,12 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     get "/collectives/#{@collective.handle}/n/#{note.truncated_id}"
     assert_response :success
 
-    # The cell value should be rendered as a clickable link, not raw markdown text
+    # The cell's DISPLAY renders the value as a clickable link, not raw markdown.
     assert_match(/<a [^>]*href="https:\/\/example\.com"/, response.body)
-    assert_not_includes response.body, "[Example](https://example.com)"
+    assert_select "span[data-table-row-edit-target='display'] a[href='https://example.com']"
+    # The raw markdown now also appears as the hidden edit input's value (#286),
+    # which is expected — so the "not raw text" guard is scoped to the rendered
+    # display cell, not the whole body.
+    assert_select "span[data-table-row-edit-target='display']", text: /\[Example\]\(/, count: 0
   end
 end


### PR DESCRIPTION
Closes #286 (sub-issue of #279).

## Problem

Table notes could **create** and **delete** rows in the HTML UI, but not **update** them — even though the `update_row` backend already existed (`NoteTableService#update_row!`, `ApiHelper#update_row`, and the `execute_update_row` route/action). The HTML view just never offered an edit affordance, and `execute_update_row` only spoke markdown.

## Fix

In-place row editing, mirroring the existing add/delete-row form pattern (plain forms + Turbo, no fetch):

- **`_table.html.erb`** — each editable row gets an **Edit** button that swaps its cells' rendered values for text inputs and reveals **Save**/**Cancel**. The cell inputs are associated (via the HTML `form=` attribute) with **one hidden `update_row` form per row**, rendered just after the table (a `<form>` can't sit between `<tr>`s). Save submits that form through Turbo → 302 redirect → the page reloads with the new values.
- **`table_row_edit_controller.ts`** — a small Stimulus controller (`table-row-edit`) toggling each row between display and edit. **Cancel** restores the server-rendered values (`input.defaultValue`) and exits edit mode.
- **`NotesController#execute_update_row`** — adds an HTML branch (redirect with a flash notice/alert), matching `add_row`/`delete_row`. The markdown branch is unchanged, so agent dispatch keeps its structured action result.

No new routes, action definitions, or capability-check entries — `update_row` already existed end-to-end; this is the missing HTML surface.

## Tests

- **Controller**: `update_row` via HTML form redirects and persists the new cell values; a missing `row_id` redirects with a "not found" alert; the table show page renders the per-row update form, the `data-controller` row, the wired inputs, and the edit/save buttons for an editor.
- **JS (vitest)**: the controller toggles display/inputs/buttons on Edit, and Cancel discards edits and restores display mode.

⚠️ Red-green by construction but **unverified locally** (no Docker/node in this environment) — leaning on CI.
🤖 Generated with [Claude Code](https://claude.com/claude-code)