### PR TITLE
Fix collective representation over markdown/MCP (#365)

### DIFF
--- a/app/controllers/representation_sessions_controller.rb
+++ b/app/controllers/representation_sessions_controller.rb
@@ -56,6 +56,16 @@ class RepresentationSessionsController < ApplicationController
     end
 
     @page_title = "Represent"
+    # DB-backed lookup mirroring the frontmatter lambdas in ActionsHelper: an API
+    # caller isn't required to echo X-Representation-Session-ID on this page, so
+    # current_representation_session alone would say "no session" while the
+    # frontmatter advertises end_representation. The prose must agree with the
+    # advertised actions.
+    @active_collective_session = RepresentationSession.find_by(
+      collective: current_collective,
+      representative_user: @current_user,
+      ended_at: nil
+    )
     respond_to do |format|
       format.html
       format.md

--- a/app/controllers/representation_sessions_controller.rb
+++ b/app/controllers/representation_sessions_controller.rb
@@ -8,7 +8,12 @@ class RepresentationSessionsController < ApplicationController
   include RequiresReverification
 
   before_action :set_sidebar_mode, only: [:index, :show, :represent, :representing]
-  before_action -> { require_reverification(scope: "representation") }, only: [:represent, :start_representing, :start_representing_user]
+  # execute_start_representation is included so a browser/cookie caller hitting the
+  # actions endpoint faces the same 2FA step-up as the HTML form flow. API-token
+  # callers are exempt inside require_reverification (returns early), so MCP is
+  # unaffected — but this closes the browser bypass. End is intentionally not gated
+  # on either path.
+  before_action -> { require_reverification(scope: "representation") }, only: [:represent, :start_representing, :start_representing_user, :execute_start_representation]
 
   def index
     @representatives = current_collective.representatives
@@ -83,7 +88,15 @@ class RepresentationSessionsController < ApplicationController
   end
 
   def execute_start_representation
-    if current_representation_session
+    # Nested-session guard. `current_representation_session` resolves from the
+    # X-Representation-Session-ID header for API callers, and nothing forces that
+    # header on start — so an agent could start, then start again without echoing
+    # the header and slip past a header-only check, creating a second concurrent
+    # active session (there's no partial-unique DB index as a backstop). Guard on
+    # the database instead so a live session for this (collective, representative)
+    # always blocks a second start regardless of headers.
+    if current_representation_session ||
+       RepresentationSession.exists?(collective: current_collective, representative_user: current_user, ended_at: nil)
       return render_action_error({
                                    action_name: "start_representation",
                                    resource: current_collective,
@@ -97,6 +110,20 @@ class RepresentationSessionsController < ApplicationController
                                    action_name: "start_representation",
                                    resource: current_collective,
                                    error: "You do not have permission to represent this collective.",
+                                   status: :forbidden,
+                                 })
+    end
+
+    # Don't let an agent start a session it can't end. end_representation routes
+    # through the capability layer (unlike the HTML stop path, which is exempt via
+    # SESSION_MANAGEMENT_WRITES), so an agent configured with start_representation
+    # but not end_representation would start a collective session and then be
+    # denied ending it over MCP — stuck until the session expires. Refuse up front.
+    if CapabilityCheck.missing_rep_lifecycle_capabilities(@current_user).include?("end_representation")
+      return render_action_error({
+                                   action_name: "start_representation",
+                                   resource: current_collective,
+                                   error: "Your agent configuration lacks the end_representation capability, so you would be unable to end this session. Grant end_representation before starting.",
                                    status: :forbidden,
                                  })
     end

--- a/app/controllers/representation_sessions_controller.rb
+++ b/app/controllers/representation_sessions_controller.rb
@@ -41,13 +41,137 @@ class RepresentationSessionsController < ApplicationController
     # User representation is initiated from the trustee authorizations settings page instead.
     @can_represent_collective = @current_user.collective_member&.can_represent?
 
-    if @can_represent_collective
-      @page_title = "Represent"
-    else
+    unless @can_represent_collective
       # TODO: - design a better solution for this
       @sidebar_mode = "minimal"
-      render layout: "application", html: "You do not have permission to access this page."
+      return respond_to do |format|
+        format.html { render layout: "application", html: "You do not have permission to access this page." }
+        format.md { render plain: "# Represent\n\nYou do not have permission to represent this collective.", status: :forbidden }
+      end
     end
+
+    @page_title = "Represent"
+    respond_to do |format|
+      format.html
+      format.md
+    end
+  end
+
+  # Markdown/MCP actions index for the collective represent page.
+  # Mirrors TrusteeGrantsController#actions_index_show — evaluates the same
+  # conditional-action lambdas the markdown frontmatter uses, so discovery
+  # over /actions agrees with what fetch_page advertises.
+  def actions_index_represent
+    route_info = ActionsHelper.actions_for_route("/collectives/:collective_handle/represent")
+    static = (route_info && route_info[:actions]) || []
+    context = { collective: current_collective, user: @current_user }
+    conditional = (route_info && route_info[:conditional_actions] || []).select do |action|
+      action[:condition].call(context)
+    rescue StandardError
+      false
+    end
+    render_actions_index({ actions: static + conditional })
+  end
+
+  # =========================================================================
+  # START REPRESENTATION (Markdown/MCP action) — collective representation
+  # Mirrors TrusteeGrantsController#{describe,execute}_start_representation.
+  # =========================================================================
+
+  def describe_start_representation
+    render_action_description(ActionsHelper.action_description("start_representation", resource: current_collective))
+  end
+
+  def execute_start_representation
+    if current_representation_session
+      return render_action_error({
+                                   action_name: "start_representation",
+                                   resource: current_collective,
+                                   error: "Nested representation sessions are not allowed. End your current session before starting a new one.",
+                                   status: :conflict,
+                                 })
+    end
+
+    unless @current_user.can_represent?(current_collective)
+      return render_action_error({
+                                   action_name: "start_representation",
+                                   resource: current_collective,
+                                   error: "You do not have permission to represent this collective.",
+                                   status: :forbidden,
+                                 })
+    end
+
+    if current_collective.archived?
+      return render_action_error({
+                                   action_name: "start_representation",
+                                   resource: current_collective,
+                                   error: "This collective is deactivated and cannot be represented.",
+                                   status: :conflict,
+                                 })
+    end
+
+    rep_session = RepresentationSession.create!(
+      tenant: current_tenant,
+      collective: current_collective,
+      representative_user: current_user,
+      confirmed_understanding: true,
+      began_at: Time.current
+    )
+    rep_session.begin!
+
+    render_action_success({
+                            action_name: "start_representation",
+                            resource: rep_session,
+                            result: "Representation session started. You are now acting on behalf of #{current_collective.name}.\n\n" \
+                                    "Session ID: `#{rep_session.id}`\n" \
+                                    "Short ID: `#{rep_session.truncated_id}`\n\n" \
+                                    "Use the session ID in the `X-Representation-Session-ID` header for subsequent API requests.",
+                            redirect_to: "/representing",
+                          })
+  end
+
+  # =========================================================================
+  # END REPRESENTATION (Markdown/MCP action) — collective representation
+  # =========================================================================
+
+  def describe_end_representation
+    render_action_description(ActionsHelper.action_description("end_representation", resource: current_collective))
+  end
+
+  def execute_end_representation
+    # Resolve the active session by (collective, representative) rather than the
+    # request's representation context: the caller may or may not send the
+    # X-Representation-Session-ID header when ending, and this mirrors how the
+    # trustee path finds its session by grant.
+    caller_user = @api_token_user || @current_human_user || @current_user
+    rep_session = RepresentationSession.find_by(
+      collective: current_collective,
+      representative_user: caller_user,
+      ended_at: nil
+    )
+
+    unless rep_session&.active?
+      return render_action_error({
+                                   action_name: "end_representation",
+                                   resource: current_collective,
+                                   error: "No active representation session found for this collective.",
+                                   status: :not_found,
+                                 })
+    end
+
+    session_url = rep_session.url
+    rep_session.end!
+    session.delete(:representation_session_id)
+    session.delete(:representing_user)
+    session.delete(:representing_collective)
+
+    render_action_success({
+                            action_name: "end_representation",
+                            resource: current_collective,
+                            result: "Representation session ended. You are no longer acting on behalf of #{current_collective.name}.\n\n" \
+                                    "Session record: #{session_url}",
+                            redirect_to: current_collective.path,
+                          })
   end
 
   # Start a collective representation session

--- a/app/controllers/representation_sessions_controller.rb
+++ b/app/controllers/representation_sessions_controller.rb
@@ -162,7 +162,10 @@ class RepresentationSessionsController < ApplicationController
                             result: "Representation session started. You are now acting on behalf of #{current_collective.name}.\n\n" \
                                     "Session ID: `#{rep_session.id}`\n" \
                                     "Short ID: `#{rep_session.truncated_id}`\n\n" \
-                                    "Use the session ID in the `X-Representation-Session-ID` header for subsequent API requests.",
+                                    "Declare this session on every call you make on the collective's behalf: set " \
+                                    "`context.representation_session_id` to the session ID and `identity.acting_as` to " \
+                                    "`@#{current_collective.handle}` on `execute_action` (`identity.viewing_as` on `fetch_page` reads). " \
+                                    "See /help/agents/representation.",
                             redirect_to: "/representing",
                           })
   end

--- a/app/controllers/trustee_grants_controller.rb
+++ b/app/controllers/trustee_grants_controller.rb
@@ -313,14 +313,17 @@ class TrusteeGrantsController < ApplicationController
     rep_session = api_helper.start_user_representation_session(grant: @grant)
 
     # For API/markdown, we return success with session info (no cookies)
-    # Include both full ID and truncated_id - the X-Representation-Session-ID header accepts either
+    # Include both full ID and truncated_id - the declared session id accepts either
     render_action_success({
                             action_name: "start_representation",
                             resource: rep_session,
                             result: "Representation session started. You are now acting on behalf of #{@grant.granting_user.display_name || @grant.granting_user.handle}.\n\n" \
                                     "Session ID: `#{rep_session.id}`\n" \
                                     "Short ID: `#{rep_session.truncated_id}`\n\n" \
-                                    "Use the session ID in the `X-Representation-Session-ID` header for subsequent API requests.",
+                                    "Declare this session on every call you make on their behalf: set " \
+                                    "`context.representation_session_id` to the session ID and `identity.acting_as` to " \
+                                    "`@#{@grant.granting_user.handle}` on `execute_action` (`identity.viewing_as` on `fetch_page` reads). " \
+                                    "See /help/agents/representation.",
                             redirect_to: trustee_grant_show_path(@grant),
                           })
   rescue ArgumentError => e

--- a/app/services/actions_helper.rb
+++ b/app/services/actions_helper.rb
@@ -1220,6 +1220,41 @@ class ActionsHelper
           description: ACTION_DEFINITIONS["remove_member"][:description], },
       ],
     },
+    "/collectives/:collective_handle/represent" => {
+      controller_actions: ["representation_sessions#represent"],
+      actions: [],
+      # Collective representation lifecycle. start/end are mutually exclusive and
+      # gated on the representative role, so they're conditional rather than
+      # static. The controller (RepresentationSessionsController) evaluates the
+      # same lambdas via #actions_index_represent, keeping discovery and the
+      # markdown frontmatter in agreement. (Harmonic#365)
+      conditional_actions: [
+        {
+          name: "start_representation",
+          params_string: ACTION_DEFINITIONS["start_representation"][:params_string],
+          description: ACTION_DEFINITIONS["start_representation"][:description],
+          condition: lambda { |context|
+            collective = context[:collective]
+            user = context[:user]
+            next false unless collective && user
+            next false unless user.can_represent?(collective)
+            next false if collective.archived?
+            !RepresentationSession.exists?(collective: collective, representative_user: user, ended_at: nil)
+          },
+        },
+        {
+          name: "end_representation",
+          params_string: ACTION_DEFINITIONS["end_representation"][:params_string],
+          description: ACTION_DEFINITIONS["end_representation"][:description],
+          condition: lambda { |context|
+            collective = context[:collective]
+            user = context[:user]
+            next false unless collective && user
+            RepresentationSession.exists?(collective: collective, representative_user: user, ended_at: nil)
+          },
+        },
+      ],
+    },
     "/collectives/:collective_handle/note" => {
       controller_actions: ["notes#new"],
       actions: [

--- a/app/views/help/agents/representation.md.erb
+++ b/app/views/help/agents/representation.md.erb
@@ -57,6 +57,13 @@ End: call `execute_action` with `end_representation`. After this, subsequent wri
 
 Both `start_representation` and `end_representation` are ordinary write actions you perform **as yourself** — their `context.identity.actor` is your handle, with no `acting_as` and no `representation_session_id`. The session id only appears once you have one and want to use it.
 
+### Where the actions live
+
+The `start_representation` / `end_representation` pair takes no params. The path you call them on depends on what you're representing:
+
+- **A collective** — on the collective's represent page: `/collectives/:handle/represent`. `fetch_page` that path to see the two actions in its frontmatter (`start_representation` shows when you hold the role and have no active session; `end_representation` shows once a session is open). Then `execute_action` the action name at that same path.
+- **Another user** (trustee grant) — on the grant's page: `/u/:your-handle/settings/trustee-authorizations/:grant_id`.
+
 ## What attribution looks like
 
 While the session is active:

--- a/app/views/help/collectives.md.erb
+++ b/app/views/help/collectives.md.erb
@@ -31,7 +31,7 @@ Collectives can act as unified entities in other collectives through **represent
 
 This enables **collective agency** — a group can participate in a larger group as a single voice, with internal deliberation happening privately and external action happening through representatives.
 
-To start a representation session, navigate to the collective's representation page at `{collective}/representation`.
+To start a representation session, go to the collective's represent page at `{collective}/represent`. The session log lives at `{collective}/representation`. Agents: see [Representation as an agent](/help/agents/representation) for the MCP mechanics.
 
 ## URL Pattern
 
@@ -39,4 +39,5 @@ To start a representation session, navigate to the collective's representation p
 - Cycle dashboard: `/collectives/{handle}/dashboard`
 - Collective settings: `/collectives/{handle}/settings`
 - Members: `/collectives/{handle}/members`
-- Representation: `/collectives/{handle}/representation`
+- Represent (start/end a session): `/collectives/{handle}/represent`
+- Representation session log: `/collectives/{handle}/representation`

--- a/app/views/representation_sessions/represent.md.erb
+++ b/app/views/representation_sessions/represent.md.erb
@@ -2,7 +2,9 @@
 
 Through representation, you can act on behalf of **<%= @current_collective.name %>** ([<%= @current_collective.path %>](<%= @current_collective.path %>)). While the session is active, every action you take assumes the collective's identity, is attributed to the collective as a whole, and is recorded in a session log visible to all members.
 
-<% if @current_representation_session -%>
+<% if @active_collective_session -%>
+**You have an active representation session for <%= @current_collective.name %>** (session ID: `<%= @active_collective_session.id %>`). Pass it in the `X-Representation-Session-ID` header on requests you make on the collective's behalf. End it with the `end_representation` action listed above, or by sending `DELETE /representing`.
+<% elsif @current_representation_session -%>
 **You are already in a representation session.** Nested sessions are not allowed — end your current session ([/representing](/representing)) before starting a new one.
 <% else -%>
 Because you hold the `representative` role in <%= @current_collective.name %>, you can start a session with the `start_representation` action listed above.

--- a/app/views/representation_sessions/represent.md.erb
+++ b/app/views/representation_sessions/represent.md.erb
@@ -1,0 +1,17 @@
+# Represent <%= @current_collective.name %>
+
+Through representation, you can act on behalf of **<%= @current_collective.name %>** ([<%= @current_collective.path %>](<%= @current_collective.path %>)). While the session is active, every action you take assumes the collective's identity, is attributed to the collective as a whole, and is recorded in a session log visible to all members.
+
+<% if @current_representation_session -%>
+**You are already in a representation session.** Nested sessions are not allowed — end your current session ([/representing](/representing)) before starting a new one.
+<% else -%>
+Because you hold the `representative` role in <%= @current_collective.name %>, you can start a session with the `start_representation` action listed above.
+
+- You assume the identity of <%= @current_collective.name %> itself.
+- Actions are attributed to <%= @current_collective.name %> as a whole.
+- All actions are recorded and visible to collective members.
+
+Once started, you'll receive a session ID to pass in the `X-Representation-Session-ID` header on subsequent requests. End the session with the `end_representation` action here, or by sending `DELETE /representing`.
+<% end -%>
+
+Past and active sessions are listed at [<%= @current_collective.path %>/representation](<%= @current_collective.path %>/representation).

--- a/app/views/representation_sessions/represent.md.erb
+++ b/app/views/representation_sessions/represent.md.erb
@@ -3,7 +3,7 @@
 Through representation, you can act on behalf of **<%= @current_collective.name %>** ([<%= @current_collective.path %>](<%= @current_collective.path %>)). While the session is active, every action you take assumes the collective's identity, is attributed to the collective as a whole, and is recorded in a session log visible to all members.
 
 <% if @active_collective_session -%>
-**You have an active representation session for <%= @current_collective.name %>** (session ID: `<%= @active_collective_session.id %>`). Pass it in the `X-Representation-Session-ID` header on requests you make on the collective's behalf. End it with the `end_representation` action listed above, or by sending `DELETE /representing`.
+**You have an active representation session for <%= @current_collective.name %>** (session ID: `<%= @active_collective_session.id %>`). Declare it on every call you make on the collective's behalf: set `context.representation_session_id` to the session ID and `identity.acting_as` to `@<%= @current_collective.handle %>` on `execute_action` (on `fetch_page` reads, use `identity.viewing_as`). See [Representation as an agent](/help/agents/representation) for the exact fields. End the session with the `end_representation` action listed above, calling as yourself with no representation fields in `context`.
 <% elsif @current_representation_session -%>
 **You are already in a representation session.** Nested sessions are not allowed — end your current session ([/representing](/representing)) before starting a new one.
 <% else -%>
@@ -13,7 +13,7 @@ Because you hold the `representative` role in <%= @current_collective.name %>, y
 - Actions are attributed to <%= @current_collective.name %> as a whole.
 - All actions are recorded and visible to collective members.
 
-Once started, you'll receive a session ID to pass in the `X-Representation-Session-ID` header on subsequent requests. End the session with the `end_representation` action here, or by sending `DELETE /representing`.
+Once started, you'll receive a session ID to declare in the `context` block of subsequent `execute_action` and `fetch_page` calls — see [Representation as an agent](/help/agents/representation) for the exact fields. End the session with the `end_representation` action on this page.
 <% end -%>
 
 Past and active sessions are listed at [<%= @current_collective.path %>/representation](<%= @current_collective.path %>/representation).

--- a/app/views/representation_sessions/representing.md.erb
+++ b/app/views/representation_sessions/representing.md.erb
@@ -51,6 +51,10 @@ You can act <%= is_user_representation ? "on behalf of #{represented_user&.displ
 <% end -%>
 <% end -%>
 
+## Using this session
+
+Declare this session on every call you make on the represented entity's behalf: set `context.representation_session_id` to the session ID above and `identity.acting_as` to `@<%= is_user_representation ? represented_user&.handle : @collective.handle %>` on `execute_action` (`identity.viewing_as` on `fetch_page` reads). See [Representation as an agent](/help/agents/representation).
+
 ## Ending the session
 
-To end this session, call `execute_action` with `end_representation` on the originating <%= is_user_representation ? "trustee authorization" : "collective representation" %>, or send `DELETE /representing` with `X-Representation-Session-ID: <%= @representation_session.id %>`.
+To end this session, call `execute_action` with `end_representation` at <%= is_user_representation ? "the originating trustee authorization page" : "[#{@collective.path}/represent](#{@collective.path}/represent)" %>, calling as yourself with no representation fields in `context`.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -576,6 +576,15 @@ Rails.application.routes.draw do
     get "#{prefix}/join/actions/join_collective" => 'collectives#describe_join_collective'
     post "#{prefix}/join/actions/join_collective" => 'collectives#join_collective_action'
     get "#{prefix}/represent" => 'representation_sessions#represent'
+    # Markdown/MCP action surface for collective representation, mirroring the
+    # trustee-grant describe/execute pair (see trustee-authorizations routes above).
+    # Without these, an agent holding the representative role can't start/end a
+    # collective representation session over MCP (Harmonic#365).
+    get "#{prefix}/represent/actions" => 'representation_sessions#actions_index_represent'
+    get "#{prefix}/represent/actions/start_representation" => 'representation_sessions#describe_start_representation'
+    post "#{prefix}/represent/actions/start_representation" => 'representation_sessions#execute_start_representation'
+    get "#{prefix}/represent/actions/end_representation" => 'representation_sessions#describe_end_representation'
+    post "#{prefix}/represent/actions/end_representation" => 'representation_sessions#execute_end_representation'
     post "#{prefix}/represent" => 'representation_sessions#start_representing'
     post "#{prefix}/represent_user" => 'representation_sessions#start_representing_user'
     delete "#{prefix}/represent" => 'representation_sessions#stop_representing'

--- a/test/integration/api_collective_representation_test.rb
+++ b/test/integration/api_collective_representation_test.rb
@@ -72,6 +72,25 @@ class ApiCollectiveRepresentationTest < ActionDispatch::IntegrationTest
                      "represent page frontmatter should advertise start_representation"
   end
 
+  # The page body must agree with the frontmatter even when the caller does not
+  # echo X-Representation-Session-ID (nothing requires the header on this page).
+  # The frontmatter lambdas are DB-backed, so the prose must be too — otherwise
+  # an agent mid-session is told it can start while only end_representation is
+  # advertised.
+  test "represent page reflects an active session without the session header" do
+    grant_representative_role!
+    session_id = start_session!
+
+    get represent_path, headers: @headers
+
+    assert_response :success
+    assert_includes response.body, "end_representation"
+    assert_includes response.body, session_id,
+                    "page should surface the active session's ID"
+    refute_match(/you can start a session/, response.body,
+                 "page must not offer to start while a session is active")
+  end
+
   # ---------------------------------------------------------------------------
   # Start
   # ---------------------------------------------------------------------------

--- a/test/integration/api_collective_representation_test.rb
+++ b/test/integration/api_collective_representation_test.rb
@@ -129,4 +129,80 @@ class ApiCollectiveRepresentationTest < ActionDispatch::IntegrationTest
 
     assert_response :not_found
   end
+
+  # ---------------------------------------------------------------------------
+  # Nested-session guard is DB-backed, not header-dependent (#365 review, #1)
+  # ---------------------------------------------------------------------------
+
+  # The header-only guard (`current_representation_session`) is bypassable: an
+  # API caller need not echo X-Representation-Session-ID on start, so a second
+  # start without the header would sail past it and create a second concurrent
+  # active session. The DB existence check must catch it.
+  test "cannot start a second collective session without echoing the session header" do
+    grant_representative_role!
+    start_session!
+
+    # Second start with NO representation header at all.
+    post "#{represent_path}/actions/start_representation", headers: @headers
+
+    assert_response :conflict
+    assert_equal 1, RepresentationSession.where(collective: @collective, ended_at: nil).count,
+                 "a duplicate concurrent session must not be created"
+  end
+
+  # ---------------------------------------------------------------------------
+  # AI-agent callers: exercise the capability layer (the actual #365 scenario).
+  # The human-token tests above never hit CapabilityCheck because restricted_user?
+  # is false for a human. (#365 review, #5)
+  # ---------------------------------------------------------------------------
+
+  # An AI agent representing @alice, added to the collective with the
+  # representative role. `capabilities: nil` means "all grantable" (the default);
+  # pass an array to restrict what the agent may do.
+  def agent_headers(capabilities:)
+    config = { "mode" => "internal" }
+    config["capabilities"] = capabilities unless capabilities.nil?
+    agent = create_ai_agent(parent: @alice, name: "Rep Agent #{SecureRandom.hex(4)}", agent_configuration: config)
+    @tenant.add_user!(agent)
+    @collective.add_user!(agent)
+    @collective.collective_members.find_by(user: agent).add_role!("representative")
+    token = ApiToken.create!(tenant: @tenant, user: agent, scopes: ApiToken.valid_scopes)
+    {
+      "Authorization" => "Bearer #{token.plaintext_token}",
+      "Accept" => "text/markdown",
+    }
+  end
+
+  test "agent with full capabilities can start a collective session" do
+    headers = agent_headers(capabilities: nil)
+
+    post "#{represent_path}/actions/start_representation", headers: headers
+
+    assert_response :success
+    assert_equal 1, RepresentationSession.where(collective: @collective, ended_at: nil).count
+  end
+
+  test "agent lacking start_representation capability is denied by the capability layer" do
+    headers = agent_headers(capabilities: ["create_note", "end_representation"])
+
+    post "#{represent_path}/actions/start_representation", headers: headers
+
+    assert_response :forbidden
+    assert_equal 0, RepresentationSession.where(collective: @collective).count,
+                 "capability-denied start must not create a session"
+  end
+
+  # #3: end_representation routes through the capability layer, so an agent that
+  # can start but not end would get locked into a session until expiry. Refuse
+  # the start up front instead.
+  test "agent lacking end_representation capability is refused at start to avoid a lockout" do
+    headers = agent_headers(capabilities: ["create_note", "start_representation"])
+
+    post "#{represent_path}/actions/start_representation", headers: headers
+
+    assert_response :forbidden
+    assert_match(/end_representation/, response.body,
+                 "should explain the missing end capability")
+    assert_equal 0, RepresentationSession.where(collective: @collective).count
+  end
 end

--- a/test/integration/api_collective_representation_test.rb
+++ b/test/integration/api_collective_representation_test.rb
@@ -1,0 +1,132 @@
+# typed: false
+
+require "test_helper"
+
+# Tests for COLLECTIVE representation over the markdown/MCP interface.
+#
+# Regression coverage for Harmonic#365: a user holding the representative role
+# in a collective could not start a collective representation session through
+# markdown/MCP because (a) /collectives/:handle/represent had no markdown
+# template (406) and (b) there was no start_representation/end_representation
+# action surface for the collective (only the HTML form flow).
+#
+# The trustee (user) representation equivalents live in api_representation_test.rb.
+class ApiCollectiveRepresentationTest < ActionDispatch::IntegrationTest
+  def setup
+    @tenant = create_tenant(subdomain: "api-crep-#{SecureRandom.hex(4)}")
+    @alice = create_user(email: "alice_#{SecureRandom.hex(4)}@example.com", name: "Alice")
+    @bob = create_user(email: "bob_#{SecureRandom.hex(4)}@example.com", name: "Bob")
+    @tenant.add_user!(@alice)
+    @tenant.add_user!(@bob)
+    mark_activated!(@alice)
+    mark_activated!(@bob)
+    @tenant.enable_api!
+    @tenant.create_main_collective!(created_by: @alice)
+    @collective = create_collective(tenant: @tenant, created_by: @alice, handle: "api-crep-collective-#{SecureRandom.hex(4)}")
+    @collective.add_user!(@alice)
+    @collective.add_user!(@bob)
+    @collective.enable_api!
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+
+    @bob_token = ApiToken.create!(
+      tenant: @tenant,
+      user: @bob,
+      scopes: ApiToken.valid_scopes
+    )
+    @headers = {
+      "Authorization" => "Bearer #{@bob_token.plaintext_token}",
+      "Accept" => "text/markdown",
+    }
+    host! "#{@tenant.subdomain}.#{ENV.fetch('HOSTNAME', nil)}"
+  end
+
+  def represent_path
+    "/collectives/#{@collective.handle}/represent"
+  end
+
+  def grant_representative_role!
+    @collective.collective_members.find_by(user: @bob).add_role!("representative")
+  end
+
+  # Extract the session ID from an action-success body ("Session ID: `uuid`").
+  def start_session!
+    post "#{represent_path}/actions/start_representation", headers: @headers
+    assert_response :success, "Failed to start collective representation: #{response.body}"
+    match = response.body.match(/Session ID: `([a-f0-9-]+)`/)
+    assert match, "Response should contain session ID: #{response.body}"
+    match[1]
+  end
+
+  # ---------------------------------------------------------------------------
+  # Discovery: the represent page must have a markdown view (no more 406) and
+  # must advertise the start_representation action.
+  # ---------------------------------------------------------------------------
+
+  test "represent page renders markdown for a representative and lists start_representation" do
+    grant_representative_role!
+
+    get represent_path, headers: @headers
+
+    assert_response :success, "represent page should render markdown, not 406: #{response.status}"
+    assert_includes response.body, "start_representation",
+                     "represent page frontmatter should advertise start_representation"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Start
+  # ---------------------------------------------------------------------------
+
+  test "representative can start a collective representation session via the action" do
+    grant_representative_role!
+
+    session_id = start_session!
+
+    session = RepresentationSession.find(session_id)
+    assert_equal @collective.id, session.collective_id
+    assert_equal @bob.id, session.representative_user_id
+    assert_nil session.trustee_grant_id, "should be a collective (not user) representation"
+    assert session.active?
+  end
+
+  test "non-representative cannot start a collective representation session via the action" do
+    post "#{represent_path}/actions/start_representation", headers: @headers
+
+    assert_response :forbidden
+    assert_equal 0, RepresentationSession.where(collective: @collective).count
+  end
+
+  test "cannot start a second nested collective session" do
+    grant_representative_role!
+    start_session!
+
+    post "#{represent_path}/actions/start_representation",
+         headers: @headers.merge("X-Representation-Session-ID" => RepresentationSession.last.id,
+                                 "X-Representing-Collective" => @collective.handle)
+
+    assert_response :conflict
+  end
+
+  # ---------------------------------------------------------------------------
+  # End
+  # ---------------------------------------------------------------------------
+
+  test "representative can end a collective representation session via the action" do
+    grant_representative_role!
+    session_id = start_session!
+
+    post "#{represent_path}/actions/end_representation",
+         headers: @headers.merge("X-Representation-Session-ID" => session_id,
+                                 "X-Representing-Collective" => @collective.handle)
+
+    assert_response :success, "Failed to end collective representation: #{response.body}"
+    assert RepresentationSession.find(session_id).ended?, "session should be ended"
+  end
+
+  test "ending with no active session returns not found" do
+    grant_representative_role!
+
+    post "#{represent_path}/actions/end_representation", headers: @headers
+
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
Fixes #365.

## Problem

An agent that holds the **representative** role in a collective couldn't start a **collective** representation session through the markdown/MCP interface. Both discovery paths were broken:

- `GET /collectives/:handle/represent` → **406** (no markdown template).
- `execute_action start_representation` → **"No actions are defined at this path"** — there was no describe/execute action pair for the collective, only the HTML form flow.

This is specific to *collective* representation; **trustee (user) representation already works** because it has the pieces the collective path was missing — that's the fix template used here.

## Changes

- **Routes** (`config/routes.rb`): add `/collectives/:handle/represent/actions/{start,end}_representation` (describe `GET` + execute `POST`) and an `/actions` index, mirroring the trustee-grant routes.
- **Controller** (`RepresentationSessionsController`): add `describe`/`execute` methods for `start_representation`/`end_representation` and an `actions_index_represent`, mirroring `TrusteeGrantsController`. `#represent` now also responds to `format.md`.
- **ActionsHelper**: register the represent route with conditional `start_representation`/`end_representation` actions, gated on `can_represent?` and mutual exclusivity, so markdown-frontmatter discovery agrees with execute-time enforcement.
- **View**: add `represent.md.erb` so the page renders instead of 406-ing.
- **Help doc**: name the collective path + params in `help/agents/representation.md.erb`.

Reuses the existing `start_representation`/`end_representation` `ACTION_DEFINITIONS` and `CapabilityCheck` entries — no visibility/capability-list changes.

## Enforcement

- Discovery: `start_representation` shows only to a member who `can_represent?` with no active session; `end_representation` shows once a session is open.
- Execution: `execute_start_representation` re-checks `can_represent?`, archived state, and nested-session conflict; `execute_end_representation` resolves the session by `(collective, representative)` and requires the caller to be its representative. Capability layer still gates both via the existing grantable `start_representation`/`end_representation` capabilities.

## Tests

Adds `test/integration/api_collective_representation_test.rb` covering: represent page renders markdown and advertises the action, start (happy path + role enforcement + nested-session rejection), and end (happy path + no-active-session).

Run locally via docker-compose.dev.yml: all 11 tests in this file pass, plus the 64 tests in the neighboring representation suites (api_representation, representation, representation_session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
