### PR TITLE
Feeds are queries

### DIFF
--- a/app/assets/stylesheets/pulse.css
+++ b/app/assets/stylesheets/pulse.css
@@ -10,6 +10,7 @@
  *= require pulse/_markdown_editor
  *= require pulse/_sidebar
  *= require pulse/_feed
+ *= require pulse/_feed_bar
  *= require pulse/_heartbeat
  *= require pulse/_responsive
  *= require hljs-github

--- a/app/assets/stylesheets/pulse/_feed_bar.css
+++ b/app/assets/stylesheets/pulse/_feed_bar.css
@@ -1,0 +1,70 @@
+/* Pulse Feed Search Bar
+ *
+ * Every feed page is search results with a fixed page scope
+ * (docs/NAVIGATION_DESIGN.md "The feed search bar"). The fixed scope
+ * renders as locked chips OUTSIDE the editable input; refinements are
+ * typed in /search syntax. Parse warnings render below the form.
+ */
+
+.pulse-feed-bar-form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* Locked page-scope chip: not editable, not dismissable. */
+.pulse-feed-bar-scope {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  background: var(--color-canvas-subtle);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--border-radius-lg);
+  color: var(--color-fg-muted);
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.pulse-feed-bar-scope .octicon {
+  fill: currentColor;
+  flex-shrink: 0;
+}
+
+.pulse-feed-bar-scope code {
+  background: none;
+  padding: 0;
+  color: inherit;
+}
+
+.pulse-feed-bar-input {
+  flex: 1;
+  min-width: 160px;
+  padding: 6px 10px;
+  font-family: monospace;
+  font-size: 13px;
+  color: var(--color-fg-default);
+  background: var(--color-canvas-default);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--border-radius-lg);
+}
+
+.pulse-feed-bar-input:focus {
+  outline: none;
+  border-color: var(--color-accent-emphasis);
+}
+
+.pulse-feed-bar-warning {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 8px 0 0;
+  color: var(--color-attention-fg);
+  font-size: 13px;
+}
+
+.pulse-feed-bar-warning .octicon {
+  fill: currentColor;
+  flex-shrink: 0;
+}

--- a/app/assets/stylesheets/pulse/_feed_bar.css
+++ b/app/assets/stylesheets/pulse/_feed_bar.css
@@ -1,58 +1,67 @@
 /* Pulse Feed Search Bar
  *
  * Every feed page is search results with a fixed page scope
- * (docs/NAVIGATION_DESIGN.md "The feed search bar"). The fixed scope
- * renders as locked chips OUTSIDE the editable input; refinements are
- * typed in /search syntax. Parse warnings render below the form.
+ * (docs/NAVIGATION_DESIGN.md "The feed search bar"). All filters — fixed
+ * and editable — appear inside the query field, since they are all part of
+ * the query. Fixed filters render as muted non-editable tokens; the rest
+ * is editable text. Parse warnings render below the form.
  */
 
 .pulse-feed-bar-form {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-wrap: wrap;
 }
 
-/* Locked page-scope chip: not editable, not dismissable. */
+/* The query field: one visual input holding fixed tokens + editable text.
+   A <label> so clicking anywhere in it focuses the text input. */
+.pulse-feed-bar-field {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 4px 8px;
+  background: var(--color-canvas-default);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--border-radius-lg);
+  cursor: text;
+  font-family: monospace;
+  font-size: 13px;
+}
+
+.pulse-feed-bar-field:focus-within {
+  border-color: var(--color-accent-emphasis);
+}
+
+/* Fixed page-scope token: part of the query, not part of the editable text. */
 .pulse-feed-bar-scope {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 5px 10px;
+  padding: 2px 6px;
   background: var(--color-canvas-subtle);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--border-radius-lg);
+  border-radius: var(--border-radius-default);
   color: var(--color-fg-muted);
-  font-size: 13px;
   white-space: nowrap;
-}
-
-.pulse-feed-bar-scope .octicon {
-  fill: currentColor;
-  flex-shrink: 0;
 }
 
 .pulse-feed-bar-scope code {
   background: none;
   padding: 0;
   color: inherit;
+  font-size: inherit;
 }
 
 .pulse-feed-bar-input {
   flex: 1;
-  min-width: 160px;
-  padding: 6px 10px;
+  min-width: 120px;
+  padding: 4px 2px;
+  border: none;
+  background: transparent;
+  outline: none;
   font-family: monospace;
   font-size: 13px;
   color: var(--color-fg-default);
-  background: var(--color-canvas-default);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--border-radius-lg);
-}
-
-.pulse-feed-bar-input:focus {
-  outline: none;
-  border-color: var(--color-accent-emphasis);
 }
 
 .pulse-feed-bar-warning {

--- a/app/assets/stylesheets/root_variables.css
+++ b/app/assets/stylesheets/root_variables.css
@@ -46,6 +46,7 @@
     --color-neutral-muted: rgba(110,118,129,0.4);
     --color-accent-fg: #58a6ff;
     --color-accent-emphasis: #1f6feb;
+    --color-attention-fg: #d29922;
     --color-attention-subtle: rgba(187,128,9,0.15);
     --color-danger-fg: #f85149;
     --color-danger-subtle: rgba(248, 81, 73, 0.15);
@@ -68,6 +69,7 @@
     --color-neutral-muted: rgba(175,184,193,0.2);
     --color-accent-fg: #0969da;
     --color-accent-emphasis: #0969da;
+    --color-attention-fg: #9a6700;
     --color-attention-subtle: #fff8c5;
     --color-danger-fg: #cf222e;
     --color-danger-subtle: rgba(207, 34, 46, 0.15);

--- a/app/components/feed_search_bar_component.html.erb
+++ b/app/components/feed_search_bar_component.html.erb
@@ -1,15 +1,15 @@
 <div class="pulse-feed-bar">
   <%= form_with url: @action, method: :get, local: true, class: "pulse-feed-bar-form" do |form| %>
-    <% @scope_filters.each do |filter| %>
-      <span class="pulse-feed-bar-scope" title="Fixed for this page">
-        <%= helpers.octicon "lock", height: 12 %><code><%= filter %></code>
-      </span>
-    <% end %>
-    <%= form.text_field :q,
-        value: @query,
-        class: "pulse-feed-bar-input",
-        placeholder: @placeholder,
-        autocomplete: "off" %>
+    <label class="pulse-feed-bar-field">
+      <% @scope_filters.each do |filter| %>
+        <span class="pulse-feed-bar-scope" title="Fixed for this page"><code><%= filter %></code></span>
+      <% end %>
+      <%= form.text_field :q,
+          value: @query,
+          class: "pulse-feed-bar-input",
+          placeholder: @placeholder,
+          autocomplete: "off" %>
+    </label>
     <%= form.submit "Search", class: "pulse-action-btn", name: nil %>
   <% end %>
   <% @warnings.each do |warning| %>

--- a/app/components/feed_search_bar_component.html.erb
+++ b/app/components/feed_search_bar_component.html.erb
@@ -10,7 +10,7 @@
           placeholder: @placeholder,
           autocomplete: "off" %>
     </label>
-    <%= form.submit "Search", class: "pulse-action-btn", name: nil %>
+    <%= form.submit @submit_label, class: "pulse-action-btn", name: nil %>
   <% end %>
   <% @warnings.each do |warning| %>
     <p class="pulse-feed-bar-warning"><%= helpers.octicon "alert", height: 12 %> <%= warning %></p>

--- a/app/components/feed_search_bar_component.html.erb
+++ b/app/components/feed_search_bar_component.html.erb
@@ -1,0 +1,18 @@
+<div class="pulse-feed-bar">
+  <%= form_with url: @action, method: :get, local: true, class: "pulse-feed-bar-form" do |form| %>
+    <% @scope_filters.each do |filter| %>
+      <span class="pulse-feed-bar-scope" title="Fixed for this page">
+        <%= helpers.octicon "lock", height: 12 %><code><%= filter %></code>
+      </span>
+    <% end %>
+    <%= form.text_field :q,
+        value: @query,
+        class: "pulse-feed-bar-input",
+        placeholder: @placeholder,
+        autocomplete: "off" %>
+    <%= form.submit "Search", class: "pulse-action-btn", name: nil %>
+  <% end %>
+  <% @warnings.each do |warning| %>
+    <p class="pulse-feed-bar-warning"><%= helpers.octicon "alert", height: 12 %> <%= warning %></p>
+  <% end %>
+</div>

--- a/app/components/feed_search_bar_component.rb
+++ b/app/components/feed_search_bar_component.rb
@@ -1,0 +1,28 @@
+# typed: true
+
+# Search bar for feed pages (docs/NAVIGATION_DESIGN.md "The feed search
+# bar"). Fixed scope filters render as locked chips OUTSIDE the editable
+# input — the scope is a statement of where the page is, not text the user
+# owns. The input carries refinements in /search syntax; parse warnings
+# (e.g. a known operator with an invalid value) render below the form.
+class FeedSearchBarComponent < ViewComponent::Base
+  extend T::Sig
+
+  sig do
+    params(
+      action: String,
+      query: T.nilable(String),
+      scope_filters: T::Array[String],
+      warnings: T::Array[String],
+      placeholder: String
+    ).void
+  end
+  def initialize(action:, query: nil, scope_filters: [], warnings: [], placeholder: "Search")
+    super()
+    @action = action
+    @query = query
+    @scope_filters = scope_filters
+    @warnings = warnings
+    @placeholder = placeholder
+  end
+end

--- a/app/components/feed_search_bar_component.rb
+++ b/app/components/feed_search_bar_component.rb
@@ -14,15 +14,19 @@ class FeedSearchBarComponent < ViewComponent::Base
       query: T.nilable(String),
       scope_filters: T::Array[String],
       warnings: T::Array[String],
-      placeholder: String
+      placeholder: String,
+      submit_label: String
     ).void
   end
-  def initialize(action:, query: nil, scope_filters: [], warnings: [], placeholder: "Search")
+  # Feed pages say "Filter" — the term "search" is reserved for /search,
+  # which passes its own labels.
+  def initialize(action:, query: nil, scope_filters: [], warnings: [], placeholder: "Filter", submit_label: "Filter")
     super()
     @action = action
     @query = query
     @scope_filters = scope_filters
     @warnings = warnings
     @placeholder = placeholder
+    @submit_label = submit_label
   end
 end

--- a/app/controllers/concerns/feed_page.rb
+++ b/app/controllers/concerns/feed_page.rb
@@ -1,0 +1,62 @@
+# typed: false
+
+# Shared mechanics for feed pages (docs/NAVIGATION_DESIGN.md "Feeds are
+# queries"): every feed is a search with a fixed page scope and a default
+# query the viewer owns. `?q` absent applies the default; `?q` present —
+# even empty — is the viewer's own refinement.
+module FeedPage
+  extend ActiveSupport::Concern
+
+  FEED_LIMIT = 30
+
+  included do
+    helper_method :default_feed_view?
+  end
+
+  private
+
+  # Sets @feed_query (what the search runs), @feed_default_query (what ?q
+  # absence means), and @page_query (markdown frontmatter `query:`).
+  def resolve_feed_query(default)
+    @feed_default_query = default
+    @feed_query = params.key?(:q) ? params[:q].to_s : default
+    @page_query = @feed_query.strip.presence
+    @feed_query
+  end
+
+  def default_feed_view?
+    @feed_query.strip == @feed_default_query
+  end
+
+  def build_feed_search(fixed_params:, params_extra: {}, query: @feed_query)
+    SearchQuery.new(
+      tenant: @current_tenant,
+      current_user: @current_user,
+      raw_query: query,
+      params: { exclude_subtypes: ["comment"], per_page: FEED_LIMIT }.merge(params_extra),
+      fixed_params: fixed_params
+    )
+  end
+
+  # Fired reminders resurface on default feed views only (a refined query
+  # is an explicit search; surprise reminders would be noise there).
+  # Reminders are events, not indexed content, so they merge in here
+  # rather than through SearchQuery.
+  def interleave_reminder_events(feed_items, author_ids:)
+    reminders = NoteHistoryEvent
+      .main_collective_scope(@current_tenant)
+      .where(event_type: "reminder")
+      .joins(:note).where(notes: { created_by_id: author_ids })
+      .includes(note: :created_by)
+      .order(happened_at: :desc)
+      .limit(FEED_LIMIT)
+      .filter_map do |event|
+        note = event.note
+        next nil unless note
+
+        { type: "Reminder", item: note, created_at: event.happened_at, created_by: note.created_by }
+      end
+
+    (feed_items + reminders).sort_by { |item| -item[:created_at].to_i }.first(FEED_LIMIT)
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,37 +3,34 @@
 class HomeController < ApplicationController
   before_action :redirect_representing
 
+  FEED_LIMIT = 30
+
   def index
     @page_title = 'Home'
-    @page_scope = "visibility:public list:tuned_in"
+    @page_scope = "visibility:public"
     @sidebar_mode = 'none'
     @hide_breadcrumb = true
+    return if @current_user.nil?
 
-    # Main-collective content authored by the people the viewer tunes in
-    # to, plus the viewer themselves (so your own writing stays on your
-    # own home view — you can't tune in to yourself).
-    primary_list = @current_user.primary_user_list_in!(@current_tenant)
-    member_ids = primary_list.user_list_members.pluck(:user_id)
-    @tuned_in_count = member_ids.size
-    # Defense in depth: drop any blocked users from the author scope. The
-    # UserBlock after_create callback removes both directions of primary-
-    # list memberships at block-time, but pre-existing memberships from
-    # before that callback shipped could otherwise leak content here —
-    # especially in markdown, which has no render-time block filter.
-    author_ids = (member_ids - block_related_user_ids.to_a) << @current_user.id
+    # The home feed is a search: fixed scope visibility:public, default
+    # query list:tuned_in (the people you tune in to, plus yourself). ?q
+    # absent applies the default; ?q present — even empty — is the viewer's
+    # own refinement (empty means "cleared": the whole public space).
+    @feed_default_query = "list:tuned_in"
+    @feed_query = params.key?(:q) ? params[:q].to_s : @feed_default_query
+    @page_query = @feed_query.strip.presence
 
-    # Chronological only. Engagement-based proximity scoring against the
-    # full tenant doesn't fit the now-filtered author set; revisit when
-    # proximity is refactored to be primary-list-based.
-    @feed_items = FeedBuilder.new(
-      notes_scope: Note.main_collective_scope(@current_tenant).where(created_by_id: author_ids),
-      decisions_scope: Decision.main_collective_scope(@current_tenant).where(created_by_id: author_ids),
-      commitments_scope: Commitment.main_collective_scope(@current_tenant).where(created_by_id: author_ids),
-      reminder_events_scope: NoteHistoryEvent
-        .main_collective_scope(@current_tenant)
-        .where(event_type: "reminder")
-        .joins(:note).where(notes: { created_by_id: author_ids }),
-    ).feed_items
+    @search = SearchQuery.new(
+      tenant: @current_tenant,
+      current_user: @current_user,
+      raw_query: @feed_query,
+      params: { exclude_subtypes: ["comment"], per_page: FEED_LIMIT },
+      fixed_params: { visibility: "public" }
+    )
+    @feed_items = SearchFeedItems.build(@search.paginated_results)
+    @feed_items = interleave_reminder_events(@feed_items) if default_feed_view?
+
+    @tuned_in_count = @current_user.primary_user_list_in!(@current_tenant).user_list_members.count
   end
 
   def subdomains
@@ -79,4 +76,32 @@ class HomeController < ApplicationController
     end
   end
 
+  def default_feed_view?
+    @feed_query.strip == @feed_default_query
+  end
+  helper_method :default_feed_view?
+
+  # Fired reminders resurface on the default home view only (parity with
+  # the pre-search feed). A refined query is an explicit search; surprise
+  # reminders would be noise there.
+  def interleave_reminder_events(feed_items)
+    member_ids = @current_user.primary_user_list_in!(@current_tenant).user_list_members.pluck(:user_id)
+    author_ids = (member_ids - block_related_user_ids.to_a) << @current_user.id
+
+    reminders = NoteHistoryEvent
+      .main_collective_scope(@current_tenant)
+      .where(event_type: "reminder")
+      .joins(:note).where(notes: { created_by_id: author_ids })
+      .includes(note: :created_by)
+      .order(happened_at: :desc)
+      .limit(FEED_LIMIT)
+      .filter_map do |event|
+        note = event.note
+        next nil unless note
+
+        { type: "Reminder", item: note, created_at: event.happened_at, created_by: note.created_by }
+      end
+
+    (feed_items + reminders).sort_by { |item| -item[:created_at].to_i }.first(FEED_LIMIT)
+  end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,6 +5,7 @@ class HomeController < ApplicationController
 
   def index
     @page_title = 'Home'
+    @page_scope = "visibility:public list:tuned_in"
     @sidebar_mode = 'none'
     @hide_breadcrumb = true
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,9 @@
 # typed: false
 
 class HomeController < ApplicationController
-  before_action :redirect_representing
+  include FeedPage
 
-  FEED_LIMIT = 30
+  before_action :redirect_representing
 
   def index
     @page_title = 'Home'
@@ -13,22 +13,11 @@ class HomeController < ApplicationController
     return if @current_user.nil?
 
     # The home feed is a search: fixed scope visibility:public, default
-    # query list:tuned_in (the people you tune in to, plus yourself). ?q
-    # absent applies the default; ?q present — even empty — is the viewer's
-    # own refinement (empty means "cleared": the whole public space).
-    @feed_default_query = "list:tuned_in"
-    @feed_query = params.key?(:q) ? params[:q].to_s : @feed_default_query
-    @page_query = @feed_query.strip.presence
-
-    @search = SearchQuery.new(
-      tenant: @current_tenant,
-      current_user: @current_user,
-      raw_query: @feed_query,
-      params: { exclude_subtypes: ["comment"], per_page: FEED_LIMIT },
-      fixed_params: { visibility: "public" }
-    )
+    # query list:tuned_in (the people you tune in to, plus yourself).
+    resolve_feed_query("list:tuned_in")
+    @search = build_feed_search(fixed_params: { visibility: "public" })
     @feed_items = SearchFeedItems.build(@search.paginated_results)
-    @feed_items = interleave_reminder_events(@feed_items) if default_feed_view?
+    @feed_items = interleave_reminder_events(@feed_items, author_ids: home_reminder_author_ids) if default_feed_view?
 
     @tuned_in_count = @current_user.primary_user_list_in!(@current_tenant).user_list_members.count
   end
@@ -76,32 +65,10 @@ class HomeController < ApplicationController
     end
   end
 
-  def default_feed_view?
-    @feed_query.strip == @feed_default_query
-  end
-  helper_method :default_feed_view?
-
-  # Fired reminders resurface on the default home view only (parity with
-  # the pre-search feed). A refined query is an explicit search; surprise
-  # reminders would be noise there.
-  def interleave_reminder_events(feed_items)
+  # The default home view's reminder authors: the tuned-in list plus the
+  # viewer, minus block-related users.
+  def home_reminder_author_ids
     member_ids = @current_user.primary_user_list_in!(@current_tenant).user_list_members.pluck(:user_id)
-    author_ids = (member_ids - block_related_user_ids.to_a) << @current_user.id
-
-    reminders = NoteHistoryEvent
-      .main_collective_scope(@current_tenant)
-      .where(event_type: "reminder")
-      .joins(:note).where(notes: { created_by_id: author_ids })
-      .includes(note: :created_by)
-      .order(happened_at: :desc)
-      .limit(FEED_LIMIT)
-      .filter_map do |event|
-        note = event.note
-        next nil unless note
-
-        { type: "Reminder", item: note, created_at: event.happened_at, created_by: note.created_by }
-      end
-
-    (feed_items + reminders).sort_by { |item| -item[:created_at].to_i }.first(FEED_LIMIT)
+    (member_ids - block_related_user_ids.to_a) << @current_user.id
   end
 end

--- a/app/controllers/pulse_controller.rb
+++ b/app/controllers/pulse_controller.rb
@@ -8,12 +8,12 @@ class PulseController < ApplicationController
     nil
   end
 
-  # The collective's feed: a search fixed to this collective (private
-  # workspaces are additionally fixed to the private zone), with the
-  # current week as the default query. The cycle dashboard (#show) stays
-  # separate; this page is the query-shaped view of the same place.
+  # The collective's default page: a feed — a search fixed to this
+  # collective (private workspaces are additionally fixed to the private
+  # zone), with the current week as the default query. The cycle
+  # dashboard (#show) lives at /dashboard.
   def feed
-    @page_title = "#{@current_collective.name} Feed"
+    @page_title = @current_collective.name
     workspace = @current_collective.private_workspace?
     @page_scope = workspace ? "visibility:private" : "collective:#{@current_collective.handle}"
 
@@ -24,6 +24,11 @@ class PulseController < ApplicationController
     # search page's implicit today-window.
     @search = build_feed_search(fixed_params: fixed, params_extra: { cycle: "all" })
     @feed_items = SearchFeedItems.build(@search.paginated_results)
+
+    # Same sidebar as the dashboard, minus the activity type filters
+    # (their counts are dashboard state; without them the nav is hidden).
+    @cycle = current_cycle
+    load_collective_sidebar_data
   end
 
   def actions_index
@@ -38,7 +43,7 @@ class PulseController < ApplicationController
   end
 
   def show
-    @page_title = @current_collective.name
+    @page_title = "#{@current_collective.name} Dashboard"
     @page_scope = if @current_collective.private_workspace?
                     "visibility:private"
                   else
@@ -47,14 +52,14 @@ class PulseController < ApplicationController
 
     # Cycle data - use param if provided, otherwise default to tempo-based cycle
     @cycle = cycle_from_param || current_cycle
-    @default_cycle = current_cycle
-    @is_viewing_current_cycle = @cycle.is_current_cycle?
 
     # Require heartbeat to view past cycles
-    if @current_user && !@is_viewing_current_cycle && @current_heartbeat.nil?
-      redirect_to @current_collective.path, notice: "Send a heartbeat to view past cycles."
+    if @current_user && !@cycle.is_current_cycle? && @current_heartbeat.nil?
+      redirect_to "#{@current_collective.path}/dashboard", notice: "Send a heartbeat to view past cycles."
       return
     end
+
+    load_collective_sidebar_data
 
     # Content scoped to current cycle
     @unread_notes = @cycle.unread_notes(@current_user) if @current_user
@@ -63,15 +68,6 @@ class PulseController < ApplicationController
     @closed_decisions = @cycle.closed_decisions
     @open_commitments = @cycle.open_commitments
     @closed_commitments = @cycle.closed_commitments
-
-    # Collective data
-    @team = @current_collective.team
-    @heartbeats = Heartbeat.where_in_cycle(@cycle)
-    @pinned_items = @current_collective.pinned_items
-    @recent_cycle_summaries = Cycle.recent_summaries(
-      collective: @current_collective,
-      tenant: current_tenant
-    )
 
     # Build unified feed (sorted by created_at desc)
     build_unified_feed
@@ -83,6 +79,20 @@ class PulseController < ApplicationController
   end
 
   private
+
+  # Everything the collective sidebar renders (cycle box, heartbeats,
+  # pinned items, recent cycles). Expects @cycle to be set.
+  def load_collective_sidebar_data
+    @default_cycle = current_cycle
+    @is_viewing_current_cycle = @cycle.is_current_cycle?
+    @team = @current_collective.team
+    @heartbeats = Heartbeat.where_in_cycle(@cycle)
+    @pinned_items = @current_collective.pinned_items
+    @recent_cycle_summaries = Cycle.recent_summaries(
+      collective: @current_collective,
+      tenant: current_tenant
+    )
+  end
 
   def cycle_from_param
     return nil unless params[:cycle].present?

--- a/app/controllers/pulse_controller.rb
+++ b/app/controllers/pulse_controller.rb
@@ -25,8 +25,11 @@ class PulseController < ApplicationController
     @search = build_feed_search(fixed_params: fixed, params_extra: { cycle: "all" })
     @feed_items = SearchFeedItems.build(@search.paginated_results)
 
-    # Same sidebar as the dashboard, minus the activity type filters
-    # (their counts are dashboard state; without them the nav is hidden).
+    # Same sidebar as the dashboard, minus the dashboard-only sections:
+    # activity type filters (their counts are dashboard state), the cycle
+    # box, and recent cycles. @cycle is still needed for the heartbeat
+    # banner and heartbeats box.
+    @hide_cycle_sidebar = true
     @cycle = current_cycle
     load_collective_sidebar_data
   end
@@ -61,6 +64,14 @@ class PulseController < ApplicationController
 
     load_collective_sidebar_data
 
+    # Cycle navigation state — dashboard-only sidebar sections key off it.
+    @default_cycle = current_cycle
+    @is_viewing_current_cycle = @cycle.is_current_cycle?
+    @recent_cycle_summaries = Cycle.recent_summaries(
+      collective: @current_collective,
+      tenant: current_tenant
+    )
+
     # Content scoped to current cycle
     @unread_notes = @cycle.unread_notes(@current_user) if @current_user
     @read_notes = @cycle.read_notes(@current_user) if @current_user
@@ -80,18 +91,14 @@ class PulseController < ApplicationController
 
   private
 
-  # Everything the collective sidebar renders (cycle box, heartbeats,
-  # pinned items, recent cycles). Expects @cycle to be set.
+  # The collective sidebar sections shared by the feed and the dashboard
+  # (heartbeats, pinned items). Expects @cycle to be set. The dashboard
+  # additionally sets cycle-navigation state (@default_cycle etc.), which
+  # the cycle box and recent-cycles sections key off.
   def load_collective_sidebar_data
-    @default_cycle = current_cycle
-    @is_viewing_current_cycle = @cycle.is_current_cycle?
     @team = @current_collective.team
     @heartbeats = Heartbeat.where_in_cycle(@cycle)
     @pinned_items = @current_collective.pinned_items
-    @recent_cycle_summaries = Cycle.recent_summaries(
-      collective: @current_collective,
-      tenant: current_tenant
-    )
   end
 
   def cycle_from_param

--- a/app/controllers/pulse_controller.rb
+++ b/app/controllers/pulse_controller.rb
@@ -19,6 +19,11 @@ class PulseController < ApplicationController
 
   def show
     @page_title = @current_collective.name
+    @page_scope = if @current_collective.private_workspace?
+                    "visibility:private"
+                  else
+                    "collective:#{@current_collective.handle}"
+                  end
 
     # Cycle data - use param if provided, otherwise default to tempo-based cycle
     @cycle = cycle_from_param || current_cycle

--- a/app/controllers/pulse_controller.rb
+++ b/app/controllers/pulse_controller.rb
@@ -1,9 +1,29 @@
 # typed: false
 
 class PulseController < ApplicationController
+  include FeedPage
+
   # Override to prevent ApplicationController from trying to find a Pulse model
   def current_resource_model
     nil
+  end
+
+  # The collective's feed: a search fixed to this collective (private
+  # workspaces are additionally fixed to the private zone), with the
+  # current week as the default query. The cycle dashboard (#show) stays
+  # separate; this page is the query-shaped view of the same place.
+  def feed
+    @page_title = "#{@current_collective.name} Feed"
+    workspace = @current_collective.private_workspace?
+    @page_scope = workspace ? "visibility:private" : "collective:#{@current_collective.handle}"
+
+    resolve_feed_query("cycle:this-week")
+    fixed = { collective_handle: @current_collective.handle }
+    fixed[:visibility] = "private" if workspace
+    # cycle "all" as the base: a cleared query means all time, not the
+    # search page's implicit today-window.
+    @search = build_feed_search(fixed_params: fixed, params_extra: { cycle: "all" })
+    @feed_items = SearchFeedItems.build(@search.paginated_results)
   end
 
   def actions_index

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,6 +3,7 @@
 class SearchController < ApplicationController
   def show
     @page_title = "Search"
+    @page_query = params[:q].to_s.strip.presence
     @sidebar_mode = "minimal"
 
     @search = SearchQuery.new(

--- a/app/controllers/user_lists_controller.rb
+++ b/app/controllers/user_lists_controller.rb
@@ -1,6 +1,8 @@
 # typed: false
 
 class UserListsController < ApplicationController
+  include FeedPage
+
   before_action :set_list, only: [
     :show, :edit, :actions_index_show,
     :describe_update_user_list, :execute_update_user_list,
@@ -52,27 +54,21 @@ class UserListsController < ApplicationController
       tenant:     @current_tenant,
     )
 
-    # Feed of recent content authored by members of this list, scoped to the
-    # tenant's main collective (matching the home-feed shape). Members only
-    # — no self-inclusion: a custom list is "these people," not "these
-    # people + me." Defense in depth: drop any blocked authors, mirroring
-    # the home_controller filter so the markdown view (which has no
-    # render-time block filter) can't leak a stale tune-in across a block.
+    # Feed of recent content authored by members of this list (the page's
+    # fixed scope: visibility:public list:<id>). Members only — no
+    # self-inclusion: a custom list is "these people," not "these people +
+    # me." SearchQuery's list filter drops block-related authors, so a
+    # stale tune-in can't leak across a block (the markdown view has no
+    # render-time block filter).
+    search = build_feed_search(
+      query: "",
+      fixed_params: { visibility: "public", list_id_or_alias: @list.truncated_id }
+    )
     author_ids = member_user_ids - block_related_user_ids.to_a
-
-    @feed_items = if author_ids.empty?
-      []
-    else
-      FeedBuilder.new(
-        notes_scope: Note.main_collective_scope(@current_tenant).where(created_by_id: author_ids),
-        decisions_scope: Decision.main_collective_scope(@current_tenant).where(created_by_id: author_ids),
-        commitments_scope: Commitment.main_collective_scope(@current_tenant).where(created_by_id: author_ids),
-        reminder_events_scope: NoteHistoryEvent
-          .main_collective_scope(@current_tenant)
-          .where(event_type: "reminder")
-          .joins(:note).where(notes: { created_by_id: author_ids }),
-      ).feed_items
-    end
+    @feed_items = interleave_reminder_events(
+      SearchFeedItems.build(search.paginated_results),
+      author_ids: author_ids
+    )
 
     respond_to do |format|
       format.html

--- a/app/controllers/user_lists_controller.rb
+++ b/app/controllers/user_lists_controller.rb
@@ -25,6 +25,7 @@ class UserListsController < ApplicationController
 
   def show
     @page_title = @list.display_name
+    @page_scope = "visibility:public list:#{@list.truncated_id}"
     @sidebar_mode = "minimal"
     @active_tab = params[:tab] == "members" ? "members" : "feed"
     # Auto-prefill the global header search with `list:<id>` while we're here.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -37,6 +37,7 @@ class UsersController < ApplicationController
 
     @showing_user = tu.user
     @showing_user.tenant_user = tu
+    @page_scope = "visibility:public creator:@#{tu.handle}"
     @page_title = @showing_user.display_name
     @page_description = "#{@showing_user.display_name} on #{@current_tenant.subdomain}.#{ENV.fetch("HOSTNAME", nil)}"
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@
 class UsersController < ApplicationController
   include RequiresReverification
   include NotificationPreferencesParams
+  include FeedPage
 
   allows_anonymous :show
   before_action :set_no_cache_headers, only: [:show]
@@ -748,20 +749,28 @@ class UsersController < ApplicationController
     @showing_user_lists ||= visible_lists_owned_by_for_profile(@showing_user)
   end
 
+  # Profile tabs are named queries over the profile's fixed scope
+  # (visibility:public creator:@handle) — see docs/NAVIGATION_DESIGN.md.
+
   def load_profile_posts_data
-    @posts_feed_items = FeedBuilder.new(
-      notes_scope: Note.main_collective_scope(@current_tenant).where(created_by_id: @showing_user.id, subtype: "post"),
-      decisions_scope: Decision.none,
-      commitments_scope: Commitment.none
-    ).feed_items
+    search = profile_feed_search("type:note subtype:post")
+    @posts_feed_items = SearchFeedItems.build(search.paginated_results)
   end
 
   def load_profile_activity_data
-    @activity_feed_items = FeedBuilder.new(
-      notes_scope: Note.main_collective_scope(@current_tenant).where(created_by_id: @showing_user.id).where.not(subtype: "post"),
-      decisions_scope: Decision.main_collective_scope(@current_tenant).where(created_by_id: @showing_user.id),
-      commitments_scope: Commitment.main_collective_scope(@current_tenant).where(created_by_id: @showing_user.id)
-    ).feed_items
+    # Everything except top-level posts; comments stay out of feeds.
+    search = profile_feed_search("-subtype:post,comment")
+    @activity_feed_items = SearchFeedItems.build(search.paginated_results)
+  end
+
+  def profile_feed_search(query)
+    build_feed_search(
+      query: query,
+      fixed_params: {
+        visibility: "public",
+        creator_handles: [@showing_user.tenant_user.handle],
+      }
+    )
   end
 
   def resolve_active_profile_tab(requested)

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -4,11 +4,30 @@ module Searchable
   extend ActiveSupport::Concern
 
   included do
-    after_commit :enqueue_search_reindex, on: [:create, :update]
+    after_commit :index_for_search, on: :create
+    after_commit :enqueue_search_reindex, on: :update
     after_commit :delete_from_search_index, on: :destroy
   end
 
   private
+
+  # New content indexes synchronously so it is immediately visible on
+  # search-backed feeds (read-your-writes). The engagement counts the
+  # indexer computes are empty or near-empty at create, so the count
+  # queries are cheap and this costs about one upsert. Updates stay
+  # async: they fire from hot interactive paths (votes, comments, links
+  # all reindex their parent) where eventual count consistency is
+  # invisible.
+  def index_for_search
+    return if Current.importing_data
+    return if respond_to?(:deleted?) && deleted?
+
+    SearchIndexer.reindex(self)
+  rescue StandardError => e
+    # Never block content creation on the index; fall back to the async job.
+    Rails.logger.error("Synchronous search indexing failed for #{self.class.name} #{id}: #{e.message}")
+    enqueue_search_reindex
+  end
 
   def enqueue_search_reindex
     return if Current.importing_data

--- a/app/services/actions_helper.rb
+++ b/app/services/actions_helper.rb
@@ -1134,6 +1134,20 @@ class ActionsHelper
       ],
     },
     "/collectives/:collective_handle" => {
+      controller_actions: ["pulse#feed"],
+      actions: [],
+      conditional_actions: [
+        {
+          name: "send_heartbeat",
+          condition: lambda { |context|
+            collective = context[:collective]
+            current_heartbeat = context[:current_heartbeat]
+            collective && !collective.is_main_collective? && !collective.private_workspace? && current_heartbeat.nil?
+          },
+        },
+      ],
+    },
+    "/collectives/:collective_handle/dashboard" => {
       controller_actions: ["pulse#show"],
       actions: [],
       conditional_actions: [

--- a/app/services/search_feed_items.rb
+++ b/app/services/search_feed_items.rb
@@ -1,0 +1,33 @@
+# typed: true
+
+# Converts SearchQuery results (SearchIndex rows) into the feed-item hashes
+# the pulse feed partials render ({ type:, item:, created_at:, created_by: }),
+# batch-loading the underlying records with their feed associations.
+class SearchFeedItems
+  extend T::Sig
+
+  LOADERS = T.let({
+    "Note" => ->(ids) { Note.where(id: ids).includes(:created_by, media_items: { file_attachment: :blob }) },
+    "Decision" => ->(ids) { Decision.where(id: ids).includes(:created_by) },
+    "Commitment" => ->(ids) { Commitment.where(id: ids).includes(:created_by) },
+  }.freeze, T::Hash[String, T.untyped])
+
+  sig { params(results: T::Enumerable[SearchIndex]).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+  def self.build(results)
+    rows = results.to_a
+    records = {}
+    rows.group_by(&:item_type).each do |type, group|
+      loader = LOADERS[type]
+      next unless loader
+
+      loader.call(group.map(&:item_id)).each { |record| records[[type, record.id]] = record }
+    end
+
+    rows.filter_map do |row|
+      record = records[[row.item_type, row.item_id]]
+      next nil unless record
+
+      { type: row.item_type, item: record, created_at: record.created_at, created_by: record.created_by }
+    end
+  end
+end

--- a/app/services/search_query.rb
+++ b/app/services/search_query.rb
@@ -80,20 +80,37 @@ class SearchQuery
 
   private
 
+  # Fixed-param key → its negated-operator counterpart, where one exists.
+  FIXED_PARAM_EXCLUDE_COUNTERPARTS = T.let({ visibility: :exclude_visibility }.freeze, T::Hash[Symbol, Symbol])
+
   # A feed page's fixed scope is enforced structurally — the user's query
-  # can never widen it. Conflicting query terms are overridden and reported
-  # rather than silently producing confusing results.
+  # can never widen it. Conflicting query terms (including negations of
+  # the fixed value) are overridden and reported rather than silently
+  # producing confusing results.
   sig { params(fixed_params: T::Hash[Symbol, T.untyped]).void }
   def apply_fixed_params(fixed_params)
     fixed_params.each do |key, value|
+      op = FIXED_PARAM_OPERATORS.fetch(key, key.to_s)
       user_value = @params[key]
       if user_value.present? && user_value != value
-        op = FIXED_PARAM_OPERATORS.fetch(key, key.to_s)
         @warnings = warnings + [
           "#{op}:#{Array(user_value).join(",")} ignored: this page is fixed to #{op}:#{Array(value).join(",")}",
         ]
       end
       @params[key] = value
+
+      # Negating the fixed value would empty the feed, never widen it —
+      # drop the negation and say so.
+      exclude_key = FIXED_PARAM_EXCLUDE_COUNTERPARTS[key]
+      next unless exclude_key && Array(@params[exclude_key]).include?(value)
+
+      @warnings = warnings + ["-#{op}:#{value} ignored: this page is fixed to #{op}:#{value}"]
+      remaining = Array(@params[exclude_key]) - [value]
+      if remaining.empty?
+        @params.delete(exclude_key)
+      else
+        @params[exclude_key] = remaining
+      end
     end
   end
 

--- a/app/services/search_query.rb
+++ b/app/services/search_query.rb
@@ -18,6 +18,13 @@ class SearchQuery
   # 0.3 is a good balance - matches partial words but filters noise
   WORD_SIMILARITY_THRESHOLD = 0.3
 
+  # Fixed-param key → the search operator users type, for warning messages.
+  FIXED_PARAM_OPERATORS = T.let({
+    collective_handle: "collective",
+    creator_handles: "creator",
+    list_id_or_alias: "list",
+  }.freeze, T::Hash[Symbol, String])
+
   sig do
     params(
       tenant: Tenant,
@@ -81,7 +88,10 @@ class SearchQuery
     fixed_params.each do |key, value|
       user_value = @params[key]
       if user_value.present? && user_value != value
-        @warnings = warnings + ["#{key}:#{user_value} ignored: this page is fixed to #{key}:#{value}"]
+        op = FIXED_PARAM_OPERATORS.fetch(key, key.to_s)
+        @warnings = warnings + [
+          "#{op}:#{Array(user_value).join(",")} ignored: this page is fixed to #{op}:#{Array(value).join(",")}",
+        ]
       end
       @params[key] = value
     end
@@ -112,19 +122,8 @@ class SearchQuery
   # users have no concept of status/type/subtype/voter/etc. The presence
   # of any of these suppresses the People section entirely; the viewer's
   # query string is clearly looking for content.
-  PEOPLE_INCOMPATIBLE_PARAM_KEYS = %i[
-    type exclude_types subtypes exclude_subtypes status
-    creator_handles exclude_creator_handles
-    read_by_handles exclude_read_by_handles
-    voter_handles exclude_voter_handles
-    participant_handles exclude_participant_handles
-    mentions_handles exclude_mentions_handles
-    replying_to_handles exclude_replying_to_handles
-    critical_mass_achieved
-    min_links max_links min_backlinks max_backlinks min_comments max_comments
-    min_readers max_readers min_voters max_voters min_participants max_participants
-    after_date before_date
-    visibility exclude_visibility
+  PEOPLE_INCOMPATIBLE_PARAM_KEYS = [
+    :type, :exclude_types, :subtypes, :exclude_subtypes, :status, :creator_handles, :exclude_creator_handles, :read_by_handles, :exclude_read_by_handles, :voter_handles, :exclude_voter_handles, :participant_handles, :exclude_participant_handles, :mentions_handles, :exclude_mentions_handles, :replying_to_handles, :exclude_replying_to_handles, :critical_mass_achieved, :min_links, :max_links, :min_backlinks, :max_backlinks, :min_comments, :max_comments, :min_readers, :max_readers, :min_voters, :max_voters, :min_participants, :max_participants, :after_date, :before_date, :visibility, :exclude_visibility,
   ].freeze
 
   sig { returns(T::Array[User]) }
@@ -154,7 +153,7 @@ class SearchQuery
         UserBlock
           .where("blocker_id = :uid OR blocked_id = :uid", uid: @current_user.id)
           .pluck(:blocker_id, :blocked_id)
-          .flatten,
+          .flatten
       )
     end
 
@@ -164,7 +163,7 @@ class SearchQuery
       .where(tenant_users: { tenant_id: @tenant.id, archived_at: nil })
       .where(
         "tenant_users.handle = ? OR tenant_users.handle ILIKE ? OR LOWER(tenant_users.display_name) LIKE LOWER(?)",
-        q, like, like,
+        q, like, like
       )
       .where.not(user_id: excluded_ids.uniq)
       .where(users: { suspended_at: nil })
@@ -183,7 +182,7 @@ class SearchQuery
       return [] unless accessible_collective_ids.include?(@collective.id)
 
       scope = scope.where(
-        user_id: CollectiveMember.where(collective_id: @collective.id).select(:user_id),
+        user_id: CollectiveMember.where(collective_id: @collective.id).select(:user_id)
       )
     end
 
@@ -458,29 +457,29 @@ class SearchQuery
     return @list_filter_user_ids = nil if value.nil?
 
     ids = case value
-    when "mutuals"
-      @current_user ? @current_user.mutual_user_ids_in(@tenant) : []
-    when "tuned_in"
-      if @current_user
-        # The viewer is always part of their own tuned-in feed: you cannot
-        # tune in to yourself, so the alias adds you to the list members.
-        UserListMember
-          .joins(:user_list)
-          .where(user_lists: {
-            tenant_id: @tenant.id, owner_id: @current_user.id,
-            is_primary: true, deleted_at: nil,
-          })
-          .pluck(:user_id) + [@current_user.id]
-      else
-        []
-      end
-    else
-      list = UserList
-        .tenant_scoped_only(@tenant.id)
-        .where(deleted_at: nil)
-        .find_by(truncated_id: value)
-      list && list.visible_to?(@current_user) ? list.user_list_members.pluck(:user_id) : []
-    end
+          when "mutuals"
+            @current_user ? @current_user.mutual_user_ids_in(@tenant) : []
+          when "tuned_in"
+            if @current_user
+              # The viewer is always part of their own tuned-in feed: you cannot
+              # tune in to yourself, so the alias adds you to the list members.
+              UserListMember
+                .joins(:user_list)
+                .where(user_lists: {
+                         tenant_id: @tenant.id, owner_id: @current_user.id,
+                         is_primary: true, deleted_at: nil,
+                       })
+                .pluck(:user_id) + [@current_user.id]
+            else
+              []
+            end
+          else
+            list = UserList
+              .tenant_scoped_only(@tenant.id)
+              .where(deleted_at: nil)
+              .find_by(truncated_id: value)
+            list && list.visible_to?(@current_user) ? list.user_list_members.pluck(:user_id) : []
+          end
 
     # Defense in depth: block callbacks remove primary-list memberships at
     # block time, but stale memberships must not resurface blocked authors.
@@ -507,12 +506,12 @@ class SearchQuery
     return if handle.blank?
 
     # "main" is a reserved handle that resolves to the tenant's main collective
-    if handle == "main"
-      @collective = @tenant.main_collective
-    else
-      # Look up collective by handle within the tenant
-      @collective = @tenant.collectives.find_by(handle: handle)
-    end
+    @collective = if handle == "main"
+                    @tenant.main_collective
+                  else
+                    # Look up collective by handle within the tenant
+                    @tenant.collectives.find_by(handle: handle)
+                  end
   end
 
   sig { returns(ActiveRecord::Relation) }
@@ -574,15 +573,15 @@ class SearchQuery
 
       # Apply visibility filter
       ids = case visibility
-      when "public"
-        [main_id].compact
-      when "shared"
-        member_ids - [main_id].compact - workspace_ids
-      when "private"
-        workspace_ids
-      else
-        member_ids
-      end
+            when "public"
+              [main_id].compact
+            when "shared"
+              member_ids - [main_id].compact - workspace_ids
+            when "private"
+              workspace_ids
+            else
+              member_ids
+            end
 
       # Apply negated visibility filter
       case exclude_visibility
@@ -1098,7 +1097,11 @@ class SearchQuery
   def parse_cursor_field_value(field, value_str)
     case field
     when "created_at", "updated_at", "deadline"
-      Time.zone.parse(value_str) rescue Time.current
+      begin
+        Time.zone.parse(value_str)
+      rescue StandardError
+        Time.current
+      end
     when "backlink_count", "link_count", "participant_count", "voter_count", "reader_count"
       value_str.to_i
     when "relevance"

--- a/app/services/search_query.rb
+++ b/app/services/search_query.rb
@@ -47,6 +47,8 @@ class SearchQuery
     # If raw_query is provided, parse DSL and merge
     if @raw_query.present?
       parsed = SearchQueryParser.new(@raw_query).parse
+      # Warnings are commentary, not query params — extract before merging.
+      @warnings = parsed.delete(:warnings)
       # Parsed values override base params (DSL takes precedence)
       base_params.merge!(parsed.compact)
     end
@@ -55,6 +57,13 @@ class SearchQuery
   end
 
   public
+
+  # Parse warnings (e.g. a known operator with an invalid value). Rendered
+  # by the feed search bar; empty for queries with no DSL issues.
+  sig { returns(T::Array[String]) }
+  def warnings
+    @warnings || []
+  end
 
   # Main query methods
 

--- a/app/services/search_query.rb
+++ b/app/services/search_query.rb
@@ -24,15 +24,20 @@ class SearchQuery
       current_user: T.nilable(User),
       collective: T.nilable(Collective),
       params: T::Hash[T.any(String, Symbol), T.untyped],
-      raw_query: T.nilable(String)
+      raw_query: T.nilable(String),
+      fixed_params: T::Hash[Symbol, T.untyped]
     ).void
   end
-  def initialize(tenant:, current_user:, collective: nil, params: {}, raw_query: nil)
+  def initialize(tenant:, current_user:, collective: nil, params: {}, raw_query: nil, fixed_params: {}) # rubocop:disable Metrics/ParameterLists
     @tenant = tenant
     @collective = collective
     @current_user = current_user
     @raw_query = raw_query
+    @fixed_params = fixed_params
     @params = build_params(params)
+
+    # Page scope: fixed params win over anything the query says, loudly.
+    apply_fixed_params(fixed_params)
 
     # Resolve collective from collective: handle
     resolve_collective_from_handle
@@ -58,12 +63,31 @@ class SearchQuery
 
   public
 
-  # Parse warnings (e.g. a known operator with an invalid value). Rendered
-  # by the feed search bar; empty for queries with no DSL issues.
+  # Parse warnings (e.g. a known operator with an invalid value) plus
+  # fixed-param conflicts. Rendered by the feed search bar; empty for
+  # queries with no issues.
   sig { returns(T::Array[String]) }
   def warnings
     @warnings || []
   end
+
+  private
+
+  # A feed page's fixed scope is enforced structurally — the user's query
+  # can never widen it. Conflicting query terms are overridden and reported
+  # rather than silently producing confusing results.
+  sig { params(fixed_params: T::Hash[Symbol, T.untyped]).void }
+  def apply_fixed_params(fixed_params)
+    fixed_params.each do |key, value|
+      user_value = @params[key]
+      if user_value.present? && user_value != value
+        @warnings = warnings + ["#{key}:#{user_value} ignored: this page is fixed to #{key}:#{value}"]
+      end
+      @params[key] = value
+    end
+  end
+
+  public
 
   # Main query methods
 
@@ -433,17 +457,23 @@ class SearchQuery
     value = @params[:list_id_or_alias].to_s.presence
     return @list_filter_user_ids = nil if value.nil?
 
-    @list_filter_user_ids = case value
+    ids = case value
     when "mutuals"
       @current_user ? @current_user.mutual_user_ids_in(@tenant) : []
     when "tuned_in"
-      @current_user ? UserListMember
-        .joins(:user_list)
-        .where(user_lists: {
-          tenant_id: @tenant.id, owner_id: @current_user.id,
-          is_primary: true, deleted_at: nil,
-        })
-        .pluck(:user_id) : []
+      if @current_user
+        # The viewer is always part of their own tuned-in feed: you cannot
+        # tune in to yourself, so the alias adds you to the list members.
+        UserListMember
+          .joins(:user_list)
+          .where(user_lists: {
+            tenant_id: @tenant.id, owner_id: @current_user.id,
+            is_primary: true, deleted_at: nil,
+          })
+          .pluck(:user_id) + [@current_user.id]
+      else
+        []
+      end
     else
       list = UserList
         .tenant_scoped_only(@tenant.id)
@@ -451,6 +481,21 @@ class SearchQuery
         .find_by(truncated_id: value)
       list && list.visible_to?(@current_user) ? list.user_list_members.pluck(:user_id) : []
     end
+
+    # Defense in depth: block callbacks remove primary-list memberships at
+    # block time, but stale memberships must not resurface blocked authors.
+    @list_filter_user_ids = (ids - block_related_user_ids_for_list_filter).uniq
+  end
+
+  sig { returns(T::Array[String]) }
+  def block_related_user_ids_for_list_filter
+    return [] unless @current_user
+
+    @block_related_user_ids_for_list_filter ||= UserBlock
+      .where("blocker_id = :uid OR blocked_id = :uid", uid: T.must(@current_user).id)
+      .pluck(:blocker_id, :blocked_id)
+      .flatten
+      .uniq - [T.must(@current_user).id]
   end
 
   sig { void }
@@ -472,8 +517,10 @@ class SearchQuery
 
   sig { returns(ActiveRecord::Relation) }
   def build_query
-    # Require a query to show results - empty search page shows nothing
-    return SearchIndex.none if @raw_query.blank?
+    # Require a query to show results - empty search page shows nothing.
+    # Feed pages (a fixed page scope is what makes a page a feed) browse
+    # instead: a blank query shows everything in scope.
+    return SearchIndex.none if @raw_query.blank? && @fixed_params.blank?
 
     # Use tenant_scoped_only to bypass collective scope while keeping tenant scope
     # We handle collective filtering explicitly below with accessible_collective_ids

--- a/app/services/search_query_parser.rb
+++ b/app/services/search_query_parser.rb
@@ -127,6 +127,7 @@ class SearchQueryParser
     @fuzzy_terms = T.let([], T::Array[String])       # Regular trigram matching
     @exact_phrases = T.let([], T::Array[String])     # Quoted phrases - exact substring match
     @excluded_terms = T.let([], T::Array[String])    # Negated terms - must NOT contain
+    @warnings = T.let([], T::Array[String])          # Known operator, invalid value
   end
 
   sig { returns(T::Hash[Symbol, T.untyped]) }
@@ -181,12 +182,25 @@ class SearchQueryParser
           end
         else
           # Invalid operator - treat as search text
+          warn_invalid_operator(text, key)
           add_search_term(text, quoted: token.quoted, negated: token.negated)
         end
       else
         add_search_term(text, quoted: token.quoted, negated: token.negated)
       end
     end
+  end
+
+  # A KNOWN operator with a bad value warns — silent degradation to search
+  # text is confusing. Unknown keys stay silent; they are legitimately
+  # searchable text ("re:invoice").
+  sig { params(text: String, key: String).void }
+  def warn_invalid_operator(text, key)
+    return unless OPERATORS.key?(key)
+
+    expected = OPERATORS.dig(key, :values)&.join(", ")
+    @warnings << "#{text} is not a valid #{key}: filter" \
+                 "#{expected ? " (expected: #{expected})" : ""}; treated as search text"
   end
 
   sig { params(text: String, quoted: T::Boolean, negated: T::Boolean).void }
@@ -243,6 +257,10 @@ class SearchQueryParser
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def build_params
     params = {}
+
+    # Parse warnings (not a filter — consumers must extract this before
+    # treating the rest as query params)
+    params[:warnings] = @warnings
 
     # Search terms - fuzzy matching (q for backwards compatibility)
     params[:q] = @fuzzy_terms.join(" ").presence

--- a/app/services/search_query_parser.rb
+++ b/app/services/search_query_parser.rb
@@ -84,12 +84,9 @@ class SearchQueryParser
     "sort" => { "new" => "newest", "old" => "oldest" },
   }.freeze, T::Hash[String, T::Hash[String, String]])
 
-  # Backward-compatible operator key aliases. `scope:` was renamed to
-  # `visibility:` to match the visibility term used in markdown/MCP actions;
-  # the old key is still accepted so existing links and saved queries keep working.
-  OPERATOR_ALIASES = T.let({
-    "scope" => "visibility",
-  }.freeze, T::Hash[String, String])
+  # NOTE: `scope` is deliberately not an operator (nor an alias for
+  # `visibility:`). The term is reserved for a page's fixed filters — see
+  # docs/NAVIGATION_DESIGN.md "Feeds are queries".
 
   # Map DSL sort values to SearchQuery sort_by format
   SORT_MAPPING = T.let({
@@ -172,7 +169,6 @@ class SearchQueryParser
 
       if match_data
         key = T.must(match_data[1]).downcase
-        key = OPERATOR_ALIASES.fetch(key, key)
         value = match_data[2]
 
         if valid_operator?(key, T.must(value))

--- a/app/views/help/collectives.md.erb
+++ b/app/views/help/collectives.md.erb
@@ -35,7 +35,8 @@ To start a representation session, navigate to the collective's representation p
 
 ## URL Pattern
 
-- Collective home: `/collectives/{handle}`
+- Collective home: `/collectives/{handle}` — a feed of the collective's content, filterable with [search syntax](/help/search); defaults to `cycle:this-week`
+- Cycle dashboard: `/collectives/{handle}/dashboard`
 - Collective settings: `/collectives/{handle}/settings`
 - Members: `/collectives/{handle}/members`
 - Representation: `/collectives/{handle}/representation`

--- a/app/views/help/cycles.md.erb
+++ b/app/views/help/cycles.md.erb
@@ -23,11 +23,12 @@ To send a heartbeat, navigate to the collective home page and use the `send_hear
 
 ## Navigating Cycles
 
-Each collective page shows the current cycle by default. You can browse previous cycles to see past activity.
+The collective's dashboard shows the current cycle by default. You can browse previous cycles to see past activity. (The collective's home page is a feed defaulting to `cycle:this-week` — refine or clear its filters to cross cycles.)
 
 ## URL Pattern
 
-- Current cycle: `{collective}` (default view)
+- Current cycle: `{collective}/dashboard`
+- Past cycle: `{collective}/dashboard?cycle={cycle-name}`
 - All cycles: `{collective}/cycles`
 - Specific cycle: `{collective}/cycles/{cycle-name}`
 

--- a/app/views/help/markdown_ui.md.erb
+++ b/app/views/help/markdown_ui.md.erb
@@ -60,13 +60,13 @@ scope: collective:my-team
 
 | Page | Scope |
 |------|-------|
-| `/` (home) | `visibility:public list:tuned_in` |
+| `/` (home) | `visibility:public` |
 | `/collectives/:handle` | `collective:handle` |
 | `/workspace/:handle` | `visibility:private` |
 | `/u/:handle` | `visibility:public creator:@handle` |
 | `/lists/:id` | `visibility:public list:id` |
 
-On `/search`, a `query:` attribute carries the current search string instead. Pages without a feed have neither key.
+A `query:` attribute carries the page's current refinements on top of the scope. The home feed defaults to `query: list:tuned_in` (the people you tune in to, plus yourself); pass `?q=` to refine it, or an empty `?q=` to browse the whole public space. On `/search`, `query:` is the whole search (there is no fixed scope). Pages without a feed have neither key.
 
 ## Actions
 

--- a/app/views/help/markdown_ui.md.erb
+++ b/app/views/help/markdown_ui.md.erb
@@ -58,15 +58,17 @@ Feed pages carry a `scope:` frontmatter attribute: the page's fixed filters, wri
 scope: collective:my-team
 ```
 
-| Page | Scope |
-|------|-------|
-| `/` (home) | `visibility:public` |
-| `/collectives/:handle` | `collective:handle` |
-| `/workspace/:handle` | `visibility:private` |
-| `/u/:handle` | `visibility:public creator:@handle` |
-| `/lists/:id` | `visibility:public list:id` |
+| Page | Scope | Default query |
+|------|-------|---------------|
+| `/` (home) | `visibility:public` | `list:tuned_in` |
+| `/collectives/:handle` | `collective:handle` | — |
+| `/collectives/:handle/feed` | `collective:handle` | `cycle:this-week` |
+| `/workspace/:handle` | `visibility:private` | — |
+| `/workspace/:handle/feed` | `visibility:private` | `cycle:this-week` |
+| `/u/:handle` | `visibility:public creator:@handle` | — |
+| `/lists/:id` | `visibility:public list:id` | — |
 
-A `query:` attribute carries the page's current refinements on top of the scope. The home feed defaults to `query: list:tuned_in` (the people you tune in to, plus yourself); pass `?q=` to refine it, or an empty `?q=` to browse the whole public space. On `/search`, `query:` is the whole search (there is no fixed scope). Pages without a feed have neither key.
+A `query:` attribute carries the page's current refinements on top of the scope. Pages with a default query (home's `list:tuned_in` — the people you tune in to, plus yourself; the collective feed's `cycle:this-week`) apply it when `?q` is absent; pass `?q=` to refine, or an empty `?q=` to browse everything in scope. On `/search`, `query:` is the whole search (there is no fixed scope). Pages without a feed have neither key.
 
 ## Actions
 

--- a/app/views/help/markdown_ui.md.erb
+++ b/app/views/help/markdown_ui.md.erb
@@ -61,10 +61,10 @@ scope: collective:my-team
 | Page | Scope | Default query |
 |------|-------|---------------|
 | `/` (home) | `visibility:public` | `list:tuned_in` |
-| `/collectives/:handle` | `collective:handle` | — |
-| `/collectives/:handle/feed` | `collective:handle` | `cycle:this-week` |
-| `/workspace/:handle` | `visibility:private` | — |
-| `/workspace/:handle/feed` | `visibility:private` | `cycle:this-week` |
+| `/collectives/:handle` (feed) | `collective:handle` | `cycle:this-week` |
+| `/collectives/:handle/dashboard` | `collective:handle` | — |
+| `/workspace/:handle` (feed) | `visibility:private` | `cycle:this-week` |
+| `/workspace/:handle/dashboard` | `visibility:private` | — |
 | `/u/:handle` | `visibility:public creator:@handle` | — |
 | `/lists/:id` | `visibility:public list:id` | — |
 

--- a/app/views/help/markdown_ui.md.erb
+++ b/app/views/help/markdown_ui.md.erb
@@ -50,6 +50,24 @@ nav: | [Home](/) | Collective: [My Team](/collectives/my-team) | Logged in as [A
 ...
 ```
 
+## Page Scope
+
+Feed pages carry a `scope:` frontmatter attribute: the page's fixed filters, written in [search syntax](/help/search). Pasting the scope into `/search?q=` reproduces the page's content, and appending more filters narrows it — every feed is navigable through search.
+
+```
+scope: collective:my-team
+```
+
+| Page | Scope |
+|------|-------|
+| `/` (home) | `visibility:public list:tuned_in` |
+| `/collectives/:handle` | `collective:handle` |
+| `/workspace/:handle` | `visibility:private` |
+| `/u/:handle` | `visibility:public creator:@handle` |
+| `/lists/:id` | `visibility:public list:id` |
+
+On `/search`, a `query:` attribute carries the current search string instead. Pages without a feed have neither key.
+
 ## Actions
 
 Every page advertises the actions you can take on it. Each entry in the frontmatter `actions` list includes:

--- a/app/views/help/search.md.erb
+++ b/app/views/help/search.md.erb
@@ -2,6 +2,8 @@
 
 Search lets you find content across all your collectives by keyword, with powerful filtering, sorting, and grouping operators.
 
+Feed pages are search results with fixed filters: each declares its **page scope** in markdown frontmatter (`scope:`), written in the syntax below. See [Markdown UI](/help/markdown-ui) for the scope table.
+
 ## How to Search
 
 Navigate to `/search?q={query}` to search. Plain text searches content. Use `"quotes"` for exact phrase matching. Prefix any term or operator with `-` to negate it.

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,14 +4,22 @@
       <h1 class="pulse-page-title"><span><%= @current_tenant.subdomain %><span class="pulse-subdomain-suffix">.<%= ENV['HOSTNAME'] %></span></span></h1>
     </header>
 
-    <%# Activity stream — content from the people you tune in to, plus your own %>
+    <%# The home feed is a search: fixed scope visibility:public, default
+        query list:tuned_in. See docs/NAVIGATION_DESIGN.md. %>
+    <%= render FeedSearchBarComponent.new(
+      action: "/",
+      query: @feed_query,
+      scope_filters: ["visibility:public"],
+      warnings: @search.warnings,
+    ) %>
+
     <% if @feed_items.present? %>
       <div class="pulse-feed" style="padding: 0;">
         <% @feed_items.each do |feed_item| %>
           <%= render 'pulse/feed_item', feed_item: feed_item %>
         <% end %>
       </div>
-    <% else %>
+    <% elsif default_feed_view? %>
       <div class="pulse-feed-empty">
         <% if @tuned_in_count.zero? %>
           <p>Your home is quiet.</p>
@@ -23,6 +31,11 @@
           <p>Nothing new from the <%= @tuned_in_count %>
             <%= @tuned_in_count == 1 ? "person" : "people" %> you tune in to.</p>
         <% end %>
+      </div>
+    <% else %>
+      <div class="pulse-feed-empty">
+        <p>No results match your filters.</p>
+        <p class="pulse-body-text-muted"><%= link_to "Clear filters", "/" %></p>
       </div>
     <% end %>
   </article>

--- a/app/views/layouts/application.md.erb
+++ b/app/views/layouts/application.md.erb
@@ -14,6 +14,12 @@ end
 app: Harmonic
 host: <%= "#{@current_tenant.subdomain}.#{ENV['HOSTNAME']}" %>
 path: <%= @current_path %>
+<% if @page_scope.present? -%>
+scope: <%= yaml_escape(@page_scope) %>
+<% end -%>
+<% if @page_query.present? -%>
+query: <%= yaml_escape(@page_query) %>
+<% end -%>
 title: <%= yaml_escape(@page_title) %>
 timestamp: <%= Time.now.utc %>
 <% actions = available_actions_for_current_route -%>

--- a/app/views/pulse/_heartbeat_banner.html.erb
+++ b/app/views/pulse/_heartbeat_banner.html.erb
@@ -1,0 +1,29 @@
+<% if @current_user && @current_heartbeat.nil? && !@current_collective.private_workspace? %>
+  <div class="pulse-heartbeat-section" data-controller="heartbeat">
+    <button
+      class="pulse-heartbeat-btn"
+      data-heartbeat-target="sendButton"
+      data-url="<%= @current_collective.path %>/heartbeats"
+    >
+      <%= octicon 'heart' %>
+      <span data-heartbeat-target="sendButtonText">Send a Heartbeat</span>
+    </button>
+    <span data-heartbeat-target="fullHeart" class="pulse-heartbeat-full-heart" style="display:none;">
+      <%= octicon 'heart-fill' %>
+    </span>
+    <span data-heartbeat-target="heartbeatMessage">
+      to access <strong><%= @current_collective.name %></strong> <%= @cycle.display_name.downcase %>.
+    </span>
+    <%= render 'shared/tooltip' do %>
+      <p>Every collective has a tempo (daily, weekly, or monthly) that defines how frequently members of the collective should check in to keep everyone in sync.</p>
+      <p><strong><%= @current_collective.name %></strong>'s tempo is set to <code><%= @current_collective.tempo %></code>.</p>
+      <p style="margin-bottom:0;">Sending a heartbeat each <%= @cycle.unit %> signals your continuing presence to the group.</p>
+    <% end %>
+    <button data-heartbeat-target="dismissButton" class="pulse-heartbeat-dismiss" style="display:none;" title="Dismiss">
+      <%= octicon 'x' %>
+    </button>
+    <span data-heartbeat-target="heartbeatsIndexLink" style="display:none;">
+      <a href="<%= @current_collective.path %>/heartbeats">View all heartbeats</a>.
+    </span>
+  </div>
+<% end %>

--- a/app/views/pulse/_sidebar.html.erb
+++ b/app/views/pulse/_sidebar.html.erb
@@ -8,6 +8,8 @@
   <% unless @current_collective&.private_workspace? %>
     <%= render 'pulse/sidebar_heartbeats' %>
   <% end %>
-  <%= render 'pulse/sidebar_nav' %>
+  <%# The activity type filters act on the dashboard's client-side
+      pulse-filter; pages without the counts (e.g. the feed) hide them. %>
+  <%= render 'pulse/sidebar_nav' if @notes_count %>
   <%= render 'pulse/sidebar_links' %>
 </aside>

--- a/app/views/pulse/_sidebar.html.erb
+++ b/app/views/pulse/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <aside class="pulse-sidebar">
   <%= render 'pulse/sidebar_collective_info' %>
   <%= render 'pulse/sidebar_pinned' %>
-  <%= render 'pulse/sidebar_cycle' %>
+  <%= render 'pulse/sidebar_cycle' unless @hide_cycle_sidebar %>
   <% if @recent_cycle_summaries.present? %>
     <%= render 'pulse/sidebar_recent_cycles' %>
   <% end %>

--- a/app/views/pulse/_sidebar_cycle.html.erb
+++ b/app/views/pulse/_sidebar_cycle.html.erb
@@ -12,7 +12,8 @@
   has_heartbeat = @current_heartbeat.present?
   can_go_previous = has_heartbeat && prev_cycle_name && prev_cycle_name != @cycle.name
   can_go_next = next_cycle_name.present?
-  pulse_path = @current_collective.path
+  # Cycle navigation is a dashboard concept; the arrows always target it.
+  pulse_path = "#{@current_collective.path}/dashboard"
 %>
 <div class="pulse-cycle-box">
   <div class="pulse-cycle-label"><%= @is_viewing_current_cycle ? 'Current Cycle' : 'Viewing Past Cycle' %></div>

--- a/app/views/pulse/_sidebar_links.html.erb
+++ b/app/views/pulse/_sidebar_links.html.erb
@@ -2,6 +2,11 @@
   <div class="pulse-section-label">Explore</div>
   <ul class="pulse-links-list">
     <li>
+      <a href="<%= @current_collective.path %>/feed">
+        <%= octicon 'rows', height: 14 %> Feed
+      </a>
+    </li>
+    <li>
       <a href="<%= @current_collective.path %>/cycles">
         <%= octicon 'iterations', height: 14 %> Cycles
       </a>

--- a/app/views/pulse/_sidebar_links.html.erb
+++ b/app/views/pulse/_sidebar_links.html.erb
@@ -2,8 +2,8 @@
   <div class="pulse-section-label">Explore</div>
   <ul class="pulse-links-list">
     <li>
-      <a href="<%= @current_collective.path %>/feed">
-        <%= octicon 'rows', height: 14 %> Feed
+      <a href="<%= @current_collective.path %>/dashboard">
+        <%= octicon 'meter', height: 14 %> Dashboard
       </a>
     </li>
     <li>

--- a/app/views/pulse/_sidebar_recent_cycles.html.erb
+++ b/app/views/pulse/_sidebar_recent_cycles.html.erb
@@ -18,7 +18,8 @@
         next if offset > 0
         cycle_name = ::Cycle.cycle_name_for_offset(offset, unit)
         is_current = offset.zero?
-        href = is_current ? @current_collective.path : "#{@current_collective.path}?cycle=#{cycle_name}"
+        dashboard_path = "#{@current_collective.path}/dashboard"
+        href = is_current ? dashboard_path : "#{dashboard_path}?cycle=#{cycle_name}"
       %>
       <li>
         <a href="<%= href %>"

--- a/app/views/pulse/feed.html.erb
+++ b/app/views/pulse/feed.html.erb
@@ -1,0 +1,40 @@
+<article class="pulse-resource-detail">
+  <header class="pulse-resource-header">
+    <div class="pulse-resource-header-top">
+      <h1 class="pulse-resource-title" style="display: flex; align-items: center; gap: 0.5rem;">
+        <%= octicon 'rows', height: 20 %>
+        Feed
+      </h1>
+      <%= link_to "Dashboard", @current_collective.path, class: "pulse-action-btn pulse-action-btn-secondary" %>
+    </div>
+  </header>
+
+  <div class="pulse-resource-body">
+    <%= render FeedSearchBarComponent.new(
+      action: "#{@current_collective.path}/feed",
+      query: @feed_query,
+      scope_filters: [@page_scope],
+      warnings: @search.warnings,
+    ) %>
+
+    <% if @feed_items.present? %>
+      <div class="pulse-feed" style="padding: 0;">
+        <% @feed_items.each do |feed_item| %>
+          <%= render 'pulse/feed_item', feed_item: feed_item %>
+        <% end %>
+      </div>
+    <% elsif default_feed_view? %>
+      <div class="pulse-feed-empty">
+        <p>Nothing here this week.</p>
+        <p class="pulse-body-text-muted">
+          <%= link_to "Show all time", "#{@current_collective.path}/feed?q=" %>
+        </p>
+      </div>
+    <% else %>
+      <div class="pulse-feed-empty">
+        <p>No results match your filters.</p>
+        <p class="pulse-body-text-muted"><%= link_to "Clear filters", "#{@current_collective.path}/feed" %></p>
+      </div>
+    <% end %>
+  </div>
+</article>

--- a/app/views/pulse/feed.html.erb
+++ b/app/views/pulse/feed.html.erb
@@ -1,3 +1,4 @@
+<%= render 'pulse/heartbeat_banner' %>
 <article class="pulse-resource-detail">
   <header class="pulse-resource-header">
     <div class="pulse-resource-header-top">
@@ -5,36 +6,37 @@
         <%= octicon 'rows', height: 20 %>
         Feed
       </h1>
-      <%= link_to "Dashboard", @current_collective.path, class: "pulse-action-btn pulse-action-btn-secondary" %>
+      <%= link_to "Dashboard", "#{@current_collective.path}/dashboard", class: "pulse-action-btn pulse-action-btn-secondary" %>
     </div>
   </header>
 
   <div class="pulse-resource-body">
     <%= render FeedSearchBarComponent.new(
-      action: "#{@current_collective.path}/feed",
+      action: @current_collective.path.to_s,
       query: @feed_query,
       scope_filters: [@page_scope],
       warnings: @search.warnings,
     ) %>
 
-    <% if @feed_items.present? %>
-      <div class="pulse-feed" style="padding: 0;">
+    <%# Same heartbeat blur ritual as the dashboard: presence before content. %>
+    <div class="pulse-feed<%= ' pulse-blur-if-no-heartbeat' if @current_user && !@current_collective.private_workspace? %><%= ' no-heartbeat' if @current_user && !@current_heartbeat && !@current_collective.private_workspace? %>" style="padding: 0;">
+      <% if @feed_items.present? %>
         <% @feed_items.each do |feed_item| %>
           <%= render 'pulse/feed_item', feed_item: feed_item %>
         <% end %>
-      </div>
-    <% elsif default_feed_view? %>
-      <div class="pulse-feed-empty">
-        <p>Nothing here this week.</p>
-        <p class="pulse-body-text-muted">
-          <%= link_to "Show all time", "#{@current_collective.path}/feed?q=" %>
-        </p>
-      </div>
-    <% else %>
-      <div class="pulse-feed-empty">
-        <p>No results match your filters.</p>
-        <p class="pulse-body-text-muted"><%= link_to "Clear filters", "#{@current_collective.path}/feed" %></p>
-      </div>
-    <% end %>
+      <% elsif default_feed_view? %>
+        <div class="pulse-feed-empty">
+          <p>Nothing here this week.</p>
+          <p class="pulse-body-text-muted">
+            <%= link_to "Show all time", "#{@current_collective.path}?q=" %>
+          </p>
+        </div>
+      <% else %>
+        <div class="pulse-feed-empty">
+          <p>No results match your filters.</p>
+          <p class="pulse-body-text-muted"><%= link_to "Clear filters", @current_collective.path.to_s %></p>
+        </div>
+      <% end %>
+    </div>
   </div>
 </article>

--- a/app/views/pulse/feed.html.erb
+++ b/app/views/pulse/feed.html.erb
@@ -1,15 +1,5 @@
 <%= render 'pulse/heartbeat_banner' %>
 <article class="pulse-resource-detail">
-  <header class="pulse-resource-header">
-    <div class="pulse-resource-header-top">
-      <h1 class="pulse-resource-title" style="display: flex; align-items: center; gap: 0.5rem;">
-        <%= octicon 'rows', height: 20 %>
-        Feed
-      </h1>
-      <%= link_to "Dashboard", "#{@current_collective.path}/dashboard", class: "pulse-action-btn pulse-action-btn-secondary" %>
-    </div>
-  </header>
-
   <div class="pulse-resource-body">
     <%= render FeedSearchBarComponent.new(
       action: @current_collective.path.to_s,

--- a/app/views/pulse/feed.md.erb
+++ b/app/views/pulse/feed.md.erb
@@ -15,7 +15,7 @@ You must send a heartbeat to access this collective for the current cycle.
 <% end -%>
 <% elsif default_feed_view? %>
 
-Nothing here this week. Pass `?q=` (empty) to browse all time, or refine with [search syntax](/help/search).
+Nothing here this week. Pass `?q=` (empty) to browse all time, or refine with [filters](/help/search).
 <% else %>
 
 No results match the current query. The canonical URL (no `q` param) restores the default view.

--- a/app/views/pulse/feed.md.erb
+++ b/app/views/pulse/feed.md.erb
@@ -1,0 +1,18 @@
+# <%= @current_collective.name %> Feed
+<% @search.warnings.each do |warning| -%>
+> ⚠️ <%= warning %>
+<% end -%>
+<% if @feed_items.present? %>
+
+<% @feed_items.each do |feed_item| -%>
+* [<%= feed_item[:type] %>] **<%= feed_item[:item].title %>** by <%= feed_item[:created_by]&.display_name || 'Anonymous' %> (<%= time_ago_in_words(feed_item[:created_at]) %> ago) - [View](<%= feed_item[:item].path %>)
+<% end -%>
+<% elsif default_feed_view? %>
+
+Nothing here this week. Pass `?q=` (empty) to browse all time, or refine with [search syntax](/help/search).
+<% else %>
+
+No results match the current query. The canonical URL (no `q` param) restores the default view.
+<% end %>
+
+[Dashboard](<%= @current_collective.path %>)

--- a/app/views/pulse/feed.md.erb
+++ b/app/views/pulse/feed.md.erb
@@ -1,4 +1,10 @@
-# <%= @current_collective.name %> Feed
+# <%= @current_collective.name %>
+<% if !@current_collective.is_main_collective? && !@current_collective.private_workspace? && @current_user && @current_heartbeat.nil? -%>
+
+## Heartbeat Required
+
+You must send a heartbeat to access this collective for the current cycle.
+<% else -%>
 <% @search.warnings.each do |warning| -%>
 > ⚠️ <%= warning %>
 <% end -%>
@@ -14,5 +20,6 @@ Nothing here this week. Pass `?q=` (empty) to browse all time, or refine with [s
 
 No results match the current query. The canonical URL (no `q` param) restores the default view.
 <% end %>
+<% end %>
 
-[Dashboard](<%= @current_collective.path %>)
+[Dashboard](<%= @current_collective.path %>/dashboard)

--- a/app/views/pulse/show.html.erb
+++ b/app/views/pulse/show.html.erb
@@ -1,32 +1,4 @@
-<% if @current_user && @current_heartbeat.nil? && !@current_collective.private_workspace? %>
-  <div class="pulse-heartbeat-section" data-controller="heartbeat">
-    <button
-      class="pulse-heartbeat-btn"
-      data-heartbeat-target="sendButton"
-      data-url="<%= @current_collective.path %>/heartbeats"
-    >
-      <%= octicon 'heart' %>
-      <span data-heartbeat-target="sendButtonText">Send a Heartbeat</span>
-    </button>
-    <span data-heartbeat-target="fullHeart" class="pulse-heartbeat-full-heart" style="display:none;">
-      <%= octicon 'heart-fill' %>
-    </span>
-    <span data-heartbeat-target="heartbeatMessage">
-      to access <strong><%= @current_collective.name %></strong> <%= @cycle.display_name.downcase %>.
-    </span>
-    <%= render 'shared/tooltip' do %>
-      <p>Every collective has a tempo (daily, weekly, or monthly) that defines how frequently members of the collective should check in to keep everyone in sync.</p>
-      <p><strong><%= @current_collective.name %></strong>'s tempo is set to <code><%= @current_collective.tempo %></code>.</p>
-      <p style="margin-bottom:0;">Sending a heartbeat each <%= @cycle.unit %> signals your continuing presence to the group.</p>
-    <% end %>
-    <button data-heartbeat-target="dismissButton" class="pulse-heartbeat-dismiss" style="display:none;" title="Dismiss">
-      <%= octicon 'x' %>
-    </button>
-    <span data-heartbeat-target="heartbeatsIndexLink" style="display:none;">
-      <a href="<%= @current_collective.path %>/heartbeats">View all heartbeats</a>.
-    </span>
-  </div>
-<% end %>
+<%= render 'pulse/heartbeat_banner' %>
 
 <div class="pulse-filter-indicator" data-pulse-filter-target="indicator" style="display: none;">
   <span>Showing: <strong data-pulse-filter-target="indicatorLabel"></strong></span>

--- a/app/views/pulse/show.md.erb
+++ b/app/views/pulse/show.md.erb
@@ -12,7 +12,7 @@ You must send a heartbeat to view past cycles.
 ## Cycle: <%= @cycle.name.titleize %>
 
 <% unless @is_viewing_current_cycle -%>
-Viewing: <%= @cycle.name.titleize %> | [Back to current cycle](<%= @current_collective.path %>)
+Viewing: <%= @cycle.name.titleize %> | [Back to current cycle](<%= @current_collective.path %>/dashboard)
 <% end -%>
 
 ## Activity Feed

--- a/app/views/search/show.html.erb
+++ b/app/views/search/show.html.erb
@@ -12,6 +12,8 @@
         action: "/search",
         query: params[:q],
         warnings: @search.warnings,
+        placeholder: "Search",
+        submit_label: "Search",
       ) %>
     </section>
 

--- a/app/views/search/show.html.erb
+++ b/app/views/search/show.html.erb
@@ -8,20 +8,11 @@
 
   <div class="pulse-resource-body">
     <section class="pulse-settings-section">
-      <%= form_with url: "/search", method: :get, local: true, class: 'pulse-form pulse-filters-form' do |form| %>
-        <div class="pulse-form-row">
-          <div class="pulse-form-group pulse-form-group-wide">
-            <%= form.text_field :q,
-                value: params[:q],
-                class: 'pulse-form-input',
-                placeholder: 'Search',
-                style: 'font-family: monospace;' %>
-          </div>
-          <div class="pulse-form-group pulse-form-group-submit">
-            <%= form.submit 'Search', class: 'pulse-action-btn', name: nil %>
-          </div>
-        </div>
-      <% end %>
+      <%= render FeedSearchBarComponent.new(
+        action: "/search",
+        query: params[:q],
+        warnings: @search.warnings,
+      ) %>
     </section>
 
     <% if @search.raw_query.present? && @people_results.present? %>
@@ -60,7 +51,10 @@
 
       <section class="pulse-settings-section">
         <% if @grouped_results.empty? && @people_results.empty? %>
-          <p class="pulse-empty-content"><em>No results found.</em></p>
+          <p class="pulse-empty-content">
+            <em>No results found.</em>
+            <%= link_to "Clear search", "/search" %>
+          </p>
         <% elsif @grouped_results.empty? %>
           <%# People matched but no content — say nothing here; the People section above stands on its own. %>
         <% else %>
@@ -117,7 +111,7 @@
           <tr><th>Operator</th><th>Values</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>scope:</code></td><td>public, shared, private</td></tr>
+          <tr><td><code>visibility:</code></td><td>public, shared, private</td></tr>
           <tr><td><code>collective:</code></td><td>collective handle</td></tr>
           <tr><td><code>list:</code></td><td>list id, or <code>mutuals</code> / <code>tuned_in</code> (your own)</td></tr>
           <tr><td><code>type:</code></td><td>note, decision, commitment</td></tr>

--- a/app/views/search/show.md.erb
+++ b/app/views/search/show.md.erb
@@ -2,6 +2,9 @@
 
 <% if @search.raw_query.present? -%>
 Query: `<%= @search.raw_query %>`
+<% @search.warnings.each do |warning| -%>
+> ⚠️ <%= warning %>
+<% end -%>
 <% if @search.collective.present? -%>
 Collective: [<%= @search.collective.name %>](<%= @search.collective.path %>)
 <% end -%>
@@ -57,7 +60,7 @@ Use operators to filter, sort, and group results. Plain text searches content. U
 
 | Operator | Values |
 |----------|--------|
-| `scope:` | public, shared, private |
+| `visibility:` | public, shared, private |
 | `collective:` | collective handle |
 | `list:` | list id, or `mutuals` / `tuned_in` (your own) |
 | `type:` | note, decision, commitment |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -511,6 +511,7 @@ Rails.application.routes.draw do
   ['collectives', 'workspace'].each do |scope_prefix|
     prefix = "#{scope_prefix}/:collective_handle"
     get "#{prefix}" => 'pulse#show'
+    get "#{prefix}/feed" => 'pulse#feed'
     get "#{prefix}/actions" => 'pulse#actions_index'
     get "#{prefix}/actions/send_heartbeat" => 'collectives#describe_send_heartbeat'
     post "#{prefix}/actions/send_heartbeat" => 'collectives#send_heartbeat'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -510,8 +510,8 @@ Rails.application.routes.draw do
   # the same controllers — private workspaces use /workspace/ while standard collectives use /collectives/.
   ['collectives', 'workspace'].each do |scope_prefix|
     prefix = "#{scope_prefix}/:collective_handle"
-    get "#{prefix}" => 'pulse#show'
-    get "#{prefix}/feed" => 'pulse#feed'
+    get "#{prefix}" => 'pulse#feed'
+    get "#{prefix}/dashboard" => 'pulse#show'
     get "#{prefix}/actions" => 'pulse#actions_index'
     get "#{prefix}/actions/send_heartbeat" => 'collectives#describe_send_heartbeat'
     post "#{prefix}/actions/send_heartbeat" => 'collectives#send_heartbeat'

--- a/test/components/feed_search_bar_component_test.rb
+++ b/test/components/feed_search_bar_component_test.rb
@@ -10,14 +10,15 @@ class FeedSearchBarComponentTest < ViewComponent::TestCase
     assert_selector "input[name='q'][value='type:note budget']"
   end
 
-  test "renders fixed scope filters as locked chips outside the input" do
+  test "renders fixed scope filters as non-editable tokens inside the query field" do
     render_inline(FeedSearchBarComponent.new(action: "/collectives/my-team/feed", scope_filters: ["collective:my-team"]))
 
-    assert_selector ".pulse-feed-bar-scope", count: 1
-    assert_selector ".pulse-feed-bar-scope code", text: "collective:my-team"
-    assert_selector ".pulse-feed-bar-scope .octicon-lock"
-    # The fixed scope is not part of the editable input.
+    # The fixed filter is part of the query visually — inside the same
+    # field as the text input — but not part of the editable text.
+    assert_selector ".pulse-feed-bar-field .pulse-feed-bar-scope code", text: "collective:my-team"
+    assert_selector ".pulse-feed-bar-field input[name='q']"
     assert_no_selector "input[value*='collective:my-team']"
+    assert_no_selector ".octicon-lock"
   end
 
   test "renders no chips when there is no fixed scope" do

--- a/test/components/feed_search_bar_component_test.rb
+++ b/test/components/feed_search_bar_component_test.rb
@@ -1,0 +1,44 @@
+# typed: false
+
+require "test_helper"
+
+class FeedSearchBarComponentTest < ViewComponent::TestCase
+  test "renders a GET form with the query prefilled" do
+    render_inline(FeedSearchBarComponent.new(action: "/search", query: "type:note budget"))
+
+    assert_selector "form[action='/search'][method='get']"
+    assert_selector "input[name='q'][value='type:note budget']"
+  end
+
+  test "renders fixed scope filters as locked chips outside the input" do
+    render_inline(FeedSearchBarComponent.new(action: "/collectives/my-team/feed", scope_filters: ["collective:my-team"]))
+
+    assert_selector ".pulse-feed-bar-scope", count: 1
+    assert_selector ".pulse-feed-bar-scope code", text: "collective:my-team"
+    assert_selector ".pulse-feed-bar-scope .octicon-lock"
+    # The fixed scope is not part of the editable input.
+    assert_no_selector "input[value*='collective:my-team']"
+  end
+
+  test "renders no chips when there is no fixed scope" do
+    render_inline(FeedSearchBarComponent.new(action: "/search"))
+
+    assert_no_selector ".pulse-feed-bar-scope"
+  end
+
+  test "renders warnings" do
+    render_inline(FeedSearchBarComponent.new(
+                    action: "/search",
+                    warnings: ["visibility:bogus is not a valid visibility: filter"]
+                  ))
+
+    assert_selector ".pulse-feed-bar-warning", count: 1
+    assert_selector ".pulse-feed-bar-warning", text: /visibility:bogus/
+  end
+
+  test "renders no warnings row when there are none" do
+    render_inline(FeedSearchBarComponent.new(action: "/search"))
+
+    assert_no_selector ".pulse-feed-bar-warning"
+  end
+end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -36,13 +36,14 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     other_main.add_user!(@user) unless other_main.user_is_member?(@user)
     Tenant.scope_thread_to_tenant(subdomain: other_tenant.subdomain)
     Collective.scope_thread_to_collective(subdomain: other_tenant.subdomain, handle: other_main.handle)
-    Note.create!(
+    canary = Note.create!(
       tenant: other_tenant,
       collective: other_main,
       created_by: @user,
       text: "CROSS_TENANT_LEAK_CANARY",
       deadline: Time.current + 1.week,
     )
+    SearchIndexer.reindex(canary)
     Collective.clear_thread_scope
     Tenant.clear_thread_scope
 
@@ -65,6 +66,7 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
       text: "A public note visible on the homepage",
       deadline: Time.current + 1.week,
     )
+    SearchIndexer.reindex(note)
     Collective.clear_thread_scope
     Tenant.clear_thread_scope
 
@@ -100,6 +102,7 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
       event_type: "reminder",
       happened_at: Time.current,
     )
+    SearchIndexer.reindex(note)
     Collective.clear_thread_scope
     Tenant.clear_thread_scope
 
@@ -120,11 +123,12 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: main_collective.handle)
     @user.primary_user_list_in!(@tenant).user_list_members.create!(added_by: @user, user: other)
-    Note.create!(
+    note = Note.create!(
       tenant: @tenant, collective: main_collective, created_by: other,
       text: "post by someone I tune in to",
       deadline: Time.current + 1.week,
     )
+    SearchIndexer.reindex(note)
     Collective.clear_thread_scope
     Tenant.clear_thread_scope
 
@@ -142,11 +146,12 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
 
     Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: main_collective.handle)
-    Note.create!(
+    note = Note.create!(
       tenant: @tenant, collective: main_collective, created_by: other,
       text: "post by a stranger",
       deadline: Time.current + 1.week,
     )
+    SearchIndexer.reindex(note)
     Collective.clear_thread_scope
     Tenant.clear_thread_scope
 
@@ -169,11 +174,12 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     main_collective = Collective.find(@tenant.main_collective_id)
     Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: main_collective.handle)
-    Note.create!(
+    note = Note.create!(
       tenant: @tenant, collective: main_collective, created_by: @user,
       text: "my own post",
       deadline: Time.current + 1.week,
     )
+    SearchIndexer.reindex(note)
     Collective.clear_thread_scope
     Tenant.clear_thread_scope
 
@@ -191,11 +197,12 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
 
     Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: main_collective.handle)
-    Note.create!(
+    note = Note.create!(
       tenant: @tenant, collective: main_collective, created_by: other,
       text: "post by blocked stale-tune-in user",
       deadline: Time.current + 1.week,
     )
+    SearchIndexer.reindex(note)
     # Create the block first (cleanup callback runs but no membership to clean
     # yet). Then bypass validation to insert a stale tune-in across the block,
     # simulating data left behind from before the cleanup callback shipped.
@@ -233,11 +240,97 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
       text: "A private note only for collective members",
       deadline: Time.current + 1.week,
     )
+    SearchIndexer.reindex(note)
     Collective.clear_thread_scope
     Tenant.clear_thread_scope
 
     get "/"
     assert_response :success
     assert_not_includes response.body, "A private note only for collective members"
+  end
+
+  # Feeds-are-queries behaviors (docs/NAVIGATION_DESIGN.md): the home feed
+  # is a search with fixed scope visibility:public and default query
+  # list:tuned_in. ?q absent applies the default; ?q present (even empty)
+  # is the user's own refinement.
+
+  def create_indexed_main_note(created_by:, text:)
+    main_collective = Collective.find(@tenant.main_collective_id)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: main_collective.handle)
+    note = Note.create!(
+      tenant: @tenant, collective: main_collective, created_by: created_by,
+      text: text, deadline: Time.current + 1.week,
+    )
+    SearchIndexer.reindex(note)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+    note
+  end
+
+  test "explicitly empty ?q= broadens the feed to everything public" do
+    other = create_user(email: "broadened-#{SecureRandom.hex(4)}@example.com", name: "Broadened")
+    @tenant.add_user!(other)
+    Collective.find(@tenant.main_collective_id).add_user!(other)
+    create_indexed_main_note(created_by: other, text: "post by a stranger, broadened")
+
+    sign_in_as(@user, tenant: @tenant)
+    get "/"
+    assert_not_includes response.body, "post by a stranger, broadened"
+
+    get "/", params: { q: "" }
+    assert_response :success
+    assert_includes response.body, "post by a stranger, broadened"
+  end
+
+  test "query refinement filters the home feed" do
+    create_indexed_main_note(created_by: @user, text: "refineme note body")
+
+    sign_in_as(@user, tenant: @tenant)
+    get "/", params: { q: "type:decision" }
+    assert_response :success
+    assert_not_includes response.body, "refineme note body"
+
+    get "/", params: { q: "type:note refineme" }
+    assert_includes response.body, "refineme note body"
+  end
+
+  test "the home feed's visibility cannot be widened by the query" do
+    sign_in_as(@user, tenant: @tenant)
+    get "/", params: { q: "visibility:private" }
+    assert_response :success
+    assert_select ".pulse-feed-bar-warning", text: /visibility:private ignored/
+  end
+
+  test "home feed bar shows the fixed scope chip and the editable default query" do
+    sign_in_as(@user, tenant: @tenant)
+    get "/"
+    assert_response :success
+    assert_select ".pulse-feed-bar-scope code", text: "visibility:public"
+    assert_select "input[name='q'][value='list:tuned_in']"
+  end
+
+  test "reminders interleave on the default view but not on refined queries" do
+    main_collective = Collective.find(@tenant.main_collective_id)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: main_collective.handle)
+    note = Note.create!(
+      tenant: @tenant, collective: main_collective, created_by: @user,
+      title: "Reminder interleave note", text: "body", subtype: "reminder",
+      deadline: Time.current + 1.week,
+    )
+    NoteHistoryEvent.create!(
+      tenant: @tenant, note: note, user: @user,
+      event_type: "reminder", happened_at: Time.current,
+    )
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    sign_in_as(@user, tenant: @tenant)
+    get "/", headers: { "Accept" => "text/markdown" }
+    assert_includes response.body, "[Reminder]"
+
+    get "/", params: { q: "type:decision" }, headers: { "Accept" => "text/markdown" }
+    assert_not_includes response.body, "[Reminder]"
   end
 end

--- a/test/controllers/pulse_controller_test.rb
+++ b/test/controllers/pulse_controller_test.rb
@@ -104,4 +104,78 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     assert_no_selector ".pulse-feed-item[data-item-type='Reminder']" rescue nil
     # Alternative: just verify the page loads without errors
   end
+
+  # Collective feed page (docs/NAVIGATION_DESIGN.md "Feeds are queries"):
+  # fixed scope collective:handle, default query cycle:this-week.
+
+  test "collective feed shows indexed content with the fixed token and default query" do
+    sign_in_as(@user, tenant: @tenant)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    create_note(tenant: @tenant, collective: @collective, created_by: @user, text: "collective feed probe")
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "#{@collective.path}/feed"
+    assert_response :success
+    assert_select ".pulse-feed-bar-scope code", text: "collective:#{@collective.handle}"
+    assert_select "input[name='q'][value='cycle:this-week']"
+    assert_includes response.body, "collective feed probe"
+  end
+
+  test "collective feed defaults to this week; cleared query shows all time" do
+    sign_in_as(@user, tenant: @tenant)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    old_note = create_note(tenant: @tenant, collective: @collective, created_by: @user, text: "ancient collective post")
+    # Genuinely past: cycles contain items ACTIVE in the window
+    # (deadline > cycle start), so the deadline must be old too.
+    old_note.update_columns(created_at: 8.weeks.ago, deadline: 7.weeks.ago)
+    SearchIndexer.reindex(old_note)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "#{@collective.path}/feed"
+    assert_response :success
+    assert_not_includes response.body, "ancient collective post"
+
+    get "#{@collective.path}/feed", params: { q: "" }
+    assert_includes response.body, "ancient collective post"
+  end
+
+  test "collective feed cannot be pointed at another collective" do
+    sign_in_as(@user, tenant: @tenant)
+    get "#{@collective.path}/feed", params: { q: "collective:someplace-else" }
+    assert_response :success
+    assert_select ".pulse-feed-bar-warning",
+                  text: /collective:someplace-else ignored: this page is fixed to collective:#{@collective.handle}/
+  end
+
+  test "collective feed markdown declares scope and query frontmatter" do
+    sign_in_as(@user, tenant: @tenant)
+    get "#{@collective.path}/feed", headers: { "Accept" => "text/markdown" }
+    assert_response :success
+    assert_includes response.body, "scope: collective:#{@collective.handle}"
+    assert_includes response.body, "query: cycle:this-week"
+  end
+
+  test "workspace feed is scoped to the private zone" do
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    workspace = Collective.create!(
+      tenant: @tenant, created_by: @user,
+      name: "Feed Test Workspace", handle: "feed-ws-#{SecureRandom.hex(4)}",
+      collective_type: "private_workspace",
+    )
+    workspace.add_user!(@user)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: workspace.handle)
+    create_note(tenant: @tenant, collective: workspace, created_by: @user, text: "private workspace feed probe")
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    sign_in_as(@user, tenant: @tenant)
+    get "#{workspace.path}/feed"
+    assert_response :success
+    assert_select ".pulse-feed-bar-scope code", text: "visibility:private"
+    assert_includes response.body, "private workspace feed probe"
+  end
 end

--- a/test/controllers/pulse_controller_test.rb
+++ b/test/controllers/pulse_controller_test.rb
@@ -179,27 +179,43 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "private workspace feed probe"
   end
 
-  test "the dashboard sidebar shows activity filters; the feed sidebar does not" do
+  test "dashboard-only sidebar sections hide on the feed" do
     sign_in_as(@user, tenant: @tenant)
 
     get "#{@collective.path}/dashboard"
     assert_response :success
     assert_select ".pulse-nav .pulse-nav-item", minimum: 3
+    assert_select ".pulse-cycle-box", minimum: 1
 
     get @collective.path.to_s
     assert_response :success
     assert_select ".pulse-nav .pulse-nav-item", count: 0
-    # But the rest of the dashboard sidebar is present on the feed.
-    assert_select ".pulse-cycle-box, .pulse-sidebar [class*='cycle']", minimum: 1
+    assert_select ".pulse-cycle-box", count: 0
+    assert_select ".pulse-recent-cycle-item", count: 0
+    # But the shared sidebar sections are present on the feed.
+    assert_select ".pulse-heartbeat-box, .pulse-sidebar [class*='heartbeat']", minimum: 1
   end
 
   test "cycle navigation links target the dashboard" do
     sign_in_as(@user, tenant: @tenant)
-    get @collective.path.to_s
+    get "#{@collective.path}/dashboard"
     assert_response :success
     # Without a heartbeat the previous-cycle arrow renders disabled with a
     # data-href; either form must point at the dashboard.
     assert_select "[data-href*='/dashboard?cycle='], a.pulse-cycle-nav-arrow[href*='/dashboard?cycle=']",
                   minimum: 1
+  end
+
+  test "the feed bar says Filter; /search keeps Search" do
+    sign_in_as(@user, tenant: @tenant)
+
+    get @collective.path.to_s
+    assert_response :success
+    assert_select "input[type=submit][value=Filter]"
+    assert_select "input[name='q'][placeholder=Filter]"
+
+    get "/search"
+    assert_response :success
+    assert_select "input[type=submit][value=Search]"
   end
 end

--- a/test/controllers/pulse_controller_test.rb
+++ b/test/controllers/pulse_controller_test.rb
@@ -30,7 +30,7 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
       happened_at: Time.current,
     )
 
-    get "/collectives/#{@collective.handle}"
+    get "/collectives/#{@collective.handle}/dashboard"
     assert_response :success
     assert_includes response.body, "Reminder"
     assert_includes response.body, "Remember to check on deployment"
@@ -67,7 +67,7 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     Collective.clear_thread_scope
     Tenant.clear_thread_scope
 
-    get "/collectives/#{main_collective.handle}", headers: { "Accept" => "text/markdown" }
+    get "/collectives/#{main_collective.handle}/dashboard", headers: { "Accept" => "text/markdown" }
     assert_response :success
     # The "**Reminder**:" prefix is the markdown type label produced for a
     # fired reminder event — distinct from the word "Reminder" appearing
@@ -97,7 +97,7 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
       happened_at: 1.year.ago,
     )
 
-    get "/collectives/#{@collective.handle}"
+    get "/collectives/#{@collective.handle}/dashboard"
     assert_response :success
     # The note itself may appear, but the old reminder event should not render as a "Reminder" feed item
     # We check that the reminder event's "clock" icon doesn't appear from the ReminderFeedItemComponent
@@ -116,7 +116,7 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     Collective.clear_thread_scope
     Tenant.clear_thread_scope
 
-    get "#{@collective.path}/feed"
+    get "#{@collective.path}"
     assert_response :success
     assert_select ".pulse-feed-bar-scope code", text: "collective:#{@collective.handle}"
     assert_select "input[name='q'][value='cycle:this-week']"
@@ -135,17 +135,17 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     Collective.clear_thread_scope
     Tenant.clear_thread_scope
 
-    get "#{@collective.path}/feed"
+    get "#{@collective.path}"
     assert_response :success
     assert_not_includes response.body, "ancient collective post"
 
-    get "#{@collective.path}/feed", params: { q: "" }
+    get "#{@collective.path}", params: { q: "" }
     assert_includes response.body, "ancient collective post"
   end
 
   test "collective feed cannot be pointed at another collective" do
     sign_in_as(@user, tenant: @tenant)
-    get "#{@collective.path}/feed", params: { q: "collective:someplace-else" }
+    get "#{@collective.path}", params: { q: "collective:someplace-else" }
     assert_response :success
     assert_select ".pulse-feed-bar-warning",
                   text: /collective:someplace-else ignored: this page is fixed to collective:#{@collective.handle}/
@@ -153,7 +153,7 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
 
   test "collective feed markdown declares scope and query frontmatter" do
     sign_in_as(@user, tenant: @tenant)
-    get "#{@collective.path}/feed", headers: { "Accept" => "text/markdown" }
+    get "#{@collective.path}", headers: { "Accept" => "text/markdown" }
     assert_response :success
     assert_includes response.body, "scope: collective:#{@collective.handle}"
     assert_includes response.body, "query: cycle:this-week"
@@ -173,9 +173,33 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     Tenant.clear_thread_scope
 
     sign_in_as(@user, tenant: @tenant)
-    get "#{workspace.path}/feed"
+    get workspace.path.to_s
     assert_response :success
     assert_select ".pulse-feed-bar-scope code", text: "visibility:private"
     assert_includes response.body, "private workspace feed probe"
+  end
+
+  test "the dashboard sidebar shows activity filters; the feed sidebar does not" do
+    sign_in_as(@user, tenant: @tenant)
+
+    get "#{@collective.path}/dashboard"
+    assert_response :success
+    assert_select ".pulse-nav .pulse-nav-item", minimum: 3
+
+    get @collective.path.to_s
+    assert_response :success
+    assert_select ".pulse-nav .pulse-nav-item", count: 0
+    # But the rest of the dashboard sidebar is present on the feed.
+    assert_select ".pulse-cycle-box, .pulse-sidebar [class*='cycle']", minimum: 1
+  end
+
+  test "cycle navigation links target the dashboard" do
+    sign_in_as(@user, tenant: @tenant)
+    get @collective.path.to_s
+    assert_response :success
+    # Without a heartbeat the previous-cycle arrow renders disabled with a
+    # data-href; either form must point at the dashboard.
+    assert_select "[data-href*='/dashboard?cycle='], a.pulse-cycle-nav-arrow[href*='/dashboard?cycle=']",
+                  minimum: 1
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -255,10 +255,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "Posts tab shows only post-subtype notes" do
-    post_note = create_note(tenant: @tenant, collective: @tenant.main_collective, created_by: @user, title: "A Post")
-    post_note.update!(subtype: "post")
-    reminder_note = create_note(tenant: @tenant, collective: @tenant.main_collective, created_by: @user, title: "A Reminder")
-    reminder_note.update!(subtype: "reminder")
+    post_note = create_note(tenant: @tenant, collective: @tenant.main_collective, created_by: @user, title: "A Post", subtype: "post")
+    reminder_note = create_note(tenant: @tenant, collective: @tenant.main_collective, created_by: @user, title: "A Reminder", subtype: "reminder")
     sign_in_as(@user, tenant: @tenant)
     get "/u/#{@user.handle}?tab=posts"
     assert_response :success
@@ -268,10 +266,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "Activity tab excludes post-subtype notes; surfaces non-post notes" do
-    post_note = create_note(tenant: @tenant, collective: @tenant.main_collective, created_by: @user, title: "A Post")
-    post_note.update!(subtype: "post")
-    reminder_note = create_note(tenant: @tenant, collective: @tenant.main_collective, created_by: @user, title: "A Reminder")
-    reminder_note.update!(subtype: "reminder")
+    post_note = create_note(tenant: @tenant, collective: @tenant.main_collective, created_by: @user, title: "A Post", subtype: "post")
+    reminder_note = create_note(tenant: @tenant, collective: @tenant.main_collective, created_by: @user, title: "A Reminder", subtype: "reminder")
     sign_in_as(@user, tenant: @tenant)
     get "/u/#{@user.handle}?tab=activity"
     assert_response :success
@@ -282,10 +278,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
   test "Posts and Activity partition the legacy feed (union equals baseline, no overlap)" do
     main = @tenant.main_collective
-    post = create_note(tenant: @tenant, collective: main, created_by: @user, title: "P")
-    post.update!(subtype: "post")
-    reminder = create_note(tenant: @tenant, collective: main, created_by: @user, title: "R")
-    reminder.update!(subtype: "reminder")
+    post = create_note(tenant: @tenant, collective: main, created_by: @user, title: "P", subtype: "post")
+    reminder = create_note(tenant: @tenant, collective: main, created_by: @user, title: "R", subtype: "reminder")
     decision = create_decision(tenant: @tenant, collective: main, created_by: @user, question: "D?")
     commitment = create_commitment(tenant: @tenant, collective: main, created_by: @user, title: "C")
 
@@ -334,10 +328,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "markdown profile renders both Posts and Activity sections inline" do
-    post_note = create_note(tenant: @tenant, collective: @tenant.main_collective, created_by: @user, title: "MdPost")
-    post_note.update!(subtype: "post")
-    reminder_note = create_note(tenant: @tenant, collective: @tenant.main_collective, created_by: @user, title: "MdReminder")
-    reminder_note.update!(subtype: "reminder")
+    post_note = create_note(tenant: @tenant, collective: @tenant.main_collective, created_by: @user, title: "MdPost", subtype: "post")
+    reminder_note = create_note(tenant: @tenant, collective: @tenant.main_collective, created_by: @user, title: "MdReminder", subtype: "reminder")
     sign_in_as(@user, tenant: @tenant)
     get "/u/#{@user.handle}", headers: { "Accept" => "text/markdown" }
     assert_response :success

--- a/test/integration/anonymous_read_access_markdown_structure_test.rb
+++ b/test/integration/anonymous_read_access_markdown_structure_test.rb
@@ -29,7 +29,9 @@ class AnonymousReadAccessMarkdownStructureTest < ActionDispatch::IntegrationTest
   # Any new layout-level key must be reviewed for per-viewer-data leakage
   # before being added here. Also indirectly covers the `actions:` key
   # (omitted because available_actions_for_current_route returns [] for anon).
-  ANON_ALLOWED_FRONTMATTER_KEYS = %w[app host path title timestamp].freeze
+  # `scope` is the page's fixed filters (search syntax) — location metadata
+  # derived from the URL, never per-viewer. See docs/NAVIGATION_DESIGN.md.
+  ANON_ALLOWED_FRONTMATTER_KEYS = %w[app host path scope title timestamp].freeze
 
   def setup
     @prior_env = ENV.fetch("ANON_READABLE_TENANT_SUBDOMAINS", nil)

--- a/test/integration/markdown_ui_test.rb
+++ b/test/integration/markdown_ui_test.rb
@@ -305,6 +305,12 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
 
   # Heartbeat gate tests
   test "collective homepage without heartbeat shows only send_heartbeat action" do
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    create_note(tenant: @tenant, collective: @collective, created_by: @user, title: "Gated feed note")
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
     # Ensure no heartbeat exists for this cycle
     Heartbeat.where(collective: @collective, user: @user).delete_all
 
@@ -320,14 +326,18 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
     assert response.body.include?("send_heartbeat"),
       "Should include send_heartbeat action"
 
-    # Should NOT show full collective content (like pinned items, team, new note/decision/commit actions)
-    refute response.body.include?("## Team"),
-      "Should NOT show Team section when heartbeat missing"
-    refute response.body.include?("[New Note]"),
-      "Should NOT show New Note action when heartbeat missing"
+    # Should NOT show the collective's feed content
+    refute response.body.include?("Gated feed note"),
+      "Should NOT show feed content when heartbeat missing"
   end
 
   test "collective homepage with heartbeat shows full content" do
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    create_note(tenant: @tenant, collective: @collective, created_by: @user, title: "Gated feed note")
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
     # Create a heartbeat for the current cycle
     heartbeat = Heartbeat.create!(
       tenant: @tenant,
@@ -344,9 +354,9 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
     refute response.body.include?("Heartbeat Required"),
       "Should NOT show heartbeat required when heartbeat exists"
 
-    # Should show full collective content
-    assert response.body.include?("## Team"),
-      "Should show Team section when heartbeat exists"
+    # Should show the collective's feed content
+    assert response.body.include?("Gated feed note"),
+      "Should show feed content when heartbeat exists"
   ensure
     heartbeat&.destroy
   end

--- a/test/integration/page_scope_frontmatter_test.rb
+++ b/test/integration/page_scope_frontmatter_test.rb
@@ -29,10 +29,20 @@ class PageScopeFrontmatterTest < ActionDispatch::IntegrationTest
     body[/\A.*?^---$(.*?)^---$/m, 1] || ""
   end
 
-  test "home feed declares its fixed scope" do
+  test "home feed declares its fixed scope and default query" do
     get "/", headers: @headers
     assert_response :success
-    assert_includes frontmatter(response.body), "\nscope: visibility:public list:tuned_in\n"
+    fm = frontmatter(response.body)
+    assert_includes fm, "\nscope: visibility:public\n"
+    assert_includes fm, "\nquery: list:tuned_in\n"
+  end
+
+  test "home feed query reflects the viewer's refinement" do
+    get "/", params: { q: "type:note" }, headers: @headers
+    assert_response :success
+    fm = frontmatter(response.body)
+    assert_includes fm, "\nscope: visibility:public\n"
+    assert_includes fm, "\nquery: type:note\n"
   end
 
   test "search page declares the current query and no scope" do

--- a/test/integration/page_scope_frontmatter_test.rb
+++ b/test/integration/page_scope_frontmatter_test.rb
@@ -1,0 +1,88 @@
+require "test_helper"
+
+# Feed pages declare their fixed filters in markdown frontmatter as a
+# `scope:` attribute (search syntax), and their current refinements as
+# `query:`. Agents can paste the scope into /search to reproduce the page's
+# content — one navigation calculus. See docs/NAVIGATION_DESIGN.md
+# ("Feeds are queries").
+class PageScopeFrontmatterTest < ActionDispatch::IntegrationTest
+  def setup
+    @tenant = @global_tenant
+    @tenant.enable_api!
+    @collective = @global_collective
+    @collective.enable_api!
+    @user = @global_user
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    api_token = ApiToken.create!(tenant: @tenant, user: @user, scopes: ApiToken.valid_scopes)
+    @headers = {
+      "Authorization" => "Bearer #{api_token.plaintext_token}",
+      "Accept" => "text/markdown",
+    }
+    host! "#{@tenant.subdomain}.#{ENV.fetch("HOSTNAME", nil)}"
+  end
+
+  # The YAML frontmatter block between the first two `---` lines.
+  def frontmatter(body)
+    body[/\A.*?^---$(.*?)^---$/m, 1] || ""
+  end
+
+  test "home feed declares its fixed scope" do
+    get "/", headers: @headers
+    assert_response :success
+    assert_includes frontmatter(response.body), "\nscope: visibility:public list:tuned_in\n"
+  end
+
+  test "search page declares the current query and no scope" do
+    get "/search", params: { q: "type:note budget" }, headers: @headers
+    assert_response :success
+    fm = frontmatter(response.body)
+    assert_includes fm, "\nquery: type:note budget\n"
+    assert_no_match(/^scope:/, fm)
+  end
+
+  test "search page with no query omits both keys" do
+    get "/search", headers: @headers
+    assert_response :success
+    fm = frontmatter(response.body)
+    assert_no_match(/^scope:/, fm)
+    assert_no_match(/^query:/, fm)
+  end
+
+  test "profile page declares a creator scope" do
+    handle = @user.tenant_user.handle
+    get "/u/#{handle}", headers: @headers
+    assert_response :success
+    assert_includes frontmatter(response.body), "\nscope: visibility:public creator:@#{handle}\n"
+  end
+
+  test "list activity page declares a list scope" do
+    list = @user.primary_user_list_in!(@tenant)
+    get "/lists/#{list.truncated_id}", headers: @headers
+    assert_response :success
+    assert_includes frontmatter(response.body), "\nscope: visibility:public list:#{list.truncated_id}\n"
+  end
+
+  test "collective page declares a collective scope" do
+    get @collective.path.to_s, headers: @headers
+    assert_response :success
+    assert_includes frontmatter(response.body), "\nscope: collective:#{@collective.handle}\n"
+  end
+
+  test "private workspace page declares the private zone as its scope" do
+    workspace = Collective.create!(
+      tenant: @tenant,
+      created_by: @user,
+      name: "My Workspace",
+      handle: "scope-test-workspace-#{SecureRandom.hex(4)}",
+      collective_type: "private_workspace"
+    )
+    workspace.add_user!(@user)
+
+    get workspace.path.to_s, headers: @headers
+    assert_response :success
+    assert_includes frontmatter(response.body), "\nscope: visibility:private\n"
+  end
+end

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -51,6 +51,38 @@ class SearchTest < ActionDispatch::IntegrationTest
     assert(response.body.include?("No results found") || response.body.include?("0 results"))
   end
 
+  test "GET search empty state offers clearing the search" do
+    sign_in_as(@user, tenant: @tenant)
+    get search_path, params: { q: "nonexistentquery12345", cycle: "all" }
+    assert_response :success
+    assert_select "a[href='/search']", text: "Clear search"
+  end
+
+  test "GET search with an invalid operator value renders a parse warning" do
+    sign_in_as(@user, tenant: @tenant)
+    get search_path, params: { q: "visibility:bogus" }
+    assert_response :success
+    assert_select ".pulse-feed-bar-warning", text: /visibility:bogus/
+  end
+
+  test "GET search markdown renders parse warnings" do
+    get search_path, params: { q: "visibility:bogus" }, headers: @headers
+    assert_response :success
+    assert_match(/^> ⚠️ visibility:bogus is not a valid visibility: filter/, response.body)
+  end
+
+  test "search syntax help documents visibility: not the removed scope: operator" do
+    sign_in_as(@user, tenant: @tenant)
+    get search_path
+    assert_response :success
+    assert_includes response.body, "<code>visibility:</code>"
+    assert_not_includes response.body, "<code>scope:</code>"
+
+    get search_path, headers: @headers
+    assert_includes response.body, "`visibility:`"
+    assert_not_includes response.body, "`scope:`"
+  end
+
   # Markdown tests
 
   test "GET search with Accept text/markdown returns markdown" do

--- a/test/models/concerns/searchable_test.rb
+++ b/test/models/concerns/searchable_test.rb
@@ -1,0 +1,57 @@
+# typed: false
+
+require "test_helper"
+
+class SearchableTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    @tenant, @collective, @user = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+  end
+
+  def index_row_for(note)
+    SearchIndex.tenant_scoped_only(@tenant.id).find_by(item_type: "Note", item_id: note.id)
+  end
+
+  test "creating an item indexes it synchronously" do
+    note = create_note(tenant: @tenant, collective: @collective, created_by: @user, text: "sync indexed on create")
+
+    row = index_row_for(note)
+    assert row, "expected a SearchIndex row at create time, before any job runs"
+    assert_includes row.searchable_text, "sync indexed on create"
+  end
+
+  test "creating an item does not also enqueue a redundant reindex job" do
+    # A Decision creates no invalidating side-records (a Note's author
+    # read-confirmation legitimately enqueues one), so Searchable's own
+    # create path must be the only indexer — and it runs synchronously.
+    assert_no_enqueued_jobs(only: ReindexSearchJob) do
+      create_decision(tenant: @tenant, collective: @collective, created_by: @user)
+    end
+  end
+
+  test "updates reindex asynchronously" do
+    note = create_note(tenant: @tenant, collective: @collective, created_by: @user, text: "original text here")
+    clear_enqueued_jobs
+
+    assert_enqueued_with(job: ReindexSearchJob, args: [{ item_type: "Note", item_id: note.id, tenant_id: @tenant.id }]) do
+      note.update!(text: "edited text here")
+    end
+    # The row stays stale until the job runs — updates are eventual.
+    assert_includes index_row_for(note).searchable_text, "original text here"
+  end
+
+  test "a failing synchronous index write does not block creation" do
+    note = nil
+    SearchIndexer.stub(:reindex, ->(_item) { raise "index down" }) do
+      assert_nothing_raised do
+        note = create_note(tenant: @tenant, collective: @collective, created_by: @user, text: "still created")
+      end
+    end
+
+    assert note.persisted?
+    # Falls back to the async job so the item is eventually indexed.
+    assert_enqueued_with(job: ReindexSearchJob, args: [{ item_type: "Note", item_id: note.id, tenant_id: @tenant.id }])
+  end
+end

--- a/test/models/concerns/searchable_test.rb
+++ b/test/models/concerns/searchable_test.rb
@@ -23,12 +23,21 @@ class SearchableTest < ActiveSupport::TestCase
   end
 
   test "creating an item does not also enqueue a redundant reindex job" do
-    # A Decision creates no invalidating side-records (a Note's author
-    # read-confirmation legitimately enqueues one), so Searchable's own
+    # Decisions and commitments create no invalidating side-records (a
+    # Note's author read-confirmation legitimately enqueues one — joining
+    # a commitment is a separate explicit action), so Searchable's own
     # create path must be the only indexer — and it runs synchronously.
     assert_no_enqueued_jobs(only: ReindexSearchJob) do
       create_decision(tenant: @tenant, collective: @collective, created_by: @user)
+      create_commitment(tenant: @tenant, collective: @collective, created_by: @user)
     end
+  end
+
+  test "commitments index synchronously on create" do
+    commitment = create_commitment(tenant: @tenant, collective: @collective, created_by: @user, title: "Sync commitment")
+    row = SearchIndex.tenant_scoped_only(@tenant.id).find_by(item_type: "Commitment", item_id: commitment.id)
+    assert row
+    assert_includes row.searchable_text, "Sync commitment"
   end
 
   test "updates reindex asynchronously" do

--- a/test/services/search_query_parser_test.rb
+++ b/test/services/search_query_parser_test.rb
@@ -652,4 +652,38 @@ class SearchQueryParserTest < ActiveSupport::TestCase
     assert_equal "has", result[:collective_handle]
     assert_equal "spaces", result[:q]
   end
+
+  # Warnings: a KNOWN operator with an invalid value silently degrading to
+  # search text is confusing — the parser reports it. Unknown operators stay
+  # silent (they are legitimately searchable text like "re:invoice").
+
+  test "invalid value for a values operator warns and names the valid values" do
+    result = SearchQueryParser.new("visibility:invalid").parse
+    assert_equal 1, result[:warnings].size
+    warning = result[:warnings].first
+    assert_includes warning, "visibility:invalid"
+    assert_includes warning, "public, shared, private"
+  end
+
+  test "invalid value for a pattern operator warns" do
+    result = SearchQueryParser.new("after:not-a-date").parse
+    assert_equal 1, result[:warnings].size
+    assert_includes result[:warnings].first, "after:not-a-date"
+  end
+
+  test "unknown operators do not warn" do
+    result = SearchQueryParser.new("re:invoice foo:bar").parse
+    assert_empty result[:warnings]
+  end
+
+  test "valid queries do not warn" do
+    result = SearchQueryParser.new("budget type:note visibility:public").parse
+    assert_empty result[:warnings]
+  end
+
+  test "negated invalid values warn too" do
+    result = SearchQueryParser.new("-status:maybe").parse
+    assert_equal 1, result[:warnings].size
+    assert_includes result[:warnings].first, "status:maybe"
+  end
 end

--- a/test/services/search_query_parser_test.rb
+++ b/test/services/search_query_parser_test.rb
@@ -636,17 +636,14 @@ class SearchQueryParserTest < ActiveSupport::TestCase
     assert_equal "note", result[:type]
   end
 
-  # Backward-compatible `scope:` alias for `visibility:`
+  # `scope` is reserved to mean a page's fixed filters, not a search
+  # operator. It is deliberately NOT an alias for `visibility:`.
 
-  test "scope: alias maps to visibility" do
+  test "scope: is not an operator and falls through to search text" do
     result = SearchQueryParser.new("scope:private").parse
-    assert_equal "private", result[:visibility]
-  end
-
-  test "-scope: alias maps to exclude_visibility" do
-    result = SearchQueryParser.new("-scope:private").parse
-    assert_equal "private", result[:exclude_visibility]
+    assert_equal "scope:private", result[:q]
     assert_nil result[:visibility]
+    assert_nil result[:exclude_visibility]
   end
 
   test "invalid collective: value is treated as search text" do

--- a/test/services/search_query_test.rb
+++ b/test/services/search_query_test.rb
@@ -1086,6 +1086,20 @@ class SearchQueryTest < ActiveSupport::TestCase
     assert_empty search.results
   end
 
+  test "negating the fixed scope is ignored with a warning" do
+    @tenant.update!(main_collective: @collective)
+    search = SearchQuery.new(
+      tenant: @tenant, current_user: @user,
+      raw_query: "budget -visibility:public cycle:all",
+      fixed_params: { visibility: "public" }
+    )
+
+    warning = search.warnings.find { |w| w.include?("-visibility:public") }
+    assert warning, "expected a conflict warning, got: #{search.warnings.inspect}"
+    # The negation is dropped; the fixed scope still returns results.
+    assert_not_empty search.results
+  end
+
   test "fixed params do not warn when the query does not conflict" do
     search = SearchQuery.new(
       tenant: @tenant, current_user: @user,

--- a/test/services/search_query_test.rb
+++ b/test/services/search_query_test.rb
@@ -983,4 +983,115 @@ class SearchQueryTest < ActiveSupport::TestCase
     # No results because access control prevents it
     assert_empty search.results.pluck(:item_id)
   end
+
+  # list:tuned_in — the home-feed alias
+
+  test "list:tuned_in includes the viewer's own content" do
+    # Your own writing stays on your home view: you cannot tune in to
+    # yourself, so the alias adds the viewer to the primary-list members.
+    @tenant.update!(main_collective: @collective)
+    @user.primary_user_list_in!(@tenant)
+
+    search = SearchQuery.new(
+      tenant: @tenant, current_user: @user,
+      raw_query: "list:tuned_in cycle:all"
+    )
+    assert_includes search.results.pluck(:item_id), @note.id
+  end
+
+  test "list:tuned_in includes tuned-in members and excludes strangers" do
+    @tenant.update!(main_collective: @collective)
+    member = create_user(email: "tuned_member@example.com", name: "Tuned Member")
+    stranger = create_user(email: "stranger@example.com", name: "Stranger")
+    [member, stranger].each do |u|
+      @tenant.add_user!(u)
+      @collective.add_user!(u)
+    end
+    list = @user.primary_user_list_in!(@tenant)
+    UserListMember.create!(
+      tenant: @tenant, collective: @collective,
+      user_list: list, user: member, added_by: @user
+    )
+    member_note = create_note(tenant: @tenant, collective: @collective, created_by: member, title: "Member note")
+    stranger_note = create_note(tenant: @tenant, collective: @collective, created_by: stranger, title: "Stranger note")
+    [member_note, stranger_note].each { |n| SearchIndexer.reindex(n) }
+
+    search = SearchQuery.new(
+      tenant: @tenant, current_user: @user,
+      raw_query: "list:tuned_in cycle:all"
+    )
+    ids = search.results.pluck(:item_id)
+    assert_includes ids, member_note.id
+    assert_not_includes ids, stranger_note.id
+  end
+
+  test "list filters exclude blocked authors even with stale list membership" do
+    # The UserBlock callback removes primary-list memberships at block time,
+    # but memberships that predate the callback could linger. The list
+    # filter itself must drop block-related authors (same defense the home
+    # feed applied before it moved to search).
+    @tenant.update!(main_collective: @collective)
+    member = create_user(email: "blocked_member@example.com", name: "Blocked Member")
+    @tenant.add_user!(member)
+    @collective.add_user!(member)
+    list = @user.primary_user_list_in!(@tenant)
+    UserBlock.create!(tenant: @tenant, blocker: @user, blocked: member)
+    # Simulate a stale membership that predates the block validation and
+    # callback (both would prevent this today) by skipping validations.
+    stale = UserListMember.new(
+      tenant: @tenant, collective: @collective,
+      user_list: list, user: member, added_by: @user
+    )
+    stale.save!(validate: false)
+    blocked_note = create_note(tenant: @tenant, collective: @collective, created_by: member, title: "Blocked author note")
+    SearchIndexer.reindex(blocked_note)
+
+    search = SearchQuery.new(
+      tenant: @tenant, current_user: @user,
+      raw_query: "list:tuned_in cycle:all"
+    )
+    assert_not_includes search.results.pluck(:item_id), blocked_note.id
+  end
+
+  # Fixed params — structural page scope enforcement
+
+  test "fixed params override conflicting query terms and warn" do
+    @tenant.update!(main_collective: @collective)
+    search = SearchQuery.new(
+      tenant: @tenant, current_user: @user,
+      raw_query: "budget visibility:private cycle:all",
+      fixed_params: { visibility: "public" }
+    )
+
+    warning = search.warnings.find { |w| w.include?("visibility:private") }
+    assert warning, "expected a conflict warning, got: #{search.warnings.inspect}"
+    assert_includes warning, "visibility:public"
+    # Enforced structurally: results are main-collective (public) content.
+    assert_not_empty search.results
+    assert search.results.all? { |r| r.collective_id == @collective.id }
+  end
+
+  test "a blank query with a fixed scope browses everything in scope" do
+    @tenant.update!(main_collective: @collective)
+    search = SearchQuery.new(
+      tenant: @tenant, current_user: @user,
+      raw_query: "",
+      fixed_params: { visibility: "public" }
+    )
+    assert_includes search.results.pluck(:item_id), @note.id
+  end
+
+  test "a blank query with no fixed scope returns nothing" do
+    search = SearchQuery.new(tenant: @tenant, current_user: @user, raw_query: "")
+    assert_empty search.results
+  end
+
+  test "fixed params do not warn when the query does not conflict" do
+    search = SearchQuery.new(
+      tenant: @tenant, current_user: @user,
+      raw_query: "budget cycle:all",
+      fixed_params: { visibility: "public" }
+    )
+    assert_empty search.warnings
+  end
 end


### PR DESCRIPTION
Implements #352 — every feed is a search with a fixed page scope, refinable with `/search` syntax. Model and guardrails in `docs/NAVIGATION_DESIGN.md` ("Feeds are queries", on the #339 branch).

## What this does

**Page scope.** Feed pages declare their fixed filters in markdown frontmatter (`scope:`) and current refinements (`query:`), so agents navigate every feed through one calculus: `search(scope + refinements)`. Documented in `/help/markdown-ui` and `/help/search`.

**Feed search bar.** All filters render inside one query field — fixed filters as muted non-editable tokens, the rest as editable text. Feed pages say "Filter"; the term "search" is reserved for `/search`. The parser now warns when a known operator gets an invalid value (`visibility:bogus … expected: public, shared, private`) instead of silently degrading to text; warnings render in HTML and markdown.

**Feeds converted to `SearchQuery`:**
- `/` — the public space feed: fixed `visibility:public`, default `list:tuned_in` as editable text ("see everything" = clear one filter). `list:tuned_in` now includes the viewer, and list filters drop block-related authors even with stale memberships.
- `/collectives/:handle` (and `/workspace/:handle`) — **the feed is now the collective's default page**; the cycle dashboard moved to `/dashboard`. Fixed `collective:handle` (workspaces also `visibility:private`), default `cycle:this-week` (cycle = active-in-window, matching dashboard semantics). Heartbeat ritual ported: HTML blurs, markdown shows Heartbeat Required + `send_heartbeat` only.
- Profile tabs (Posts = `type:note subtype:post`, Activity = `-subtype:post,comment`) and list feeds (`list:<id>`) — engines converted; the bar on tabbed pages is a design follow-up.

**Semantics:** `?q` absent → page defaults; `?q=` present-but-empty → cleared (browse everything in scope). Fixed scopes are enforced structurally — conflicting terms are overridden with a visible warning ("`collective:other` ignored: this page is fixed to collective:x"), never widened. A blank query with a fixed scope browses; `/search` keeps its empty-page behavior.

**Sync-on-create indexing.** New notes/decisions/commitments write their index row inline at commit (read-your-writes on search-backed feeds) with a rescue-and-enqueue fallback; updates and count-invalidation stay async.

**Clean break:** the `scope:` operator alias for `visibility:` is removed — "scope" now means exactly one thing (a page's fixed filters). `scope:x` parses as search text.

## Notes for review

- Home/feed results come from the search index; sync-on-create closes the freshness gap for new content, but *edits* are searchable only after the async reindex job runs.
- Reminders interleave on default feed views only (controller-level) — they're events, not indexed content, and don't compose with cursor pagination.
- `FeedBuilder`'s last caller is the cycle dashboard; it retires when the dashboard converts.
- Includes a `rubocop -a` sweep of `search_query.rb` (pre-existing style debt).

## Performance

Net read win: the collective root (previously the dashboard's ~12+ queries per view) is now one indexed scan on `search_index` at limit 30 plus batched record loads; the dashboard's cost is paid only when visited. Creates pay ~2-10ms for the synchronous index write (deliberate, for read-your-writes).

**Known scaling gap:** author-filtered feeds (home `list:tuned_in`, profiles `creator:`, lists) filter `created_by_id`, which has no supporting index on `search_index` — Postgres walks `(tenant_id, collective_id, created_at)` newest-first and filters until the limit fills. Fine at current scale; the degenerate case is a large busy tenant where the viewer's authors post rarely. If it shows in slow-query logs, the fix is a single migration: an index on `(tenant_id, collective_id, created_by_id, created_at)`. No code changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

