### PR TITLE
Update Pulse read count live on confirm-read (#300)

### DIFF
--- a/app/assets/stylesheets/collective_pulse.css
+++ b/app/assets/stylesheets/collective_pulse.css
@@ -769,6 +769,13 @@ a:hover {
   gap: 4px;
 }
 
+/* Hidden until the first read is confirmed (revealed live by pulse-action).
+   Attribute+class specificity overrides the display:flex rule above. */
+.pulse-confirmed-reads[hidden],
+.pulse-confirmed-self[hidden] {
+  display: none;
+}
+
 .pulse-confirmed-avatars {
   display: flex;
 }

--- a/app/components/feed_item_component.html.erb
+++ b/app/components/feed_item_component.html.erb
@@ -168,27 +168,47 @@
   <div class="pulse-feed-item-footer">
     <% case @type %>
     <% when 'Note' %>
-      <% if @current_user.nil? %>
-        <a href="/login" data-redirect-to-resource="<%= @item.path %>" class="pulse-feed-action-btn-link"><%= helpers.octicon 'sign-in' %> Log in to confirm reading</a>
-      <% elsif user_has_read? %>
-        <button type="button" class="pulse-feed-action-btn pulse-feed-action-btn-disabled" disabled><%= helpers.octicon 'book' %> Confirmed</button>
-      <% else %>
+      <% if @current_user && !user_has_read? %>
+        <%# Unread: the pulse-action controller wraps the button and the count
+            block so a successful confirm updates the "N confirmed" figure live
+            (revealing it, and the viewer's avatar, on the first confirmation). %>
         <div data-controller="pulse-action" data-pulse-action-url-value="<%= @item.path %>/actions/confirm_read" data-pulse-action-loading-text-value="Confirming..." data-pulse-action-confirmed-text-value="Confirmed">
           <button type="button" class="pulse-feed-action-btn" data-pulse-action-target="button" data-action="click->pulse-action#performAction"><%= helpers.octicon 'book' %> Confirm read</button>
-        </div>
-      <% end %>
-      <% if read_count > 0 %>
-        <div class="pulse-confirmed-reads">
-          <div class="pulse-confirmed-avatars">
-            <% read_confirmations_scope.includes(:user).select(:user_id).distinct.limit(3).each do |event| %>
-              <%= render "shared/avatar", user: event.user, css_class: "pulse-confirmed-avatar" %>
-            <% end %>
-            <% if read_count > 3 %>
-              <div class="pulse-confirmed-avatar">+<%= read_count - 3 %></div>
-            <% end %>
+          <div class="pulse-confirmed-reads" data-pulse-action-target="readCount" <%= "hidden" if read_count.zero? %>>
+            <div class="pulse-confirmed-avatars">
+              <% if read_count.zero? %>
+                <span class="pulse-confirmed-self" data-pulse-action-target="selfAvatar" hidden><%= render "shared/avatar", user: @current_user, css_class: "pulse-confirmed-avatar" %></span>
+              <% end %>
+              <% read_confirmations_scope.includes(:user).select(:user_id).distinct.limit(3).each do |event| %>
+                <%= render "shared/avatar", user: event.user, css_class: "pulse-confirmed-avatar" %>
+              <% end %>
+              <% if read_count > 3 %>
+                <div class="pulse-confirmed-avatar">+<%= read_count - 3 %></div>
+              <% end %>
+            </div>
+            <span data-pulse-action-target="count"><%= read_count %> confirmed</span>
           </div>
-          <span><%= read_count %> confirmed</span>
         </div>
+      <% else %>
+        <%# Anonymous (login CTA) or already-confirmed: static count, no live update. %>
+        <% if @current_user.nil? %>
+          <a href="/login" data-redirect-to-resource="<%= @item.path %>" class="pulse-feed-action-btn-link"><%= helpers.octicon 'sign-in' %> Log in to confirm reading</a>
+        <% else %>
+          <button type="button" class="pulse-feed-action-btn pulse-feed-action-btn-disabled" disabled><%= helpers.octicon 'book' %> Confirmed</button>
+        <% end %>
+        <% if read_count > 0 %>
+          <div class="pulse-confirmed-reads">
+            <div class="pulse-confirmed-avatars">
+              <% read_confirmations_scope.includes(:user).select(:user_id).distinct.limit(3).each do |event| %>
+                <%= render "shared/avatar", user: event.user, css_class: "pulse-confirmed-avatar" %>
+              <% end %>
+              <% if read_count > 3 %>
+                <div class="pulse-confirmed-avatar">+<%= read_count - 3 %></div>
+              <% end %>
+            </div>
+            <span><%= read_count %> confirmed</span>
+          </div>
+        <% end %>
       <% end %>
     <% when 'Decision' %>
       <% if @item.closed? %>

--- a/app/javascript/controllers/pulse_action_controller.test.ts
+++ b/app/javascript/controllers/pulse_action_controller.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import PulseActionController from "./pulse_action_controller"
+
+describe("PulseActionController", () => {
+  let application: Application
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    document.head.innerHTML = `<meta name="csrf-token" content="csrf-test-token">`
+    application = Application.start()
+    application.register("pulse-action", PulseActionController)
+    fetchSpy = vi.spyOn(global, "fetch")
+  })
+
+  afterEach(() => {
+    application.stop()
+    fetchSpy.mockRestore()
+    document.body.innerHTML = ""
+    document.head.innerHTML = ""
+  })
+
+  function flushMicrotasks(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 0))
+  }
+
+  // Mirrors the confirm-read footer rendered by FeedItemComponent: the
+  // controller wraps both the button and the "N confirmed" count block.
+  async function mountConfirmRead(opts: {
+    readCount: number
+    withSelfAvatar?: boolean
+  }): Promise<HTMLElement> {
+    const hidden = opts.readCount === 0 ? "hidden" : ""
+    const selfAvatar = opts.withSelfAvatar
+      ? `<span class="pulse-confirmed-self" data-pulse-action-target="selfAvatar" hidden>me</span>`
+      : ""
+    document.body.innerHTML = `
+      <div data-controller="pulse-action"
+           data-pulse-action-url-value="/n/abc/actions/confirm_read"
+           data-pulse-action-loading-text-value="Confirming..."
+           data-pulse-action-confirmed-text-value="Confirmed">
+        <button type="button" class="pulse-feed-action-btn"
+                data-pulse-action-target="button"
+                data-action="click->pulse-action#performAction">Confirm read</button>
+        <div class="pulse-confirmed-reads" data-pulse-action-target="readCount" ${hidden}>
+          <div class="pulse-confirmed-avatars">${selfAvatar}</div>
+          <span data-pulse-action-target="count">${opts.readCount} confirmed</span>
+        </div>
+      </div>
+    `
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    return document.querySelector("[data-controller='pulse-action']") as HTMLElement
+  }
+
+  // Mirrors the commitment "Join" footer, which reuses the controller but has
+  // no count block and returns a different JSON shape.
+  async function mountJoin(): Promise<HTMLButtonElement> {
+    document.body.innerHTML = `
+      <div data-controller="pulse-action"
+           data-pulse-action-url-value="/c/xyz/actions/join_commitment"
+           data-pulse-action-loading-text-value="Joining..."
+           data-pulse-action-confirmed-text-value="Joined">
+        <button type="button" class="pulse-feed-action-btn"
+                data-pulse-action-target="button"
+                data-action="click->pulse-action#performAction">Join</button>
+      </div>
+    `
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    return document.querySelector("button") as HTMLButtonElement
+  }
+
+  it("flips the button to the confirmed label on success", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ success: true, confirmed_reads: 3 }), { status: 200 })
+    )
+    const root = await mountConfirmRead({ readCount: 2 })
+    const button = root.querySelector("button") as HTMLButtonElement
+
+    button.click()
+    await flushMicrotasks()
+
+    expect(button.textContent?.trim()).toBe("Confirmed")
+    expect(button.disabled).toBe(true)
+  })
+
+  it("updates the confirmed count from the JSON response", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ success: true, confirmed_reads: 3 }), { status: 200 })
+    )
+    const root = await mountConfirmRead({ readCount: 2 })
+    const count = root.querySelector("[data-pulse-action-target='count']") as HTMLElement
+
+    root.querySelector("button")!.dispatchEvent(new Event("click"))
+    await flushMicrotasks()
+
+    expect(count.textContent?.trim()).toBe("3 confirmed")
+  })
+
+  it("reveals the count block and self avatar on the first confirmation", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ success: true, confirmed_reads: 1 }), { status: 200 })
+    )
+    const root = await mountConfirmRead({ readCount: 0, withSelfAvatar: true })
+    const readCount = root.querySelector("[data-pulse-action-target='readCount']") as HTMLElement
+    const selfAvatar = root.querySelector("[data-pulse-action-target='selfAvatar']") as HTMLElement
+    const count = root.querySelector("[data-pulse-action-target='count']") as HTMLElement
+
+    expect(readCount.hidden).toBe(true)
+    expect(selfAvatar.hidden).toBe(true)
+
+    root.querySelector("button")!.dispatchEvent(new Event("click"))
+    await flushMicrotasks()
+
+    expect(readCount.hidden).toBe(false)
+    expect(selfAvatar.hidden).toBe(false)
+    expect(count.textContent?.trim()).toBe("1 confirmed")
+  })
+
+  it("does not change the count when the request fails", async () => {
+    fetchSpy.mockResolvedValue(new Response("", { status: 422 }))
+    const root = await mountConfirmRead({ readCount: 2 })
+    const count = root.querySelector("[data-pulse-action-target='count']") as HTMLElement
+    const button = root.querySelector("button") as HTMLButtonElement
+
+    button.click()
+    await flushMicrotasks()
+
+    expect(count.textContent?.trim()).toBe("2 confirmed")
+    expect(button.textContent?.trim()).toBe("Confirm read")
+    expect(button.disabled).toBe(false)
+  })
+
+  it("still works for the commitment join button (no count target)", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), { status: 200 })
+    )
+    const button = await mountJoin()
+
+    button.click()
+    await flushMicrotasks()
+
+    expect(button.textContent?.trim()).toBe("Joined")
+    expect(button.disabled).toBe(true)
+  })
+
+  it("tolerates a non-JSON success body without throwing", async () => {
+    fetchSpy.mockResolvedValue(new Response("<div>ok</div>", { status: 200 }))
+    const root = await mountConfirmRead({ readCount: 2 })
+    const count = root.querySelector("[data-pulse-action-target='count']") as HTMLElement
+
+    root.querySelector("button")!.dispatchEvent(new Event("click"))
+    await flushMicrotasks()
+
+    // Button still flips; count is left untouched since there was no number.
+    expect(root.querySelector("button")!.textContent?.trim()).toBe("Confirmed")
+    expect(count.textContent?.trim()).toBe("2 confirmed")
+  })
+})

--- a/app/javascript/controllers/pulse_action_controller.ts
+++ b/app/javascript/controllers/pulse_action_controller.ts
@@ -4,9 +4,15 @@ import { getCsrfToken } from "../utils/csrf"
 /**
  * Handles AJAX-based action buttons in the Pulse feed.
  * Used for "Confirm read" (Notes) and "Join" (Commitments) actions.
+ *
+ * For "Confirm read", the JSON response includes the updated `confirmed_reads`
+ * count. When a count block is present we update the "N confirmed" figure live
+ * (revealing it, and the viewer's avatar, on the first confirmation) so it
+ * stays in sync without a page reload. Actions without a count target — e.g.
+ * the Commitment "Join" button — just flip the button as before.
  */
 export default class PulseActionController extends Controller {
-  static targets = ["button"]
+  static targets = ["button", "count", "readCount", "selfAvatar"]
   static values = {
     url: String,
     loadingText: String,
@@ -14,6 +20,12 @@ export default class PulseActionController extends Controller {
   }
 
   declare readonly buttonTarget: HTMLButtonElement
+  declare readonly countTarget: HTMLElement
+  declare readonly hasCountTarget: boolean
+  declare readonly readCountTarget: HTMLElement
+  declare readonly hasReadCountTarget: boolean
+  declare readonly selfAvatarTarget: HTMLElement
+  declare readonly hasSelfAvatarTarget: boolean
   declare readonly urlValue: string
   declare readonly loadingTextValue: string
   declare readonly confirmedTextValue: string
@@ -33,11 +45,13 @@ export default class PulseActionController extends Controller {
         method: "POST",
         headers: {
           "X-CSRF-Token": getCsrfToken(),
+          Accept: "application/json",
         },
       })
 
       if (response.ok) {
         this.showConfirmedState()
+        await this.updateReadCount(response)
       } else {
         // Revert to original state on error
         this.showErrorState()
@@ -47,6 +61,33 @@ export default class PulseActionController extends Controller {
     }
 
     this.isLoading = false
+  }
+
+  // Sync the "N confirmed" figure from the JSON body. No-op for actions that
+  // don't render a count (e.g. Commitment "Join") or when the body isn't the
+  // expected JSON, so those paths keep their prior behavior.
+  private async updateReadCount(response: Response): Promise<void> {
+    if (!this.hasCountTarget) return
+
+    let confirmedReads: unknown
+    try {
+      const data = await response.json()
+      confirmedReads = data?.confirmed_reads
+    } catch {
+      return
+    }
+    if (typeof confirmedReads !== "number") return
+
+    this.countTarget.textContent = `${confirmedReads} confirmed`
+
+    // First confirmation: the count block (and the viewer's avatar) start
+    // hidden because the server rendered zero reads. Reveal them now.
+    if (this.hasReadCountTarget) {
+      this.readCountTarget.hidden = false
+    }
+    if (this.hasSelfAvatarTarget) {
+      this.selfAvatarTarget.hidden = false
+    }
   }
 
   private showLoadingState(): void {

--- a/test/components/feed_item_component_test.rb
+++ b/test/components/feed_item_component_test.rb
@@ -265,6 +265,24 @@ class FeedItemComponentTest < ViewComponent::TestCase
     assert_selector "button", text: /Confirm read/
   end
 
+  test "renders the confirmed-reads count block hidden until the first confirmation" do
+    note = build_note(text: "Read me")
+    user = build_user(display_name: "Alice")
+    current_user = build_user(display_name: "Viewer", handle: "viewer")
+    render_inline(FeedItemComponent.new(
+                    item: note,
+                    type: "Note",
+                    created_by: user,
+                    created_at: 1.hour.ago,
+                    current_user: current_user
+                  ))
+    # No reads yet: the count block and the viewer's avatar render hidden inside
+    # the pulse-action controller, ready to be revealed on a successful confirm.
+    assert_selector "[data-controller='pulse-action'] .pulse-confirmed-reads[hidden]", visible: :hidden
+    assert_selector "[data-pulse-action-target='count']", text: "0 confirmed", visible: :hidden
+    assert_selector "[data-pulse-action-target='selfAvatar']", visible: :hidden
+  end
+
   test "renders confirmed button when already read" do
     note = build_note(text: "Read me")
     note.define_singleton_method(:user_has_read?) { |_u| true }


### PR DESCRIPTION
Closes #300.

## What
In the Pulse feed, clicking **Confirm read** flipped the button label but ignored the response body, so the **"N confirmed"** count stayed stale until a page reload. Worse, a note with zero prior reads had no count block in the DOM at all, so nothing could appear. Now the count updates live on confirm.

## How
- `pulse_action_controller.ts` now parses the JSON response and, when a count block is present, updates the `N confirmed` text from `confirmed_reads`. On the **first** confirmation it reveals the count block and the viewer's avatar (both server-rendered hidden).
- `feed_item_component.html.erb`: for the **unread** case, the `pulse-action` controller now wraps both the button and the count block (so the count is a reachable Stimulus target). The count block always renders — hidden until there's at least one read. **Anonymous** and **already-confirmed** states keep the original *static* count block untouched, so the confirm-read controller/URL is still never emitted for logged-out viewers (preserves the anonymous-access test).
- `collective_pulse.css`: `.pulse-confirmed-reads[hidden]` / `.pulse-confirmed-self[hidden]` → `display: none` (attribute+class specificity overrides the block's `display: flex`).

The controller is shared with the Commitment **Join** button. Count updates are guarded on the count target existing and tolerate a non-JSON body, so the Join path is unchanged.

## Scope note
The avatar strip is only live-updated in the zero→one case (where it would otherwise be empty). When a note already has reads, the number bumps but the avatar strip (which already caps at 3 + "+N") is left as the server rendered it; it reconciles on next load. Keeping it this way avoids duplicating the 3-avatar/overflow logic client-side. Happy to sync avatars fully if you'd prefer.

## Tests
- New `pulse_action_controller.test.ts` (6): button flip, count update from JSON, first-confirmation reveal of block + self-avatar, error path leaves count/button untouched, Commitment-join path unchanged, non-JSON body tolerated.
- New `FeedItemComponent` test: count block + self-avatar render hidden at zero reads.
- Full Vitest suite (381) and `tsc --noEmit` pass locally. Ruby tests left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)