### PR TITLE
Local Docker testing: add fast dev loop + fix docker-compose.test.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,92 @@
+# docker-compose.dev.yml — fast local "edit code, re-run a targeted test" loop.
+#
+# This is the day-to-day iteration stack. Unlike docker-compose.test.yml (which
+# bakes the code into the image to mirror CI exactly), this bind-mounts the
+# working tree over /app, so you change a .rb file and re-run a targeted test
+# with NO rebuild. CI still runs the full suite from the Dockerfile; this exists
+# only to iterate quickly on subsets locally. Do not run the whole suite here —
+# run targeted files/dirs and let CI cover the rest.
+#
+# How the mount stays correct:
+#   - Source is live-mounted (.:/app), so edits are visible immediately.
+#   - Gems live at /gems (BUNDLE_PATH), OUTSIDE /app, so the mount can't hide them.
+#   - node_modules and app/assets/builds DO live under /app, and the host tree
+#     doesn't have them, so a plain mount would blank them out. Named volumes mask
+#     those two paths, preserving the copies baked into the image.
+#   - Runs as uid 1002:1002 to match the host checkout owner, so the container can
+#     write log/, tmp/, and any generated files back to the working tree.
+#
+# One-time setup (db + redis stay up across runs):
+#   docker compose -f docker-compose.dev.yml up -d db redis
+#   docker compose -f docker-compose.dev.yml run --rm dev bin/rails db:prepare
+#
+# Iterate — edit code, then run a targeted subset (no rebuild, no db:prepare):
+#   docker compose -f docker-compose.dev.yml run --rm dev bin/rails test test/models/user_test.rb
+#   docker compose -f docker-compose.dev.yml run --rm dev bin/rails test test/models -n /handle/
+#   docker compose -f docker-compose.dev.yml run --rm dev bash        # a shell in the stack
+#
+# Rebuild ONLY when Gemfile.lock or package.json changes (new gems / npm deps):
+#   docker compose -f docker-compose.dev.yml build
+#   docker compose -f docker-compose.dev.yml down -v   # drops the dep + db volumes so they repopulate
+#
+# The named volumes populate from the image the first time they're used, then
+# persist. After a rebuild that changes deps, `down -v` clears them so the fresh
+# image contents get copied in.
+
+name: harmonic-dev
+
+services:
+  dev:
+    build: .
+    # Match the host checkout owner (uid 1002 = bridge) so bind-mounted writes
+    # (log/, tmp/, generated files) succeed. The image's own uid 1000 can't.
+    user: "1002:1002"
+    volumes:
+      - .:/app
+      # Mask the two under-/app paths the host tree lacks; keep the baked copies.
+      - node_modules:/app/node_modules
+      - asset_builds:/app/app/assets/builds
+    environment:
+      # uid 1002 has no passwd entry, so give bundler/rails a writable HOME.
+      HOME: /tmp
+      RAILS_ENV: test
+      DB_HOST: db
+      REDIS_URL: redis://redis:6379/0
+      AUTH_MODE: oauth
+      HOSTNAME: harmonic.localhost
+      PRIMARY_SUBDOMAIN: app
+      AUTH_SUBDOMAIN: auth
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    # Default to a shell when run with no command.
+    command: bash
+
+  db:
+    image: postgres:13
+    environment:
+      POSTGRES_USER: decisiveteam
+      POSTGRES_PASSWORD: decisiveteam
+      POSTGRES_DB: decisive_team_test
+    volumes:
+      - pg_data_dev:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U decisiveteam -d decisive_team_test"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:6.2-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  node_modules:
+  asset_builds:
+  pg_data_dev:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,19 +8,39 @@
 #
 # Usage:
 #   docker compose -f docker-compose.test.yml build
-#   docker compose -f docker-compose.test.yml run --rm test                                   # full suite
-#   docker compose -f docker-compose.test.yml run --rm test bundle exec rails test test/models  # a subset
-#   docker compose -f docker-compose.test.yml down -v                                         # tear down + drop the db volume
+#   docker compose -f docker-compose.test.yml run --rm test                                          # full suite
+#   docker compose -f docker-compose.test.yml run --rm test bash -c "bin/rails db:create && bin/rails db:schema:load && bundle exec rails test test/models"  # a subset
+#   docker compose -f docker-compose.test.yml down -v                                                # tear down + drop the db volume
 #
 # The image bakes the app code, gems, node_modules and built JS assets (see
-# Dockerfile), so there is no source bind-mount: rebuild after changing code.
+# Dockerfile), so app code is NOT bind-mounted: rebuild after changing app code.
+#
+# The one exception is `test/`: the production .dockerignore excludes test/ (and
+# spec/, docs/) so those never ship in prod images — which also means the built
+# image has no test files to run. We bind-mount ./test:/app/test at runtime to
+# supply them. It overlays only the missing directory, so nothing baked (gems,
+# node_modules, built assets) is hidden. Edit a test and re-run — no rebuild.
+#
+# NOTE on subsets: a subset must still create + load the DB first, so pass the
+# whole `bin/rails db:create && db:schema:load && rails test <path>` chain (see
+# the subset example above). Overriding the command with a bare
+# `rails test test/models` skips DB setup and will fail.
 
 services:
   test:
     build: .
+    # Overlay the host test suite: the prod image excludes test/ via .dockerignore
+    # (see header note). This adds the missing dir without hiding baked app/gems.
+    volumes:
+      - ./test:/app/test
+    # db:prepare (not create + schema:load) so re-runs against the persistent
+    # pg_data_test volume are idempotent. The schema loads from db/structure.sql
+    # (SQL format), which is NOT re-runnable: a bare `db:schema:load` on an
+    # already-loaded DB aborts with "function ... already exists". db:prepare
+    # creates the DB + loads the schema on first run, then no-ops on later runs.
+    # CI gets a fresh DB each time so it never hit this; a local volume does.
     command: >
-      bash -c "bin/rails db:create &&
-               bin/rails db:schema:load &&
+      bash -c "bin/rails db:prepare &&
                bundle exec rails test"
     depends_on:
       db:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,19 +1,53 @@
 # Running tests locally
 
-## Rails test suite (Docker)
+## Rails tests (Docker)
 
-The Rails test suite runs in Docker via a trimmed, CI-faithful compose file
-([`docker-compose.test.yml`](../docker-compose.test.yml)) — just a test runner
-plus Postgres and Redis, matching the versions and environment used in CI.
+Run **targeted subsets** locally, not the whole suite — the full suite is slow
+everywhere and CI owns it. There are two compose files, for two different jobs:
+
+- [`docker-compose.dev.yml`](../docker-compose.dev.yml) — the **fast iterate
+  loop**. It bind-mounts your working tree, so you edit a `.rb` file and re-run a
+  targeted test with **no rebuild**. This is the day-to-day one.
+- [`docker-compose.test.yml`](../docker-compose.test.yml) — **reproduces CI
+  exactly** (bakes the code into the image the way the Dockerfile and CI do).
+  Reach for it only to confirm "does this behave the same as CI"; it needs a
+  rebuild after every code change.
+
+### Fast loop — `docker-compose.dev.yml`
+
+One-time setup (Postgres + Redis stay up across runs):
+
+```bash
+docker compose -f docker-compose.dev.yml up -d db redis
+docker compose -f docker-compose.dev.yml run --rm dev bin/rails db:test:prepare
+```
+
+Then iterate — edit code and re-run a targeted subset, no rebuild, no re-prepare:
+
+```bash
+docker compose -f docker-compose.dev.yml run --rm dev bin/rails test test/models/user_test.rb
+docker compose -f docker-compose.dev.yml run --rm dev bin/rails test test/models -n /handle/
+docker compose -f docker-compose.dev.yml run --rm dev bash        # a shell in the stack
+```
+
+The working tree is live-mounted, so any `app/` or `test/` edit is picked up
+immediately. Rebuild only when `Gemfile.lock` or `package.json` changes:
+
+```bash
+docker compose -f docker-compose.dev.yml build
+docker compose -f docker-compose.dev.yml down -v   # refresh the dep + db volumes
+```
+
+### CI-faithful — `docker-compose.test.yml`
 
 ```bash
 docker compose -f docker-compose.test.yml build
-docker compose -f docker-compose.test.yml run --rm test                                   # full suite
-docker compose -f docker-compose.test.yml run --rm test bundle exec rails test test/models  # a subset
-docker compose -f docker-compose.test.yml down -v                                         # tear down
+docker compose -f docker-compose.test.yml run --rm test bash -c "bin/rails db:prepare && bundle exec rails test test/models"
+docker compose -f docker-compose.test.yml down -v   # tear down + drop the db volume
 ```
 
-The image bakes the app code, gems and assets, so rebuild after changing code.
+The image bakes the app code, gems and assets, so rebuild after changing code —
+that's the price of matching CI's fresh-checkout build exactly.
 
 ## TypeScript / JavaScript tests (no Docker)
 


### PR DESCRIPTION
## Goal

Make local test runs fast to iterate on. The point of running tests locally is a
quick edit→run loop on **targeted subsets** — CI owns the full suite. This PR adds
that fast loop and fixes the CI-faithful compose so it actually works.

## `docker-compose.dev.yml` — the fast iterate loop (new)

Bind-mounts the working tree over `/app`, so you edit an `app/` or `test/` `.rb`
file and re-run a targeted test with **no rebuild** (a single model file runs in
~2s on the constrained box).

- Full source is live-mounted. Gems live at `/gems` (outside `/app`), so the mount
  can't hide them; `node_modules` and `app/assets/builds` are masked with named
  volumes so the copies baked into the image survive the mount.
- Runs as `uid 1002:1002` to match the host checkout owner, so bind-mounted writes
  (`log/`, `tmp/`, generated files) succeed.
- `db`/`redis` persist across runs; one-time `db:test:prepare` (not `db:prepare`,
  which runs seeds that fail in the test env).

```bash
docker compose -f docker-compose.dev.yml up -d db redis
docker compose -f docker-compose.dev.yml run --rm dev bin/rails db:test:prepare
docker compose -f docker-compose.dev.yml run --rm dev bin/rails test test/models/user_test.rb  # no rebuild
```

## `docker-compose.test.yml` — fixes so CI-faithful runs work

The test-runner compose from #311 could not actually run tests as written (found
empirically on the upgraded box):

1. **The image ships with no tests.** The prod `.dockerignore` excludes `test/`,
   so the image built from that Dockerfile has zero test files — `rails test`
   died with `LoadError: cannot load such file -- /app/test/models`. Fixed by
   bind-mounting `./test:/app/test` at runtime.
2. **Re-runs failed on schema load.** Schema loads from non-idempotent
   `db/structure.sql`; a second run against the persistent volume aborted with
   `function "prevent_audit_entry_mutation" already exists`. Fixed by switching
   `db:create && db:schema:load` → `db:prepare`.

## Docs

`docs/TESTING.md` now leads with the fast dev loop as the day-to-day path, keeps
`docker-compose.test.yml` as the "reproduce CI exactly" tool, and drops the
local full-suite example — targeted subsets locally, CI owns the full suite.

## Verification (2 GB / 1 vCPU box)

- Fast loop: `db:test:prepare` + a targeted model file pass; host edits to both
  `app/` and `test/` picked up with **no rebuild**.
- `test/models` subset via the fixed test compose: ✅ 1589 runs, 3437 assertions,
  0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)