### PR TITLE
Fix #299: don't notify @handles inside code spans/blocks

### DIFF
--- a/app/services/mention_parser.rb
+++ b/app/services/mention_parser.rb
@@ -1,18 +1,48 @@
 # typed: true
 
+require "redcarpet/render_strip"
+
 class MentionParser
   extend T::Sig
 
   MENTION_PATTERN = /@([a-zA-Z0-9_-]+)/
   TRIO_HANDLE = "trio"
 
-  # A fenced code block: an opening run of >=3 backticks or tildes at line
-  # start, through the matching closing fence (or end of text if unclosed).
-  FENCED_CODE_BLOCK = /^[ \t]*(`{3,}|~{3,})[^\n]*\n.*?(?:^[ \t]*\1[ \t]*$|\z)/m
+  # A Redcarpet plain-text renderer that drops code while keeping every other
+  # kind of text. It subclasses StripDown — which already extracts the text
+  # content of each node — and blanks only the code callbacks. The upshot is
+  # that "what counts as code" is decided by the same Markdown tokenizer the
+  # HTML renderer uses (MarkdownRenderer, #295), so the notification path can't
+  # drift from the render path the way a separate hand-rolled regex would: a
+  # fenced block, an *indented* (4-space/tab) block, an inline span, and a
+  # mention inside a nested list are all classified here exactly as on render.
+  # Code is replaced with whitespace (never nothing) so text on either side of
+  # a span can't fuse into a spurious handle — "@" `x` "foo" must not read as
+  # "@foo". (#299)
+  class CodeStrippingRenderer < Redcarpet::Render::StripDown
+    def block_code(_code, _language)
+      "\n"
+    end
 
-  # An inline code span: a run of backticks, the shortest span up to the same
-  # run. (`@trio` -> matched and excluded; a lone stray backtick won't match.)
-  INLINE_CODE_SPAN = /(`+)[^`]*?\1/
+    def codespan(_code)
+      " "
+    end
+  end
+
+  # Tokenizer extensions mirror MarkdownRenderer's so code is recognized
+  # identically on both paths: fenced_code_blocks so ``` fences route through
+  # block_code, and no_intra_emphasis so underscores in handles aren't eaten as
+  # emphasis (e.g. @a_b_c stays one handle rather than splitting on the _b_).
+  CODE_STRIPPER = T.let(
+    Redcarpet::Markdown.new(
+      CodeStrippingRenderer,
+      autolink: true,
+      tables: true,
+      fenced_code_blocks: true,
+      no_intra_emphasis: true,
+    ),
+    Redcarpet::Markdown,
+  )
 
   sig do
     params(
@@ -87,7 +117,8 @@ class MentionParser
   def self.resolve_paths(text, tenant_id:, collective: nil)
     return {} if text.blank? || tenant_id.blank?
 
-    handles = extract_handles(text)
+    # Render path: text is a single, already code-free node, so skip stripping.
+    handles = extract_handles(text, strip: false)
     return {} if handles.empty?
 
     # Same @trio handling as .parse: when a collective is provided, "@trio"
@@ -118,30 +149,32 @@ class MentionParser
     paths
   end
 
-  sig { params(text: T.nilable(String)).returns(T::Array[String]) }
-  def self.extract_handles(text)
+  sig { params(text: T.nilable(String), strip: T::Boolean).returns(T::Array[String]) }
+  def self.extract_handles(text, strip: true)
     return [] if text.blank?
 
-    # Skip @handles written inside code spans/blocks so they don't generate
-    # mention notifications — they render as literal text, not links. This
-    # mirrors the Markdown renderer (MarkdownRenderer::MentionRenderer, #295),
-    # which gets the same exclusion for free because Redcarpet routes code
-    # through callbacks that never reach #normal_text. Here the notification
-    # path parses the raw Markdown source, so we strip code first. (#299)
+    # The notification path parses the raw Markdown source, so strip code first:
+    # @handles inside code spans/blocks render as literal text, not links, and
+    # must not generate mention notifications. This mirrors the renderer
+    # (MarkdownRenderer::MentionRenderer, #295), which gets the same exclusion
+    # for free because Redcarpet routes code through callbacks that never reach
+    # #normal_text. (#299)
     #
-    # On the rendering path this is a no-op: resolve_paths only ever sees a
-    # single (already code-free) text node, so there is nothing to strip.
-    strip_code(text).scan(MENTION_PATTERN).flatten.uniq
+    # The render path passes strip: false — resolve_paths is only ever called
+    # with a single, already code-free text node, so stripping there is both
+    # unnecessary and undesirable (it would re-tokenize each fragment).
+    source = strip ? strip_code(text) : T.must(text)
+    source.scan(MENTION_PATTERN).flatten.uniq
   end
 
-  # Replace fenced code blocks and inline code spans with a space so the
-  # mention pattern can't match handles inside them. Fenced blocks are removed
-  # first so their delimiter backticks don't get consumed as inline spans.
+  # Render the Markdown to plain text with every code construct removed (see
+  # CodeStrippingRenderer), so the mention pattern can't match handles inside
+  # code. Returns "" for nil input.
   sig { params(text: T.nilable(String)).returns(String) }
   def self.strip_code(text)
     return "" if text.nil?
 
-    text.gsub(FENCED_CODE_BLOCK, " ").gsub(INLINE_CODE_SPAN, " ")
+    CODE_STRIPPER.render(text)
   end
   private_class_method :strip_code
 end

--- a/app/services/mention_parser.rb
+++ b/app/services/mention_parser.rb
@@ -6,6 +6,14 @@ class MentionParser
   MENTION_PATTERN = /@([a-zA-Z0-9_-]+)/
   TRIO_HANDLE = "trio"
 
+  # A fenced code block: an opening run of >=3 backticks or tildes at line
+  # start, through the matching closing fence (or end of text if unclosed).
+  FENCED_CODE_BLOCK = /^[ \t]*(`{3,}|~{3,})[^\n]*\n.*?(?:^[ \t]*\1[ \t]*$|\z)/m
+
+  # An inline code span: a run of backticks, the shortest span up to the same
+  # run. (`@trio` -> matched and excluded; a lone stray backtick won't match.)
+  INLINE_CODE_SPAN = /(`+)[^`]*?\1/
+
   sig do
     params(
       text: T.nilable(String),
@@ -114,6 +122,26 @@ class MentionParser
   def self.extract_handles(text)
     return [] if text.blank?
 
-    text.scan(MENTION_PATTERN).flatten.uniq
+    # Skip @handles written inside code spans/blocks so they don't generate
+    # mention notifications — they render as literal text, not links. This
+    # mirrors the Markdown renderer (MarkdownRenderer::MentionRenderer, #295),
+    # which gets the same exclusion for free because Redcarpet routes code
+    # through callbacks that never reach #normal_text. Here the notification
+    # path parses the raw Markdown source, so we strip code first. (#299)
+    #
+    # On the rendering path this is a no-op: resolve_paths only ever sees a
+    # single (already code-free) text node, so there is nothing to strip.
+    strip_code(text).scan(MENTION_PATTERN).flatten.uniq
   end
+
+  # Replace fenced code blocks and inline code spans with a space so the
+  # mention pattern can't match handles inside them. Fenced blocks are removed
+  # first so their delimiter backticks don't get consumed as inline spans.
+  sig { params(text: T.nilable(String)).returns(String) }
+  def self.strip_code(text)
+    return "" if text.nil?
+
+    text.gsub(FENCED_CODE_BLOCK, " ").gsub(INLINE_CODE_SPAN, " ")
+  end
+  private_class_method :strip_code
 end

--- a/sorbet/rbi/shims/redcarpet.rbi
+++ b/sorbet/rbi/shims/redcarpet.rbi
@@ -1,0 +1,13 @@
+# typed: true
+
+# Redcarpet's plain-text renderer lives in `redcarpet/render_strip`, which the
+# gem does not require by default — so it isn't loaded when tapioca generates
+# the gem RBI and is therefore absent from it. MentionParser requires the file
+# explicitly and subclasses StripDown, so declare the constant here.
+module Redcarpet
+  module Render
+    # rubocop:disable Lint/EmptyClass
+    class StripDown < ::Redcarpet::Render::Base; end
+    # rubocop:enable Lint/EmptyClass
+  end
+end

--- a/test/services/mention_parser_test.rb
+++ b/test/services/mention_parser_test.rb
@@ -329,4 +329,60 @@ class MentionParserTest < ActiveSupport::TestCase
     assert_equal 1, result.size
     assert_includes result, "alice"
   end
+
+  # === code-span / code-block exclusion (#299) ===
+
+  test "extract_handles skips a handle inside an inline code span" do
+    assert_equal [], MentionParser.extract_handles("Enable it by mentioning `@trio` in a note.")
+  end
+
+  test "extract_handles skips handles inside a fenced code block" do
+    text = <<~MD
+      Here is an example:
+
+      ```
+      @alice please review
+      ```
+
+      Done.
+    MD
+
+    assert_equal [], MentionParser.extract_handles(text)
+  end
+
+  test "extract_handles skips handles in a tilde-fenced code block" do
+    text = "~~~\n@bob ping\n~~~"
+
+    assert_equal [], MentionParser.extract_handles(text)
+  end
+
+  test "extract_handles still returns a real handle alongside a code-span example" do
+    result = MentionParser.extract_handles("Hey @alice, mention people like `@bob` to ping them.")
+
+    assert_equal ["alice"], result
+  end
+
+  test "extract_handles still matches a normal handle adjacent to a code span" do
+    result = MentionParser.extract_handles("`code` then @carol")
+
+    assert_equal ["carol"], result
+  end
+
+  test "extract_handles is unaffected by a lone unbalanced backtick" do
+    result = MentionParser.extract_handles("a stray ` and then @dave")
+
+    assert_equal ["dave"], result
+  end
+
+  test "parse does not notify a handle that only appears inside a code span" do
+    tenant, collective, user = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    user.tenant_user.update!(handle: "alice")
+
+    # @alice resolves normally, but here it appears only inside a code span, so
+    # it must not generate a mention notification.
+    result = MentionParser.parse("Document it as `@alice`.", tenant_id: tenant.id)
+
+    assert_empty result
+  end
 end

--- a/test/services/mention_parser_test.rb
+++ b/test/services/mention_parser_test.rb
@@ -385,4 +385,45 @@ class MentionParserTest < ActiveSupport::TestCase
 
     assert_empty result
   end
+
+  # An indented (4-space) code block is just as much "code" as a fenced one and
+  # renders as literal text, so handles inside it must not notify. The blank
+  # line before the indent is what makes it a code block rather than a
+  # paragraph continuation — see the contrast test below.
+  test "extract_handles skips handles inside an indented code block" do
+    text = <<~MD
+      Here is an example:
+
+          @alice please review
+
+      Done.
+    MD
+
+    assert_equal [], MentionParser.extract_handles(text)
+  end
+
+  test "extract_handles skips handles inside a tab-indented code block" do
+    text = "Example:\n\n\t@bob ping\n\nDone."
+
+    assert_equal [], MentionParser.extract_handles(text)
+  end
+
+  # The contrast to the indented-code-block case: with no blank line before it,
+  # an indented line is a lazy paragraph continuation, NOT a code block, so the
+  # handle renders as a live link and must still notify. A regex that blanked
+  # any 4-space-indented line would wrongly drop this; deferring to the Markdown
+  # tokenizer (as the renderer does) gets the distinction right.
+  test "extract_handles still returns a handle on an indented paragraph continuation line" do
+    text = "Talking about\n    @carol here."
+
+    assert_equal ["carol"], MentionParser.extract_handles(text)
+  end
+
+  # Nested list items are indented but are not code — they render as normal text
+  # with live mentions, so they must still notify.
+  test "extract_handles still returns a handle inside a nested list item" do
+    text = "- outer point\n  - inner mentioning @dave"
+
+    assert_equal ["dave"], MentionParser.extract_handles(text)
+  end
 end


### PR DESCRIPTION
Closes #299.

## Problem

The **notification** mention-parser didn't share the **renderer's** code-span exclusion. An `@handle` inside an inline code span or fenced code block still generated a real mention notification, even though it renders as plain (non-linked) text. Concretely, a note containing `` `@trio` `` (a documentation example) fired a real "Trio isn't enabled" notification.

PR #295 fixed the renderer by linkifying mentions in a Redcarpet `normal_text` callback — which gets code-span exclusion for free, because Redcarpet routes code through callbacks that never reach `normal_text`. But notification dispatch is a separate parser (`MentionParser.parse` → `extract_handles`) that ran a flat regex over the raw Markdown source.

## Fix

Strip fenced code blocks and inline code spans in the **shared** `MentionParser.extract_handles`, before applying `MENTION_PATTERN`. Both paths funnel through `extract_handles`:
- **notifications**: `parse` / `parse_for_notification` (over raw text) — now correctly excludes code.
- **rendering**: `resolve_paths` (called from the renderer's `normal_text`) — only ever receives a single, already code-free text node, so stripping is a **no-op** and renderer behavior is unchanged.

One mention-detection rule, shared.

**Scope**: covers code spans and fenced (```` ``` ```` / `~~~`) blocks — the reported case. Handles in link *targets* are out of scope: the renderer resolves mentions in link *text* too, so full link alignment is a separate, subtler concern worth its own change.

## Tests

`extract_handles` skips handles in inline spans and fenced/tilde blocks, still returns real handles alongside a code-span example and adjacent to a code span, and isn't tripped by a lone unbalanced backtick; `parse` doesn't notify a resolvable handle that only appears inside a code span. The renderer's existing code-span tests are unaffected (different path).

⚠️ Red-green by construction but **unverified locally** (no Docker here) — leaning on CI.
🤖 Generated with [Claude Code](https://claude.com/claude-code)