### PR TITLE
Add the my: viewer-state filters (notified, unread, read)

### DIFF
--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -195,19 +195,24 @@ class NotificationService
       .in_app.unread.not_scheduled.count
   end
 
-  # Unread counts grouped by the notification event's collective, for the
-  # rail's per-collective badges. Reminders (no event) have no collective and
-  # are excluded — they only count toward the header total. String joins keep
-  # the Notification/Event default scopes (thread collective scope) out of
-  # the query: badges must cover every collective, not just the current one.
+  # Unread counts grouped by collective, for the rail's per-collective
+  # badges. A notification's collective is its event's (mentions, comments,
+  # ...) or, for reminders — which have no event — the reminder note's,
+  # derived through notes.reminder_notification_id. Truly placeless
+  # notifications (chat, tenant-level) only count toward the header total.
+  # String joins keep the Notification/Event/Note default scopes (thread
+  # collective scope) out of the query: badges must cover every collective,
+  # not just the current one.
   sig { params(user: User, tenant: Tenant).returns(T::Hash[String, Integer]) }
   def self.unread_count_by_collective_for(user, tenant:)
     NotificationRecipient
       .where(user: user, tenant: tenant)
       .in_app.unread.not_scheduled
       .joins("INNER JOIN notifications ON notifications.id = notification_recipients.notification_id")
-      .joins("INNER JOIN events ON events.id = notifications.event_id")
-      .group("events.collective_id")
+      .joins("LEFT JOIN events ON events.id = notifications.event_id")
+      .joins("LEFT JOIN notes ON notes.reminder_notification_id = notifications.id")
+      .where("events.collective_id IS NOT NULL OR notes.collective_id IS NOT NULL")
+      .group(Arel.sql("COALESCE(events.collective_id, notes.collective_id)"))
       .count
   end
 
@@ -307,7 +312,13 @@ class NotificationService
   sig { params(tenant: Tenant, collective_id: String).returns(T::Array[String]) }
   def self.notification_ids_for_collective(tenant, collective_id)
     event_ids = Event.tenant_scoped_only(tenant.id).where(collective_id: collective_id).pluck(:id)
-    Notification.tenant_scoped_only(tenant.id).where(event_id: event_ids).pluck(:id)
+    evented = Notification.tenant_scoped_only(tenant.id).where(event_id: event_ids).pluck(:id)
+    # Reminders have no event; their home is the reminder note's collective.
+    reminders = Note.tenant_scoped_only(tenant.id)
+      .where(collective_id: collective_id)
+      .where.not(reminder_notification_id: nil)
+      .pluck(:reminder_notification_id)
+    (evented + reminders).uniq
   end
 
   sig { params(tenant: Tenant, subject: ApplicationRecord).returns(T::Array[String]) }

--- a/app/services/search_query.rb
+++ b/app/services/search_query.rb
@@ -48,6 +48,9 @@ class SearchQuery
 
     # Resolve collective from collective: handle
     resolve_collective_from_handle
+
+    # Viewer-state filters are meaningless without a viewer.
+    enforce_my_filters_require_user
   end
 
   private
@@ -140,7 +143,7 @@ class SearchQuery
   # of any of these suppresses the People section entirely; the viewer's
   # query string is clearly looking for content.
   PEOPLE_INCOMPATIBLE_PARAM_KEYS = [
-    :type, :exclude_types, :subtypes, :exclude_subtypes, :status, :creator_handles, :exclude_creator_handles, :read_by_handles, :exclude_read_by_handles, :voter_handles, :exclude_voter_handles, :participant_handles, :exclude_participant_handles, :mentions_handles, :exclude_mentions_handles, :replying_to_handles, :exclude_replying_to_handles, :critical_mass_achieved, :min_links, :max_links, :min_backlinks, :max_backlinks, :min_comments, :max_comments, :min_readers, :max_readers, :min_voters, :max_voters, :min_participants, :max_participants, :after_date, :before_date, :visibility, :exclude_visibility,
+    :type, :exclude_types, :subtypes, :exclude_subtypes, :status, :creator_handles, :exclude_creator_handles, :read_by_handles, :exclude_read_by_handles, :voter_handles, :exclude_voter_handles, :participant_handles, :exclude_participant_handles, :mentions_handles, :exclude_mentions_handles, :replying_to_handles, :exclude_replying_to_handles, :my_filters, :exclude_my_filters, :critical_mass_achieved, :min_links, :max_links, :min_backlinks, :max_backlinks, :min_comments, :max_comments, :min_readers, :max_readers, :min_voters, :max_voters, :min_participants, :max_participants, :after_date, :before_date, :visibility, :exclude_visibility,
   ].freeze
 
   sig { returns(T::Array[User]) }
@@ -537,6 +540,7 @@ class SearchQuery
     # Feed pages (a fixed page scope is what makes a page a feed) browse
     # instead: a blank query shows everything in scope.
     return SearchIndex.none if @raw_query.blank? && @fixed_params.blank?
+    return SearchIndex.none if @my_filters_unresolvable
 
     # Use tenant_scoped_only to bypass collective scope while keeping tenant scope
     # We handle collective filtering explicitly below with accessible_collective_ids
@@ -561,6 +565,7 @@ class SearchQuery
     apply_time_window
     apply_basic_filters
     apply_user_filters
+    apply_my_filters
     apply_list_filter
     apply_integer_filters
     apply_boolean_filters
@@ -570,6 +575,16 @@ class SearchQuery
     @relation = T.must(@relation).includes(:collective, :created_by)
 
     @relation
+  end
+
+  sig { void }
+  def enforce_my_filters_require_user
+    return if @current_user.present?
+    return if Array(@params[:my_filters]).blank? && Array(@params[:exclude_my_filters]).blank?
+
+    @warnings ||= []
+    T.must(@warnings) << "my: filters need a signed-in user — showing no results"
+    @my_filters_unresolvable = T.let(true, T.nilable(T::Boolean))
   end
 
   sig { returns(T::Array[String]) }
@@ -813,6 +828,110 @@ class SearchQuery
     apply_participant_filter
     apply_mentions_filter
     apply_replying_to_filter
+  end
+
+  # `my:<notified|unread|read>` — viewer-state filters. Each value becomes
+  # an independently composable SQL condition (EXISTS subqueries, never
+  # joins: read-by/voter already claim the unaliased user_item_status join,
+  # and my: values must combine with them and each other). Multiple values
+  # union (like other multi operators); negations intersect.
+  sig { void }
+  def apply_my_filters
+    positives = Array(@params[:my_filters])
+    negatives = Array(@params[:exclude_my_filters])
+    return if positives.blank? && negatives.blank?
+
+    if positives.present?
+      conditions = positives.map { |value| my_filter_condition(value) }
+      sql = conditions.map { |c, _| "(#{c})" }.join(" OR ")
+      @relation = T.must(@relation).where(sql, *conditions.flat_map { |_, binds| binds })
+    end
+
+    negatives.each do |value|
+      condition, binds = my_filter_condition(value)
+      @relation = T.must(@relation).where("NOT (#{condition})", *binds)
+    end
+  end
+
+  sig { params(value: String).returns([String, T::Array[T.untyped]]) }
+  def my_filter_condition(value)
+    user_id = T.must(@current_user).id
+    read_exists = <<~SQL.squish
+      EXISTS (SELECT 1 FROM user_item_status uis
+              WHERE uis.item_id = search_index.item_id
+              AND uis.item_type = search_index.item_type
+              AND uis.tenant_id = search_index.tenant_id
+              AND uis.user_id = ?
+              AND uis.has_read = true)
+    SQL
+
+    case value
+    when "read"
+      [read_exists, [user_id]]
+    when "unread"
+      # Read state is a note concept — decisions/commitments are neither
+      # read nor unread, so they are excluded rather than always-matching.
+      ["search_index.item_type = 'Note' AND NOT #{read_exists}", [user_id]]
+    when "notified"
+      notified_items_condition
+    else
+      # Parser validation makes this unreachable; fail closed if it drifts.
+      ["1=0", []]
+    end
+  end
+
+  # Items behind the viewer's undismissed, due, in-app notifications — the
+  # inbox projected onto the feed. Evented notifications resolve through
+  # their event's subject (comments climb to the thread root); reminders
+  # resolve through notes.reminder_notification_id. Placeless notifications
+  # (chat, tenant-level) have no content item and resolve to nothing.
+  sig { returns([String, T::Array[T.untyped]]) }
+  def notified_items_condition
+    items = notified_items_by_type
+    return ["1=0", []] if items.empty?
+
+    sql = items.keys.map { "(search_index.item_type = ? AND search_index.item_id IN (?))" }.join(" OR ")
+    binds = items.flat_map { |type, ids| [type, ids] }
+    [sql, binds]
+  end
+
+  sig { returns(T::Hash[String, T::Array[String]]) }
+  def notified_items_by_type
+    notification_ids = NotificationRecipient
+      .where(user: @current_user, tenant: @tenant)
+      .in_app.undismissed.not_scheduled
+      .pluck(:notification_id).uniq
+    return {} if notification_ids.empty?
+
+    items = Hash.new { |h, k| h[k] = [] }
+    notified_event_subjects(notification_ids).each { |type, id| items[type] << id }
+
+    # Reminders: the reminder note is the content item.
+    Note.tenant_scoped_only(@tenant.id)
+      .where(reminder_notification_id: notification_ids)
+      .pluck(:id).each { |id| items["Note"] << id }
+
+    items.transform_values!(&:uniq)
+    items
+  end
+
+  sig { params(notification_ids: T::Array[String]).returns(T::Array[[String, String]]) }
+  def notified_event_subjects(notification_ids)
+    event_ids = Notification.tenant_scoped_only(@tenant.id)
+      .where(id: notification_ids).where.not(event_id: nil).pluck(:event_id)
+    subject_pairs = Event.tenant_scoped_only(@tenant.id)
+      .where(id: event_ids, subject_type: ["Note", "Decision", "Commitment"])
+      .pluck(:subject_type, :subject_id)
+
+    # Comment subjects point the viewer at the thread, not the comment row
+    # (feeds exclude comment rows structurally).
+    note_ids = subject_pairs.filter_map { |type, id| id if type == "Note" }
+    resolved = Note.tenant_scoped_only(@tenant.id).where(id: note_ids).filter_map do |note|
+      root = note.subtype == "comment" ? note.root_commentable : note
+      [root.class.name, root.id] if root
+    end
+
+    resolved + subject_pairs.reject { |pair| pair.first == "Note" }
   end
 
   # `list:<id|mutuals|tuned_in>` narrows content to items authored by

--- a/app/services/search_query_parser.rb
+++ b/app/services/search_query_parser.rb
@@ -38,6 +38,12 @@ class SearchQueryParser
     "visibility" => { values: ["public", "shared", "private"], multi: true },
 
     # User filters
+    # Viewer-state filters: the viewer's own state per item (notification
+    # queue, read confirmations), unlike creator:/list: which resolve to
+    # authors. Requires a signed-in user — SearchQuery warns and matches
+    # nothing otherwise.
+    "my" => { values: ["notified", "unread", "read"], multi: true },
+
     "creator" => { pattern: HANDLE_PATTERN, multi: true },
     "read-by" => { pattern: HANDLE_PATTERN, multi: true },
     "voter" => { pattern: HANDLE_PATTERN, multi: true },
@@ -293,6 +299,10 @@ class SearchQueryParser
     params[:exclude_mentions_handles] = build_negated_user_filter_param("mentions")
     params[:replying_to_handles] = build_user_filter_param("replying-to")
     params[:exclude_replying_to_handles] = build_negated_user_filter_param("replying-to")
+
+    # Viewer-state filters
+    params[:my_filters] = (@operators["my"] || []).uniq.presence
+    params[:exclude_my_filters] = (@negated_operators["my"] || []).uniq.presence
 
     # Boolean filters
     params[:critical_mass_achieved] = build_boolean_param("critical-mass-achieved")

--- a/app/views/help/search.md.erb
+++ b/app/views/help/search.md.erb
@@ -36,6 +36,24 @@ Use operators in your query to filter, sort, and group results.
 | `replying-to:` | @handle | `replying-to:@alice` |
 | `critical-mass-achieved:` | true, false | `critical-mass-achieved:true` |
 
+### Your State (`my:`)
+
+`my:` filters on your own relationship to each item, so results differ per
+viewer. Requires being signed in — otherwise the query warns and matches
+nothing.
+
+| Value | Meaning | Example |
+|-------|---------|---------|
+| `my:notified` | Items behind your undismissed notifications — your [inbox](/notifications) projected onto the feed | `my:notified` |
+| `my:unread` | Notes you have not confirmed read | `my:unread type:note` |
+| `my:read` | Items you have confirmed read | `my:read cycle:this-week` |
+
+Notes on semantics: `my:notified` matches the notifications page — read
+notifications stay until dismissed, so it can show more items than an
+unread-count badge. `my:unread`/`my:read` are about read *confirmations*
+(the social act), not notifications; only notes can be unread, so
+`my:unread` never matches decisions or commitments.
+
 ### Numeric Filters
 
 Use `min-` and `max-` prefixes with these fields:

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -81,6 +81,14 @@
       "note": "Pre-existing warning, tracked for future remediation"
     },
     {
+      "fingerprint": "e27b9c0a6109be7a67164d2aeae280cc5018ddae99fef27e659b10304b4045aa",
+      "code": "T.must(T.must(@relation).where(Array(build_params(params)[:my_filters]).map do\n my_filter_condition(value)\n end.map do\n \"(#{c})\"\n end.join(\" OR \"), *Array(build_params(params)[:my_filters]).map do\n my_filter_condition(value)\n end.flat_map do\n binds\n end)).where(\"NOT (#{condition})\", *binds)",
+      "message": "Possible SQL injection",
+      "file": "app/services/search_query.rb",
+      "line": 852,
+      "note": "False positive. The interpolated fragments come from my_filter_condition, whose case statement returns only fixed string literals with ? placeholders (unknown values return '1=0'); my: values are whitelisted by SearchQueryParser before they reach the query. All data flows through parameterized binds. Pinned by the my: tests in search_query_test.rb."
+    },
+    {
       "fingerprint": "183eeb0260180cc6f8a1fe181e3b8e1bdba2ea32207be3629bc4f07b4c27b578",
       "code": "MarkdownRenderer.render(render_to_string(:template => Mcp::Connect.help_template(params[:harness].to_s), :formats => ([:md]), :layout => false), :shift_headers => false, :display_references => false)",
       "message": "Unescaped parameter value",
@@ -89,6 +97,6 @@
       "note": "Brakeman traces params[:harness] into Mcp::Connect.help_template, but cannot see that the method returns nil or a value from the frozen HELP_TEMPLATES hash (whose values are all literal template paths derived from the static HARNESSES hash). HelpController#mcp_connect 404s when the lookup returns nil, so params[:harness] never reaches render_to_string; only fixed template paths do. Pinned in help_controller_test.rb (mcp_connect 404 cases)."
     }
   ],
-  "updated": "2026-06-17",
+  "updated": "2026-07-03",
   "brakeman_version": "8.0.4"
 }

--- a/docs/NAVIGATION_DESIGN.md
+++ b/docs/NAVIGATION_DESIGN.md
@@ -403,8 +403,12 @@ Shipped from this list:
    Prerequisite: **reminder-notification attribution.** Reminder *notes*
    have a collective; only their notification rows are placeless
    (`event_id: nil` — an implementation artifact, not a semantic truth).
-   Attribute them and reminders flow into per-collective badges and
-   `my:notified` like everything else. The genuinely placeless residue —
+   Attribution is derived at read time through the existing
+   `notes.reminder_notification_id` link (no schema change — a
+   `collective_id`-family column on notifications would collide with
+   ApplicationRecord's collective auto-scoping, and notifications must
+   span collectives). With it, reminders flow into per-collective badges
+   and `my:notified` like everything else. The genuinely placeless residue —
    tenant-level notifications (trustee authorizations, account security)
    plus chat (which has its own entry) — is what keeps the header inbox:
    it stays, as the cross-place queue and the mobile Inbox tab, but it

--- a/test/services/notification_service_test.rb
+++ b/test/services/notification_service_test.rb
@@ -338,6 +338,50 @@ class NotificationServiceTest < ActiveSupport::TestCase
     assert_equal({ collective2.id => 1 }, counts)
   end
 
+  # Builds the real reminder shape: a reminder note in the collective whose
+  # notification (eventless) is linked back via notes.reminder_notification_id.
+  def create_reminder_in(collective, tenant:, user:, title:)
+    note = create_note(tenant: tenant, collective: collective, created_by: user, subtype: "reminder", title: title)
+    notification = Notification.create!(tenant: tenant, event: nil, notification_type: "reminder", title: title)
+    note.update!(reminder_notification_id: notification.id)
+    notification
+  end
+
+  test "unread_count_by_collective_for attributes reminders to their note's collective" do
+    # Reminder notifications carry no event, but the reminder note has a
+    # home — derived through notes.reminder_notification_id, it puts due
+    # reminders in the place's badge.
+    tenant, collective, user = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    Tenant.current_id = tenant.id
+
+    due = create_reminder_in(collective, tenant: tenant, user: user, title: "Due")
+    NotificationRecipient.create!(notification: due, user: user, channel: "in_app", status: "delivered", tenant: tenant)
+
+    # Future-scheduled reminders still don't count until due.
+    future = create_reminder_in(collective, tenant: tenant, user: user, title: "Future")
+    NotificationRecipient.create!(
+      notification: future, user: user, channel: "in_app", status: "pending", scheduled_for: 1.hour.from_now, tenant: tenant
+    )
+
+    counts = NotificationService.unread_count_by_collective_for(user, tenant: tenant)
+    assert_equal({ collective.id => 1 }, counts)
+  end
+
+  test "dismiss_all_for_collective covers reminders homed in the collective" do
+    tenant, collective, user = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    Tenant.current_id = tenant.id
+
+    reminder = create_reminder_in(collective, tenant: tenant, user: user, title: "Due")
+    recipient = NotificationRecipient.create!(notification: reminder, user: user, channel: "in_app", status: "delivered", tenant: tenant)
+
+    count = NotificationService.dismiss_all_for_collective(user, tenant: tenant, collective_id: collective.id)
+
+    assert_equal 1, count
+    assert_equal "dismissed", recipient.reload.status
+  end
+
   test "unread_chat_count_for counts only unread in-app chat_message notifications" do
     tenant, collective, user = create_tenant_collective_user
     Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)

--- a/test/services/search_query_parser_test.rb
+++ b/test/services/search_query_parser_test.rb
@@ -686,4 +686,29 @@ class SearchQueryParserTest < ActiveSupport::TestCase
     assert_equal 1, result[:warnings].size
     assert_includes result[:warnings].first, "status:maybe"
   end
+
+  # my: — the viewer-state namespace (filters on the current user's own
+  # state per item, unlike list:/creator: which resolve to authors)
+
+  test "my: parses its known values" do
+    result = SearchQueryParser.new("my:notified").parse
+    assert_equal ["notified"], result[:my_filters]
+
+    result = SearchQueryParser.new("my:unread,read").parse
+    assert_equal ["unread", "read"], result[:my_filters]
+  end
+
+  test "negated my: values parse into the exclusion param" do
+    result = SearchQueryParser.new("-my:read").parse
+    assert_equal ["read"], result[:exclude_my_filters]
+    assert_nil result[:my_filters]
+  end
+
+  test "invalid my: value warns and names the valid values" do
+    result = SearchQueryParser.new("my:bogus").parse
+    assert_nil result[:my_filters]
+    assert_equal 1, result[:warnings].size
+    assert_includes result[:warnings].first, "my:bogus"
+    assert_includes result[:warnings].first, "notified, unread, read"
+  end
 end

--- a/test/services/search_query_test.rb
+++ b/test/services/search_query_test.rb
@@ -1108,4 +1108,97 @@ class SearchQueryTest < ActiveSupport::TestCase
     )
     assert_empty search.warnings
   end
+
+  # my: — viewer-state filters
+
+  def add_member(name)
+    member = create_user(name: name)
+    @tenant.add_user!(member)
+    @collective.add_user!(member)
+    member
+  end
+
+  def notify(user, subject:, dismissed: false, read: false, scheduled_for: nil)
+    event = Event.create!(tenant: @tenant, collective: @collective, event_type: "test.notified", actor: @user, subject: subject)
+    notification = Notification.create!(tenant: @tenant, event: event, notification_type: "mention", title: "About #{subject.class}")
+    NotificationRecipient.create!(
+      notification: notification, user: user, channel: "in_app", tenant: @tenant,
+      status: dismissed ? "dismissed" : "delivered",
+      dismissed_at: dismissed ? Time.current : nil,
+      read_at: read || dismissed ? Time.current : nil,
+      scheduled_for: scheduled_for,
+    )
+  end
+
+  def my_search(user, query)
+    SearchQuery.new(tenant: @tenant, collective: @collective, current_user: user, raw_query: "#{query} cycle:all")
+  end
+
+  test "my:unread returns notes the viewer has not confirmed read; my:read the inverse" do
+    viewer = add_member("Reader")
+
+    unread = my_search(viewer, "my:unread").results
+    assert_equal [["Note", @note.id]], unread.map { |r| [r.item_type, r.item_id] }
+
+    assert_empty my_search(viewer, "my:read").results
+
+    @note.confirm_read!(viewer)
+
+    assert_empty my_search(viewer, "my:unread").results
+    assert_equal [["Note", @note.id]], my_search(viewer, "my:read").results.map { |r| [r.item_type, r.item_id] }
+  end
+
+  test "my:unread does not include the viewer's own notes" do
+    # Authors confirm-read their own notes at creation.
+    assert_empty my_search(@user, "my:unread").results
+  end
+
+  test "my:notified returns items behind undismissed due notifications" do
+    viewer = add_member("Notified")
+
+    notify(viewer, subject: @decision, read: true) # read but undismissed still shows
+    notify(viewer, subject: @commitment, dismissed: true) # dismissed is gone
+
+    reminder_note = create_note(tenant: @tenant, collective: @collective, created_by: viewer, subtype: "reminder", text: "Due reminder note")
+    reminder = Notification.create!(tenant: @tenant, event: nil, notification_type: "reminder", title: "Due")
+    reminder_note.update!(reminder_notification_id: reminder.id)
+    NotificationRecipient.create!(notification: reminder, user: viewer, channel: "in_app", status: "delivered", tenant: @tenant)
+
+    future = Notification.create!(tenant: @tenant, event: nil, notification_type: "reminder", title: "Future")
+    future_note = create_note(tenant: @tenant, collective: @collective, created_by: viewer, subtype: "reminder", text: "Future reminder note")
+    future_note.update!(reminder_notification_id: future.id)
+    NotificationRecipient.create!(
+      notification: future, user: viewer, channel: "in_app", status: "pending", scheduled_for: 1.hour.from_now, tenant: @tenant
+    )
+
+    results = my_search(viewer, "my:notified").results.map { |r| [r.item_type, r.item_id] }
+    assert_equal [["Decision", @decision.id], ["Note", reminder_note.id]].sort, results.sort
+  end
+
+  test "my:notified resolves comment notifications to the thread root" do
+    viewer = add_member("Commented At")
+    comment = create_note(
+      tenant: @tenant, collective: @collective, created_by: @user, commentable: @note, text: "A reply mentioning you"
+    )
+    notify(viewer, subject: comment)
+
+    results = my_search(viewer, "my:notified").results.map { |r| [r.item_type, r.item_id] }
+    assert_equal [["Note", @note.id]], results
+  end
+
+  test "my: filters warn and match nothing for anonymous viewers" do
+    search = SearchQuery.new(tenant: @tenant, collective: nil, current_user: nil, raw_query: "my:notified cycle:all")
+
+    assert_empty search.results
+    assert search.warnings.any? { |w| w.include?("my:") }, "expected a warning about my: requiring sign-in"
+  end
+
+  test "negated my:read excludes items the viewer has confirmed read" do
+    viewer = add_member("Skimmer")
+    @note.confirm_read!(viewer)
+
+    results = my_search(viewer, "-my:read").results.map { |r| [r.item_type, r.item_id] }
+    assert_not_includes results, ["Note", @note.id]
+    assert_includes results, ["Decision", @decision.id]
+  end
 end


### PR DESCRIPTION
The `my:` viewer-state filter namespace — `my:notified`, `my:unread`, `my:read` — plus the reminder-attribution fix it depends on. This is the query-engine half of the badge click-through plan in `docs/NAVIGATION_DESIGN.md`; the UI wiring (badged rail entries linking to `?q=my:notified`, clearing affordances) follows separately.

## The `my:` namespace

`my:*` filters on the viewer's own relationship to each item — a different data layer from `creator:`/`list:`, which resolve to authors — and the prefix wears the per-viewer relativity on its sleeve. Anonymous queries warn and match nothing. Invalid values warn and name the valid ones. Multiple values union; negations intersect (`-my:read` works).

- **`my:notified`** — the inbox projected onto the feed: items behind your undismissed, due, in-app notifications. *Undismissed*, not unread, deliberately — it matches the notifications page's own retention semantics (the badge count is the urgent subset; the view is the full queue). Evented notifications resolve through their event's subject, with comment subjects climbing to the thread root (feeds exclude comment rows structurally, so the root is what's visible); reminders resolve through `notes.reminder_notification_id`. Chat and tenant-level notifications have no content item and resolve to nothing.
- **`my:read` / `my:unread`** — read-*confirmation* state (the social act, not notifications), via the existing `user_item_status` table. Only notes can be unread, so `my:unread` never matches decisions or commitments; your own notes never show as unread (authors auto-confirm at creation).

Implementation note: every `my:` condition is an `EXISTS` subquery, never a join — `read-by:`/`voter:` already claim the un-aliased `user_item_status` join, and `my:` values must compose with them and with each other.

## Reminder attribution (prerequisite)

Reminder notifications have no event, so they were invisible to the per-collective badge counts and per-collective bulk actions — inbox-only. But the reminder *note* has a collective, and `notes.reminder_notification_id` already links them, so attribution is **derived at read time** with a join (`COALESCE(events.collective_id, notes.collective_id)`). No schema change: a `collective_id`-family column on notifications would opt the model into ApplicationRecord's collective auto-scoping (and `MightNotBelongToCollective`'s current-or-NULL scope is wrong for recipient-owned rows — default scopes propagate through `joins(:notification)`, which would silently filter reminder lists per-collective and undercount the reminder quota). Due reminders now count toward their collective's badge; scheduled ones wait until due.

## Docs & follow-ups

- `/help/search` gains a "Your State (`my:`)" section with the semantics.
- The rest of the namespace is cataloged in #373 — pure aliases (`my:mentions`, `my:voted`, `my:committed`, `my:rsvps`, `my:notes`, `my:mutuals`) vs. new-resolution filters (`my:represented` for trustee-representation accountability, `my:lists`, `my:agents`, `my:bookmarks`).
- Known seam, deliberately left: the /notifications page still groups reminders under the "Reminders" bucket rather than their collective — small, separable.

## Verification

- Red-first tests: 3 parser (values, negation, warning), 6 query (read/unread inverse, own-notes exclusion, notified semantics incl. dismissed/scheduled exclusion, comment→root resolution, anonymous warning, negation), 3 attribution (badge counts, scheduled exclusion, per-collective dismiss).
- Full parser (115), search-query (71), search-integration (37), notification/reminder service (50) suites green; `srb tc` clean; no new rubocop offenses (baseline-compared).
- Verified live: `my:unread` returns the dev user's unconfirmed notes; `my:notified` correctly resolves their trustee/subject-less notifications to nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
