### PR TITLE
Fix #301: feed item timestamps update live without refresh

### DIFF
--- a/app/components/feed_item_component.html.erb
+++ b/app/components/feed_item_component.html.erb
@@ -33,7 +33,7 @@
       <% else %>
         <span>Anonymous</span>
       <% end %>
-      &middot; <%= helpers.time_ago_in_words(@created_at) %> ago
+      &middot; <%= helpers.timeago(@created_at) %>
     </div>
   </div>
   <div class="pulse-feed-item-body">


### PR DESCRIPTION
## Problem

Pulse feed item timestamps ("X ago") were rendered with the static `time_ago_in_words` helper and never updated until a full page refresh (#301).

## Fix

Swap the single call in `feed_item_component.html.erb` to the existing `timeago` helper, which renders a `<time data-controller="timeago" …>` element. The `timeago_controller` Stimulus controller already keeps these live client-side — the same pattern is used on statement cards, cycles, and history logs. The helper appends the "ago"/"from now" suffix, so the literal `" ago"` is removed.

## Scope

One-line view change. Left the "Closed X ago" labels on disabled/closed decision buttons (lines ~195/207) alone — those reflect a settled past deadline and aren't the live-update concern in the issue.

## Verification

Not run locally — the test suite runs in Docker/CI only from this environment. Relying on CI. Change mirrors existing, tested `timeago` usages.

Closes #301