### PR TITLE
Fix #270: MCP tool-call log page for agent principals

### DIFF
--- a/app/controllers/ai_agents_controller.rb
+++ b/app/controllers/ai_agents_controller.rb
@@ -6,13 +6,20 @@ class AiAgentsController < ApplicationController
 
   TASK_RUNS_PER_MINUTE = 5
 
+  # Cap the MCP tool-call log page at the most recent N rows. The table is
+  # append-only with no retention policy yet (see McpToolCallLog), so an
+  # unbounded query would grow without limit for a chatty agent.
+  MCP_TOOL_CALLS_PER_PAGE = 100
+
   before_action :set_sidebar_mode,
-                only: [:new, :index, :show, :settings, :run_task, :execute_task, :runs, :show_run, :cancel_run, :create, :execute_create_ai_agent, :deactivate,
+                only: [:new, :index, :show, :settings, :run_task, :execute_task, :runs, :show_run, :cancel_run, :mcp_tool_calls, :show_mcp_tool_call, :create,
+                       :execute_create_ai_agent, :deactivate,
                        :reactivate,]
   before_action :require_any_ai_agents_enabled, only: [
     :index, :show, :settings, :update_settings,
     :describe_update_ai_agent, :execute_update_ai_agent, :settings_actions_index,
     :describe_update_notification_preferences, :execute_update_notification_preferences,
+    :mcp_tool_calls, :show_mcp_tool_call,
   ]
   before_action :require_internal_ai_agents_enabled, only: [:run_task, :execute_task, :runs, :show_run, :cancel_run]
   before_action :require_flag_for_create_mode, only: [:new, :create, :execute_create_ai_agent]
@@ -346,6 +353,36 @@ class AiAgentsController < ApplicationController
       end
       format.json { render json: { status: @task_run.status } }
     end
+  end
+
+  # GET /ai-agents/:handle/mcp-tool-calls - List MCP tool calls made by this agent
+  def mcp_tool_calls
+    return render status: :forbidden, plain: "403 Unauthorized - Only human accounts can view MCP tool calls" unless current_user&.human?
+
+    @ai_agent = find_ai_agent_by_handle
+    return render status: :not_found, plain: "404 Not Found" unless @ai_agent
+
+    @page_title = "MCP Tool Calls - #{@ai_agent.display_name}"
+    @log_limit = MCP_TOOL_CALLS_PER_PAGE
+    @logs = McpToolCallLog
+      .where(user: @ai_agent)
+      .includes(:api_token, :ai_agent_task_run)
+      .recent
+      .limit(@log_limit)
+  end
+
+  # GET /ai-agents/:handle/mcp-tool-calls/:log_id - Inspect a single MCP tool call
+  def show_mcp_tool_call
+    return render status: :forbidden, plain: "403 Unauthorized - Only human accounts can view MCP tool calls" unless current_user&.human?
+
+    @ai_agent = find_ai_agent_by_handle
+    return render status: :not_found, plain: "404 Not Found" unless @ai_agent
+
+    @log = McpToolCallLog.where(user: @ai_agent).find_by(id: params[:log_id])
+    return render status: :not_found, plain: "404 Not Found" unless @log
+
+    @page_title = "MCP Tool Call - #{@ai_agent.display_name}"
+    @resources = @log.mcp_tool_call_resources.order(:created_at)
   end
 
   def new

--- a/app/helpers/ai_agents_helper.rb
+++ b/app/helpers/ai_agents_helper.rb
@@ -15,6 +15,22 @@ module AiAgentsHelper
       .strip
   end
 
+  # True when `path` is a safe same-origin relative URL — a single leading
+  # slash followed by a non-slash, e.g. "/collectives/foo/n/abc".
+  #
+  # Stored `display_path` values are computed server-side from `resource.path`
+  # (see ApiHelper#compute_display_path) and are always of this shape, so a
+  # scheme-bearing value ("javascript:...", "data:...") or a protocol-relative
+  # host ("//evil.com") can't legitimately appear. Rendering the path as an
+  # `href` only when this returns true converts that construction-time
+  # invariant into an enforced one: if a scheme ever reaches the column via a
+  # future regression, it renders as inert text instead of a clickable link.
+  # HTML-escaping alone does NOT neutralize a `javascript:` href — the scheme
+  # contains no metacharacters — so this gate is the actual guard.
+  def safe_internal_path?(path)
+    path.to_s.match?(%r{\A/(?!/)})
+  end
+
   # Returns list of available LLM model names from litellm_config.yaml
   def available_llm_models
     config_path = Rails.root.join("config/litellm_config.yaml")

--- a/app/models/mcp_tool_call_log.rb
+++ b/app/models/mcp_tool_call_log.rb
@@ -35,4 +35,19 @@ class McpToolCallLog < ApplicationRecord
   validates :tool_name, presence: true
   validates :status, presence: true, inclusion: { in: STATUSES }
   validates :duration_ms, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  # Newest first — the order a principal inspecting the log wants by default.
+  scope :recent, -> { order(created_at: :desc) }
+
+  # True when the call was attributed to an AiAgentTaskRun — i.e. it came from
+  # an internal agent-runner ephemeral token. False for external MCP clients
+  # (Claude Desktop / Code / Cursor / etc.).
+  def internal?
+    ai_agent_task_run_id.present?
+  end
+
+  # Human-readable label for where the call originated, for log views.
+  def source_label
+    internal? ? "Internal task run" : "External client"
+  end
 end

--- a/app/models/mcp_tool_call_log.rb
+++ b/app/models/mcp_tool_call_log.rb
@@ -50,4 +50,23 @@ class McpToolCallLog < ApplicationRecord
   def source_label
     internal? ? "Internal task run" : "External client"
   end
+
+  # The Harmonic page path the call targeted, when the tool records one
+  # (fetch_page / execute_action). Nil for tools that take no path
+  # (search / get_help).
+  def logged_path
+    arguments&.dig("path").presence
+  end
+
+  # The action name for execute_action calls; nil for every other tool.
+  def logged_action_name
+    arguments&.dig("action").presence
+  end
+
+  # The agent's declared intention for the call, pulled from the context
+  # block. Present only when a context block was supplied (required for
+  # execute_action, optional for representation-session reads).
+  def intention
+    context&.dig("intention").presence
+  end
 end

--- a/app/views/ai_agents/mcp_tool_calls.html.erb
+++ b/app/views/ai_agents/mcp_tool_calls.html.erb
@@ -29,9 +29,9 @@
           <tr>
             <th>Time</th>
             <th>Tool</th>
-            <th>Status</th>
-            <th>Duration</th>
-            <th>Source</th>
+            <th>Path</th>
+            <th>Action</th>
+            <th>Intention</th>
           </tr>
         </thead>
         <tbody>
@@ -44,16 +44,20 @@
               </td>
               <td><code><%= log.tool_name %></code></td>
               <td>
-                <% if log.status == "ok" %>
-                  <span class="pulse-tag pulse-tag-success">ok</span>
-                <% elsif log.status == "pending" %>
-                  <span class="pulse-tag">pending</span>
+                <% if log.logged_path %>
+                  <code><%= log.logged_path %></code>
                 <% else %>
-                  <span class="pulse-tag pulse-tag-danger"><%= log.status %></span>
+                  <span class="pulse-muted">—</span>
                 <% end %>
               </td>
-              <td><%= log.duration_ms %> ms</td>
-              <td><%= log.source_label %></td>
+              <td>
+                <% if log.logged_action_name %>
+                  <code><%= log.logged_action_name %></code>
+                <% else %>
+                  <span class="pulse-muted">—</span>
+                <% end %>
+              </td>
+              <td><%= log.intention.presence || content_tag(:span, "—", class: "pulse-muted") %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/ai_agents/mcp_tool_calls.html.erb
+++ b/app/views/ai_agents/mcp_tool_calls.html.erb
@@ -1,0 +1,75 @@
+<%= render 'shared/pulse_breadcrumb', items: [
+  ['Home', '/'],
+  ['My AI Agents', ai_agents_path],
+  [@ai_agent.display_name, ai_agent_path(@ai_agent.handle)],
+  'MCP Tool Calls'
+] %>
+
+<article class="pulse-resource-detail">
+  <header class="pulse-resource-header">
+    <div class="pulse-resource-header-top">
+      <span class="pulse-resource-type-label">
+        <%= octicon 'log', height: 14, class: 'pulse-resource-icon' %>
+        MCP Tool Calls
+      </span>
+    </div>
+    <h1 class="pulse-resource-title">MCP Tool Calls for <%= @ai_agent.display_name %></h1>
+    <p class="pulse-resource-subtitle">
+      Every MCP tool call this agent has made, newest first.
+    </p>
+  </header>
+
+  <div class="pulse-resource-body">
+    <% if @logs.any? %>
+      <p class="pulse-muted" style="margin-bottom: 12px;">
+        Showing the <%= @logs.size %> most recent call<%= @logs.size == 1 ? "" : "s" %> (max <%= @log_limit %>).
+      </p>
+      <table class="pulse-table">
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>Tool</th>
+            <th>Status</th>
+            <th>Duration</th>
+            <th>Source</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @logs.each do |log| %>
+            <tr>
+              <td>
+                <a href="<%= ai_agent_mcp_tool_call_path(@ai_agent.handle, log.id) %>" class="pulse-link">
+                  <%= time_ago_in_words(log.created_at) %> ago
+                </a>
+              </td>
+              <td><code><%= log.tool_name %></code></td>
+              <td>
+                <% if log.status == "ok" %>
+                  <span class="pulse-tag pulse-tag-success">ok</span>
+                <% elsif log.status == "pending" %>
+                  <span class="pulse-tag">pending</span>
+                <% else %>
+                  <span class="pulse-tag pulse-tag-danger"><%= log.status %></span>
+                <% end %>
+              </td>
+              <td><%= log.duration_ms %> ms</td>
+              <td><%= log.source_label %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <div class="pulse-empty-state" style="text-align: center; padding: 48px 24px;">
+        <%= octicon 'log', height: 48, class: 'pulse-muted' %>
+        <h3 style="margin: 16px 0 8px 0;">No MCP Tool Calls Yet</h3>
+        <p class="pulse-muted">When this agent makes MCP tool calls, they'll appear here.</p>
+      </div>
+    <% end %>
+
+    <p class="pulse-action-row" style="margin-top: 24px;">
+      <a href="<%= ai_agent_path(@ai_agent.handle) %>" class="pulse-action-btn">
+        <%= octicon 'arrow-left' %> Back to Agent
+      </a>
+    </p>
+  </div>
+</article>

--- a/app/views/ai_agents/mcp_tool_calls.md.erb
+++ b/app/views/ai_agents/mcp_tool_calls.md.erb
@@ -7,10 +7,10 @@ No MCP tool calls have been recorded for this agent yet.
 <% else -%>
 Showing the <%= @logs.size %> most recent call<%= @logs.size == 1 ? "" : "s" %> (most recent first, max <%= @log_limit %>).
 
-| Time | Tool | Status | Duration | Source | Details |
-|------|------|--------|----------|--------|---------|
+| Time | Tool | Path | Action | Intention | Details |
+|------|------|------|--------|-----------|---------|
 <% @logs.each do |log| -%>
-| <%= time_ago_in_words(log.created_at) %> ago | `<%= log.tool_name %>` | <%= log.status %> | <%= log.duration_ms %> ms | <%= log.source_label %> | [view](/ai-agents/<%= @ai_agent.handle %>/mcp-tool-calls/<%= log.id %>) |
+| <%= time_ago_in_words(log.created_at) %> ago | `<%= log.tool_name %>` | <%= log.logged_path ? "`#{log.logged_path}`" : "—" %> | <%= log.logged_action_name ? "`#{log.logged_action_name}`" : "—" %> | <%= log.intention.present? ? log.intention.gsub(/[|\r\n]+/, " ").strip : "—" %> | [view](/ai-agents/<%= @ai_agent.handle %>/mcp-tool-calls/<%= log.id %>) |
 <% end -%>
 <% end -%>
 

--- a/app/views/ai_agents/mcp_tool_calls.md.erb
+++ b/app/views/ai_agents/mcp_tool_calls.md.erb
@@ -1,0 +1,20 @@
+# MCP Tool Calls — <%= @ai_agent.display_name %>
+
+Handle: `<%= @ai_agent.handle %>`
+
+<% if @logs.empty? -%>
+No MCP tool calls have been recorded for this agent yet.
+<% else -%>
+Showing the <%= @logs.size %> most recent call<%= @logs.size == 1 ? "" : "s" %> (most recent first, max <%= @log_limit %>).
+
+| Time | Tool | Status | Duration | Source | Details |
+|------|------|--------|----------|--------|---------|
+<% @logs.each do |log| -%>
+| <%= time_ago_in_words(log.created_at) %> ago | `<%= log.tool_name %>` | <%= log.status %> | <%= log.duration_ms %> ms | <%= log.source_label %> | [view](/ai-agents/<%= @ai_agent.handle %>/mcp-tool-calls/<%= log.id %>) |
+<% end -%>
+<% end -%>
+
+## Navigation
+
+* [Back to agent](/ai-agents/<%= @ai_agent.handle %>)
+* [Back to AI Agents](/ai-agents)

--- a/app/views/ai_agents/show.html.erb
+++ b/app/views/ai_agents/show.html.erb
@@ -114,6 +114,9 @@
       <a href="/ai-agents/<%= @ai_agent.handle %>/settings" class="pulse-action-btn">
         <%= octicon 'gear' %> Settings
       </a>
+      <a href="<%= ai_agent_mcp_tool_calls_path(@ai_agent.handle) %>" class="pulse-action-btn">
+        <%= octicon 'log' %> MCP Tool Calls
+      </a>
       <a href="<%= @ai_agent.path %>" class="pulse-action-btn">
         <%= octicon 'person' %> View Profile
       </a>

--- a/app/views/ai_agents/show.md.erb
+++ b/app/views/ai_agents/show.md.erb
@@ -74,5 +74,6 @@ No task runs yet.
 <% end %>
 <% end %>
 * [Settings](/ai-agents/<%= @ai_agent.handle %>/settings)
+* [MCP Tool Calls](/ai-agents/<%= @ai_agent.handle %>/mcp-tool-calls)
 * [View Profile](<%= @ai_agent.path %>)
 * [Back to AI Agents](/ai-agents)

--- a/app/views/ai_agents/show_mcp_tool_call.html.erb
+++ b/app/views/ai_agents/show_mcp_tool_call.html.erb
@@ -59,8 +59,10 @@
                 <td><%= res.action_name %></td>
                 <td><%= res.resource_type %></td>
                 <td>
-                  <% if res.display_path.present? %>
+                  <% if safe_internal_path?(res.display_path) %>
                     <a href="<%= res.display_path %>" class="pulse-link"><%= res.display_path %></a>
+                  <% elsif res.display_path.present? %>
+                    <%= res.display_path %>
                   <% else %>
                     —
                   <% end %>

--- a/app/views/ai_agents/show_mcp_tool_call.html.erb
+++ b/app/views/ai_agents/show_mcp_tool_call.html.erb
@@ -1,0 +1,81 @@
+<%= render 'shared/pulse_breadcrumb', items: [
+  ['Home', '/'],
+  ['My AI Agents', ai_agents_path],
+  [@ai_agent.display_name, ai_agent_path(@ai_agent.handle)],
+  ['MCP Tool Calls', ai_agent_mcp_tool_calls_path(@ai_agent.handle)],
+  @log.tool_name
+] %>
+
+<article class="pulse-resource-detail">
+  <header class="pulse-resource-header">
+    <div class="pulse-resource-header-top">
+      <span class="pulse-resource-type-label">
+        <%= octicon 'log', height: 14, class: 'pulse-resource-icon' %>
+        MCP Tool Call
+      </span>
+    </div>
+    <h1 class="pulse-resource-title"><code><%= @log.tool_name %></code></h1>
+  </header>
+
+  <div class="pulse-resource-body">
+    <table class="pulse-table" style="width: auto;">
+      <tbody>
+        <tr><th style="text-align: left; padding-right: 24px;">Status</th><td><%= @log.status %></td></tr>
+        <tr><th style="text-align: left; padding-right: 24px;">Duration</th><td><%= @log.duration_ms %> ms</td></tr>
+        <tr><th style="text-align: left; padding-right: 24px;">Source</th><td><%= @log.source_label %></td></tr>
+        <tr><th style="text-align: left; padding-right: 24px;">Time</th><td><%= @log.created_at.utc.iso8601 %></td></tr>
+        <tr><th style="text-align: left; padding-right: 24px;">Request ID</th><td><code><%= @log.request_id.presence || "—" %></code></td></tr>
+        <% if @log.ai_agent_task_run_id.present? %>
+          <tr>
+            <th style="text-align: left; padding-right: 24px;">Task Run</th>
+            <td><a href="<%= ai_agent_run_path(@ai_agent.handle, @log.ai_agent_task_run_id) %>" class="pulse-link"><%= @log.ai_agent_task_run_id %></a></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <section class="pulse-settings-section">
+      <h3>Arguments</h3>
+      <pre class="pulse-code-block"><code><%= JSON.pretty_generate(@log.arguments || {}) %></code></pre>
+    </section>
+
+    <% if @log.context.present? %>
+      <section class="pulse-settings-section">
+        <h3>Context</h3>
+        <pre class="pulse-code-block"><code><%= JSON.pretty_generate(@log.context) %></code></pre>
+      </section>
+    <% end %>
+
+    <% if @resources.any? %>
+      <section class="pulse-settings-section">
+        <h3>Resources touched (<%= @resources.size %>)</h3>
+        <table class="pulse-table">
+          <thead>
+            <tr><th>Action</th><th>Resource</th><th>Path</th></tr>
+          </thead>
+          <tbody>
+            <% @resources.each do |res| %>
+              <tr>
+                <td><%= res.action_name %></td>
+                <td><%= res.resource_type %></td>
+                <td>
+                  <% if res.display_path.present? %>
+                    <a href="<%= res.display_path %>" class="pulse-link"><%= res.display_path %></a>
+                  <% else %>
+                    —
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </section>
+    <% end %>
+
+    <p class="pulse-action-row" style="margin-top: 24px;">
+      <a href="<%= ai_agent_mcp_tool_calls_path(@ai_agent.handle) %>" class="pulse-action-btn">
+        <%= octicon 'arrow-left' %> Back to Tool Calls
+      </a>
+    </p>
+  </div>
+</article>

--- a/app/views/ai_agents/show_mcp_tool_call.md.erb
+++ b/app/views/ai_agents/show_mcp_tool_call.md.erb
@@ -1,0 +1,42 @@
+# MCP Tool Call — <%= @ai_agent.display_name %>
+
+| Field | Value |
+|-------|-------|
+| Tool | `<%= @log.tool_name %>` |
+| Status | <%= @log.status %> |
+| Duration | <%= @log.duration_ms %> ms |
+| Source | <%= @log.source_label %> |
+| Time | <%= @log.created_at.utc.iso8601 %> |
+| Request ID | <%= @log.request_id.presence || "—" %> |
+<% if @log.ai_agent_task_run_id.present? -%>
+| Task Run | [<%= @log.ai_agent_task_run_id %>](/ai-agents/<%= @ai_agent.handle %>/runs/<%= @log.ai_agent_task_run_id %>) |
+<% end -%>
+
+## Arguments
+
+```json
+<%= JSON.pretty_generate(@log.arguments || {}) %>
+```
+
+<% if @log.context.present? -%>
+## Context
+
+```json
+<%= JSON.pretty_generate(@log.context) %>
+```
+
+<% end -%>
+<% if @resources.any? -%>
+## Resources touched (<%= @resources.size %>)
+
+| Action | Resource | Path |
+|--------|----------|------|
+<% @resources.each do |res| -%>
+| <%= res.action_name %> | <%= res.resource_type %> | <% if res.display_path.present? %>[<%= res.display_path %>](<%= res.display_path %>)<% else %>—<% end %> |
+<% end -%>
+
+<% end -%>
+## Navigation
+
+* [Back to tool calls](/ai-agents/<%= @ai_agent.handle %>/mcp-tool-calls)
+* [Back to agent](/ai-agents/<%= @ai_agent.handle %>)

--- a/app/views/ai_agents/show_run.html.erb
+++ b/app/views/ai_agents/show_run.html.erb
@@ -152,7 +152,7 @@
           <div style="display: flex; align-items: center; gap: 12px; padding: 10px 12px; background: var(--color-canvas-subtle); border-radius: 6px; margin-bottom: 8px;">
             <div style="display: flex; align-items: center; gap: 8px; flex: 1; min-width: 0;">
               <i class="<%= resource.class.to_s.downcase %>-icon icon-sm"></i>
-              <% if task_run_resource.display_path.present? %>
+              <% if safe_internal_path?(task_run_resource.display_path) %>
                 <a href="<%= task_run_resource.display_path %>" style="font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
                   <%= resource_title %>
                 </a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,9 @@ Rails.application.routes.draw do
   get 'ai-agents/:handle/runs' => 'ai_agents#runs', as: 'ai_agent_runs'
   get 'ai-agents/:handle/runs/:run_id' => 'ai_agents#show_run', as: 'ai_agent_run'
   post 'ai-agents/:handle/runs/:run_id/cancel' => 'ai_agents#cancel_run', as: 'cancel_ai_agent_run'
+  # MCP tool-call log — principal-facing inspection of an agent's MCP calls
+  get 'ai-agents/:handle/mcp-tool-calls' => 'ai_agents#mcp_tool_calls', as: 'ai_agent_mcp_tool_calls'
+  get 'ai-agents/:handle/mcp-tool-calls/:log_id' => 'ai_agents#show_mcp_tool_call', as: 'ai_agent_mcp_tool_call'
   # AI Agent automations
   get 'ai-agents/:handle/automations' => 'agent_automations#index', as: 'ai_agent_automations'
   get 'ai-agents/:handle/automations/new' => 'agent_automations#new', as: 'new_ai_agent_automation'

--- a/test/controllers/ai_agents_controller_test.rb
+++ b/test/controllers/ai_agents_controller_test.rb
@@ -1380,6 +1380,19 @@ class AiAgentsControllerTest < ActionDispatch::IntegrationTest
     assert_match "fetch_page", response.body
   end
 
+  test "MCP tool calls list surfaces path, action, and intention" do
+    create_mcp_log_for(@ai_agent,
+                       tool_name: "execute_action",
+                       arguments: { "path" => "/collectives/team/n/abc123", "action" => "add_comment" },
+                       context: { "intention" => "Reply to Dan on the doc thread", "visibility" => "shared" })
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/mcp-tool-calls"
+    assert_response :success
+    assert_match "/collectives/team/n/abc123", response.body
+    assert_match "add_comment", response.body
+    assert_match "Reply to Dan on the doc thread", response.body
+  end
+
   test "MCP tool calls list renders markdown" do
     create_mcp_log_for(@ai_agent)
     sign_in_as(@user, tenant: @tenant)

--- a/test/controllers/ai_agents_controller_test.rb
+++ b/test/controllers/ai_agents_controller_test.rb
@@ -1440,6 +1440,50 @@ class AiAgentsControllerTest < ActionDispatch::IntegrationTest
     assert_match "execute_action", response.body
   end
 
+  def attach_resource_to_log(log, display_path:)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    note = create_note(tenant: @tenant, collective: @collective, created_by: @ai_agent)
+    McpToolCallResource.create!(
+      tenant: @tenant,
+      mcp_tool_call_log: log,
+      resource: note,
+      resource_collective: @collective,
+      action_name: "create_note",
+      display_path: display_path,
+    )
+  ensure
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+  end
+
+  test "MCP tool call detail renders a safe stored display_path as a link" do
+    log = create_mcp_log_for(@ai_agent, tool_name: "execute_action", arguments: {})
+    safe_path = "/collectives/#{@collective.handle}/n/abc123"
+    attach_resource_to_log(log, display_path: safe_path)
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/mcp-tool-calls/#{log.id}"
+    assert_response :success
+    assert_match %r{<a[^>]+href="#{Regexp.escape(safe_path)}"}, response.body
+  end
+
+  # Regression guard for the show_mcp_tool_call.html.erb review finding
+  # (Harmonic PR #308): a stored `display_path` is only ever rendered as an
+  # `href` when it's a same-origin relative path. Server-side path computation
+  # can't produce a scheme, but if one ever reached the column it must render
+  # as inert text, never as an executable javascript: link.
+  test "MCP tool call detail renders a hostile stored display_path as inert text, not an href" do
+    log = create_mcp_log_for(@ai_agent, tool_name: "execute_action", arguments: {})
+    attach_resource_to_log(log, display_path: "javascript:alert(document.cookie)")
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/mcp-tool-calls/#{log.id}"
+    assert_response :success
+    # The value is still shown to the human operator ...
+    assert_match "javascript:alert(document.cookie)", response.body
+    # ... but never as a clickable link that would execute it.
+    assert_no_match %r{href=["']\s*javascript:}i, response.body
+  end
+
   test "MCP tool call detail returns 404 for an unknown log id" do
     sign_in_as(@user, tenant: @tenant)
     get "/ai-agents/#{@ai_agent_handle}/mcp-tool-calls/00000000-0000-0000-0000-000000000000"

--- a/test/controllers/ai_agents_controller_test.rb
+++ b/test/controllers/ai_agents_controller_test.rb
@@ -1350,6 +1350,98 @@ class AiAgentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [], @ai_agent.agent_configuration["capabilities"]
   end
 
+  # === MCP Tool Call Log Tests ===
+
+  def create_mcp_log_for(agent, **attrs)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    log = McpToolCallLog.create!({
+      tenant: @tenant,
+      user: agent,
+      tool_name: "fetch_page",
+      arguments: { "path" => "/whoami" },
+      status: "ok",
+      duration_ms: 12,
+    }.merge(attrs))
+    Tenant.clear_thread_scope
+    log
+  end
+
+  test "human user can access the MCP tool calls list for their agent" do
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/mcp-tool-calls"
+    assert_response :success
+  end
+
+  test "MCP tool calls list shows the agent's logged calls" do
+    create_mcp_log_for(@ai_agent, tool_name: "fetch_page")
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/mcp-tool-calls"
+    assert_response :success
+    assert_match "fetch_page", response.body
+  end
+
+  test "MCP tool calls list renders markdown" do
+    create_mcp_log_for(@ai_agent)
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/mcp-tool-calls", headers: { "Accept" => "text/markdown" }
+    assert_response :success
+    assert_includes response.content_type, "text/markdown"
+    assert_match "MCP Tool Calls", response.body
+  end
+
+  test "unauthenticated user is redirected from MCP tool calls list" do
+    get "/ai-agents/#{@ai_agent_handle}/mcp-tool-calls"
+    assert_response :redirect
+    assert_match %r{/login}, response.location
+  end
+
+  test "MCP tool calls list returns 404 for non-existent agent" do
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/non-existent-handle/mcp-tool-calls"
+    assert_response :not_found
+  end
+
+  test "user cannot view another user's agent MCP tool calls" do
+    other_user = create_user
+    @tenant.add_user!(other_user)
+    sign_in_as(other_user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/mcp-tool-calls"
+    assert_response :not_found
+  end
+
+  test "MCP tool calls list is forbidden when AI agents feature is disabled" do
+    @tenant.set_feature_flag!("internal_ai_agents", false)
+    @tenant.set_feature_flag!("external_ai_agents", false)
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/mcp-tool-calls"
+    assert_response :forbidden
+  end
+
+  test "human user can view a single MCP tool call detail" do
+    log = create_mcp_log_for(@ai_agent, tool_name: "execute_action",
+                                        arguments: { "path" => "/x", "action" => "add_comment" },
+                                        request_id: "req-xyz")
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/mcp-tool-calls/#{log.id}"
+    assert_response :success
+    assert_match "execute_action", response.body
+  end
+
+  test "MCP tool call detail returns 404 for an unknown log id" do
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/mcp-tool-calls/00000000-0000-0000-0000-000000000000"
+    assert_response :not_found
+  end
+
+  test "MCP tool call detail returns 404 for a log belonging to a different agent" do
+    other_agent = create_ai_agent(parent: @user, name: "Other Agent")
+    @tenant.add_user!(other_agent)
+    log = create_mcp_log_for(other_agent, tool_name: "search", arguments: {})
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/mcp-tool-calls/#{log.id}"
+    assert_response :not_found
+  end
+
   private
 
   def enable_stripe_billing_flag!(tenant)

--- a/test/helpers/ai_agents_helper_test.rb
+++ b/test/helpers/ai_agents_helper_test.rb
@@ -91,6 +91,39 @@ class AiAgentsHelperTest < ActionView::TestCase
     assert_not_includes result, '"type": "navigate"'
   end
 
+  # === safe_internal_path? ===
+  #
+  # Guards the `display_path` -> `<a href>` render in show_mcp_tool_call and
+  # show_run against a scheme-bearing value ever reaching the column. These
+  # cases are the exploit shapes a regression would have to slip through.
+
+  test "safe_internal_path? accepts a same-origin relative path" do
+    assert safe_internal_path?("/collectives/team/n/abc123")
+    assert safe_internal_path?("/workspace/foo/d/xyz?comment_id=q1")
+    assert safe_internal_path?("/")
+  end
+
+  test "safe_internal_path? rejects a javascript: URI" do
+    assert_not safe_internal_path?("javascript:alert(document.cookie)")
+    assert_not safe_internal_path?("JavaScript:alert(1)")
+  end
+
+  test "safe_internal_path? rejects data: and other schemes" do
+    assert_not safe_internal_path?("data:text/html,<script>alert(1)</script>")
+    assert_not safe_internal_path?("http://evil.example/x")
+    assert_not safe_internal_path?("https://evil.example/x")
+  end
+
+  test "safe_internal_path? rejects a protocol-relative host" do
+    assert_not safe_internal_path?("//evil.example/x")
+  end
+
+  test "safe_internal_path? rejects blank and nil" do
+    assert_not safe_internal_path?(nil)
+    assert_not safe_internal_path?("")
+    assert_not safe_internal_path?("   ")
+  end
+
   test "available_llm_models returns models from litellm config" do
     models = available_llm_models
 

--- a/test/models/mcp_tool_call_log_test.rb
+++ b/test/models/mcp_tool_call_log_test.rb
@@ -123,6 +123,39 @@ class McpToolCallLogTest < ActiveSupport::TestCase
     assert_equal task_run, log.ai_agent_task_run
   end
 
+  test "recent scope orders newest first" do
+    older = McpToolCallLog.create!(
+      tenant: @tenant, user: @agent, api_token: @token,
+      tool_name: "search", status: "ok", duration_ms: 1, created_at: 2.hours.ago
+    )
+    newer = McpToolCallLog.create!(
+      tenant: @tenant, user: @agent, api_token: @token,
+      tool_name: "fetch_page", status: "ok", duration_ms: 1, created_at: 1.minute.ago
+    )
+
+    assert_equal [newer, older], McpToolCallLog.recent.to_a
+  end
+
+  test "internal? and source_label reflect the ai_agent_task_run association" do
+    external = McpToolCallLog.create!(
+      tenant: @tenant, user: @agent, api_token: @token,
+      tool_name: "search", status: "ok", duration_ms: 1
+    )
+    assert_not external.internal?
+    assert_equal "External client", external.source_label
+
+    task_run = AiAgentTaskRun.create!(
+      tenant: @tenant, ai_agent: @agent, initiated_by: @user,
+      task: "test", max_steps: 5, status: "running"
+    )
+    internal = McpToolCallLog.create!(
+      tenant: @tenant, user: @agent, api_token: @token,
+      tool_name: "search", status: "ok", duration_ms: 1, ai_agent_task_run: task_run
+    )
+    assert internal.internal?
+    assert_equal "Internal task run", internal.source_label
+  end
+
   test "destroying the api_token nullifies the log's api_token_id (audit row survives)" do
     # Task-scoped internal tokens are destroyed on task completion. Logs
     # written during the task must survive that destroy — the audit trail

--- a/test/models/mcp_tool_call_log_test.rb
+++ b/test/models/mcp_tool_call_log_test.rb
@@ -156,6 +156,36 @@ class McpToolCallLogTest < ActiveSupport::TestCase
     assert_equal "Internal task run", internal.source_label
   end
 
+  test "logged_path returns the path argument, or nil when absent" do
+    with_path = McpToolCallLog.new(arguments: { "path" => "/collectives/team/n/abc123", "action" => "add_comment" })
+    assert_equal "/collectives/team/n/abc123", with_path.logged_path
+
+    without_path = McpToolCallLog.new(arguments: { "query" => "budget" })
+    assert_nil without_path.logged_path
+
+    assert_nil McpToolCallLog.new(arguments: nil).logged_path
+    assert_nil McpToolCallLog.new(arguments: { "path" => "" }).logged_path
+  end
+
+  test "logged_action_name returns the action for execute_action, nil otherwise" do
+    action_call = McpToolCallLog.new(arguments: { "path" => "/x", "action" => "update_row" })
+    assert_equal "update_row", action_call.logged_action_name
+
+    fetch_call = McpToolCallLog.new(arguments: { "path" => "/x" })
+    assert_nil fetch_call.logged_action_name
+
+    assert_nil McpToolCallLog.new(arguments: nil).logged_action_name
+  end
+
+  test "intention returns the context intention, or nil when absent" do
+    with_intention = McpToolCallLog.new(context: { "intention" => "Reply to Dan on the thread", "visibility" => "shared" })
+    assert_equal "Reply to Dan on the thread", with_intention.intention
+
+    assert_nil McpToolCallLog.new(context: { "visibility" => "shared" }).intention
+    assert_nil McpToolCallLog.new(context: nil).intention
+    assert_nil McpToolCallLog.new(context: { "intention" => "" }).intention
+  end
+
   test "destroying the api_token nullifies the log's api_token_id (audit row survives)" do
     # Task-scoped internal tokens are destroyed on task completion. Logs
     # written during the task must survive that destroy — the audit trail


### PR DESCRIPTION
Closes #270.

## Problem
Every MCP tool call is already persisted to `mcp_tool_call_logs`, but there was nowhere for an agent's principal to actually read them.

## What this adds
A principal-facing **list + detail** view of an agent's MCP tool calls, living under the agent and mirroring the existing `runs` / `show_run` pattern:

- **Routes**
  - `GET /ai-agents/:handle/mcp-tool-calls` — list
  - `GET /ai-agents/:handle/mcp-tool-calls/:log_id` — detail
- **Controller** (`AiAgentsController`)
  - `#mcp_tool_calls` — most-recent-first, capped at `MCP_TOOL_CALLS_PER_PAGE` (100) since the table is append-only with no retention policy yet
  - `#show_mcp_tool_call` — single call with full args/context/resources
  - Both are human-only and scoped to the caller's **own** agents via `find_ai_agent_by_handle`, plus the model's tenant default scope
- **Views** — HTML (pulse styling) and Markdown for both list and detail. Detail shows status, duration, source (internal task-run vs external client), timestamp, request id, arguments, context, and any resources the call touched.
- **Model** — `McpToolCallLog.recent` scope and `internal?` / `source_label` helpers.
- **Navigation** — "MCP Tool Calls" link added to the agent show page (HTML + Markdown).

## Scoping notes
- Works for **external** agents (Claude Desktop/Code/Cursor) as well as internal task-run agents — the source column distinguishes them.
- This is the read-only "initial" page the issue asks for; the longer-term unified agent-task-run model is out of scope here.

## Tests
Controller integration tests (access, tenant/owner scoping, 404s for unknown agent/log and cross-agent logs, feature-flag gating, markdown rendering) and model tests (`recent` ordering, `internal?`/`source_label`).

## Caveat
Written red-green by construction but **unverified locally** — this environment has no Docker, and the repo's tests/rubocop/sorbet run in containers. Relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)