### PR TITLE
Auto-hiding header that reveals on scroll-up (#338)

### DIFF
--- a/app/assets/stylesheets/pulse/_layout.css
+++ b/app/assets/stylesheets/pulse/_layout.css
@@ -67,6 +67,23 @@
   background: var(--color-canvas-default);
   min-height: 56px;
   box-sizing: border-box;
+  /* Auto-hiding header: pinned to the top, translated out of view on
+   * scroll-down and revealed on scroll-up by the auto-hide-header controller. */
+  position: sticky;
+  top: 0;
+  z-index: 200;
+  transition: transform 0.25s ease;
+  will-change: transform;
+}
+
+.pulse-top-header--hidden {
+  transform: translateY(-100%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pulse-top-header {
+    transition: none;
+  }
 }
 
 .pulse-top-header .pulse-logo {

--- a/app/assets/stylesheets/pulse/_responsive.css
+++ b/app/assets/stylesheets/pulse/_responsive.css
@@ -30,7 +30,10 @@
 
   .pulse-top-header {
     padding: 8px 12px;
-    position: relative;
+    /* Stay sticky (not static) so the header still auto-hides on mobile and
+     * remains the containing block for the expanded search overlay below. */
+    position: sticky;
+    top: 0;
   }
 
   .header-search-wrapper {

--- a/app/javascript/controllers/auto_hide_header_controller.test.ts
+++ b/app/javascript/controllers/auto_hide_header_controller.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import AutoHideHeaderController from "./auto_hide_header_controller"
+
+const HIDDEN_CLASS = "pulse-top-header--hidden"
+
+describe("AutoHideHeaderController", () => {
+  let application: Application
+  let header: HTMLElement
+
+  // The controller coalesces scroll handling through requestAnimationFrame;
+  // run the callback synchronously so scroll events resolve within the test.
+  beforeEach(() => {
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback): number => {
+      cb(0)
+      return 0
+    })
+    application = Application.start()
+    application.register("auto-hide-header", AutoHideHeaderController)
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+    setScroll(0)
+    vi.unstubAllGlobals()
+  })
+
+  function setScroll(y: number): void {
+    Object.defineProperty(window, "scrollY", { value: y, configurable: true })
+  }
+
+  async function mount(): Promise<void> {
+    document.body.innerHTML = `
+      <header class="pulse-top-header"
+              data-controller="auto-hide-header"
+              data-auto-hide-header-hidden-class="${HIDDEN_CLASS}">Header</header>
+      <div style="height: 5000px">tall content</div>
+    `
+    header = document.querySelector(".pulse-top-header") as HTMLElement
+    // Give the header a measurable height so the "near top" band is exercised.
+    Object.defineProperty(header, "offsetHeight", { value: 56, configurable: true })
+    await new Promise((r) => setTimeout(r, 0))
+  }
+
+  function scrollTo(y: number): void {
+    setScroll(y)
+    window.dispatchEvent(new Event("scroll"))
+  }
+
+  it("hides the header when scrolling down past the threshold", async () => {
+    await mount()
+    scrollTo(400)
+    expect(header.classList.contains(HIDDEN_CLASS)).toBe(true)
+  })
+
+  it("reveals the header when scrolling back up past the threshold", async () => {
+    await mount()
+    scrollTo(400)
+    expect(header.classList.contains(HIDDEN_CLASS)).toBe(true)
+    scrollTo(300)
+    expect(header.classList.contains(HIDDEN_CLASS)).toBe(false)
+  })
+
+  it("always reveals the header near the top of the page", async () => {
+    await mount()
+    scrollTo(400)
+    expect(header.classList.contains(HIDDEN_CLASS)).toBe(true)
+    // Within the header's own height of the top: force-reveal regardless of direction.
+    scrollTo(20)
+    expect(header.classList.contains(HIDDEN_CLASS)).toBe(false)
+  })
+
+  it("ignores scroll deltas smaller than the threshold", async () => {
+    await mount()
+    scrollTo(400)
+    expect(header.classList.contains(HIDDEN_CLASS)).toBe(true)
+    // A tiny upward nudge should not flip the state.
+    scrollTo(397)
+    expect(header.classList.contains(HIDDEN_CLASS)).toBe(true)
+  })
+
+  it("starts revealed even if a cached snapshot restored the hidden class", async () => {
+    document.body.innerHTML = `
+      <header class="pulse-top-header ${HIDDEN_CLASS}"
+              data-controller="auto-hide-header"
+              data-auto-hide-header-hidden-class="${HIDDEN_CLASS}">Header</header>
+    `
+    await new Promise((r) => setTimeout(r, 0))
+    const restored = document.querySelector(".pulse-top-header") as HTMLElement
+    expect(restored.classList.contains(HIDDEN_CLASS)).toBe(false)
+  })
+
+  it("reveals the header when a descendant receives focus", async () => {
+    document.body.innerHTML = `
+      <header class="pulse-top-header ${HIDDEN_CLASS}"
+              data-controller="auto-hide-header"
+              data-auto-hide-header-hidden-class="${HIDDEN_CLASS}">
+        <input id="search" />
+      </header>
+    `
+    header = document.querySelector(".pulse-top-header") as HTMLElement
+    await new Promise((r) => setTimeout(r, 0))
+    // Simulate the header hidden after a scroll, then focus lands inside it.
+    header.classList.add(HIDDEN_CLASS)
+    header.dispatchEvent(new FocusEvent("focusin", { bubbles: true }))
+    expect(header.classList.contains(HIDDEN_CLASS)).toBe(false)
+  })
+})

--- a/app/javascript/controllers/auto_hide_header_controller.ts
+++ b/app/javascript/controllers/auto_hide_header_controller.ts
@@ -1,0 +1,87 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Auto-hiding top header.
+//
+// Hides the app header (translated off-screen via a CSS class) when the user
+// scrolls down, and reveals it again when they scroll up or return to the top
+// of the page. Attaches to <header class="pulse-top-header"> in the layout.
+//
+//   <header class="pulse-top-header"
+//           data-controller="auto-hide-header"
+//           data-auto-hide-header-hidden-class="pulse-top-header--hidden">
+//
+// The reveal-on-scroll-up behaviour keeps the header one flick away without it
+// eating vertical space while reading, which matters most on small screens.
+export default class AutoHideHeaderController extends Controller<HTMLElement> {
+  static classes = ["hidden"]
+  static values = {
+    // Minimum scroll distance (px) before we react, to avoid jitter.
+    threshold: { type: Number, default: 8 },
+  }
+
+  declare readonly hiddenClass: string
+  declare readonly hasHiddenClass: boolean
+  declare readonly thresholdValue: number
+
+  private lastScrollY = 0
+  private ticking = false
+  private readonly onScroll = (): void => this.requestUpdate()
+  private readonly onFocusIn = (): void => this.reveal()
+
+  connect(): void {
+    this.lastScrollY = this.currentScrollY()
+    // A restored Turbo snapshot may bring back a stale hidden class; always
+    // start visible so navigation never lands on an invisible header.
+    this.reveal()
+    window.addEventListener("scroll", this.onScroll, { passive: true })
+    this.element.addEventListener("focusin", this.onFocusIn)
+  }
+
+  disconnect(): void {
+    window.removeEventListener("scroll", this.onScroll)
+    this.element.removeEventListener("focusin", this.onFocusIn)
+  }
+
+  private requestUpdate(): void {
+    if (this.ticking) return
+    this.ticking = true
+    window.requestAnimationFrame(() => {
+      this.update()
+      this.ticking = false
+    })
+  }
+
+  update(): void {
+    const current = this.currentScrollY()
+    const delta = current - this.lastScrollY
+    const headerHeight = this.element.offsetHeight
+
+    if (current <= headerHeight) {
+      // Near the top of the page: keep the header pinned.
+      this.reveal()
+    } else if (delta > this.thresholdValue) {
+      this.hide()
+    } else if (delta < -this.thresholdValue) {
+      this.reveal()
+    }
+
+    this.lastScrollY = current
+  }
+
+  private hide(): void {
+    this.element.classList.add(this.hiddenClassName)
+  }
+
+  private reveal(): void {
+    this.element.classList.remove(this.hiddenClassName)
+  }
+
+  private get hiddenClassName(): string {
+    return this.hasHiddenClass ? this.hiddenClass : "pulse-top-header--hidden"
+  }
+
+  private currentScrollY(): number {
+    // Clamp negative offsets from iOS rubber-band overscroll.
+    return Math.max(0, window.scrollY)
+  }
+}

--- a/app/javascript/controllers/index.ts
+++ b/app/javascript/controllers/index.ts
@@ -12,6 +12,7 @@ window.Stimulus = application
 
 // Import all controllers
 import AjaxToggleController from "./ajax_toggle_controller"
+import AutoHideHeaderController from "./auto_hide_header_controller"
 import ListFormController from "./list_form_controller"
 import CardExpandController from "./card_expand_controller"
 import CardNavigateController from "./card_navigate_controller"
@@ -84,6 +85,7 @@ import WebhookTestController from "./webhook_test_controller"
 
 // Register all controllers
 application.register("ajax-toggle", AjaxToggleController)
+application.register("auto-hide-header", AutoHideHeaderController)
 application.register("card-expand", CardExpandController)
 application.register("card-navigate", CardNavigateController)
 application.register("clipboard", ClipboardController)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,9 @@
       <%= octicon 'heart' %>
     </div>
     <% unless @hide_header %>
-      <header class="pulse-top-header">
+      <header class="pulse-top-header"
+              data-controller="auto-hide-header"
+              data-auto-hide-header-hidden-class="pulse-top-header--hidden">
         <a href="/" class="pulse-logo">
           <i class="tri-logo-icon icon-sm"></i>
           <span>Harmonic</span>


### PR DESCRIPTION
Closes #338.

## What

The top app header now auto-hides on scroll-down and reveals on scroll-up (or when you return near the top of the page) — reclaiming vertical space while reading, especially on mobile.

## How

- **CSS** (`pulse/_layout.css`): `.pulse-top-header` is now `position: sticky; top: 0` with a `transform` transition. A new `.pulse-top-header--hidden` class translates it out of view (`translateY(-100%)`). `prefers-reduced-motion` drops the transition.
- **CSS** (`pulse/_responsive.css`): the mobile override keeps the header `sticky` (was `relative`) so it still auto-hides on mobile while remaining the containing block for the expanded search overlay.
- **JS**: new `auto-hide-header` Stimulus controller toggles the hidden class based on scroll direction, coalesced through `requestAnimationFrame`. It:
  - always reveals within the header's own height of the top,
  - ignores sub-threshold jitter (default 8px),
  - reveals when a descendant receives focus (keyboard a11y),
  - resets to visible on `connect` (guards against a stale Turbo-cached hidden state),
  - clamps negative iOS rubber-band overscroll offsets.
- Wired into the layout header and registered in `controllers/index.ts`.

The existing top-right dropdown menu positions itself relative to its `offsetParent`, which becomes the now-positioned header — so it continues to anchor correctly.

## Tests

Added `auto_hide_header_controller.test.ts` (vitest) covering hide-on-down, reveal-on-up, always-reveal-near-top, sub-threshold no-op, stale-snapshot reset, and focus reveal.

## Verification

Not verified locally — Docker isn't available on this VM and the disk was full so `npm install` couldn't run. Relying on CI for the frontend test suite + typecheck. Reviewed statically against existing controller conventions (Stimulus `classes`/`values` API, `Controller<HTMLElement>` generic) and the style-guide check (`pulse-` prefixed class, no hardcoded colors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)