### PR TITLE
Fix #344: settings page primary buttons render styled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-- **Settings page primary buttons render styled** (fixes #344) — "Save Changes", "Change Email", the workspace-Trio "Save", and "Save notification preferences" used `pulse-action-btn-primary` on its own. That class is only a modifier (no standalone rule), so those buttons fell back to unstyled browser defaults. Paired them with the base `pulse-action-btn`.
-
 ## [1.37.0] - 2026-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Settings page primary buttons render styled** (fixes #344) — "Save Changes", "Change Email", the workspace-Trio "Save", and "Save notification preferences" used `pulse-action-btn-primary` on its own. That class is only a modifier (no standalone rule), so those buttons fell back to unstyled browser defaults. Paired them with the base `pulse-action-btn`.
+
 ## [1.37.0] - 2026-07-02
 
 ### Added

--- a/app/views/shared/_notification_preferences.html.erb
+++ b/app/views/shared/_notification_preferences.html.erb
@@ -8,6 +8,6 @@
 <%= form_with url: post_url, method: :post, class: "pulse-form" do %>
   <%= render 'shared/notification_preferences_fields', tenant_user: tenant_user, simple: false %>
   <div class="pulse-form-actions">
-    <%= submit_tag "Save notification preferences", class: "pulse-action-btn-primary" %>
+    <%= submit_tag "Save notification preferences", class: "pulse-action-btn pulse-action-btn-primary" %>
   </div>
 <% end %>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -69,7 +69,7 @@
       </div>
 
       <div class="pulse-form-actions">
-        <%= form.submit 'Save Changes', class: 'pulse-action-btn-primary' %>
+        <%= form.submit 'Save Changes', class: 'pulse-action-btn pulse-action-btn-primary' %>
       </div>
     <% end %>
   <% end %>
@@ -122,7 +122,7 @@
             </label>
           </div>
           <div class="pulse-form-actions">
-            <%= form.submit 'Save', class: 'pulse-action-btn-primary', disabled: workspace_tier_locked %>
+            <%= form.submit 'Save', class: 'pulse-action-btn pulse-action-btn-primary', disabled: workspace_tier_locked %>
           </div>
         <% end %>
       <% end %>
@@ -156,7 +156,7 @@
           <%= form.email_field :email, placeholder: 'Enter new email address', class: 'pulse-input' %>
         </div>
         <div class="pulse-form-actions">
-          <%= form.submit 'Change Email', class: 'pulse-action-btn-primary' %>
+          <%= form.submit 'Change Email', class: 'pulse-action-btn pulse-action-btn-primary' %>
         </div>
       <% end %>
     <% end %>


### PR DESCRIPTION
Fixes #344.

## Root cause
`pulse-action-btn-primary` is a **modifier** — there is no standalone `.pulse-action-btn-primary` rule in the stylesheets (grep confirms zero matches). It's meant to pair with the base `.pulse-action-btn`, which is how ~53 other usages apply it. Four buttons applied it **alone**, so they matched no button rule and fell back to unstyled native browser buttons:

| Button | Location |
|---|---|
| Save Changes (profile) | `users/settings.html.erb` |
| Save (workspace Trio) | `users/settings.html.erb` |
| Change Email | `users/settings.html.erb` |
| Save notification preferences | `shared/_notification_preferences.html.erb` (rendered on the settings page; also reusable elsewhere) |

That matches the report: "many of the buttons on the user settings page do not use the correct button styles… there might be other pages also."

## Fix
Add the base `pulse-action-btn` class to all four. View-only; no behavior change.

Note: `.pulse-action-btn-primary` still has no distinct visual treatment of its own (base `.pulse-action-btn` is already the filled/dark style), so "primary" currently reads identically to a default action button across the whole app. Whether primary buttons should get a distinct accent is a design call I left for you rather than fold into this bug fix — happy to open a follow-up if you want it.

## Verification
View-only. **No Docker on this VM**, so no local render — leaning on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
