### PR TITLE
Add the mobile places sheet

### DIFF
--- a/app/assets/stylesheets/pulse.css
+++ b/app/assets/stylesheets/pulse.css
@@ -7,6 +7,7 @@
  *= require pulse/_base
  *= require pulse/_layout
  *= require pulse/_rail
+ *= require pulse/_places_sheet
  *= require pulse/_components
  *= require pulse/_markdown_editor
  *= require pulse/_sidebar

--- a/app/assets/stylesheets/pulse/_places_sheet.css
+++ b/app/assets/stylesheets/pulse/_places_sheet.css
@@ -1,0 +1,159 @@
+/* Pulse Places Sheet
+ *
+ * The mobile place switcher: the rail's destinations as labeled rows in a
+ * slide-over panel, opened from a header toggle. Desktop widths hide both
+ * (the rail is the desktop projection of the same destinations — see the
+ * form-factors section of docs/NAVIGATION_DESIGN.md).
+ */
+
+.pulse-places-toggle {
+  display: none;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  background: none;
+  color: var(--color-fg-muted);
+  cursor: pointer;
+}
+
+.pulse-places-toggle .octicon {
+  fill: currentColor;
+}
+
+/* Aggregate unread dot: any place has activity. */
+.pulse-places-toggle-dot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-accent-fg);
+}
+
+.pulse-places-backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--color-overlay-backdrop);
+  z-index: 200;
+}
+
+.pulse-places-sheet {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: min(320px, 85vw);
+  background: var(--color-canvas-default);
+  border-right: 1px solid var(--color-border-default);
+  z-index: 201;
+  transform: translateX(-100%);
+  transition: transform 0.2s ease;
+  overflow-y: auto;
+  visibility: hidden;
+}
+
+.pulse-places-sheet.open {
+  transform: translateX(0);
+  visibility: visible;
+}
+
+.pulse-places-nav {
+  display: flex;
+  flex-direction: column;
+  padding: 12px 8px;
+  gap: 2px;
+}
+
+.pulse-places-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--border-radius-default);
+  color: var(--color-fg-default);
+  text-decoration: none;
+}
+
+.pulse-places-row {
+  position: relative;
+}
+
+.pulse-places-row:hover {
+  background: var(--color-canvas-subtle);
+}
+
+/* Current place: the rail's left-edge indicator pill, verbatim — same
+   element and rules, repositioned to hug the sheet's edge (the nav has
+   8px side padding). */
+.pulse-places-row .pulse-rail-indicator {
+  left: -8px;
+}
+
+.pulse-places-row:hover .pulse-rail-indicator {
+  height: 20px;
+}
+
+.pulse-places-row.active .pulse-rail-indicator {
+  height: 32px;
+}
+
+.pulse-places-row-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  color: var(--color-fg-muted);
+}
+
+.pulse-places-row-icon .octicon {
+  fill: currentColor;
+}
+
+.pulse-places-row-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--border-radius-default);
+  object-fit: cover;
+}
+
+.pulse-places-row-avatar.inline-avatar {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.pulse-places-row-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Row badges reuse .pulse-rail-badge display rules but sit in-flow at the
+   row's right edge rather than absolutely over an icon. */
+.pulse-places-row-badge {
+  position: static;
+  flex-shrink: 0;
+}
+
+.pulse-places-row-add {
+  color: var(--color-fg-muted);
+}
+
+.pulse-places-divider {
+  height: 1px;
+  background: var(--color-border-default);
+  margin: 6px 12px;
+}
+
+@media (max-width: 768px) {
+  .pulse-places-toggle {
+    display: flex;
+  }
+}

--- a/app/assets/stylesheets/root_variables.css
+++ b/app/assets/stylesheets/root_variables.css
@@ -44,6 +44,7 @@
     --color-border-default: #30363d;
     --color-border-muted: #21262d;
     --color-neutral-muted: rgba(110,118,129,0.4);
+    --color-overlay-backdrop: rgba(1,4,9,0.8);
     --color-accent-fg: #58a6ff;
     --color-accent-emphasis: #1f6feb;
     --color-attention-fg: #d29922;
@@ -67,6 +68,7 @@
     --color-border-default: #d0d7de;
     --color-border-muted: hsla(210,18%,87%,1);
     --color-neutral-muted: rgba(175,184,193,0.2);
+    --color-overlay-backdrop: rgba(31,35,40,0.5);
     --color-accent-fg: #0969da;
     --color-accent-emphasis: #0969da;
     --color-attention-fg: #9a6700;

--- a/app/components/collective_rail_component.rb
+++ b/app/components/collective_rail_component.rb
@@ -12,6 +12,8 @@
 # up on every such page.
 class CollectiveRailComponent < ViewComponent::Base
   extend T::Sig
+  include UnreadBadgeDisplay
+  include PlaceActiveStates
 
   sig do
     params(
@@ -40,31 +42,6 @@ class CollectiveRailComponent < ViewComponent::Base
 
   private
 
-  sig { params(collective: Collective).returns(T::Boolean) }
-  def active?(collective)
-    current = @current_path
-    path = collective.path
-    return false if current.nil? || path.nil?
-
-    current == path || current.start_with?("#{path}/")
-  end
-
-  sig { returns(T::Boolean) }
-  def public_space_active?
-    @current_path == "/"
-  end
-
-  # The chat entry aggregates every chat collective behind one icon, so it
-  # is active across all of /chat, and its count is type-based (unread
-  # chat_message notifications), not collective-based.
-  sig { returns(T::Boolean) }
-  def chat_active?
-    current = @current_path
-    return false if current.nil?
-
-    current == "/chat" || current.start_with?("/chat/")
-  end
-
   # Server-rendered initial badge state, so navigation never flashes the
   # badges out. The rail-badges controller overwrites this on every poll
   # using the same display rules — keep the two in sync.
@@ -86,17 +63,5 @@ class CollectiveRailComponent < ViewComponent::Base
   sig { returns(T.nilable(String)) }
   def chat_badge_style
     count_badge_style(@chat_unread_count)
-  end
-
-  sig { params(count: Integer).returns(String) }
-  def count_badge_text(count)
-    return "" if count.zero?
-
-    count > 99 ? "99+" : count.to_s
-  end
-
-  sig { params(count: Integer).returns(T.nilable(String)) }
-  def count_badge_style(count)
-    "display: none" if count.zero?
   end
 end

--- a/app/components/place_active_states.rb
+++ b/app/components/place_active_states.rb
@@ -1,0 +1,35 @@
+# typed: true
+
+# Shared "where am I" rules for the rail and the places sheet — both are
+# projections of the same destinations, so a place must light up (or not)
+# identically in each. Path-based, never current_collective-based: the
+# current-collective fallback would activate the public space on every
+# handle-less route (/billing, /settings, ...). Expects the including
+# component to set @current_path.
+module PlaceActiveStates
+  extend T::Sig
+
+  sig { params(collective: Collective).returns(T::Boolean) }
+  def active?(collective)
+    current = @current_path
+    path = collective.path
+    return false if current.nil? || path.nil?
+
+    current == path || current.start_with?("#{path}/")
+  end
+
+  sig { returns(T::Boolean) }
+  def public_space_active?
+    @current_path == "/"
+  end
+
+  # The chat entry aggregates every chat collective behind one icon, so it
+  # is active across all of /chat.
+  sig { returns(T::Boolean) }
+  def chat_active?
+    current = @current_path
+    return false if current.nil?
+
+    current == "/chat" || current.start_with?("/chat/")
+  end
+end

--- a/app/components/places_sheet_component.html.erb
+++ b/app/components/places_sheet_component.html.erb
@@ -1,0 +1,46 @@
+<div class="pulse-places-backdrop" data-places-sheet-target="backdrop"
+     data-action="click->places-sheet#close" hidden></div>
+<div class="pulse-places-sheet" data-places-sheet-target="panel" aria-hidden="true">
+  <nav class="pulse-places-nav" aria-label="Places" data-controller="rail-badges">
+    <% if @main_collective %>
+      <%= tag.a href: "/",
+                class: ["pulse-places-row", ("active" if public_space_active?)],
+                aria: { current: ("page" if public_space_active?) } do %>
+        <span class="pulse-rail-indicator"></span>
+        <span class="pulse-places-row-icon"><%= helpers.octicon "globe", height: 20 %></span>
+        <span class="pulse-places-row-name">Public space</span>
+        <span class="pulse-rail-badge pulse-places-row-badge" data-collective-id="<%= @main_collective.id %>"
+              style="<%= count_badge_style(unread_count_for(@main_collective)) %>"><%= count_badge_text(unread_count_for(@main_collective)) %></span>
+      <% end %>
+      <%= tag.a href: "/chat",
+                class: ["pulse-places-row", ("active" if chat_active?)],
+                aria: { current: ("page" if chat_active?) } do %>
+        <span class="pulse-rail-indicator"></span>
+        <span class="pulse-places-row-icon"><%= helpers.octicon "comment-discussion", height: 20 %></span>
+        <span class="pulse-places-row-name">Chat</span>
+        <span class="pulse-rail-badge pulse-places-row-badge" data-chat-badge
+              style="<%= count_badge_style(@chat_unread_count) %>"><%= count_badge_text(@chat_unread_count) %></span>
+      <% end %>
+      <div class="pulse-places-divider"></div>
+    <% end %>
+
+    <% @collectives.each do |collective| %>
+      <%= tag.a href: collective.path,
+                class: ["pulse-places-row", ("active" if active?(collective))],
+                aria: { current: ("page" if active?(collective)) } do %>
+        <span class="pulse-rail-indicator"></span>
+        <span class="pulse-places-row-icon">
+          <%= helpers.inline_avatar(collective, css_class: "pulse-places-row-avatar", variant: :icon) %>
+        </span>
+        <span class="pulse-places-row-name"><%= collective.name %></span>
+        <span class="pulse-rail-badge pulse-places-row-badge" data-collective-id="<%= collective.id %>"
+              style="<%= count_badge_style(unread_count_for(collective)) %>"><%= count_badge_text(unread_count_for(collective)) %></span>
+      <% end %>
+    <% end %>
+
+    <a href="/collectives" class="pulse-places-row pulse-places-row-add">
+      <span class="pulse-places-row-icon"><%= helpers.octicon "plus", height: 20 %></span>
+      <span class="pulse-places-row-name">Create or join a collective</span>
+    </a>
+  </nav>
+</div>

--- a/app/components/places_sheet_component.rb
+++ b/app/components/places_sheet_component.rb
@@ -1,0 +1,42 @@
+# typed: true
+
+# The mobile place switcher: the rail's destinations (globe, chat,
+# collectives, create/join) as labeled rows in a slide-over sheet. Rows
+# carry names because touch has no tooltips. Opened/closed by the
+# places-sheet Stimulus controller; badges stay fresh via a rail-badges
+# controller instance listening to the shared unread-count broadcast.
+class PlacesSheetComponent < ViewComponent::Base
+  extend T::Sig
+  include UnreadBadgeDisplay
+  include PlaceActiveStates
+
+  sig do
+    params(
+      main_collective: T.nilable(Collective),
+      collectives: T::Array[Collective],
+      current_path: T.nilable(String),
+      unread_counts: T::Hash[String, Integer],
+      chat_unread_count: Integer
+    ).void
+  end
+  def initialize(main_collective: nil, collectives: [], current_path: nil, unread_counts: {}, chat_unread_count: 0)
+    super()
+    @main_collective = main_collective
+    @collectives = T.let(collectives.select { |c| c.path.present? }, T::Array[Collective])
+    @current_path = current_path
+    @unread_counts = unread_counts
+    @chat_unread_count = chat_unread_count
+  end
+
+  sig { returns(T::Boolean) }
+  def render?
+    @main_collective.present? || @collectives.any?
+  end
+
+  private
+
+  sig { params(collective: Collective).returns(Integer) }
+  def unread_count_for(collective)
+    @unread_counts[collective.id].to_i
+  end
+end

--- a/app/components/unread_badge_display.rb
+++ b/app/components/unread_badge_display.rb
@@ -1,0 +1,20 @@
+# typed: true
+
+# Shared display rules for the unread count pills on the rail and the
+# places sheet. The rail-badges Stimulus controller reimplements the same
+# rules for post-poll updates — keep the two in sync.
+module UnreadBadgeDisplay
+  extend T::Sig
+
+  sig { params(count: Integer).returns(String) }
+  def count_badge_text(count)
+    return "" if count.zero?
+
+    count > 99 ? "99+" : count.to_s
+  end
+
+  sig { params(count: Integer).returns(T.nilable(String)) }
+  def count_badge_style(count)
+    "display: none" if count.zero?
+  end
+end

--- a/app/javascript/controllers/index.ts
+++ b/app/javascript/controllers/index.ts
@@ -48,6 +48,7 @@ import MoreButtonController from "./more_button_controller"
 import NavController from "./nav_controller"
 import NotificationActionsController from "./notification_actions_controller"
 import NotificationBadgeController from "./notification_badge_controller"
+import PlacesSheetController from "./places_sheet_controller"
 import RailBadgesController from "./rail_badges_controller"
 import CsvImportController from "./csv_import_controller"
 import NoteController from "./note_controller"
@@ -126,6 +127,7 @@ application.register("more-button", MoreButtonController)
 application.register("nav", NavController)
 application.register("notification-actions", NotificationActionsController)
 application.register("notification-badge", NotificationBadgeController)
+application.register("places-sheet", PlacesSheetController)
 application.register("rail-badges", RailBadgesController)
 application.register("note", NoteController)
 application.register("note-media-uploader", NoteMediaUploaderController)

--- a/app/javascript/controllers/places_sheet_controller.test.ts
+++ b/app/javascript/controllers/places_sheet_controller.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import PlacesSheetController from "./places_sheet_controller"
+
+describe("PlacesSheetController", () => {
+  let application: Application
+
+  afterEach(() => {
+    application.stop()
+  })
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div data-controller="places-sheet">
+        <button data-places-sheet-target="toggle" data-action="click->places-sheet#toggle"
+                aria-expanded="false">
+          Places
+          <span data-places-sheet-target="dot" style="display: none"></span>
+        </button>
+        <div data-places-sheet-target="backdrop" data-action="click->places-sheet#close" hidden></div>
+        <div class="pulse-places-sheet" data-places-sheet-target="panel" aria-hidden="true"></div>
+      </div>
+    `
+    application = Application.start()
+    application.register("places-sheet", PlacesSheetController)
+  })
+
+  function el(target: string): HTMLElement {
+    return document.querySelector(`[data-places-sheet-target='${target}']`) as HTMLElement
+  }
+
+  it("opens and closes from the toggle button", async () => {
+    el("toggle").click()
+    await vi.waitFor(() => {
+      expect(el("panel").getAttribute("aria-hidden")).toBe("false")
+      expect(el("panel").classList.contains("open")).toBe(true)
+      expect(el("backdrop").hidden).toBe(false)
+      expect(el("toggle").getAttribute("aria-expanded")).toBe("true")
+    })
+
+    el("toggle").click()
+    await vi.waitFor(() => {
+      expect(el("panel").getAttribute("aria-hidden")).toBe("true")
+      expect(el("panel").classList.contains("open")).toBe(false)
+      expect(el("backdrop").hidden).toBe(true)
+      expect(el("toggle").getAttribute("aria-expanded")).toBe("false")
+    })
+  })
+
+  it("closes on backdrop click and on Escape", async () => {
+    el("toggle").click()
+    await vi.waitFor(() => expect(el("panel").classList.contains("open")).toBe(true))
+
+    el("backdrop").click()
+    await vi.waitFor(() => expect(el("panel").classList.contains("open")).toBe(false))
+
+    el("toggle").click()
+    await vi.waitFor(() => expect(el("panel").classList.contains("open")).toBe(true))
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }))
+    await vi.waitFor(() => expect(el("panel").classList.contains("open")).toBe(false))
+  })
+
+  it("shows the aggregate dot when any place has unread activity", async () => {
+    window.dispatchEvent(
+      new CustomEvent("notifications:counts", {
+        detail: { byCollective: { "aaa-111": 2 }, chat: 0 },
+      }),
+    )
+    await vi.waitFor(() => expect(el("dot").style.display).toBe(""))
+
+    window.dispatchEvent(
+      new CustomEvent("notifications:counts", {
+        detail: { byCollective: {}, chat: 0 },
+      }),
+    )
+    await vi.waitFor(() => expect(el("dot").style.display).toBe("none"))
+
+    window.dispatchEvent(
+      new CustomEvent("notifications:counts", {
+        detail: { byCollective: {}, chat: 3 },
+      }),
+    )
+    await vi.waitFor(() => expect(el("dot").style.display).toBe(""))
+  })
+})

--- a/app/javascript/controllers/places_sheet_controller.ts
+++ b/app/javascript/controllers/places_sheet_controller.ts
@@ -1,0 +1,76 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * PlacesSheetController opens/closes the mobile place-switcher sheet and
+ * lights the toggle's aggregate unread dot from the shared
+ * "notifications:counts" broadcast (the badges inside the sheet are kept
+ * fresh separately, by the sheet's own rail-badges controller).
+ *
+ * Registered on an ancestor of both the header toggle and the sheet
+ * (the layout wraps them), since they live in different DOM subtrees.
+ */
+export default class PlacesSheetController extends Controller<HTMLElement> {
+  static targets = ["panel", "backdrop", "toggle", "dot"]
+
+  declare readonly panelTarget: HTMLElement
+  declare readonly backdropTarget: HTMLElement
+  declare readonly toggleTarget: HTMLElement
+  declare readonly dotTarget: HTMLElement
+  declare readonly hasPanelTarget: boolean
+  declare readonly hasDotTarget: boolean
+
+  connect(): void {
+    document.addEventListener("keydown", this.handleKeydown)
+    window.addEventListener("notifications:counts", this.handleCounts)
+  }
+
+  disconnect(): void {
+    document.removeEventListener("keydown", this.handleKeydown)
+    window.removeEventListener("notifications:counts", this.handleCounts)
+  }
+
+  toggle(): void {
+    if (this.isOpen()) {
+      this.close()
+    } else {
+      this.open()
+    }
+  }
+
+  open(): void {
+    if (!this.hasPanelTarget) return
+    this.panelTarget.classList.add("open")
+    this.panelTarget.setAttribute("aria-hidden", "false")
+    this.backdropTarget.hidden = false
+    this.toggleTarget.setAttribute("aria-expanded", "true")
+  }
+
+  close(): void {
+    if (!this.hasPanelTarget) return
+    this.panelTarget.classList.remove("open")
+    this.panelTarget.setAttribute("aria-hidden", "true")
+    this.backdropTarget.hidden = true
+    this.toggleTarget.setAttribute("aria-expanded", "false")
+  }
+
+  private isOpen(): boolean {
+    return this.hasPanelTarget && this.panelTarget.classList.contains("open")
+  }
+
+  private handleKeydown = (event: KeyboardEvent): void => {
+    if (event.key === "Escape" && this.isOpen()) {
+      this.close()
+    }
+  }
+
+  private handleCounts = (event: Event): void => {
+    if (!this.hasDotTarget) return
+
+    const detail = (event as CustomEvent).detail
+    const byCollective: Record<string, number> = detail?.byCollective ?? {}
+    const chat: number = detail?.chat ?? 0
+    const anyUnread = chat > 0 || Object.values(byCollective).some((count) => count > 0)
+
+    this.dotTarget.style.display = anyUnread ? "" : "none"
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,7 @@
     <%= stylesheet_link_tag "pulse", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
-  <body>
+  <body data-controller="places-sheet">
     <div id="expanding-heart">
       <%= octicon 'heart' %>
     </div>
@@ -41,6 +41,16 @@
       <header class="pulse-top-header"
               data-controller="auto-hide-header"
               data-auto-hide-header-hidden-class="pulse-top-header--hidden">
+        <% if @current_user %>
+          <button type="button" class="pulse-places-toggle"
+                  data-places-sheet-target="toggle"
+                  data-action="click->places-sheet#toggle"
+                  aria-expanded="false" aria-label="Places">
+            <%= octicon "three-bars", height: 20 %>
+            <span class="pulse-places-toggle-dot" data-places-sheet-target="dot"
+                  style="<%= 'display: none' unless rail_unread_counts.values.any?(&:positive?) || rail_chat_unread_count.positive? %>"></span>
+          </button>
+        <% end %>
         <a href="/" class="pulse-logo">
           <i class="tri-logo-icon icon-sm"></i>
           <span>Harmonic</span>
@@ -81,6 +91,15 @@
           <%= button_to "End Session", "#{@current_representation_session.collective.path}/represent", method: :delete, class: "pulse-banner-btn" %>
         <% end %>
       </div>
+    <% end %>
+    <% if @current_user %>
+      <%= render PlacesSheetComponent.new(
+        main_collective: @current_tenant&.main_collective,
+        collectives: rail_collectives,
+        current_path: request.path,
+        unread_counts: rail_unread_counts,
+        chat_unread_count: rail_chat_unread_count,
+      ) %>
     <% end %>
     <div class="pulse-app-shell">
       <% if @current_user %>

--- a/docs/NAVIGATION_DESIGN.md
+++ b/docs/NAVIGATION_DESIGN.md
@@ -291,18 +291,23 @@ chrome to reshape per form factor without forking the model.
 
 ### Increments (each independently shippable, none undone by the next)
 
-1. **Ship the rail desktop-only** (hide under 768px; mobile stays as it is
-   on prod today). Unblocks PR #339 honestly. Constraint for any hide/fold,
-   here and later: collapse by redefining `--pulse-rail-width` (the motto
-   footer's border-continuation offset derives from it), not by hiding the
-   element alone.
-2. **Places-as-sheet on mobile** — the switcher list (icon + name + badge
-   + "+"), initially opened from a header toggle; built as the future
-   Places tab's content, not a throwaway drawer.
-3. **Bottom tab bar** — the sheet gets its tab; Inbox/Search/You move
+1. **Bottom tab bar** — the sheet gets its tab; Inbox/Search/You move
    down; the top bar slims to a place label.
-4. **Sidebar → place header**, paced by how much of the sidebar
+2. **Sidebar → place header**, paced by how much of the sidebar
    feeds-are-queries continues to absorb.
+
+Shipped from this list:
+
+- **Rail desktop-only** (#339): hidden under 768px by redefining
+  `--pulse-rail-width` (the motto footer's border-continuation offset
+  derives from it — keep that constraint for any future hide/fold).
+- **Places sheet on mobile**: the rail's destinations as labeled rows
+  (`PlacesSheetComponent` — globe, chat, collectives with names, "+"),
+  slid over from a mobile-only header toggle that carries an aggregate
+  unread dot. Badges reuse the rail's classes so a second rail-badges
+  controller instance keeps them fresh from the same
+  `notifications:counts` broadcast; first paint is server-rendered. Built
+  as the future Places tab's content, not a throwaway drawer.
 
 ## Decided (current iteration)
 

--- a/docs/NAVIGATION_DESIGN.md
+++ b/docs/NAVIGATION_DESIGN.md
@@ -291,9 +291,13 @@ chrome to reshape per form factor without forking the model.
 
 ### Increments (each independently shippable, none undone by the next)
 
-1. **Bottom tab bar** — the sheet gets its tab; Inbox/Search/You move
+1. **Badge click-through** (`my:notified` + clearing affordances +
+   reminder-notification attribution — see open question 3). Comes before
+   the bar: the bar's Places/Inbox split only feels right once badges
+   drain in place.
+2. **Bottom tab bar** — the sheet gets its tab; Inbox/Search/You move
    down; the top bar slims to a place label.
-2. **Sidebar → place header**, paced by how much of the sidebar
+3. **Sidebar → place header**, paced by how much of the sidebar
    feeds-are-queries continues to absorb.
 
 Shipped from this list:
@@ -360,33 +364,65 @@ Shipped from this list:
    The route swap landed (feed is the default page, dashboard at
    `/dashboard`), but the dashboard itself hasn't converted to a query —
    decide the sidebar question together with that conversion.
-3. **Badges promise more than the click delivers.** A square's unread badge
-   implies clicking will show what you're being notified about, but the
-   collective feed renders with no notification context. Candidate fix in
-   the feeds-are-queries vocabulary: a viewer-relative filter that surfaces
-   the items behind the count directly in the feed.
+3. **Badge click-through — direction resolved, unbuilt.** A square's
+   unread badge implies clicking will show what you're being notified
+   about, but the collective feed renders with no notification context.
+   The fix is a `my:` filter namespace: the DSL is already viewer-relative
+   (`list:tuned_in` resolves against the current user), but `list:*`
+   resolves to *authors* and filters on content facts, while `my:*`
+   filters on the viewer's own state per item — a different data layer
+   the prefix makes explicit.
 
-   Syntax direction: a `my:` namespace (`my:unread`, later perhaps
-   `my:bookmarks`) rather than `notifications:unread`. The DSL is already
-   viewer-relative — `list:tuned_in` resolves against the current user —
-   but `list:tuned_in` resolves to a set of *authors* and then filters on
-   content facts, while `my:*` would filter on the viewer's own
-   interaction state with each item. That is a different data layer, and
-   the `my:` prefix makes the relativity explicit in the syntax instead of
-   hiding it inside an operator's special values.
+   Harmonic has two such layers, and they get **two names** (the earlier
+   draft's "choose one meaning" fork is resolved by not blending):
 
-   Two things to pin down before building:
+   - **`my:notified`** — the delivery layer: items in scope with an
+     **undismissed** notification addressed to the viewer. This is the
+     inbox projected onto the feed. Undismissed-not-unread is deliberate
+     and matches existing precedent: the header badge counts *unread*
+     while the notifications page shows *undismissed* — the count is the
+     urgent subset, the view is the full queue. Badge click lands on the
+     place's feed at `?q=my:notified`.
+   - **`my:unread`** — the social layer: notes in scope the viewer has
+     not confirmed read. Anchored to read-confirmation (reader counts,
+     confirm-read), which is what "read" already means everywhere else
+     in the product. Fully separable from the badge system, and a
+     different query shape (a negative join against read-confirmations
+     vs. `my:notified`'s id-set resolution) — build it later,
+     independently.
 
-   - **Which "unread"?** Harmonic has two candidate meanings that do not
-     agree: notification recipient-state (what the badge counts) and
-     read-confirmation state (items the viewer hasn't confirmed-read — a
-     first-class content-adjacent feature). Read-confirmations sit more
-     comfortably with guardrail 3 (which keeps `/notifications`
-     recipient-state out of the feed model), but only the notification
-     meaning makes a badge click show exactly the items behind the badge's
-     number. Choose one meaning per filter name; do not blend.
-   - **Anonymous viewers.** `my:*` with no signed-in user should warn and
-     match nothing, same pattern as other unresolvable filters.
+   What makes the click-through actually drain the badge:
+
+   - Confirm-read already clears the pointing notification (shipped in
+     1.38.0), covering notes and reminders.
+   - Non-confirmable items (votes, tune-ins) need per-item dismiss
+     chrome in the `my:notified` view, or a "mark all read here"
+     affordance — `mark_read_for_collective` /
+     `dismiss_for_collective` already exist server-side.
+
+   Prerequisite: **reminder-notification attribution.** Reminder *notes*
+   have a collective; only their notification rows are placeless
+   (`event_id: nil` — an implementation artifact, not a semantic truth).
+   Attribute them and reminders flow into per-collective badges and
+   `my:notified` like everything else. The genuinely placeless residue —
+   tenant-level notifications (trustee authorizations, account security)
+   plus chat (which has its own entry) — is what keeps the header inbox:
+   it stays, as the cross-place queue and the mobile Inbox tab, but it
+   stops being the *only* place a badge can drain, which was the actual
+   problem. **Do not hide the inbox** to dedupe against the badges; they
+   are two projections of one state with different jobs.
+
+   Guardrail 3 is intact: `my:notified` filters *content* by
+   recipient-state; `/notifications` itself (deliveries, lifecycle) stays
+   out of the feed model.
+
+   Anonymous viewers: `my:*` with no signed-in user warns and matches
+   nothing, same pattern as other unresolvable filters.
+
+   Sequencing: reminder attribution → `my:notified` + badge click-through
+   + clearing affordances → bottom tab bar (its Places/Inbox split only
+   feels right once badges drain in place) → `my:unread` when it earns
+   its slot.
 
 (The former "what is the globe?" question is resolved — see Decided: `/`
 unifies home and the public space via the default `list:tuned_in` chip.
@@ -395,13 +431,14 @@ the unification makes the default view a *default*, not a separate page.)
 
 ## Planned next steps (rough order)
 
-1. **"+" at the rail bottom** — create/join collective (and the escape hatch
-   to browse `/collectives` when the rail overflows). Place-related, so it
-   belongs in the place layer.
-2. **Ordering/overflow**: alphabetical until it hurts; then recency or
+1. **Ordering/overflow**: alphabetical until it hurts; then recency or
    pinning. The "+"/browse entry is the overflow escape hatch.
 
 Shipped from this list:
+
+- **"+" at the rail bottom** — create/join collective, linking to
+  `/collectives` (also the escape hatch when the rail overflows). A
+  dashed hollow square: a utility, not a place; no active state.
 
 - **Sticky rail** (`position: sticky; top: 0; height: 100dvh`): pinned to
   the viewport while the document scrolls; the rail scrolls independently

--- a/e2e/tests/collectives/places-sheet.spec.ts
+++ b/e2e/tests/collectives/places-sheet.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "../../fixtures/test-fixtures"
+
+test.describe("Places Sheet", () => {
+  test("opens from the header toggle on mobile and lists places by name", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage
+    await page.setViewportSize({ width: 375, height: 667 })
+
+    await page.goto("/")
+
+    const toggle = page.locator(".pulse-places-toggle")
+    await expect(toggle).toBeVisible()
+
+    const sheet = page.locator(".pulse-places-sheet")
+    await expect(sheet).toBeHidden()
+
+    await toggle.click()
+    await expect(sheet).toBeVisible()
+    await expect(sheet.locator("a[href='/']")).toContainText("Public space")
+    await expect(sheet.locator("a[href='/chat']")).toContainText("Chat")
+    await expect(sheet.locator("a[href='/collectives']")).toContainText(
+      "Create or join a collective",
+    )
+
+    await page.keyboard.press("Escape")
+    await expect(sheet).toBeHidden()
+  })
+
+  test("the toggle is hidden on desktop where the rail serves instead", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage
+
+    await page.goto("/")
+
+    await expect(page.locator(".pulse-places-toggle")).toBeHidden()
+    await expect(page.locator(".pulse-rail")).toBeVisible()
+  })
+})

--- a/test/components/places_sheet_component_test.rb
+++ b/test/components/places_sheet_component_test.rb
@@ -1,0 +1,104 @@
+# typed: false
+
+require "test_helper"
+require_relative "component_test_helper"
+
+class PlacesSheetComponentTest < ViewComponent::TestCase
+  include ComponentTestHelper
+
+  def build_sheet_collective(name:, handle:, path: "/collectives/#{handle}")
+    collective = build_collective(name: name, handle: handle)
+    collective.define_singleton_method(:path) { path }
+    collective.define_singleton_method(:avatar_color) { "#336699" }
+    collective.define_singleton_method(:image_url) { |**| nil }
+    collective
+  end
+
+  def main_collective
+    build_sheet_collective(name: "Public", handle: "public", path: nil)
+  end
+
+  test "renders the same destinations as the rail, as labeled rows" do
+    a = build_sheet_collective(name: "Team A", handle: "team-a")
+    render_inline(PlacesSheetComponent.new(main_collective: main_collective, collectives: [a]))
+
+    assert_selector ".pulse-places-sheet a[href='/'] .octicon-globe"
+    assert_selector ".pulse-places-sheet a[href='/']", text: "Public space"
+    assert_selector ".pulse-places-sheet a[href='/chat'] .octicon-comment-discussion"
+    assert_selector ".pulse-places-sheet a[href='/chat']", text: "Chat"
+    assert_selector ".pulse-places-sheet a[href='/collectives/team-a']", text: "Team A"
+    assert_selector ".pulse-places-sheet a[href='/collectives']", text: "Create or join a collective"
+  end
+
+  test "is closed by default and marked as a places-sheet panel target" do
+    render_inline(PlacesSheetComponent.new(main_collective: main_collective, collectives: []))
+
+    assert_selector ".pulse-places-sheet[data-places-sheet-target='panel'][aria-hidden='true']", visible: :all
+    assert_selector "[data-places-sheet-target='backdrop']", visible: :all
+  end
+
+  test "renders unread badges server-side with the same keys the poller broadcast uses" do
+    a = build_sheet_collective(name: "Team A", handle: "team-a")
+    a.id = "11111111-1111-1111-1111-111111111111"
+    main = main_collective
+    main.id = "22222222-2222-2222-2222-222222222222"
+
+    render_inline(PlacesSheetComponent.new(
+                    main_collective: main,
+                    collectives: [a],
+                    unread_counts: { a.id => 4 },
+                    chat_unread_count: 2,
+                  ))
+
+    assert_selector ".pulse-places-sheet .pulse-rail-badge[data-collective-id='#{a.id}']", text: "4", visible: :all
+    assert_selector ".pulse-places-sheet .pulse-rail-badge[data-chat-badge]", text: "2", visible: :all
+    assert_selector ".pulse-places-sheet .pulse-rail-badge[data-collective-id='#{main.id}']", text: "", visible: :all
+    # A second rail-badges controller instance keeps these fresh after polls.
+    assert_selector ".pulse-places-sheet [data-controller~='rail-badges']", visible: :all
+  end
+
+  test "marks the current place active, same rules as the rail" do
+    a = build_sheet_collective(name: "Team A", handle: "team-a")
+    b = build_sheet_collective(name: "Team B", handle: "team-b")
+
+    render_inline(PlacesSheetComponent.new(
+                    main_collective: main_collective, collectives: [a, b], current_path: "/collectives/team-a/cycles/3"
+                  ))
+    assert_selector "a.pulse-places-row.active[href='/collectives/team-a'][aria-current='page']"
+    assert_no_selector "a.pulse-places-row.active[href='/collectives/team-b']"
+
+    render_inline(PlacesSheetComponent.new(
+                    main_collective: main_collective, collectives: [a], current_path: "/"
+                  ))
+    assert_selector "a.pulse-places-row.active[href='/'][aria-current='page']"
+
+    render_inline(PlacesSheetComponent.new(
+                    main_collective: main_collective, collectives: [a], current_path: "/chat/somebody"
+                  ))
+    assert_selector "a.pulse-places-row.active[href='/chat'][aria-current='page']"
+
+    # Sibling path prefixes and you-level pages activate nothing.
+    render_inline(PlacesSheetComponent.new(
+                    main_collective: main_collective, collectives: [a], current_path: "/collectives/team-alpha"
+                  ))
+    assert_no_selector ".pulse-places-row.active"
+    render_inline(PlacesSheetComponent.new(
+                    main_collective: main_collective, collectives: [a], current_path: "/billing"
+                  ))
+    assert_no_selector ".pulse-places-row.active"
+    assert_no_selector "[aria-current]"
+  end
+
+  test "skips collectives without a path" do
+    unroutable = build_sheet_collective(name: "No Path", handle: "no-path", path: nil)
+    render_inline(PlacesSheetComponent.new(main_collective: main_collective, collectives: [unroutable]))
+
+    assert_no_selector "a", text: "No Path"
+  end
+
+  test "renders nothing without a main collective or collectives" do
+    render_inline(PlacesSheetComponent.new(main_collective: nil, collectives: []))
+
+    assert_no_selector ".pulse-places-sheet", visible: :all
+  end
+end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -39,6 +39,20 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "layout renders the places sheet and its header toggle for signed-in users" do
+    sign_in_as(@user, tenant: @tenant)
+    get "/"
+    assert_response :success
+
+    assert_select "body[data-controller~='places-sheet']"
+    assert_select ".pulse-places-toggle[data-places-sheet-target='toggle'][aria-expanded='false']"
+    assert_select ".pulse-places-sheet[aria-hidden='true']" do
+      assert_select "a[href='/']", text: /Public space/
+      assert_select "a[href='/chat']", text: /Chat/
+      assert_select "a[href='/collectives']", text: /Create or join a collective/
+    end
+  end
+
   test "rail chat badge renders its unread count server-side on first paint" do
     Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
     chat = Notification.create!(tenant: @tenant, event: nil, notification_type: "chat_message", title: "Ping", url: "/chat/somebody")


### PR DESCRIPTION
Increment 2 of the form-factors plan in `docs/NAVIGATION_DESIGN.md`: the mobile place switcher. The rail stays desktop-only; under 768px its destinations are now reachable again — as a sheet.

## What

A slide-over **places sheet**, opened from a mobile-only ☰ toggle at the header's left:

- The rail's destinations as **labeled rows** — globe ("Public space"), chat, each collective with its avatar and name, and "Create or join a collective". Names matter here: the rail's square icons rely on `title` tooltips, which don't exist on touch.
- **Current place** marked with the rail's own left-edge indicator pill (same element, same rules), repositioned to hug the sheet's edge.
- **Unread badges** on every row, server-rendered on first paint and kept fresh by a second `rail-badges` controller instance listening to the same `notifications:counts` broadcast the rail uses — still one poll for all badge surfaces.
- The **toggle carries an aggregate unread dot** (any place has activity), so the badges' ambient value survives while the sheet is closed.
- Backdrop click and Escape close it; the toggle is hidden at desktop widths where the rail serves instead.

Built deliberately as the future Places tab's content (bottom tab bar, increment 3) — not a throwaway drawer.

## Shared modules

The sheet and the rail are two projections of the same destinations, so their rules now live in one place each, included by both components:

- `UnreadBadgeDisplay` — badge text/visibility (zero hides, >99 → "99+").
- `PlaceActiveStates` — path-based active states (globe at `/`, chat across `/chat*`, collectives by path prefix with the sibling-prefix guard).

New `--color-overlay-backdrop` token in both palettes for the scrim (no scrim token existed; the app's other overlays hardcode rgba, which `check-style-guide.sh` flags).

## Design doc

- Increment 2 recorded as shipped.
- The badge click-through question is **resolved** (unbuilt): a `my:` filter namespace with two filters, one per viewer-state layer — `my:notified` (undismissed notifications projected onto the feed; the badge click target) and `my:unread` (notes not confirmed-read; separable, later). Records the drain mechanics, the reminder-notification attribution prerequisite, why the header inbox stays, and the sequencing: click-through before the bottom tab bar.

## Verification

- Red-first: component tests (rows, ordering, badges, active states), layout integration tests, vitest for the `places-sheet` controller (toggle/backdrop/Escape/aggregate dot), and Playwright e2e (opens on mobile viewport with named rows; toggle hidden on desktop).
- rubocop, `srb tc`, tsc green; `check-style-guide.sh` clean for the new CSS.
- Verified in-browser at 375px: sheet contents, badge fill, active pill on the current place, both backdrop palettes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
