### PR TITLE
Fix #329: send email from "Harmonic <address>" instead of a bare noreply

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,18 @@
 # typed: false
 
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV['MAILER_FROM_ADDRESS']
+  default from: -> { ApplicationMailer.default_from_address }
   layout "mailer"
+
+  # Sender address with a human-friendly display name, e.g.
+  # "Harmonic <noreply@harmonic.social>", so inboxes show "Harmonic" instead
+  # of a bare "noreply@..." address. If MAILER_FROM_ADDRESS already carries
+  # its own display name (contains "<"), it is used verbatim.
+  def self.default_from_address
+    address = ENV["MAILER_FROM_ADDRESS"].presence || "noreply@harmonic.social"
+    return address if address.include?("<")
+
+    name = ENV["MAILER_FROM_NAME"].presence || "Harmonic"
+    "#{name} <#{address}>"
+  end
 end

--- a/app/mailers/email_change_mailer.rb
+++ b/app/mailers/email_change_mailer.rb
@@ -6,7 +6,6 @@ class EmailChangeMailer < ApplicationMailer
     @confirm_url = email_confirm_url(user, raw_token, tenant)
     mail(
       to: user.pending_email,
-      from: ENV["MAILER_FROM_ADDRESS"] || "noreply@harmonic.social",
       subject: "Confirm your new email address on #{ENV['HOSTNAME']}",
     )
   end
@@ -18,7 +17,6 @@ class EmailChangeMailer < ApplicationMailer
     @login_url = login_url(tenant)
     mail(
       to: user.email,
-      from: ENV["MAILER_FROM_ADDRESS"] || "noreply@harmonic.social",
       subject: "Email change requested for your #{ENV['HOSTNAME']} account",
     )
   end

--- a/app/mailers/email_confirmation_mailer.rb
+++ b/app/mailers/email_confirmation_mailer.rb
@@ -6,7 +6,6 @@ class EmailConfirmationMailer < ApplicationMailer
     @confirm_url = confirm_email_url(raw_token, tenant)
     mail(
       to: identity.email,
-      from: ENV["MAILER_FROM_ADDRESS"] || "noreply@harmonic.social",
       subject: "Confirm your email on #{ENV['HOSTNAME']}",
     )
   end

--- a/app/mailers/password_reset_mailer.rb
+++ b/app/mailers/password_reset_mailer.rb
@@ -8,7 +8,6 @@ class PasswordResetMailer < ApplicationMailer
     @reset_url = password_reset_url(token: raw_token)
     mail(
       to: @identity.email,
-      from: ENV['MAILER_FROM_ADDRESS'] || 'noreply@harmonic.social',
       subject: "Reset your password on #{ENV['HOSTNAME']}"
     )
   end

--- a/test/mailers/application_mailer_test.rb
+++ b/test/mailers/application_mailer_test.rb
@@ -1,0 +1,63 @@
+# typed: false
+
+require "test_helper"
+
+class ApplicationMailerTest < ActiveSupport::TestCase
+  def with_env(overrides)
+    original = {}
+    overrides.each do |key, value|
+      original[key] = ENV[key]
+      if value.nil?
+        ENV.delete(key)
+      else
+        ENV[key] = value
+      end
+    end
+    yield
+  ensure
+    original.each { |key, value| value.nil? ? ENV.delete(key) : (ENV[key] = value) }
+  end
+
+  test "wraps a bare from address with the default display name" do
+    with_env("MAILER_FROM_ADDRESS" => "noreply@example.com", "MAILER_FROM_NAME" => nil) do
+      assert_equal "Harmonic <noreply@example.com>", ApplicationMailer.default_from_address
+    end
+  end
+
+  test "honors a custom MAILER_FROM_NAME" do
+    with_env("MAILER_FROM_ADDRESS" => "noreply@example.com", "MAILER_FROM_NAME" => "Acme") do
+      assert_equal "Acme <noreply@example.com>", ApplicationMailer.default_from_address
+    end
+  end
+
+  test "uses the address verbatim when it already carries a display name" do
+    with_env("MAILER_FROM_ADDRESS" => "Support <help@example.com>", "MAILER_FROM_NAME" => nil) do
+      assert_equal "Support <help@example.com>", ApplicationMailer.default_from_address
+    end
+  end
+
+  test "falls back to a default address when none is configured" do
+    with_env("MAILER_FROM_ADDRESS" => nil, "MAILER_FROM_NAME" => nil) do
+      assert_equal "Harmonic <noreply@harmonic.social>", ApplicationMailer.default_from_address
+    end
+  end
+
+  test "delivered mail carries the display name in its From header" do
+    with_env("MAILER_FROM_ADDRESS" => "noreply@example.com", "MAILER_FROM_NAME" => "Harmonic") do
+      tenant = create_tenant(subdomain: "mailer-app-#{SecureRandom.hex(4)}", name: "App Mailer")
+      host = create_user(email: "apphost-#{SecureRandom.hex(4)}@example.com", name: "App Host")
+      tenant.add_user!(host)
+      tenant.create_main_collective!(created_by: host)
+      identity = OmniAuthIdentity.create!(
+        user: host, email: host.email, name: host.name,
+        password: "validpassword123", password_confirmation: "validpassword123",
+      )
+      raw_token = identity.send_email_confirmation!
+
+      email = EmailConfirmationMailer.confirm(identity, raw_token, tenant)
+
+      assert_equal ["noreply@example.com"], email.from
+      assert_equal "Harmonic <noreply@example.com>", email[:from].to_s
+    end
+  end
+end


### PR DESCRIPTION
## Problem

All mailers sent from a bare address (`ENV['MAILER_FROM_ADDRESS'] || 'noreply@harmonic.social'`), so recipients' inboxes showed the sender as "noreply" with no product name (#329).

## Fix

- Add `ApplicationMailer.default_from_address`, which prefixes a display name onto the configured bare address → `Harmonic <noreply@harmonic.social>`. The name defaults to "Harmonic" and is overridable via a new `MAILER_FROM_NAME` env var.
- Wire it in as the mailer-wide `default from:` (a proc, so ENV is read at send time as before).
- Remove the now-redundant per-mailer `from:` overrides in `email_change_mailer`, `email_confirmation_mailer`, and `password_reset_mailer` so every mailer inherits the display-name default consistently.

### Backwards compatibility

If `MAILER_FROM_ADDRESS` already contains a display name (i.e. includes `<`), it's used verbatim — deployments that set a full `Name <addr>` value are unaffected. `.env.example` documents the bare-address form, which is what this wraps.

## Tests

Added `test/mailers/application_mailer_test.rb` covering all four branches (bare wrap, custom name, verbatim when already-named, default fallback) plus an integration assertion that a delivered `EmailConfirmationMailer` message carries the display name in its `From` header. No existing mailer test asserted `from`, so nothing else changes.

## Verification

Not run locally — suite runs in Docker/CI only here. Relying on CI.

Closes #329