### PR TITLE
Badge click-through: badged places lead to my:notified, comments surface as comments, no hidden feed filters

### DIFF
--- a/app/assets/stylesheets/pulse/_feed_bar.css
+++ b/app/assets/stylesheets/pulse/_feed_bar.css
@@ -22,6 +22,7 @@
   gap: 6px;
   flex-wrap: wrap;
   padding: 4px 8px;
+  margin-bottom: 8px;
   background: var(--color-canvas-default);
   border: 1px solid var(--color-border-default);
   border-radius: var(--border-radius-lg);
@@ -52,6 +53,9 @@
   font-size: inherit;
 }
 
+/* A one-row textarea that grows with its content (feed-bar-input
+   controller) — long queries wrap instead of hiding behind horizontal
+   scroll. */
 .pulse-feed-bar-input {
   flex: 1;
   min-width: 120px;
@@ -62,6 +66,9 @@
   font-family: monospace;
   font-size: 13px;
   color: var(--color-fg-default);
+  resize: none;
+  overflow: hidden;
+  line-height: 1.5;
 }
 
 /* The my:notified view's clearing affordance: a slim row between the bar

--- a/app/assets/stylesheets/pulse/_feed_bar.css
+++ b/app/assets/stylesheets/pulse/_feed_bar.css
@@ -64,6 +64,18 @@
   color: var(--color-fg-default);
 }
 
+/* The my:notified view's clearing affordance: a slim row between the bar
+   and the feed items. */
+.pulse-feed-bar-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 8px 0 0;
+  color: var(--color-fg-muted);
+  font-size: 13px;
+}
+
 .pulse-feed-bar-warning {
   display: flex;
   align-items: center;

--- a/app/components/collective_rail_component.html.erb
+++ b/app/components/collective_rail_component.html.erb
@@ -1,8 +1,9 @@
 <nav class="pulse-rail" aria-label="Collectives" data-controller="rail-badges">
   <% if @main_collective %>
-    <%= tag.a href: "/",
+    <%= tag.a href: place_entry_href("/", unread_count_for(@main_collective)),
               class: ["pulse-rail-item", "pulse-rail-public", ("active" if public_space_active?)],
               title: "Public space",
+              data: { place_path: "/" },
               aria: { label: "Public space", current: ("page" if public_space_active?) } do %>
       <span class="pulse-rail-indicator"></span>
       <span class="pulse-rail-globe"><%= helpers.octicon "globe", height: 22 %></span>
@@ -22,9 +23,10 @@
   <% end %>
 
   <% @collectives.each do |collective| %>
-    <%= tag.a href: collective.path,
+    <%= tag.a href: place_entry_href(collective.path, unread_count_for(collective)),
               class: ["pulse-rail-item", ("active" if active?(collective))],
               title: collective.name,
+              data: { place_path: collective.path },
               aria: { label: collective.name, current: ("page" if active?(collective)) } do %>
       <span class="pulse-rail-indicator"></span>
       <%= helpers.inline_avatar(collective, css_class: "pulse-rail-avatar", variant: :icon) %>

--- a/app/components/collective_rail_component.rb
+++ b/app/components/collective_rail_component.rb
@@ -45,14 +45,19 @@ class CollectiveRailComponent < ViewComponent::Base
   # Server-rendered initial badge state, so navigation never flashes the
   # badges out. The rail-badges controller overwrites this on every poll
   # using the same display rules — keep the two in sync.
+  sig { params(collective: Collective).returns(Integer) }
+  def unread_count_for(collective)
+    @unread_counts[collective.id].to_i
+  end
+
   sig { params(collective: Collective).returns(String) }
   def badge_text(collective)
-    count_badge_text(@unread_counts[collective.id].to_i)
+    count_badge_text(unread_count_for(collective))
   end
 
   sig { params(collective: Collective).returns(T.nilable(String)) }
   def badge_style(collective)
-    count_badge_style(@unread_counts[collective.id].to_i)
+    count_badge_style(unread_count_for(collective))
   end
 
   sig { returns(String) }

--- a/app/components/feed_item_component.html.erb
+++ b/app/components/feed_item_component.html.erb
@@ -3,7 +3,7 @@
          data-pulse-filter-target="feedItem"
          data-item-type="<%= @type %>"
          data-controller="card-navigate"
-         data-card-navigate-url-value="<%= @item.path %>"
+         data-card-navigate-url-value="<%= navigate_path %>"
          data-action="click->card-navigate#navigate auxclick->card-navigate#navigate keydown->card-navigate#keydown"
          role="link"
          tabindex="0"
@@ -58,7 +58,7 @@
     <% end %>
     <% if show_title? %>
       <div class="pulse-feed-item-title">
-        <a href="<%= @item.path %>"><%= helpers.strip_tags(helpers.markdown(item_title)).presence || "(Untitled)" %></a>
+        <a href="<%= navigate_path %>"><%= helpers.strip_tags(helpers.markdown(item_title)).presence || "(Untitled)" %></a>
       </div>
     <% end %>
     <% if item_content.present? %>

--- a/app/components/feed_item_component.rb
+++ b/app/components/feed_item_component.rb
@@ -34,6 +34,16 @@ class FeedItemComponent < ViewComponent::Base
 
   private
 
+  # Where clicking the card (or its title) lands. Notes use display_path so
+  # a comment opens its thread with the comment marked (?comment_id=) —
+  # the same URL its notification links to — rather than the isolated
+  # comment page. Action endpoints keep building from @item.path, the
+  # canonical bare resource URL.
+  sig { returns(T.nilable(String)) }
+  def navigate_path
+    @item.is_a?(Note) ? @item.display_path : @item.path
+  end
+
   sig { returns(T::Boolean) }
   def author_blocked?
     @created_by.present? && @blocked_user_ids.include?(@created_by.id)

--- a/app/components/feed_search_bar_component.html.erb
+++ b/app/components/feed_search_bar_component.html.erb
@@ -4,11 +4,19 @@
       <% @scope_filters.each do |filter| %>
         <span class="pulse-feed-bar-scope" title="Fixed for this page"><code><%= filter %></code></span>
       <% end %>
-      <%= form.text_field :q,
+      <%# A textarea, not an <input>: long queries wrap and the field grows
+          instead of hiding overflow behind horizontal scroll. The
+          controller keeps Enter as submit. %>
+      <%= form.text_area :q,
           value: @query,
+          rows: 1,
           class: "pulse-feed-bar-input",
           placeholder: @placeholder,
-          autocomplete: "off" %>
+          autocomplete: "off",
+          data: {
+            controller: "feed-bar-input",
+            action: "input->feed-bar-input#resize keydown->feed-bar-input#keydown resize@window->feed-bar-input#resize",
+          } %>
     </label>
     <%= form.submit @submit_label, class: "pulse-action-btn", name: nil %>
   <% end %>

--- a/app/components/places_sheet_component.html.erb
+++ b/app/components/places_sheet_component.html.erb
@@ -3,8 +3,9 @@
 <div class="pulse-places-sheet" data-places-sheet-target="panel" aria-hidden="true">
   <nav class="pulse-places-nav" aria-label="Places" data-controller="rail-badges">
     <% if @main_collective %>
-      <%= tag.a href: "/",
+      <%= tag.a href: place_entry_href("/", unread_count_for(@main_collective)),
                 class: ["pulse-places-row", ("active" if public_space_active?)],
+                data: { place_path: "/" },
                 aria: { current: ("page" if public_space_active?) } do %>
         <span class="pulse-rail-indicator"></span>
         <span class="pulse-places-row-icon"><%= helpers.octicon "globe", height: 20 %></span>
@@ -25,8 +26,9 @@
     <% end %>
 
     <% @collectives.each do |collective| %>
-      <%= tag.a href: collective.path,
+      <%= tag.a href: place_entry_href(collective.path, unread_count_for(collective)),
                 class: ["pulse-places-row", ("active" if active?(collective))],
+                data: { place_path: collective.path },
                 aria: { current: ("page" if active?(collective)) } do %>
         <span class="pulse-rail-indicator"></span>
         <span class="pulse-places-row-icon">

--- a/app/components/unread_badge_display.rb
+++ b/app/components/unread_badge_display.rb
@@ -17,4 +17,13 @@ module UnreadBadgeDisplay
   def count_badge_style(count)
     "display: none" if count.zero?
   end
+
+  # A badged place entry links to its feed filtered to what the viewer was
+  # notified about; unbadged it links plainly (docs/NAVIGATION_DESIGN.md
+  # "Badge click-through"). Applies to feed-backed places only — chat has
+  # no feed, so its entry never swaps.
+  sig { params(path: String, count: Integer).returns(String) }
+  def place_entry_href(path, count)
+    count.positive? ? "#{path}?q=my:notified" : path
+  end
 end

--- a/app/controllers/concerns/feed_page.rb
+++ b/app/controllers/concerns/feed_page.rb
@@ -28,12 +28,16 @@ module FeedPage
     @feed_query.strip == @feed_default_query
   end
 
+  # No hidden filters: a feed's comment exclusion lives in its visible
+  # default query (`-subtype:comment`), where the viewer can see it and
+  # remove it. A viewer-supplied query gets raw search semantics, same as
+  # /search.
   def build_feed_search(fixed_params:, params_extra: {}, query: @feed_query)
     SearchQuery.new(
       tenant: @current_tenant,
       current_user: @current_user,
       raw_query: query,
-      params: { exclude_subtypes: ["comment"], per_page: FEED_LIMIT }.merge(params_extra),
+      params: { per_page: FEED_LIMIT }.merge(params_extra),
       fixed_params: fixed_params
     )
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -13,8 +13,9 @@ class HomeController < ApplicationController
     return if @current_user.nil?
 
     # The home feed is a search: fixed scope visibility:public, default
-    # query list:tuned_in (the people you tune in to, plus yourself).
-    resolve_feed_query("list:tuned_in")
+    # query list:tuned_in (the people you tune in to, plus yourself) minus
+    # comments — both visible and removable in the query input.
+    resolve_feed_query("list:tuned_in -subtype:comment")
     @search = build_feed_search(fixed_params: { visibility: "public" })
     @feed_items = SearchFeedItems.build(@search.paginated_results)
     @feed_items = interleave_reminder_events(@feed_items, author_ids: home_reminder_author_ids) if default_feed_view?

--- a/app/controllers/pulse_controller.rb
+++ b/app/controllers/pulse_controller.rb
@@ -17,7 +17,7 @@ class PulseController < ApplicationController
     workspace = @current_collective.private_workspace?
     @page_scope = workspace ? "visibility:private" : "collective:#{@current_collective.handle}"
 
-    resolve_feed_query("cycle:this-week")
+    resolve_feed_query("cycle:this-week -subtype:comment")
     fixed = { collective_handle: @current_collective.handle }
     fixed[:visibility] = "private" if workspace
     # cycle "all" as the base: a cleared query means all time, not the

--- a/app/controllers/user_lists_controller.rb
+++ b/app/controllers/user_lists_controller.rb
@@ -61,7 +61,7 @@ class UserListsController < ApplicationController
     # stale tune-in can't leak across a block (the markdown view has no
     # render-time block filter).
     search = build_feed_search(
-      query: "",
+      query: "-subtype:comment",
       fixed_params: { visibility: "public", list_id_or_alias: @list.truncated_id }
     )
     author_ids = member_user_ids - block_related_user_ids.to_a

--- a/app/javascript/controllers/feed_bar_input_controller.test.ts
+++ b/app/javascript/controllers/feed_bar_input_controller.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import FeedBarInputController from "./feed_bar_input_controller"
+
+describe("FeedBarInputController", () => {
+  let submitted: boolean
+
+  beforeEach(() => {
+    submitted = false
+    document.body.innerHTML = `
+      <form>
+        <textarea name="q" rows="1"
+                  data-controller="feed-bar-input"
+                  data-action="input->feed-bar-input#resize keydown->feed-bar-input#keydown">cycle:this-week -subtype:comment</textarea>
+      </form>
+    `
+    document.querySelector("form")?.addEventListener("submit", (e) => {
+      e.preventDefault()
+      submitted = true
+    })
+    const application = Application.start()
+    application.register("feed-bar-input", FeedBarInputController)
+  })
+
+  function textarea(): HTMLTextAreaElement {
+    return document.querySelector("textarea") as HTMLTextAreaElement
+  }
+
+  it("grows to fit its content on input", async () => {
+    await vi.waitFor(() => expect(textarea().dataset.controller).toBe("feed-bar-input"))
+    Object.defineProperty(textarea(), "scrollHeight", { get: () => 42 })
+
+    textarea().dispatchEvent(new Event("input", { bubbles: true }))
+
+    await vi.waitFor(() => expect(textarea().style.height).toBe("42px"))
+  })
+
+  it("submits the form on Enter instead of inserting a newline", async () => {
+    await vi.waitFor(() => expect(textarea().dataset.controller).toBe("feed-bar-input"))
+
+    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
+    textarea().dispatchEvent(event)
+
+    await vi.waitFor(() => expect(submitted).toBe(true))
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it("leaves other keys alone", async () => {
+    await vi.waitFor(() => expect(textarea().dataset.controller).toBe("feed-bar-input"))
+
+    const event = new KeyboardEvent("keydown", { key: "a", bubbles: true, cancelable: true })
+    textarea().dispatchEvent(event)
+
+    expect(submitted).toBe(false)
+    expect(event.defaultPrevented).toBe(false)
+  })
+})

--- a/app/javascript/controllers/feed_bar_input_controller.ts
+++ b/app/javascript/controllers/feed_bar_input_controller.ts
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * FeedBarInputController makes the feed bar's query textarea behave like a
+ * wrapping text input: it grows to fit its content (a single-line <input>
+ * hides long queries behind horizontal scroll), and Enter submits the form
+ * instead of inserting a newline — queries have no meaningful line breaks.
+ *
+ * Usage:
+ * <textarea rows="1" data-controller="feed-bar-input"
+ *           data-action="input->feed-bar-input#resize keydown->feed-bar-input#keydown">
+ */
+export default class FeedBarInputController extends Controller<HTMLTextAreaElement> {
+  connect(): void {
+    // The prefilled query may already wrap; size to it on first paint.
+    this.resize()
+  }
+
+  resize(): void {
+    this.element.style.height = "auto"
+    this.element.style.height = `${this.element.scrollHeight}px`
+  }
+
+  keydown(event: KeyboardEvent): void {
+    if (event.key !== "Enter") return
+
+    event.preventDefault()
+    this.element.form?.requestSubmit()
+  }
+}

--- a/app/javascript/controllers/index.ts
+++ b/app/javascript/controllers/index.ts
@@ -31,6 +31,7 @@ import DecisionController from "./decision_controller"
 import DecisionResultsController from "./decision_results_controller"
 import FormTrackerController from "./form_tracker_controller"
 import DecisionVotersController from "./decision_voters_controller"
+import FeedBarInputController from "./feed_bar_input_controller"
 import HeaderSearchController from "./header_search_controller"
 import HandleAvailabilityController from "./handle_availability_controller"
 import HeartbeatController from "./heartbeat_controller"
@@ -108,6 +109,7 @@ application.register("commitment-subtype", CommitmentSubtypeController)
 application.register("decision-subtype", DecisionSubtypeController)
 application.register("decision-results", DecisionResultsController)
 application.register("form-tracker", FormTrackerController)
+application.register("feed-bar-input", FeedBarInputController)
 application.register("decision-voters", DecisionVotersController)
 application.register("header-search", HeaderSearchController)
 application.register("handle-availability", HandleAvailabilityController)

--- a/app/javascript/controllers/rail_badges_controller.test.ts
+++ b/app/javascript/controllers/rail_badges_controller.test.ts
@@ -9,10 +9,10 @@ describe("RailBadgesController", () => {
         <a href="/chat">
           <span class="pulse-rail-badge" data-chat-badge style="display: none"></span>
         </a>
-        <a href="/collectives/team-a">
+        <a href="/collectives/team-a" data-place-path="/collectives/team-a">
           <span class="pulse-rail-badge" data-collective-id="aaa-111" style="display: none"></span>
         </a>
-        <a href="/collectives/team-b">
+        <a href="/collectives/team-b" data-place-path="/collectives/team-b">
           <span class="pulse-rail-badge" data-collective-id="bbb-222" style="display: none"></span>
         </a>
       </nav>
@@ -31,6 +31,10 @@ describe("RailBadgesController", () => {
 
   function chatBadge(): HTMLElement {
     return document.querySelector("[data-chat-badge]") as HTMLElement
+  }
+
+  function anchor(collectiveId: string): HTMLAnchorElement {
+    return badge(collectiveId).closest("a") as HTMLAnchorElement
   }
 
   it("shows counts on squares with unread notifications", async () => {
@@ -60,6 +64,28 @@ describe("RailBadgesController", () => {
     await vi.waitFor(() => {
       expect(badge("aaa-111").textContent).toBe("99+")
     })
+  })
+
+  it("points a badged entry at the my:notified view, and back when it drains", async () => {
+    broadcast({ "aaa-111": 4 })
+
+    await vi.waitFor(() => {
+      expect(anchor("aaa-111").getAttribute("href")).toBe("/collectives/team-a?q=my:notified")
+      expect(anchor("bbb-222").getAttribute("href")).toBe("/collectives/team-b")
+    })
+
+    broadcast({})
+
+    await vi.waitFor(() => {
+      expect(anchor("aaa-111").getAttribute("href")).toBe("/collectives/team-a")
+    })
+  })
+
+  it("never rewrites the chat link — chat is not a feed", async () => {
+    broadcast({}, 5)
+
+    await vi.waitFor(() => expect(chatBadge().textContent).toBe("5"))
+    expect(chatBadge().closest("a")?.getAttribute("href")).toBe("/chat")
   })
 
   it("fills and clears the aggregated chat badge", async () => {

--- a/app/javascript/controllers/rail_badges_controller.ts
+++ b/app/javascript/controllers/rail_badges_controller.ts
@@ -45,5 +45,18 @@ export default class RailBadgesController extends Controller<HTMLElement> {
       badge.textContent = ""
       badge.style.display = "none"
     }
+    this.updateEntryHref(badge, count)
+  }
+
+  // A badged place entry links to its feed filtered to what the viewer was
+  // notified about; unbadged it links plainly. Entries without a
+  // data-place-path (chat — not a feed) never swap. Mirrors
+  // UnreadBadgeDisplay#place_entry_href — keep the two in sync.
+  private updateEntryHref(badge: HTMLElement, count: number): void {
+    const anchor = badge.closest<HTMLAnchorElement>("a[data-place-path]")
+    if (!anchor) return
+
+    const basePath = anchor.dataset.placePath ?? ""
+    anchor.setAttribute("href", count > 0 ? `${basePath}?q=my:notified` : basePath)
   }
 }

--- a/app/services/search_query.rb
+++ b/app/services/search_query.rb
@@ -891,9 +891,12 @@ class SearchQuery
 
   # Items behind the viewer's undismissed, due, in-app notifications — the
   # inbox projected onto the feed. Evented notifications resolve through
-  # their event's subject (comments climb to the thread root); reminders
-  # resolve through notes.reminder_notification_id. Placeless notifications
-  # (chat, tenant-level) have no content item and resolve to nothing.
+  # their event's subject: a comment surfaces as the comment itself, so
+  # the viewer sees what they were actually notified about (feeds only
+  # exclude comments through their default query, which a my:notified
+  # query replaces). Reminders resolve through
+  # notes.reminder_notification_id. Placeless notifications (chat,
+  # tenant-level) have no content item and resolve to nothing.
   sig { returns([String, T::Array[T.untyped]]) }
   def notified_items_condition
     items = notified_items_by_type
@@ -928,19 +931,9 @@ class SearchQuery
   def notified_event_subjects(notification_ids)
     event_ids = Notification.tenant_scoped_only(@tenant.id)
       .where(id: notification_ids).where.not(event_id: nil).pluck(:event_id)
-    subject_pairs = Event.tenant_scoped_only(@tenant.id)
+    Event.tenant_scoped_only(@tenant.id)
       .where(id: event_ids, subject_type: ["Note", "Decision", "Commitment"])
       .pluck(:subject_type, :subject_id)
-
-    # Comment subjects point the viewer at the thread, not the comment row
-    # (feeds exclude comment rows structurally).
-    note_ids = subject_pairs.filter_map { |type, id| id if type == "Note" }
-    resolved = Note.tenant_scoped_only(@tenant.id).where(id: note_ids).filter_map do |note|
-      root = note.subtype == "comment" ? note.root_commentable : note
-      [root.class.name, root.id] if root
-    end
-
-    resolved + subject_pairs.reject { |pair| pair.first == "Note" }
   end
 
   # `list:<id|mutuals|tuned_in>` narrows content to items authored by

--- a/app/services/search_query.rb
+++ b/app/services/search_query.rb
@@ -81,6 +81,15 @@ class SearchQuery
     @warnings || []
   end
 
+  # Whether a positive my: filter is active in this query. Feed chrome keys
+  # off this (e.g. the my:notified view's mark-all-read affordance);
+  # negations don't count — excluding your notifications is not viewing
+  # them.
+  sig { params(value: String).returns(T::Boolean) }
+  def my_filter?(value)
+    Array(@params[:my_filters]).include?(value)
+  end
+
   private
 
   # Fixed-param key → its negated-operator counterpart, where one exists.

--- a/app/views/help/markdown_ui.md.erb
+++ b/app/views/help/markdown_ui.md.erb
@@ -60,15 +60,15 @@ scope: collective:my-team
 
 | Page | Scope | Default query |
 |------|-------|---------------|
-| `/` (home) | `visibility:public` | `list:tuned_in` |
-| `/collectives/:handle` (feed) | `collective:handle` | `cycle:this-week` |
+| `/` (home) | `visibility:public` | `list:tuned_in -subtype:comment` |
+| `/collectives/:handle` (feed) | `collective:handle` | `cycle:this-week -subtype:comment` |
 | `/collectives/:handle/dashboard` | `collective:handle` | — |
-| `/workspace/:handle` (feed) | `visibility:private` | `cycle:this-week` |
+| `/workspace/:handle` (feed) | `visibility:private` | `cycle:this-week -subtype:comment` |
 | `/workspace/:handle/dashboard` | `visibility:private` | — |
 | `/u/:handle` | `visibility:public creator:@handle` | — |
 | `/lists/:id` | `visibility:public list:id` | — |
 
-A `query:` attribute carries the page's current refinements on top of the scope. Pages with a default query (home's `list:tuned_in` — the people you tune in to, plus yourself; the collective feed's `cycle:this-week`) apply it when `?q` is absent; pass `?q=` to refine, or an empty `?q=` to browse everything in scope. On `/search`, `query:` is the whole search (there is no fixed scope). Pages without a feed have neither key.
+A `query:` attribute carries the page's current refinements on top of the scope. Pages with a default query (home's `list:tuned_in` — the people you tune in to, plus yourself; the collective feed's `cycle:this-week`; both minus comments) apply it when `?q` is absent; pass `?q=` to refine, or an empty `?q=` to browse everything in scope, comments included. On `/search`, `query:` is the whole search (there is no fixed scope). Pages without a feed have neither key.
 
 ## Actions
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,6 +13,9 @@
       warnings: @search.warnings,
     ) %>
 
+    <%# The globe's badge counts the main collective — home is its feed. %>
+    <%= render "shared/notified_feed_banner", collective: @current_tenant.main_collective %>
+
     <% if @feed_items.present? %>
       <div class="pulse-feed" style="padding: 0;">
         <% @feed_items.each do |feed_item| %>

--- a/app/views/pulse/feed.html.erb
+++ b/app/views/pulse/feed.html.erb
@@ -1,6 +1,9 @@
 <%= render 'pulse/heartbeat_banner' %>
 <article class="pulse-resource-detail">
-  <div class="pulse-resource-body">
+  <%# Same heartbeat blur ritual as the dashboard: presence before content.
+      The blur wraps the whole content column — filter bar and feed chrome
+      included, not just the items. %>
+  <div class="pulse-resource-body<%= ' pulse-blur-if-no-heartbeat' if @current_user && !@current_collective.private_workspace? %><%= ' no-heartbeat' if @current_user && !@current_heartbeat && !@current_collective.private_workspace? %>">
     <%= render FeedSearchBarComponent.new(
       action: @current_collective.path.to_s,
       query: @feed_query,
@@ -10,8 +13,7 @@
 
     <%= render "shared/notified_feed_banner", collective: @current_collective %>
 
-    <%# Same heartbeat blur ritual as the dashboard: presence before content. %>
-    <div class="pulse-feed<%= ' pulse-blur-if-no-heartbeat' if @current_user && !@current_collective.private_workspace? %><%= ' no-heartbeat' if @current_user && !@current_heartbeat && !@current_collective.private_workspace? %>" style="padding: 0;">
+    <div class="pulse-feed" style="padding: 0;">
       <% if @feed_items.present? %>
         <% @feed_items.each do |feed_item| %>
           <%= render 'pulse/feed_item', feed_item: feed_item %>

--- a/app/views/pulse/feed.html.erb
+++ b/app/views/pulse/feed.html.erb
@@ -8,6 +8,8 @@
       warnings: @search.warnings,
     ) %>
 
+    <%= render "shared/notified_feed_banner", collective: @current_collective %>
+
     <%# Same heartbeat blur ritual as the dashboard: presence before content. %>
     <div class="pulse-feed<%= ' pulse-blur-if-no-heartbeat' if @current_user && !@current_collective.private_workspace? %><%= ' no-heartbeat' if @current_user && !@current_heartbeat && !@current_collective.private_workspace? %>" style="padding: 0;">
       <% if @feed_items.present? %>

--- a/app/views/shared/_notified_feed_banner.html.erb
+++ b/app/views/shared/_notified_feed_banner.html.erb
@@ -1,0 +1,16 @@
+<%# Clearing affordance for the my:notified view (docs/NAVIGATION_DESIGN.md
+    "Badge click-through"). Confirm-read clears note and reminder
+    notifications one by one; this drains the rest (votes, tune-ins) in one
+    tap. Items stay in the view — my:notified shows the undismissed queue,
+    the badge counts its unread subset. %>
+<% if @current_user && collective && @search&.my_filter?("notified") %>
+  <div class="pulse-feed-bar-notice" data-controller="notification-actions">
+    <span>Showing items you've been notified about here.</span>
+    <button type="button"
+            class="pulse-action-btn-secondary"
+            data-action="click->notification-actions#markReadForCollective"
+            data-collective-id="<%= collective.id %>">
+      Mark all read
+    </button>
+  </div>
+<% end %>

--- a/docs/NAVIGATION_DESIGN.md
+++ b/docs/NAVIGATION_DESIGN.md
@@ -291,16 +291,25 @@ chrome to reshape per form factor without forking the model.
 
 ### Increments (each independently shippable, none undone by the next)
 
-1. **Badge click-through** (`my:notified` + clearing affordances +
-   reminder-notification attribution — see open question 3). Comes before
-   the bar: the bar's Places/Inbox split only feels right once badges
-   drain in place.
-2. **Bottom tab bar** — the sheet gets its tab; Inbox/Search/You move
+1. **Bottom tab bar** — the sheet gets its tab; Inbox/Search/You move
    down; the top bar slims to a place label.
-3. **Sidebar → place header**, paced by how much of the sidebar
+2. **Sidebar → place header**, paced by how much of the sidebar
    feeds-are-queries continues to absorb.
 
 Shipped from this list:
+
+- **Badge click-through + clearing affordance** (open question 3, built):
+  reminder-notification attribution, the `my:` filter namespace
+  (`my:notified`, `my:unread`, `my:read`), badged rail/sheet entries
+  linking to the place's feed at `?q=my:notified`, and a mark-all-read
+  affordance on that view. Deliberately sequenced before the bar so
+  badges drain in place. The click target is the **whole entry**, not the
+  badge: a nested anchor is invalid HTML and the badge is too small a tap
+  target, so a badged entry's href swaps to the filtered view and swaps
+  back when the count drains (`UnreadBadgeDisplay#place_entry_href`
+  server-side, mirrored by the rail-badges controller via
+  `data-place-path`). Chat never swaps — it is not a feed; `/chat` is
+  already its queue.
 
 - **Rail desktop-only** (#339): hidden under 768px by redefining
   `--pulse-rail-width` (the motto footer's border-continuation offset
@@ -364,10 +373,10 @@ Shipped from this list:
    The route swap landed (feed is the default page, dashboard at
    `/dashboard`), but the dashboard itself hasn't converted to a query —
    decide the sidebar question together with that conversion.
-3. **Badge click-through — direction resolved, unbuilt.** A square's
-   unread badge implies clicking will show what you're being notified
-   about, but the collective feed renders with no notification context.
-   The fix is a `my:` filter namespace: the DSL is already viewer-relative
+3. **Badge click-through — resolved, shipped.** A square's unread badge
+   implies clicking will show what you're being notified about, but the
+   collective feed rendered with no notification context. The fix is a
+   `my:` filter namespace: the DSL is already viewer-relative
    (`list:tuned_in` resolves against the current user), but `list:*`
    resolves to *authors* and filters on content facts, while `my:*`
    filters on the viewer's own state per item — a different data layer
@@ -388,17 +397,19 @@ Shipped from this list:
      confirm-read), which is what "read" already means everywhere else
      in the product. Fully separable from the badge system, and a
      different query shape (a negative join against read-confirmations
-     vs. `my:notified`'s id-set resolution) — build it later,
-     independently.
+     vs. `my:notified`'s id-set resolution) — shipped alongside it as
+     part of the same filter engine.
 
    What makes the click-through actually drain the badge:
 
    - Confirm-read already clears the pointing notification (shipped in
      1.38.0), covering notes and reminders.
-   - Non-confirmable items (votes, tune-ins) need per-item dismiss
-     chrome in the `my:notified` view, or a "mark all read here"
-     affordance — `mark_read_for_collective` /
-     `dismiss_for_collective` already exist server-side.
+   - Non-confirmable items (votes, tune-ins) drain via the mark-all-read
+     affordance on the `my:notified` view, wired to the inbox's existing
+     per-collective action (`mark_read_for_collective`, which reaches
+     reminders through read-time attribution). Marked-read items stay in
+     the view — `my:notified` shows the undismissed queue; the badge
+     counts its unread subset. Dismissal stays on `/notifications`.
 
    Prerequisite: **reminder-notification attribution.** Reminder *notes*
    have a collective; only their notification rows are placeless
@@ -423,10 +434,10 @@ Shipped from this list:
    Anonymous viewers: `my:*` with no signed-in user warns and matches
    nothing, same pattern as other unresolvable filters.
 
-   Sequencing: reminder attribution → `my:notified` + badge click-through
-   + clearing affordances → bottom tab bar (its Places/Inbox split only
-   feels right once badges drain in place) → `my:unread` when it earns
-   its slot.
+   Sequencing: everything through the clearing affordance has shipped.
+   Next is the bottom tab bar — its Places/Inbox split only feels right
+   now that badges drain in place. Dedicated `my:unread` UX (beyond the
+   filter itself) waits until it earns its slot.
 
 (The former "what is the globe?" question is resolved — see Decided: `/`
 unifies home and the public space via the default `list:tuned_in` chip.

--- a/docs/NAVIGATION_DESIGN.md
+++ b/docs/NAVIGATION_DESIGN.md
@@ -167,7 +167,7 @@ Filters come in three tiers, and the UI must make the tier visible:
 | Tier | Example | Rendering | Editable? |
 |---|---|---|---|
 | **Fixed** (the page scope) | `collective:my-team` on `/collectives/my-team` | Muted token inside the field, not editable | No — it *is* the page |
-| **Default** | `cycle:this-week` on a collective home | Ordinary query text | Yes — remove or replace freely |
+| **Default** | `cycle:this-week -subtype:comment` on a collective home | Ordinary query text | Yes — remove or replace freely |
 | **User** | anything typed | Query text | Yes |
 
 Decisions and rationale:
@@ -192,6 +192,16 @@ Decisions and rationale:
   "defaults". GitHub Issues has exactly this distinction. A blank query
   with a fixed scope *browses* — the fixed scope is what makes a page a
   feed; only `/search` keeps blank-means-empty behavior.
+- **No hidden filters — the comment exclusion is default query text.**
+  Feed defaults read `… -subtype:comment` in the input, visible and
+  removable, instead of a structural `exclude_subtypes` param silently
+  ANDed onto whatever the viewer types. A viewer-supplied `?q` therefore
+  gets raw search semantics, comments included — the same universe as
+  `/search`. Fixed internal feeds that want no comments say so in their
+  own query (list activity; the profile Posts/Activity tabs already
+  did). An earlier draft special-cased `my:notified` to lift a hidden
+  exclusion; rejected — defaults carry the curation, queries carry
+  nothing invisible.
 - **Refinements live in the URL** (`/collectives/x?q=type:decision`), so
   filtered views are shareable and the back button works. The canonical
   page URL (no `q`) always shows the default view. Markdown frontmatter
@@ -352,6 +362,14 @@ Shipped from this list:
   viewing past cycles on the dashboard additionally requires a heartbeat,
   while queries (including `cycle:` refinements on feed pages and
   `/search`) cross cycles freely.
+- **Comment notifications surface as the comment.** `my:notified`
+  resolves a comment notification to the comment itself (an earlier
+  build climbed to the thread root because feeds hid comment rows — the
+  root then appeared with no sign it was about a comment). Feed cards
+  for notes navigate via `display_path`, so a comment card opens its
+  thread at `?comment_id=` — the same URL the notification carries —
+  where the comment scrolls into view highlighted. Action endpoints
+  keep building from `path`, the canonical bare resource URL.
 - **Chat is one aggregated rail entry beneath the globe.** A bare icon
   (like the globe, not a square) linking to `/chat`, active on all chat
   pages. Its badge is type-based — unread `chat_message` notifications —

--- a/e2e/tests/collectives/places-sheet.spec.ts
+++ b/e2e/tests/collectives/places-sheet.spec.ts
@@ -17,7 +17,9 @@ test.describe("Places Sheet", () => {
 
     await toggle.click()
     await expect(sheet).toBeVisible()
-    await expect(sheet.locator("a[href='/']")).toContainText("Public space")
+    // data-place-path, not href: a badged entry's href swaps to the
+    // my:notified view, and the e2e user may have main-collective unread.
+    await expect(sheet.locator("a[data-place-path='/']")).toContainText("Public space")
     await expect(sheet.locator("a[href='/chat']")).toContainText("Chat")
     await expect(sheet.locator("a[href='/collectives']")).toContainText(
       "Create or join a collective",

--- a/test/components/collective_rail_component_test.rb
+++ b/test/components/collective_rail_component_test.rb
@@ -71,6 +71,32 @@ class CollectiveRailComponentTest < ViewComponent::TestCase
     assert_selector ".pulse-rail-badge[data-collective-id='#{b.id}']", visible: :hidden
   end
 
+  test "a badged entry links to the place's feed filtered to what you were notified about" do
+    a = build_rail_collective(name: "Team A", handle: "team-a")
+    a.id = "11111111-1111-1111-1111-111111111111"
+    b = build_rail_collective(name: "Team B", handle: "team-b")
+    b.id = "33333333-3333-3333-3333-333333333333"
+    main = main_collective
+    main.id = "22222222-2222-2222-2222-222222222222"
+
+    render_inline(CollectiveRailComponent.new(
+                    main_collective: main,
+                    collectives: [a, b],
+                    unread_counts: { a.id => 4, main.id => 2 },
+                    chat_unread_count: 7,
+                  ))
+
+    # Badged entries carry the my:notified refinement; the base path rides
+    # along so the rail-badges controller can swap the href as counts change.
+    assert_selector "a.pulse-rail-item[href='/collectives/team-a?q=my:notified'][data-place-path='/collectives/team-a']"
+    assert_selector "a.pulse-rail-public[href='/?q=my:notified'][data-place-path='/']"
+    # Unbadged entries link plainly.
+    assert_selector "a.pulse-rail-item[href='/collectives/team-b'][data-place-path='/collectives/team-b']"
+    # Chat is not a feed — its link never swaps, badge or not.
+    assert_selector "a.pulse-rail-chat[href='/chat']"
+    assert_no_selector "a.pulse-rail-chat[data-place-path]"
+  end
+
   test "renders a chat entry beneath the globe, above the divider" do
     render_inline(CollectiveRailComponent.new(main_collective: main_collective, collectives: []))
 

--- a/test/components/feed_item_component_test.rb
+++ b/test/components/feed_item_component_test.rb
@@ -49,6 +49,20 @@ class FeedItemComponentTest < ViewComponent::TestCase
     assert_selector ".pulse-feed-item-type span", text: "Comment"
   end
 
+  test "comment cards navigate to the thread with the comment marked, not the isolated comment page" do
+    commentable = build_note(truncated_id: "parent01", title: "Parent Note", text: "Parent text")
+    note = build_note(truncated_id: "comment05", text: "A reply", is_comment: true, commentable: commentable,
+                      commentable_type: "Note", commentable_id: "11111111-1111-1111-1111-111111111111")
+    user = build_user(display_name: "Bob")
+    render_inline(FeedItemComponent.new(
+                    item: note,
+                    type: "Note",
+                    created_by: user,
+                    created_at: 30.minutes.ago
+                  ))
+    assert_selector ".pulse-feed-item[data-card-navigate-url-value='/n/parent01?comment_id=comment05']"
+  end
+
   test "renders reply indicator with commentable link" do
     commentable = build_note(truncated_id: "parent01", title: "Parent Note", text: "Parent text")
     note = build_note(text: "A reply", is_comment: true, commentable: commentable)

--- a/test/components/feed_search_bar_component_test.rb
+++ b/test/components/feed_search_bar_component_test.rb
@@ -7,7 +7,21 @@ class FeedSearchBarComponentTest < ViewComponent::TestCase
     render_inline(FeedSearchBarComponent.new(action: "/search", query: "type:note budget"))
 
     assert_selector "form[action='/search'][method='get']"
-    assert_selector "input[name='q'][value='type:note budget']"
+    assert_selector "textarea[name='q']", text: "type:note budget"
+  end
+
+  test "the query field is a one-row textarea that grows instead of scrolling horizontally" do
+    render_inline(FeedSearchBarComponent.new(action: "/search", query: "type:note budget"))
+
+    # A single-line <input> hides overflow behind horizontal scroll —
+    # long defaults like `-subtype:comment` would be invisible. The
+    # feed-bar-input controller grows the textarea and keeps Enter as
+    # submit.
+    assert_selector "textarea[name='q'][rows='1'][data-controller='feed-bar-input']"
+    assert_selector "textarea[name='q'][data-action*='input->feed-bar-input#resize']"
+    assert_selector "textarea[name='q'][data-action*='feed-bar-input#keydown']"
+    # Re-fit when the viewport changes — wrapped line count depends on width.
+    assert_selector "textarea[name='q'][data-action*='resize@window->feed-bar-input#resize']"
   end
 
   test "renders fixed scope filters as non-editable tokens inside the query field" do
@@ -16,8 +30,8 @@ class FeedSearchBarComponentTest < ViewComponent::TestCase
     # The fixed filter is part of the query visually — inside the same
     # field as the text input — but not part of the editable text.
     assert_selector ".pulse-feed-bar-field .pulse-feed-bar-scope code", text: "collective:my-team"
-    assert_selector ".pulse-feed-bar-field input[name='q']"
-    assert_no_selector "input[value*='collective:my-team']"
+    assert_selector ".pulse-feed-bar-field textarea[name='q']"
+    assert_no_selector "textarea[name='q']", text: "collective:my-team"
     assert_no_selector ".octicon-lock"
   end
 

--- a/test/components/places_sheet_component_test.rb
+++ b/test/components/places_sheet_component_test.rb
@@ -57,6 +57,29 @@ class PlacesSheetComponentTest < ViewComponent::TestCase
     assert_selector ".pulse-places-sheet [data-controller~='rail-badges']", visible: :all
   end
 
+  test "a badged row links to the place's feed filtered to what you were notified about" do
+    a = build_sheet_collective(name: "Team A", handle: "team-a")
+    a.id = "11111111-1111-1111-1111-111111111111"
+    main = main_collective
+    main.id = "22222222-2222-2222-2222-222222222222"
+
+    render_inline(PlacesSheetComponent.new(
+                    main_collective: main,
+                    collectives: [a],
+                    unread_counts: { a.id => 4 },
+                    chat_unread_count: 2,
+                  ))
+
+    assert_selector ".pulse-places-sheet a[href='/collectives/team-a?q=my:notified'][data-place-path='/collectives/team-a']",
+                    visible: :all
+    # The globe has no unread here, so it links plainly — but still carries
+    # the base path for live href swaps.
+    assert_selector ".pulse-places-sheet a[href='/'][data-place-path='/']", visible: :all
+    # Chat is not a feed — badge or not, its link never swaps.
+    assert_selector ".pulse-places-sheet a[href='/chat']", visible: :all
+    assert_no_selector ".pulse-places-sheet a[href='/chat'][data-place-path]", visible: :all
+  end
+
   test "marks the current place active, same rules as the rail" do
     a = build_sheet_collective(name: "Team A", handle: "team-a")
     b = build_sheet_collective(name: "Team B", handle: "team-b")

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -368,7 +368,7 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_select ".pulse-feed-bar-scope code", text: "visibility:public"
     # The comment exclusion is part of the visible default query — the
     # viewer can see it and remove it, not a hidden structural filter.
-    assert_select "input[name='q'][value='list:tuned_in -subtype:comment']"
+    assert_select "textarea[name='q']", text: "list:tuned_in -subtype:comment"
   end
 
   test "reminders interleave on the default view but not on refined queries" do

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -366,7 +366,9 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get "/"
     assert_response :success
     assert_select ".pulse-feed-bar-scope code", text: "visibility:public"
-    assert_select "input[name='q'][value='list:tuned_in']"
+    # The comment exclusion is part of the visible default query — the
+    # viewer can see it and remove it, not a hidden structural filter.
+    assert_select "input[name='q'][value='list:tuned_in -subtype:comment']"
   end
 
   test "reminders interleave on the default view but not on refined queries" do

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -21,6 +21,19 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "the home my:notified view offers mark-all-read scoped to the main collective" do
+    sign_in_as(@user, tenant: @tenant)
+
+    get "/", params: { q: "my:notified" }
+    assert_response :success
+    main = Collective.find(@tenant.main_collective_id)
+    assert_select "button[data-action='click->notification-actions#markReadForCollective'][data-collective-id='#{main.id}']"
+
+    get "/"
+    assert_response :success
+    assert_select "button[data-action='click->notification-actions#markReadForCollective']", count: 0
+  end
+
   test "rail badges render with unread counts server-side on first paint" do
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
     other = Collective.create!(tenant: @tenant, name: "Rail Badge Collective", handle: "rail-badge-collective", created_by: @user)

--- a/test/controllers/pulse_controller_test.rb
+++ b/test/controllers/pulse_controller_test.rb
@@ -119,8 +119,33 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     get "#{@collective.path}"
     assert_response :success
     assert_select ".pulse-feed-bar-scope code", text: "collective:#{@collective.handle}"
-    assert_select "input[name='q'][value='cycle:this-week']"
+    # The comment exclusion is part of the visible default query — the
+    # viewer can see it and remove it, not a hidden structural filter.
+    assert_select "input[name='q'][value='cycle:this-week -subtype:comment']"
     assert_includes response.body, "collective feed probe"
+  end
+
+  test "the default feed hides comments; a viewer's own query includes them" do
+    sign_in_as(@user, tenant: @tenant)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    root = create_note(tenant: @tenant, collective: @collective, created_by: @user, text: "Root for comment default test")
+    comment = create_note(
+      tenant: @tenant, collective: @collective, created_by: @user, commentable: root, text: "A default-hidden comment"
+    )
+    SearchIndexer.reindex(comment)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "#{@collective.path}"
+    assert_response :success
+    assert_not_includes response.body, "A default-hidden comment"
+
+    # ?q present — even empty — is the viewer's own query: raw search
+    # semantics, same as /search, comments included.
+    get "#{@collective.path}", params: { q: "" }
+    assert_response :success
+    assert_includes response.body, "A default-hidden comment"
   end
 
   test "collective feed defaults to this week; cleared query shows all time" do
@@ -161,6 +186,30 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "a notified comment surfaces in the my:notified view as the comment, linking into its thread" do
+    sign_in_as(@user, tenant: @tenant)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    root = create_note(tenant: @tenant, collective: @collective, created_by: @user, text: "Thread root note")
+    comment = create_note(
+      tenant: @tenant, collective: @collective, created_by: @user, commentable: root, text: "A reply about you"
+    )
+    SearchIndexer.reindex(comment)
+    event = Event.create!(tenant: @tenant, collective: @collective, event_type: "note.created", actor: @user, subject: comment)
+    notification = Notification.create!(tenant: @tenant, event: event, notification_type: "mention", title: "You were mentioned")
+    NotificationRecipient.create!(notification: notification, user: @user, channel: "in_app", status: "delivered", tenant: @tenant)
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+
+    get "#{@collective.path}", params: { q: "my:notified" }
+    assert_response :success
+    # The comment itself renders (feeds normally exclude comment rows), and
+    # its card points into the thread with the comment marked — the same
+    # URL the notification links to.
+    assert_includes response.body, "A reply about you"
+    assert_select ".pulse-feed-item[data-card-navigate-url-value='#{root.path}?comment_id=#{comment.truncated_id}']"
+  end
+
   test "feed views without my:notified render no mark-all-read chrome" do
     sign_in_as(@user, tenant: @tenant)
 
@@ -179,7 +228,7 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     get "#{@collective.path}", headers: { "Accept" => "text/markdown" }
     assert_response :success
     assert_includes response.body, "scope: collective:#{@collective.handle}"
-    assert_includes response.body, "query: cycle:this-week"
+    assert_includes response.body, "query: cycle:this-week -subtype:comment"
   end
 
   test "workspace feed is scoped to the private zone" do

--- a/test/controllers/pulse_controller_test.rb
+++ b/test/controllers/pulse_controller_test.rb
@@ -121,7 +121,7 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     assert_select ".pulse-feed-bar-scope code", text: "collective:#{@collective.handle}"
     # The comment exclusion is part of the visible default query — the
     # viewer can see it and remove it, not a hidden structural filter.
-    assert_select "input[name='q'][value='cycle:this-week -subtype:comment']"
+    assert_select "textarea[name='q']", text: "cycle:this-week -subtype:comment"
     assert_includes response.body, "collective feed probe"
   end
 
@@ -284,10 +284,21 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     get @collective.path.to_s
     assert_response :success
     assert_select "input[type=submit][value=Filter]"
-    assert_select "input[name='q'][placeholder=Filter]"
+    assert_select "textarea[name='q'][placeholder=Filter]"
 
     get "/search"
     assert_response :success
     assert_select "input[type=submit][value=Search]"
+  end
+
+  test "the heartbeat gate blurs the filter bar along with the feed" do
+    sign_in_as(@user, tenant: @tenant)
+
+    get "#{@collective.path}"
+    assert_response :success
+    # The whole content column sits behind the ritual — the filter bar and
+    # any feed chrome included, not just the items.
+    assert_select ".pulse-blur-if-no-heartbeat .pulse-feed-bar"
+    assert_select ".pulse-blur-if-no-heartbeat .pulse-feed"
   end
 end

--- a/test/controllers/pulse_controller_test.rb
+++ b/test/controllers/pulse_controller_test.rb
@@ -151,6 +151,29 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
                   text: /collective:someplace-else ignored: this page is fixed to collective:#{@collective.handle}/
   end
 
+  test "the my:notified view offers mark-all-read chrome to drain the badge" do
+    sign_in_as(@user, tenant: @tenant)
+
+    get "#{@collective.path}", params: { q: "my:notified" }
+    assert_response :success
+    assert_select "[data-controller='notification-actions']" do
+      assert_select "button[data-action='click->notification-actions#markReadForCollective'][data-collective-id='#{@collective.id}']"
+    end
+  end
+
+  test "feed views without my:notified render no mark-all-read chrome" do
+    sign_in_as(@user, tenant: @tenant)
+
+    get "#{@collective.path}"
+    assert_response :success
+    assert_select "button[data-action='click->notification-actions#markReadForCollective']", count: 0
+
+    # Negating my:notified is not viewing your notifications.
+    get "#{@collective.path}", params: { q: "-my:notified" }
+    assert_response :success
+    assert_select "button[data-action='click->notification-actions#markReadForCollective']", count: 0
+  end
+
   test "collective feed markdown declares scope and query frontmatter" do
     sign_in_as(@user, tenant: @tenant)
     get "#{@collective.path}", headers: { "Accept" => "text/markdown" }

--- a/test/controllers/user_lists_show_test.rb
+++ b/test/controllers/user_lists_show_test.rb
@@ -164,6 +164,28 @@ class UserListsShowTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "markdown feed note from a member"
   end
 
+  test "show markdown activity section excludes members' comments" do
+    list = UserList.create!(creator: @user, owner: @user, name: "Feedy")
+    list.user_list_members.create!(added_by: @user, user: @other)
+
+    root = Note.create!(
+      tenant: @tenant, collective: @collective, created_by: @other,
+      text: "top-level list feed note",
+      deadline: Time.current + 1.week,
+    )
+    Note.create!(
+      tenant: @tenant, collective: @collective, created_by: @other,
+      text: "a comment that stays out of the list feed",
+      subtype: "comment", commentable: root,
+      deadline: Time.current + 1.week,
+    )
+
+    get "/lists/#{list.truncated_id}", headers: @headers
+    assert_response :success
+    assert_includes response.body, "top-level list feed note"
+    assert_not_includes response.body, "a comment that stays out of the list feed"
+  end
+
   test "show markdown activity section excludes content from blocked members" do
     list = UserList.create!(creator: @user, owner: @user, name: "Feedy")
     list.user_list_members.create!(added_by: @user, user: @other)

--- a/test/integration/page_scope_frontmatter_test.rb
+++ b/test/integration/page_scope_frontmatter_test.rb
@@ -34,7 +34,7 @@ class PageScopeFrontmatterTest < ActionDispatch::IntegrationTest
     assert_response :success
     fm = frontmatter(response.body)
     assert_includes fm, "\nscope: visibility:public\n"
-    assert_includes fm, "\nquery: list:tuned_in\n"
+    assert_includes fm, "\nquery: list:tuned_in -subtype:comment\n"
   end
 
   test "home feed query reflects the viewer's refinement" do

--- a/test/services/search_query_test.rb
+++ b/test/services/search_query_test.rb
@@ -1175,15 +1175,16 @@ class SearchQueryTest < ActiveSupport::TestCase
     assert_equal [["Decision", @decision.id], ["Note", reminder_note.id]].sort, results.sort
   end
 
-  test "my:notified resolves comment notifications to the thread root" do
+  test "my:notified resolves comment notifications to the comment itself, not the thread root" do
     viewer = add_member("Commented At")
     comment = create_note(
       tenant: @tenant, collective: @collective, created_by: @user, commentable: @note, text: "A reply mentioning you"
     )
+    SearchIndexer.reindex(comment)
     notify(viewer, subject: comment)
 
     results = my_search(viewer, "my:notified").results.map { |r| [r.item_type, r.item_id] }
-    assert_equal [["Note", @note.id]], results
+    assert_equal [["Note", comment.id]], results
   end
 
   test "my: filters warn and match nothing for anonymous viewers" do

--- a/test/services/search_query_test.rb
+++ b/test/services/search_query_test.rb
@@ -1193,6 +1193,15 @@ class SearchQueryTest < ActiveSupport::TestCase
     assert search.warnings.any? { |w| w.include?("my:") }, "expected a warning about my: requiring sign-in"
   end
 
+  test "my_filter? reports positive my: filters so feed chrome can key off them" do
+    viewer = add_member("Chrome")
+
+    assert my_search(viewer, "my:notified").my_filter?("notified")
+    assert_not my_search(viewer, "my:notified").my_filter?("unread")
+    assert_not my_search(viewer, "-my:notified").my_filter?("notified")
+    assert_not my_search(viewer, "budget").my_filter?("notified")
+  end
+
   test "negated my:read excludes items the viewer has confirmed read" do
     viewer = add_member("Skimmer")
     @note.confirm_read!(viewer)


### PR DESCRIPTION
Completes the badge story: a place's unread badge now leads somewhere, shows what it counts, and can be cleared where you read it. Along the way, comment notifications got fixed to surface as comments, and feed defaults stopped hiding filters.

## Badge click-through

- A badged rail square, sheet row, or globe links to that place's feed at `?q=my:notified`; when the badge drains, the link reverts to the plain feed. The **whole entry** is the click target — a nested anchor is invalid HTML and the badge is too small to tap. Server-rendered via `UnreadBadgeDisplay#place_entry_href`, kept live by the rail-badges controller through a `data-place-path` attribute. Chat never swaps: it is not a feed; `/chat` is already its queue.
- The `my:notified` view renders a clearing affordance: a slim notice with a **Mark all read** button wired to the inbox's existing per-collective action. It reaches reminders through read-time attribution (`notification_ids_for_collective`) and drains rail + sheet badges live over the existing `notifications:changed` → recount loop. Marked-read items stay in the view — `my:notified` shows the undismissed queue; the badge counts its unread subset. Dismissal stays on `/notifications`.

## Comment notifications surface as the comment

A notification about a comment used to appear in `my:notified` as the thread root with no sign it was about a comment, and clicking lost the `comment_id`. Root cause was a hidden filter: feeds excluded comment rows via a structural `exclude_subtypes` param silently ANDed onto the viewer's query — which is why `my:notified` had to climb comment subjects to the thread root.

- `my:notified` now resolves a comment notification to the comment itself.
- Feed cards for notes navigate via `display_path`, so a comment card opens its thread at `?comment_id=<id>` — the same URL the notification carries — where `comment_thread_controller` scrolls to and highlights it. Action endpoints keep building from `path`.

## No hidden filters: the comment exclusion is default query text

Feed defaults now read `list:tuned_in -subtype:comment` (home) and `cycle:this-week -subtype:comment` (collective feed) in the filter input — visible and removable. A viewer-supplied `?q` (even empty) gets raw search semantics, comments included, same universe as `/search`. Fixed internal feeds say it in their own query (list activity; the profile tabs already did). An earlier draft special-cased `my:notified` to lift a hidden exclusion — rejected in review: defaults carry the curation, queries carry nothing invisible.

Behavior note: the empty-state "Show all time" link (`?q=`) and typed refinements now match comments too — a feed with a query behaves like `/search` scoped to that place.

## Feed bar visual fixes (follow-on)

- The query field is a one-row textarea that grows with its content (new `feed-bar-input` controller: resize on input/window-resize, Enter submits). A single-line `<input>` hid the now-longer defaults behind horizontal scroll.
- The heartbeat blur on the collective feed wraps the whole content column — filter bar and notice included — instead of only the feed items.

## Docs / tests

- `docs/NAVIGATION_DESIGN.md`: click-through recorded as shipped (with the whole-entry-swaps rationale); "No hidden filters" added to the feed bar's decided list; comment-notification resolution added to Decided.
- Canonical default-query table updated in `/help/markdown-ui`; `my:` semantics unchanged in `/help/search`.
- Red-green throughout: component tests for both badge surfaces, vitest for href swaps and the new input controller, controller tests for the notice, the visible defaults (HTML input + markdown `query:` frontmatter), default-hides/query-shows comments, `my:notified` comment resolution, and the card's navigate URL. The places-sheet e2e spec finds the globe by `data-place-path` since its href legitimately varies with unread state.

Verified in the browser end to end: badged square → filtered feed showing exactly the notified items (comments as Comment cards with reply context) → Mark all read → badge hides and rail/sheet hrefs revert live; comment click-through lands on the thread with the comment highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
