### PR TITLE
Prevent mobile autozoom on input focus (font-size ≥ 16px)

### DIFF
--- a/app/assets/stylesheets/pulse/_responsive.css
+++ b/app/assets/stylesheets/pulse/_responsive.css
@@ -92,10 +92,13 @@
     padding: 24px 16px;
   }
 
-  /* iOS Safari zooms the viewport on focus when input font-size < 16px. */
-  .pulse-form-input,
-  .pulse-form-textarea,
-  .pulse-form-select {
+  /* iOS Safari zooms the viewport on focus when input font-size < 16px.
+     Force every text-entry control to at least 16px on mobile so focusing
+     never triggers an autozoom. Element selectors with :not() keep enough
+     specificity to override class-based sizes like .header-search-input. */
+  input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),
+  textarea,
+  select {
     font-size: 16px;
   }
 }


### PR DESCRIPTION
Closes #362.

iOS Safari zooms the viewport when a focused input has `font-size` below 16px. There was already a mobile rule for this, but it only covered the `.pulse-form-*` classes — so the header search input (`.header-search-input`, 13px) and other non-form-class inputs still triggered autozoom.

## Change
Broadens the existing `@media (max-width: 768px)` rule in `pulse/_responsive.css` to force **every** text-entry control to 16px:

```css
input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),
textarea,
select { font-size: 16px; }
```

Element selectors with `:not()` keep enough specificity to override class-based sizes like `.header-search-input`. Non-text inputs (checkbox/radio/range/color) are excluded since their font-size is irrelevant to autozoom.

This is scoped to mobile widths only; desktop rendering is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)