### PR TITLE
Change AI agent attribution label to "agent of"

### DIFF
--- a/app/components/author_component.html.erb
+++ b/app/components/author_component.html.erb
@@ -6,7 +6,7 @@
   <% if representation? %>
     <span class="pulse-representation-label">on behalf of <%= helpers.link_to author.display_name, author.path %></span>
   <% elsif author.ai_agent? && author.parent %>
-    <span class="pulse-ai-agent-label">(managed by <%= helpers.link_to author.parent.display_name, author.parent.path %>)</span>
+    <span class="pulse-ai-agent-label">(agent of <%= helpers.link_to author.parent.display_name, author.parent.path %>)</span>
   <% end %>
   <% if @verb.present? %>
     <span><%= @verb %></span>

--- a/app/components/comment_component.html.erb
+++ b/app/components/comment_component.html.erb
@@ -20,7 +20,7 @@
         <%= author.display_name %>
       </a>
       <% if author.ai_agent? && author.parent %>
-        <span class="pulse-ai-agent-label">(managed by <%= helpers.link_to author.parent.display_name, author.parent.path %>)</span>
+        <span class="pulse-ai-agent-label">(agent of <%= helpers.link_to author.parent.display_name, author.parent.path %>)</span>
       <% end %>
     <% end %>
     <a href="<%= @comment.path %>" class="pulse-comment-timestamp"><%= helpers.timeago(@comment.created_at) %></a>

--- a/app/views/shared/_created_by.html.erb
+++ b/app/views/shared/_created_by.html.erb
@@ -11,7 +11,7 @@
     <%= profile_pic(resource.created_by, size: 20, style: 'vertical-align:bottom;margin-right:0;margin-bottom:0px;') %>
     <strong><%= resource.created_by.display_name %></strong>
     <% if resource.created_by.ai_agent? && resource.created_by.parent %>
-      <span class="ai_agent-attribution" title="managed by <%= resource.created_by.parent.display_name %>">(managed by <%= link_to resource.created_by.parent.display_name, resource.created_by.parent.path %>)</span>
+      <span class="ai_agent-attribution" title="agent of <%= resource.created_by.parent.display_name %>">(agent of <%= link_to resource.created_by.parent.display_name, resource.created_by.parent.path %>)</span>
     <% end %>
     <%= link_to "@#{resource.created_by.handle}", resource.created_by.path %>
   <% end %>
@@ -22,7 +22,7 @@
     by <%= profile_pic(resource.updated_by, size: 20, style: 'vertical-align:bottom;margin-right:0;margin-bottom:0px;') %>
     <strong><%= resource.updated_by.display_name %></strong>
     <% if resource.updated_by.ai_agent? && resource.updated_by.parent %>
-      <span class="ai_agent-attribution" title="managed by <%= resource.updated_by.parent.display_name %>">(managed by <%= link_to resource.updated_by.parent.display_name, resource.updated_by.parent.path %>)</span>
+      <span class="ai_agent-attribution" title="agent of <%= resource.updated_by.parent.display_name %>">(agent of <%= link_to resource.updated_by.parent.display_name, resource.updated_by.parent.path %>)</span>
     <% end %>
     <%= link_to "@#{resource.updated_by.handle}", resource.updated_by.path %>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -124,7 +124,7 @@
 
   <% if @showing_user.ai_agent? && @showing_user.parent %>
     <div class="pulse-user-parent-info">
-      <span style="color: var(--color-fg-muted);">Managed by</span>
+      <span style="color: var(--color-fg-muted);">Agent of</span>
       <a href="<%= @showing_user.parent.path %>" class="pulse-user-parent-link">
         <%= profile_pic(@showing_user.parent, size: 20, style: 'vertical-align:middle;margin-right:4px;border-radius:50%;') %>
         <strong><%= @showing_user.parent.display_name %></strong>

--- a/test/components/author_component_test.rb
+++ b/test/components/author_component_test.rb
@@ -50,7 +50,7 @@ class AuthorComponentTest < ViewComponent::TestCase
     agent = build_user(display_name: "Bot", handle: "bot", user_type: "ai_agent", parent: owner)
     resource = build_note(created_by: agent, created_at: @now, updated_at: @now)
     render_inline(AuthorComponent.new(resource: resource))
-    assert_selector ".pulse-ai-agent-label", text: /managed by/
+    assert_selector ".pulse-ai-agent-label", text: /agent of/
     assert_selector "a[href='/u/owner']", text: "Owner"
   end
 

--- a/test/components/comment_component_test.rb
+++ b/test/components/comment_component_test.rb
@@ -148,7 +148,7 @@ class CommentComponentTest < ViewComponent::TestCase
                     show_reply_context: false,
                     root_comment_id: "root123"
                   ))
-    assert_selector ".pulse-ai-agent-label", text: /managed by/
+    assert_selector ".pulse-ai-agent-label", text: /agent of/
   end
 
   test "renders reply context when applicable" do


### PR DESCRIPTION
Closes #364.

Changes the AI agent attribution label from `(managed by [principal])` to `(agent of [principal])` in author displays and on the AI agent profile page.

## Changes
- `author_component` and `comment_component` feed/comment author labels
- `shared/_created_by` partial (created-by and updated-by, both visible text and `title` tooltip)
- AI agent profile page parent-info block ("Managed by" → "Agent of")

This aligns with the "agent of" phrasing already used elsewhere (`User#display_name`, `ProfilePicComponent`, the collective team roster).

Left untouched: descriptive sentence tooltips ("This is an AI agent managed by X" on the badge), the `/whoami` page, and collective settings copy — none are the `(managed by X)` attribution label the issue targets.

## Testing
- `test/components/author_component_test.rb` and `test/components/comment_component_test.rb` updated and passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)