### PR TITLE
Add the aggregated chat entry to the rail

### DIFF
--- a/app/assets/stylesheets/pulse/_rail.css
+++ b/app/assets/stylesheets/pulse/_rail.css
@@ -110,9 +110,27 @@
   padding: 0 4px;
 }
 
-/* The globe glyph is smaller than the 48px hit area, so pull its badge in
-   toward the icon instead of the box corner. */
-.pulse-rail-public .pulse-rail-badge {
+/* Chat: one aggregated entry for all chat collectives — a bare icon like
+   the globe, not a square. */
+.pulse-rail-chat .pulse-rail-chat-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pulse-rail-chat:hover,
+.pulse-rail-chat.active {
+  color: var(--color-fg-default);
+}
+
+.pulse-rail-chat .octicon {
+  fill: currentColor;
+}
+
+/* The globe and chat glyphs are smaller than the 48px hit area, so pull
+   their badges in toward the icon instead of the box corner. */
+.pulse-rail-public .pulse-rail-badge,
+.pulse-rail-chat .pulse-rail-badge {
   top: 2px;
   right: 2px;
 }

--- a/app/components/collective_rail_component.html.erb
+++ b/app/components/collective_rail_component.html.erb
@@ -9,6 +9,15 @@
       <span class="pulse-rail-badge" data-collective-id="<%= @main_collective.id %>"
             style="<%= badge_style(@main_collective) %>"><%= badge_text(@main_collective) %></span>
     <% end %>
+    <%= tag.a href: "/chat",
+              class: ["pulse-rail-item", "pulse-rail-chat", ("active" if chat_active?)],
+              title: "Chat",
+              aria: { label: "Chat", current: ("page" if chat_active?) } do %>
+      <span class="pulse-rail-indicator"></span>
+      <span class="pulse-rail-chat-icon"><%= helpers.octicon "comment-discussion", height: 22 %></span>
+      <span class="pulse-rail-badge" data-chat-badge
+            style="<%= chat_badge_style %>"><%= chat_badge_text %></span>
+    <% end %>
     <div class="pulse-rail-divider"></div>
   <% end %>
 

--- a/app/components/collective_rail_component.rb
+++ b/app/components/collective_rail_component.rb
@@ -18,10 +18,11 @@ class CollectiveRailComponent < ViewComponent::Base
       main_collective: T.nilable(Collective),
       collectives: T::Array[Collective],
       current_path: T.nilable(String),
-      unread_counts: T::Hash[String, Integer]
+      unread_counts: T::Hash[String, Integer],
+      chat_unread_count: Integer
     ).void
   end
-  def initialize(main_collective: nil, collectives: [], current_path: nil, unread_counts: {})
+  def initialize(main_collective: nil, collectives: [], current_path: nil, unread_counts: {}, chat_unread_count: 0)
     super()
     @main_collective = main_collective
     # Collective#path is nil for main collectives; an entry the rail cannot
@@ -29,6 +30,7 @@ class CollectiveRailComponent < ViewComponent::Base
     @collectives = T.let(collectives.select { |c| c.path.present? }, T::Array[Collective])
     @current_path = current_path
     @unread_counts = unread_counts
+    @chat_unread_count = chat_unread_count
   end
 
   sig { returns(T::Boolean) }
@@ -52,19 +54,49 @@ class CollectiveRailComponent < ViewComponent::Base
     @current_path == "/"
   end
 
+  # The chat entry aggregates every chat collective behind one icon, so it
+  # is active across all of /chat, and its count is type-based (unread
+  # chat_message notifications), not collective-based.
+  sig { returns(T::Boolean) }
+  def chat_active?
+    current = @current_path
+    return false if current.nil?
+
+    current == "/chat" || current.start_with?("/chat/")
+  end
+
   # Server-rendered initial badge state, so navigation never flashes the
   # badges out. The rail-badges controller overwrites this on every poll
   # using the same display rules — keep the two in sync.
   sig { params(collective: Collective).returns(String) }
   def badge_text(collective)
-    count = @unread_counts[collective.id].to_i
+    count_badge_text(@unread_counts[collective.id].to_i)
+  end
+
+  sig { params(collective: Collective).returns(T.nilable(String)) }
+  def badge_style(collective)
+    count_badge_style(@unread_counts[collective.id].to_i)
+  end
+
+  sig { returns(String) }
+  def chat_badge_text
+    count_badge_text(@chat_unread_count)
+  end
+
+  sig { returns(T.nilable(String)) }
+  def chat_badge_style
+    count_badge_style(@chat_unread_count)
+  end
+
+  sig { params(count: Integer).returns(String) }
+  def count_badge_text(count)
     return "" if count.zero?
 
     count > 99 ? "99+" : count.to_s
   end
 
-  sig { params(collective: Collective).returns(T.nilable(String)) }
-  def badge_style(collective)
-    "display: none" if @unread_counts[collective.id].to_i.zero?
+  sig { params(count: Integer).returns(T.nilable(String)) }
+  def count_badge_style(count)
+    "display: none" if count.zero?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -817,6 +817,16 @@ class ApplicationController < ActionController::Base
   end
   helper_method :rail_unread_counts
 
+  # Initial count for the rail's aggregated chat entry — same lifecycle as
+  # rail_unread_counts.
+  def rail_chat_unread_count
+    return @rail_chat_unread_count if defined?(@rail_chat_unread_count)
+    return (@rail_chat_unread_count = 0) if @current_user.nil? || current_tenant.nil?
+
+    @rail_chat_unread_count = NotificationService.unread_chat_count_for(@current_user, tenant: current_tenant)
+  end
+  helper_method :rail_chat_unread_count
+
   # Active representation sessions owned by this caller that are not attached
   # to the current request. The markdown layout surfaces these as a warning
   # so the agent can attach or end them.

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -102,7 +102,8 @@ class NotificationsController < ApplicationController
   def unread_count
     count = NotificationService.unread_count_for(current_user, tenant: current_tenant)
     by_collective = NotificationService.unread_count_by_collective_for(current_user, tenant: current_tenant)
-    render json: { count: count, by_collective: by_collective }
+    chat = NotificationService.unread_chat_count_for(current_user, tenant: current_tenant)
+    render json: { count: count, by_collective: by_collective, chat: chat }
   end
 
   def actions_index

--- a/app/javascript/controllers/notification_badge_controller.test.ts
+++ b/app/javascript/controllers/notification_badge_controller.test.ts
@@ -94,23 +94,27 @@ describe("NotificationBadgeController", () => {
     expect(afterThird).toBeGreaterThan(afterSecond)
   })
 
-  it("broadcasts per-collective counts so the rail badges can update", async () => {
+  it("broadcasts per-collective and chat counts so the rail badges can update", async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ count: 3, by_collective: { "abc-123": 2, "def-456": 1 } }),
+      json: () => Promise.resolve({ count: 3, by_collective: { "abc-123": 2, "def-456": 1 }, chat: 4 }),
     })
     vi.stubGlobal("fetch", mockFetch)
 
-    const received: Array<Record<string, number>> = []
+    const received: Array<{ byCollective: Record<string, number>; chat: number }> = []
     window.addEventListener("notifications:counts", (event) => {
-      received.push((event as CustomEvent).detail.byCollective)
+      const detail = (event as CustomEvent).detail
+      received.push({ byCollective: detail.byCollective, chat: detail.chat })
     })
 
     await vi.advanceTimersByTimeAsync(5000)
 
     await vi.waitFor(() => {
       expect(received.length).toBeGreaterThan(0)
-      expect(received[received.length - 1]).toEqual({ "abc-123": 2, "def-456": 1 })
+      expect(received[received.length - 1]).toEqual({
+        byCollective: { "abc-123": 2, "def-456": 1 },
+        chat: 4,
+      })
     })
   })
 

--- a/app/javascript/controllers/notification_badge_controller.ts
+++ b/app/javascript/controllers/notification_badge_controller.ts
@@ -72,7 +72,11 @@ export default class NotificationBadgeController extends Controller<HTMLElement>
       // per-square badges without polling on its own.
       window.dispatchEvent(
         new CustomEvent("notifications:counts", {
-          detail: { count: data.count, byCollective: data.by_collective ?? {} },
+          detail: {
+            count: data.count,
+            byCollective: data.by_collective ?? {},
+            chat: data.chat ?? 0,
+          },
         }),
       )
     } catch {

--- a/app/javascript/controllers/rail_badges_controller.test.ts
+++ b/app/javascript/controllers/rail_badges_controller.test.ts
@@ -6,6 +6,9 @@ describe("RailBadgesController", () => {
   beforeEach(() => {
     document.body.innerHTML = `
       <nav class="pulse-rail" data-controller="rail-badges">
+        <a href="/chat">
+          <span class="pulse-rail-badge" data-chat-badge style="display: none"></span>
+        </a>
         <a href="/collectives/team-a">
           <span class="pulse-rail-badge" data-collective-id="aaa-111" style="display: none"></span>
         </a>
@@ -22,8 +25,12 @@ describe("RailBadgesController", () => {
     return document.querySelector(`.pulse-rail-badge[data-collective-id='${collectiveId}']`) as HTMLElement
   }
 
-  function broadcast(byCollective: Record<string, number>): void {
-    window.dispatchEvent(new CustomEvent("notifications:counts", { detail: { byCollective } }))
+  function broadcast(byCollective: Record<string, number>, chat = 0): void {
+    window.dispatchEvent(new CustomEvent("notifications:counts", { detail: { byCollective, chat } }))
+  }
+
+  function chatBadge(): HTMLElement {
+    return document.querySelector("[data-chat-badge]") as HTMLElement
   }
 
   it("shows counts on squares with unread notifications", async () => {
@@ -52,6 +59,19 @@ describe("RailBadgesController", () => {
 
     await vi.waitFor(() => {
       expect(badge("aaa-111").textContent).toBe("99+")
+    })
+  })
+
+  it("fills and clears the aggregated chat badge", async () => {
+    broadcast({}, 5)
+    await vi.waitFor(() => {
+      expect(chatBadge().textContent).toBe("5")
+      expect(chatBadge().style.display).toBe("")
+    })
+
+    broadcast({}, 0)
+    await vi.waitFor(() => {
+      expect(chatBadge().style.display).toBe("none")
     })
   })
 })

--- a/app/javascript/controllers/rail_badges_controller.ts
+++ b/app/javascript/controllers/rail_badges_controller.ts
@@ -22,20 +22,28 @@ export default class RailBadgesController extends Controller<HTMLElement> {
   }
 
   private handleCounts = (event: Event): void => {
-    const byCollective: Record<string, number> =
-      (event as CustomEvent).detail?.byCollective ?? {}
+    const detail = (event as CustomEvent).detail
+    const byCollective: Record<string, number> = detail?.byCollective ?? {}
 
     this.element
       .querySelectorAll<HTMLElement>(".pulse-rail-badge[data-collective-id]")
       .forEach((badge) => {
-        const count = byCollective[badge.dataset.collectiveId ?? ""] ?? 0
-        if (count > 0) {
-          badge.textContent = count > 99 ? "99+" : count.toString()
-          badge.style.display = ""
-        } else {
-          badge.textContent = ""
-          badge.style.display = "none"
-        }
+        this.updateBadge(badge, byCollective[badge.dataset.collectiveId ?? ""] ?? 0)
       })
+
+    const chatBadge = this.element.querySelector<HTMLElement>(".pulse-rail-badge[data-chat-badge]")
+    if (chatBadge) {
+      this.updateBadge(chatBadge, detail?.chat ?? 0)
+    }
+  }
+
+  private updateBadge(badge: HTMLElement, count: number): void {
+    if (count > 0) {
+      badge.textContent = count > 99 ? "99+" : count.toString()
+      badge.style.display = ""
+    } else {
+      badge.textContent = ""
+      badge.style.display = "none"
+    }
   }
 }

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -211,6 +211,20 @@ class NotificationService
       .count
   end
 
+  # Unread chat pings for the rail's aggregated chat entry. Chat-message
+  # notifications carry no event (see notify_chat_message!), so they are
+  # invisible to unread_count_by_collective_for and counted here by type —
+  # the two never overlap.
+  sig { params(user: User, tenant: Tenant).returns(Integer) }
+  def self.unread_chat_count_for(user, tenant:)
+    NotificationRecipient
+      .where(user: user, tenant: tenant)
+      .in_app.unread.not_scheduled
+      .joins("INNER JOIN notifications ON notifications.id = notification_recipients.notification_id")
+      .where(notifications: { notification_type: "chat_message" })
+      .count
+  end
+
   sig { params(user: User, tenant: Tenant).void }
   def self.dismiss_all_for(user, tenant:)
     # Exclude scheduled future reminders - they shouldn't be dismissed before they trigger

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -89,6 +89,7 @@
           collectives: rail_collectives,
           current_path: request.path,
           unread_counts: rail_unread_counts,
+          chat_unread_count: rail_chat_unread_count,
         ) %>
       <% end %>
       <%= render SidebarComponent.new(requested_mode: @sidebar_mode || "full", collective: @current_collective) do %>

--- a/docs/NAVIGATION_DESIGN.md
+++ b/docs/NAVIGATION_DESIGN.md
@@ -334,19 +334,23 @@ chrome to reshape per form factor without forking the model.
   viewing past cycles on the dashboard additionally requires a heartbeat,
   while queries (including `cycle:` refinements on feed pages and
   `/search`) cross cycles freely.
+- **Chat is one aggregated rail entry beneath the globe.** A bare icon
+  (like the globe, not a square) linking to `/chat`, active on all chat
+  pages. Its badge is type-based — unread `chat_message` notifications —
+  because chat notifications carry no event and therefore no collective;
+  they never appear in the per-collective counts, so the chat badge and
+  the square badges partition the event-space cleanly. A click lands on
+  the chat index, which lists conversations.
 
 ## Open questions
 
-1. **Chat placement — direction decided, design open.** Chat gets a single
-   pinned rail entry beneath the globe (the Discord "DMs" slot), not one
-   square per chat collective. The open design problem is the badge: every
-   other rail entry maps 1:1 to a collective, but the chat entry aggregates
-   many chat collectives behind one icon, so its count is a sum and a click
-   cannot land in a single place — it needs a chat index or sheet. Also
-   requires the by-collective count query to distinguish chat collectives
-   (excluded from squares today) so they roll up to the chat entry instead
-   of disappearing. Significant addition — deliberately deferred past the
-   initial rail PR (#339).
+1. **Chat placement — resolved.** Chat is a single pinned rail entry
+   beneath the globe (the Discord "DMs" slot), not one square per chat
+   collective: a bare comment icon linking to `/chat` (the chat index is
+   the landing place for an aggregate count), active across all of
+   `/chat`. Its badge counts unread `chat_message` notifications by *type*
+   — chat notifications carry no event, so they were never in the
+   per-collective counts and the two can't double-count. See Decided.
 2. **Sidebar contents per place** (issue #337's "cycles as channels").
    The route swap landed (feed is the default page, dashboard at
    `/dashboard`), but the dashboard itself hasn't converted to a query —

--- a/test/components/collective_rail_component_test.rb
+++ b/test/components/collective_rail_component_test.rb
@@ -71,6 +71,39 @@ class CollectiveRailComponentTest < ViewComponent::TestCase
     assert_selector ".pulse-rail-badge[data-collective-id='#{b.id}']", visible: :hidden
   end
 
+  test "renders a chat entry beneath the globe, above the divider" do
+    render_inline(CollectiveRailComponent.new(main_collective: main_collective, collectives: []))
+
+    assert_selector "a.pulse-rail-chat[href='/chat'][title='Chat'] .octicon-comment-discussion"
+    # Order: globe, chat, divider — chat belongs to the zone strip's top
+    # group, not to the collective squares.
+    page_html = page.native.to_html
+    assert page_html.index("pulse-rail-public") < page_html.index("pulse-rail-chat")
+    assert page_html.index("pulse-rail-chat") < page_html.index("pulse-rail-divider")
+  end
+
+  test "marks the chat entry active on chat pages" do
+    render_inline(CollectiveRailComponent.new(
+                    main_collective: main_collective, collectives: [], current_path: "/chat/somebody"
+                  ))
+    assert_selector "a.pulse-rail-chat.active[aria-current='page']"
+
+    render_inline(CollectiveRailComponent.new(
+                    main_collective: main_collective, collectives: [], current_path: "/"
+                  ))
+    assert_no_selector ".pulse-rail-chat.active"
+  end
+
+  test "renders the aggregated chat unread count server-side" do
+    render_inline(CollectiveRailComponent.new(
+                    main_collective: main_collective, collectives: [], chat_unread_count: 3
+                  ))
+    assert_selector ".pulse-rail-chat .pulse-rail-badge[data-chat-badge]", visible: :visible, text: "3"
+
+    render_inline(CollectiveRailComponent.new(main_collective: main_collective, collectives: []))
+    assert_selector ".pulse-rail-chat .pulse-rail-badge[data-chat-badge]", visible: :hidden
+  end
+
   test "marks a collective active on its own page" do
     a = build_rail_collective(name: "Team A", handle: "team-a")
     b = build_rail_collective(name: "Team B", handle: "team-b")

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -39,6 +39,20 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "rail chat badge renders its unread count server-side on first paint" do
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    chat = Notification.create!(tenant: @tenant, event: nil, notification_type: "chat_message", title: "Ping", url: "/chat/somebody")
+    NotificationRecipient.create!(notification: chat, user: @user, channel: "in_app", status: "delivered", tenant: @tenant)
+    Collective.clear_thread_scope
+
+    sign_in_as(@user, tenant: @tenant)
+    get "/"
+    assert_response :success
+    assert_select ".pulse-rail-chat .pulse-rail-badge[data-chat-badge]", text: "1" do |badges|
+      assert_not_includes badges.first["style"].to_s, "display: none"
+    end
+  end
+
   test "homepage hides content from tuned-in user posting in a different tenant" do
     sign_in_as(@user, tenant: @tenant)
     main = @tenant.main_collective

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -158,6 +158,22 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal({ @collective.id => 2, other.id => 1 }, json_response["by_collective"])
   end
 
+  test "unread_count includes the aggregated chat count for the rail's chat entry" do
+    sign_in_as(@user, tenant: @tenant)
+
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    chat = Notification.create!(tenant: @tenant, event: nil, notification_type: "chat_message", title: "Ping", url: "/chat/somebody")
+    NotificationRecipient.create!(notification: chat, user: @user, channel: "in_app", status: "delivered", tenant: @tenant)
+    Collective.clear_thread_scope
+
+    get "/notifications/unread_count", headers: { "Accept" => "application/json" }
+    assert_response :success
+    json_response = JSON.parse(response.body)
+    assert_equal 1, json_response["chat"]
+    # Eventless chat pings never appear in the per-collective map.
+    assert_equal({}, json_response["by_collective"])
+  end
+
   # === Dismiss Tests ===
 
   test "dismiss dismisses notification" do

--- a/test/services/notification_service_test.rb
+++ b/test/services/notification_service_test.rb
@@ -338,6 +338,29 @@ class NotificationServiceTest < ActiveSupport::TestCase
     assert_equal({ collective2.id => 1 }, counts)
   end
 
+  test "unread_chat_count_for counts only unread in-app chat_message notifications" do
+    tenant, collective, user = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    Tenant.current_id = tenant.id
+
+    # Two unread chat pings (eventless, like notify_chat_message! creates).
+    2.times do |i|
+      chat = Notification.create!(tenant: tenant, event: nil, notification_type: "chat_message", title: "Chat #{i}", url: "/chat/somebody")
+      NotificationRecipient.create!(notification: chat, user: user, channel: "in_app", status: "delivered", tenant: tenant)
+    end
+
+    # A read chat ping, an email chat row, and a non-chat notification don't count.
+    read_chat = Notification.create!(tenant: tenant, event: nil, notification_type: "chat_message", title: "Read chat", url: "/chat/somebody")
+    read_row = NotificationRecipient.create!(notification: read_chat, user: user, channel: "in_app", status: "delivered", tenant: tenant)
+    read_row.mark_read!
+    NotificationRecipient.create!(notification: read_chat, user: user, channel: "email", status: "pending", tenant: tenant)
+    event = Event.create!(tenant: tenant, collective: collective, event_type: "note.created", actor: user)
+    mention = Notification.create!(tenant: tenant, event: event, notification_type: "mention", title: "Mention")
+    NotificationRecipient.create!(notification: mention, user: user, channel: "in_app", status: "pending", tenant: tenant)
+
+    assert_equal 2, NotificationService.unread_chat_count_for(user, tenant: tenant)
+  end
+
   test "dismiss_all_for dismisses all in_app notifications" do
     tenant, collective, user = create_tenant_collective_user
     Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)


### PR DESCRIPTION
Adds the chat entry to the collective rail — the follow-up deferred from #339.

## What

One pinned entry beneath the globe (the Discord "DMs" slot), not a square per chat collective: a bare `comment-discussion` icon linking to `/chat`, active across all chat pages, with its own unread badge. Bare like the globe deliberately — places you're *in* get squares; zone-level entries don't.

## Why the badge is type-based

The aggregation problem #339's design doc worried about (many chat collectives behind one icon — how do their counts roll up?) dissolves on contact with the notification model: chat-message notifications carry **no event** (`notify_chat_message!` creates them eventless), so they were never in the per-collective counts. The chat badge counts unread `chat_message` notifications **by type**, which means the chat badge and the square badges partition the space cleanly — no chat-collective detection, no double-counting possible. A click lands on `/chat`, the conversations index, which is the right destination for an aggregate count.

## Changes

Same three-stage pipeline as the square badges, one new lane:

- `NotificationService.unread_chat_count_for` — unread in-app `chat_message` rows (same unread semantics as the other counts).
- `GET /notifications/unread_count` gains a `chat` key alongside `count` and `by_collective`.
- `CollectiveRailComponent` renders the entry (order pinned by test: globe → chat → divider → squares) with server-rendered first-paint count via a lazy `rail_chat_unread_count` helper; the `notifications:counts` broadcast now carries `chat`, projected onto `[data-chat-badge]` by the rail-badges controller. The badge display rule (zero hides, >99 → "99+") is extracted and shared between the collective and chat badges on both the Ruby and TS sides.
- `docs/NAVIGATION_DESIGN.md`: chat placement moves from open question to Decided, with the type-vs-collective counting rationale recorded.

## Verification

- Red-first tests at every layer: service, endpoint JSON shape, component (entry, ordering, active states, server-rendered badge), layout integration, and vitest for both Stimulus controllers. 101 backend tests green across touched files; rubocop/`srb tc`/tsc green.
- Verified in-browser: globe and chat stacked with independent badges; the chat badge fills from a seeded chat ping (seed data cleaned up afterward). Clear-on-read is covered by the shared zero-hides rule tested in vitest, not re-verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
