### PR TITLE
Fix #335: primary button color for unconfirmed comment read-confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Unconfirmed comment read-confirm control uses the primary button color** (fixes #335) — the clickable read-confirm count on a comment you haven't confirmed now shows as a filled primary button, matching the Confirm Read button on feed item notes, instead of a muted icon.
+
 ## [1.37.0] - 2026-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-- **Unconfirmed comment read-confirm control uses the primary button color** (fixes #335) — the clickable read-confirm count on a comment you haven't confirmed now shows as a filled primary button, matching the Confirm Read button on feed item notes, instead of a muted icon.
-
 ## [1.37.0] - 2026-07-02
 
 ### Added

--- a/app/assets/stylesheets/pulse/_components.css
+++ b/app/assets/stylesheets/pulse/_components.css
@@ -859,7 +859,10 @@
   font-size: 12px;
   color: var(--color-fg-muted);
   background: transparent;
-  border: none;
+  /* Transparent border keeps every state the same box size, so the primary
+     (unconfirmed) variant below can add a visible border without shifting
+     layout relative to the confirmed/display states. */
+  border: 1px solid transparent;
   cursor: pointer;
   border-radius: 4px;
 }
@@ -868,9 +871,19 @@
   cursor: default;
 }
 
+/* Unconfirmed: the clickable read-confirm control takes the primary (filled)
+   button color to invite the confirmation, matching the Confirm Read button
+   on feed item notes (#335). */
+.pulse-comment-confirm-btn:not(.is-confirmed) {
+  color: var(--color-canvas-default);
+  background: var(--color-fg-default);
+  border-color: var(--color-fg-default);
+}
+
 .pulse-comment-confirm-btn:hover:not(.is-confirmed) {
   color: var(--color-fg-default);
-  background: var(--color-canvas-subtle);
+  background: var(--color-canvas-default);
+  border-color: var(--color-border-default);
 }
 
 .pulse-comment-confirm-btn.is-confirmed {


### PR DESCRIPTION
Fixes #335.

## Problem
On a comment the current user has **not** confirmed reading, the clickable read-confirm count (`.pulse-comment-confirm-btn`) was styled with the muted foreground color and a transparent background — visually indistinguishable from static metadata, so it didn't read as an actionable control. The issue asks for it to appear in the primary button color, like the Confirm Read button on feed item notes.

## Fix
CSS only, in `pulse/_components.css`:
- The unconfirmed clickable button (`.pulse-comment-confirm-btn:not(.is-confirmed)`) now gets the filled primary treatment: `--color-fg-default` background, `--color-canvas-default` text — the same fill as `.pulse-action-btn` (the feed-item Confirm Read button). Hover inverts, mirroring `.pulse-action-btn:hover`.
- The shared base rule's `border: none` became `border: 1px solid transparent` so the primary variant can carry a visible border without changing box size relative to the confirmed / logged-out states (no cross-state layout shift within a thread).

Unchanged: the confirmed state (`.is-confirmed`, green) and the logged-out display span stay as they were.

## Verification
CSS-only change; no unit coverage for stylesheet rules. **No Docker on this VM**, so I could not render it locally — leaning on CI. Visual check recommended in light and dark mode (both use `--color-*` tokens, so both track automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
