### PR TITLE
Build a fresh Redcarpet::Markdown per render call

### DIFF
--- a/app/services/markdown_renderer.rb
+++ b/app/services/markdown_renderer.rb
@@ -64,24 +64,34 @@ class MarkdownRenderer
     end
   end
 
-  @@markdown = Redcarpet::Markdown.new(
-    MentionRenderer.new(
-      hard_wrap: true,
-      safe_links_only: true,
-      filter_html: false, # Turned off so we can handle sanitization manually
-      no_images: false,   # Same as above
-      no_links: false,    # Same as above
-      no_styles: true     # No need for inline styles
-    ),
+  RENDERER_OPTIONS = {
+    hard_wrap: true,
+    safe_links_only: true,
+    filter_html: false, # Turned off so we can handle sanitization manually
+    no_images: false,   # Same as above
+    no_links: false,    # Same as above
+    no_styles: true,    # No need for inline styles
+  }.freeze
+
+  MARKDOWN_OPTIONS = {
     autolink: true,
     tables: true,
     fenced_code_blocks: true,
-    no_intra_emphasis: true # Don't treat intra-word underscores as emphasis (e.g. a_b c_d)
-  )
+    no_intra_emphasis: true, # Don't treat intra-word underscores as emphasis (e.g. a_b c_d)
+  }.freeze
+
+  # Redcarpet's C extension is not thread-safe: concurrent #render calls on a
+  # shared Markdown instance corrupt its internal work buffer and SIGABRT the
+  # process. A new instance per call is the standard recommendation and avoids
+  # shared mutable state under Puma's threaded mode.
+  sig { returns(Redcarpet::Markdown) }
+  def self.build_markdown
+    Redcarpet::Markdown.new(MentionRenderer.new(RENDERER_OPTIONS), MARKDOWN_OPTIONS)
+  end
 
   sig { params(content: T.untyped, shift_headers: T::Boolean, display_references: T::Boolean).returns(String) }
   def self.render(content, shift_headers: true, display_references: true)
-    raw_html = @@markdown.render(content.to_s)
+    raw_html = build_markdown.render(content.to_s)
     sanitized_html = sanitize(raw_html)
     if shift_headers
       output = shift_headers(sanitized_html)
@@ -96,7 +106,7 @@ class MarkdownRenderer
 
   sig { params(content: T.untyped).returns(String) }
   def self.render_inline(content)
-    raw_html = @@markdown.render(content.to_s)
+    raw_html = build_markdown.render(content.to_s)
     sanitized_html = sanitize(raw_html)
     sanitized_html.gsub(/<p>(.*)<\/p>/, '\1')
   end

--- a/test/services/markdown_renderer_test.rb
+++ b/test/services/markdown_renderer_test.rb
@@ -502,4 +502,52 @@ class MarkdownRendererTest < ActiveSupport::TestCase
     assert html.include?("Title")
     assert html.include?("<strong>Bold text</strong>")
   end
+
+  # === Concurrency ===
+  #
+  # Redcarpet's C extension is not thread-safe: two threads calling render on
+  # the same Markdown instance corrupt its internal work buffer and the process
+  # dies with `markdown.c: Assertion 'md->work_bufs[BUFFER_SPAN].size == 0'
+  # failed.` from SIGABRT. The renderer must therefore avoid sharing a single
+  # Markdown instance across Puma threads.
+  #
+  # Reproducing the race needs a GVL release mid-render. Redcarpet's C `render`
+  # never releases the GVL on its own, so plain markdown is effectively atomic
+  # under threads and won't show the bug. In production the release happens
+  # inside MentionRenderer#normal_text → MentionParser.resolve_paths, which
+  # queries the DB. Here the stub simulates that release with Thread.pass,
+  # widening the race window without taking a DB connection per thread (which
+  # would deadlock against transactional fixtures).
+  #
+  # When this regresses, the test runner itself dies with the [BUG] crash, not
+  # a clean assertion failure — that *is* the red signal.
+  test "render is safe under concurrent calls from multiple threads" do
+    inputs = [
+      "Hello @alice, see [the docs](https://example.com).",
+      "**Bold** _italic_ and `code` with @alice mentioned.",
+      "# Heading\n\nParagraph mentioning @alice inline.\n\n- a\n- b\n- c",
+      "Multiple @alice mentions of @alice in one line.",
+      "Mixed [link to @alice](/u/alice) and plain @alice text.",
+    ]
+    fake_paths = { "alice" => "/u/alice" }
+
+    MentionParser.stub :resolve_paths, ->(*_) {
+      Thread.pass
+      fake_paths
+    } do
+      threads = 8.times.map do
+        Thread.new do
+          Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+          100.times do |i|
+            html = MarkdownRenderer.render(inputs[i % inputs.size], display_references: false)
+            raise "empty output for input #{i}" if html.to_s.empty?
+          end
+          :ok
+        end
+      end
+
+      results = threads.map(&:value)
+      assert_equal Array.new(8, :ok), results
+    end
+  end
 end


### PR DESCRIPTION
Redcarpet's C extension is not thread-safe: concurrent #render calls on a shared Markdown instance corrupt its internal work buffer and the process dies with `markdown.c: Assertion 'md->work_bufs[...].size == 0' failed.` from SIGABRT. The shared @@markdown class variable plus Puma's threaded mode was racing in production whenever MentionRenderer#normal_text released the GVL during MentionParser.resolve_paths, taking down Puma and 502ing every in-flight request until restart.

Build a fresh Markdown per call from frozen option hashes. Allocation cost is negligible next to the render work. Regression test stubs resolve_paths with Thread.pass to reliably reproduce the race without taking a DB connection per thread (which would deadlock against transactional fixtures); without the fix, the test runner SIGABRTs with the same crash signature.