### PR TITLE
Add docker-compose.test.yml for running tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ cp .env.example .env
 ./scripts/stop.sh    # stop the app
 ```
 
+## Running tests locally
+
+The Rails test suite runs in Docker via a trimmed, CI-faithful compose file
+([`docker-compose.test.yml`](docker-compose.test.yml)) — just a test runner plus
+Postgres and Redis, matching the versions and environment used in CI.
+
+```bash
+docker compose -f docker-compose.test.yml build
+docker compose -f docker-compose.test.yml run --rm test                                   # full suite
+docker compose -f docker-compose.test.yml run --rm test bundle exec rails test test/models  # a subset
+docker compose -f docker-compose.test.yml down -v                                         # tear down
+```
+
+The image bakes the app code, gems and assets, so rebuild after changing code.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ cp .env.example .env
 
 ## Running tests locally
 
+### Rails test suite (Docker)
+
 The Rails test suite runs in Docker via a trimmed, CI-faithful compose file
 ([`docker-compose.test.yml`](docker-compose.test.yml)) — just a test runner plus
 Postgres and Redis, matching the versions and environment used in CI.
@@ -44,6 +46,43 @@ docker compose -f docker-compose.test.yml down -v                               
 ```
 
 The image bakes the app code, gems and assets, so rebuild after changing code.
+
+### TypeScript / JavaScript tests (no Docker)
+
+The TS tests are plain Node (v22) and need no Postgres, Redis, or containers —
+they run natively in seconds. This mirrors CI's separate `typescript` job, which
+covers three independent packages:
+
+```bash
+# Frontend UI (root package.json) — Stimulus controllers etc., vitest + jsdom
+npm install
+npm run typecheck      # tsc --noEmit
+npm test               # vitest run  (app/javascript/**/*.test.ts)
+npm run build          # esbuild bundle
+
+# agent-runner (vitest)
+cd agent-runner && npm install && npm run build && npm run typecheck && npm test
+
+# harmonic-bridge (node's built-in --test runner)
+cd harmonic-bridge && npm install && npm run typecheck && npm test && npm run build
+```
+
+So frontend Stimulus work, `agent-runner`, and `harmonic-bridge` need neither
+Docker nor the upgraded box — just Node and disk for `node_modules`.
+
+### End-to-end tests (Playwright)
+
+Playwright e2e is the one TS surface that needs a **running app** — it drives a
+real Chromium against the stack (web + db + redis up), reachable at
+`E2E_BASE_URL` (default `https://app.harmonic.local`) with the authed storage
+state from [`e2e/global-setup.ts`](e2e/global-setup.ts).
+
+```bash
+npm run playwright:install   # one-time: install the Chromium browser
+npm run test:e2e             # playwright test  (needs the app running)
+```
+
+CI does **not** run Playwright in the `typescript` job — it's for local/manual use.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -32,57 +32,8 @@ cp .env.example .env
 
 ## Running tests locally
 
-### Rails test suite (Docker)
-
-The Rails test suite runs in Docker via a trimmed, CI-faithful compose file
-([`docker-compose.test.yml`](docker-compose.test.yml)) — just a test runner plus
-Postgres and Redis, matching the versions and environment used in CI.
-
-```bash
-docker compose -f docker-compose.test.yml build
-docker compose -f docker-compose.test.yml run --rm test                                   # full suite
-docker compose -f docker-compose.test.yml run --rm test bundle exec rails test test/models  # a subset
-docker compose -f docker-compose.test.yml down -v                                         # tear down
-```
-
-The image bakes the app code, gems and assets, so rebuild after changing code.
-
-### TypeScript / JavaScript tests (no Docker)
-
-The TS tests are plain Node (v22) and need no Postgres, Redis, or containers —
-they run natively in seconds. This mirrors CI's separate `typescript` job, which
-covers three independent packages:
-
-```bash
-# Frontend UI (root package.json) — Stimulus controllers etc., vitest + jsdom
-npm install
-npm run typecheck      # tsc --noEmit
-npm test               # vitest run  (app/javascript/**/*.test.ts)
-npm run build          # esbuild bundle
-
-# agent-runner (vitest)
-cd agent-runner && npm install && npm run build && npm run typecheck && npm test
-
-# harmonic-bridge (node's built-in --test runner)
-cd harmonic-bridge && npm install && npm run typecheck && npm test && npm run build
-```
-
-So frontend Stimulus work, `agent-runner`, and `harmonic-bridge` need neither
-Docker nor the upgraded box — just Node and disk for `node_modules`.
-
-### End-to-end tests (Playwright)
-
-Playwright e2e is the one TS surface that needs a **running app** — it drives a
-real Chromium against the stack (web + db + redis up), reachable at
-`E2E_BASE_URL` (default `https://app.harmonic.local`) with the authed storage
-state from [`e2e/global-setup.ts`](e2e/global-setup.ts).
-
-```bash
-npm run playwright:install   # one-time: install the Chromium browser
-npm run test:e2e             # playwright test  (needs the app running)
-```
-
-CI does **not** run Playwright in the `typescript` job — it's for local/manual use.
+See [docs/TESTING.md](docs/TESTING.md) for how to run the Rails suite (Docker),
+the TypeScript/JavaScript tests (no Docker), and the Playwright e2e tests.
 
 ## License
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,65 @@
+# docker-compose.test.yml — run the Rails test suite locally in Docker.
+#
+# Mirrors the `rails-tests` job in .github/workflows/ci.yml (same postgres/redis
+# versions, same env vars, db:create + db:schema:load) so a green run here should
+# mean a green run in CI. It deliberately omits everything tests don't need —
+# web/js/sidekiq, caddy/ngrok, mailcatcher, litellm/agent-runner — to keep the
+# footprint small enough for a modest box.
+#
+# Usage:
+#   docker compose -f docker-compose.test.yml build
+#   docker compose -f docker-compose.test.yml run --rm test                                   # full suite
+#   docker compose -f docker-compose.test.yml run --rm test bundle exec rails test test/models  # a subset
+#   docker compose -f docker-compose.test.yml down -v                                         # tear down + drop the db volume
+#
+# The image bakes the app code, gems, node_modules and built JS assets (see
+# Dockerfile), so there is no source bind-mount: rebuild after changing code.
+
+services:
+  test:
+    build: .
+    command: >
+      bash -c "bin/rails db:create &&
+               bin/rails db:schema:load &&
+               bundle exec rails test"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      RAILS_ENV: test
+      DB_HOST: db
+      REDIS_URL: redis://redis:6379/0
+      AUTH_MODE: oauth
+      HOSTNAME: harmonic.localhost
+      PRIMARY_SUBDOMAIN: app
+      AUTH_SUBDOMAIN: auth
+
+  db:
+    image: postgres:13
+    environment:
+      POSTGRES_USER: decisiveteam
+      POSTGRES_PASSWORD: decisiveteam
+      POSTGRES_DB: decisive_team_test
+    # Test data is disposable. A named volume keeps RAM use low; swap it for
+    # `tmpfs: /var/lib/postgresql/data` to run the DB in RAM (faster, but adds a
+    # few hundred MB of RAM pressure — drop it back on a tight box).
+    volumes:
+      - pg_data_test:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U decisiveteam -d decisive_team_test"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:6.2-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pg_data_test:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,53 @@
+# Running tests locally
+
+## Rails test suite (Docker)
+
+The Rails test suite runs in Docker via a trimmed, CI-faithful compose file
+([`docker-compose.test.yml`](../docker-compose.test.yml)) — just a test runner
+plus Postgres and Redis, matching the versions and environment used in CI.
+
+```bash
+docker compose -f docker-compose.test.yml build
+docker compose -f docker-compose.test.yml run --rm test                                   # full suite
+docker compose -f docker-compose.test.yml run --rm test bundle exec rails test test/models  # a subset
+docker compose -f docker-compose.test.yml down -v                                         # tear down
+```
+
+The image bakes the app code, gems and assets, so rebuild after changing code.
+
+## TypeScript / JavaScript tests (no Docker)
+
+The TS tests are plain Node (v22) and need no Postgres, Redis, or containers —
+they run natively in seconds. This mirrors CI's separate `typescript` job, which
+covers three independent packages:
+
+```bash
+# Frontend UI (root package.json) — Stimulus controllers etc., vitest + jsdom
+npm install
+npm run typecheck      # tsc --noEmit
+npm test               # vitest run  (app/javascript/**/*.test.ts)
+npm run build          # esbuild bundle
+
+# agent-runner (vitest)
+cd agent-runner && npm install && npm run build && npm run typecheck && npm test
+
+# harmonic-bridge (node's built-in --test runner)
+cd harmonic-bridge && npm install && npm run typecheck && npm test && npm run build
+```
+
+So frontend Stimulus work, `agent-runner`, and `harmonic-bridge` need neither
+Docker nor a database — just Node and disk for `node_modules`.
+
+## End-to-end tests (Playwright)
+
+Playwright e2e is the one TS surface that needs a **running app** — it drives a
+real Chromium against the stack (web + db + redis up), reachable at
+`E2E_BASE_URL` (default `https://app.harmonic.local`) with the authed storage
+state from [`e2e/global-setup.ts`](../e2e/global-setup.ts).
+
+```bash
+npm run playwright:install   # one-time: install the Chromium browser
+npm run test:e2e             # playwright test  (needs the app running)
+```
+
+CI does **not** run Playwright in the `typescript` job — it's for local/manual use.


### PR DESCRIPTION
## What

Adds `docker-compose.test.yml` so the Rails test suite can be run locally in Docker, plus a short "Running tests locally" note in the README.

Follow-up to Dan's note about getting tests running on my machine ([harmonic-devs note `9f9fc34e`](https://www.harmonic.social/collectives/harmonic-devs/n/9f9fc34e)).

## Design

A **trimmed, CI-faithful** stack — just `test` + `db` + `redis`:

- **Mirrors CI** (`.github/workflows/ci.yml` → `rails-tests`): `postgres:13`, `redis:6.2-alpine`, the same env vars (`RAILS_ENV=test`, `DB_HOST`, `AUTH_MODE=oauth`, `HOSTNAME`, `PRIMARY_SUBDOMAIN`, `AUTH_SUBDOMAIN`, `REDIS_URL`), and `db:create` + `db:schema:load` before `rails test`.
- **Drops** everything tests don't need — web/js/sidekiq, caddy/ngrok, mailcatcher, and the 512 MB-each `litellm`/`agent-runner` — to keep memory/disk down (the box this was requested for is small).
- **No source bind-mount.** The `Dockerfile` already bakes app code, gems, `node_modules` and built JS assets via `COPY . .` + `npm run build`, and runs as `harmonic` (uid 1000). Bind-mounting `.:/app` would hide those, so the file relies on the baked image instead — rebuild after changing code. (This also matches CI's fresh-checkout semantics.)
- **db healthcheck** (`pg_isready`) gates the test runner via `depends_on: condition: service_healthy`, avoiding a `db:create` race on startup.

## Usage

```bash
docker compose -f docker-compose.test.yml build
docker compose -f docker-compose.test.yml run --rm test                                   # full suite
docker compose -f docker-compose.test.yml run --rm test bundle exec rails test test/models  # a subset
docker compose -f docker-compose.test.yml down -v
```

## ⚠️ Unverified

I can't run this yet — my current box has no Docker and is at 98% disk / ~458 MB RAM (the very constraint that motivated the note). The compose file was written against `main`'s `Dockerfile`, `docker-compose.yml`, `config/database.yml`, and `ci.yml`, but it has **not** been executed. Worth a real run on the upgraded instance before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)