### PR TITLE
Allow editing calendar event schedule from commitment settings

### DIFF
--- a/app/controllers/commitments_controller.rb
+++ b/app/controllers/commitments_controller.rb
@@ -277,6 +277,24 @@ class CommitmentsController < ApplicationController
       critical_mass: model_params[:critical_mass],
       deadline: deadline_from_params,
     }
+    if @commitment.is_calendar_event?
+      # Same timezone handling as create: DatetimeInputComponent submits a
+      # per-input timezone alongside each datetime-local value.
+      collective_tz = current_collective.timezone&.name
+      if model_params[:starts_at].present?
+        helper_params[:starts_at] = parse_scheduled_time(
+          model_params[:starts_at],
+          timezone: model_params[:starts_at_timezone].presence || collective_tz,
+        )
+      end
+      if model_params[:ends_at].present?
+        helper_params[:ends_at] = parse_scheduled_time(
+          model_params[:ends_at],
+          timezone: model_params[:ends_at_timezone].presence || collective_tz,
+        )
+      end
+      helper_params[:location] = model_params[:location] if model_params.key?(:location)
+    end
     @commitment = api_helper(params: helper_params).update_commitment_settings
     # Handle close_at_critical_mass option (HTML form specific)
     if params[:deadline_option] == "close_at_critical_mass"
@@ -285,6 +303,8 @@ class CommitmentsController < ApplicationController
       @commitment.save!
     end
     redirect_to @commitment.path
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to "#{current_commitment.path}/settings", alert: e.record.errors.full_messages.join(", ")
   end
 
   def actions_index_settings

--- a/app/javascript/controllers/datetime_input_controller.test.ts
+++ b/app/javascript/controllers/datetime_input_controller.test.ts
@@ -170,6 +170,19 @@ describe("DatetimeInputController", () => {
     expect(Math.abs(minDate.getTime() - Date.now())).toBeLessThan(60_000)
   })
 
+  it("does not set min attribute when requireFuture is false", async () => {
+    // Edit forms (require_future: false) must be able to keep an already-past
+    // prefilled value — pinning min to now would make native browser
+    // validation block saving a schedule edit on an event that has started.
+    renderInput({ requireFuture: "false", value: "2020-01-01T00:00" })
+    await waitForController()
+
+    const input = document.querySelector("[data-datetime-input-target='datetimeInput']") as HTMLInputElement
+    expect(input.min).toBe("")
+    // The past prefilled value survives and is not clamped by min.
+    expect(input.value).toBe("2020-01-01T00:00")
+  })
+
   // --- Countdown preview ---
 
   it("updates countdown end-time attribute for future datetime", async () => {

--- a/app/javascript/controllers/datetime_input_controller.ts
+++ b/app/javascript/controllers/datetime_input_controller.ts
@@ -91,6 +91,11 @@ export default class DatetimeInputController extends Controller {
   }
 
   private setMinAttribute() {
+    // Only pin a floor of "now" when a future value is actually required.
+    // Edit forms pass requireFuture: false so an already-started event can
+    // still be corrected — a past prefilled value must not fall below `min`
+    // and get blocked by native browser validation.
+    if (!this.requireFutureValue) return
     this.datetimeInputTarget.min = this.formatDatetimeLocal(new Date())
   }
 

--- a/app/views/commitments/settings.html.erb
+++ b/app/views/commitments/settings.html.erb
@@ -41,6 +41,36 @@
         <%= render 'shared/multi_file_select', form: form %>
       </section>
 
+      <% if @commitment.is_calendar_event? %>
+      <section class="pulse-settings-section">
+        <h2 class="pulse-section-title">Schedule</h2>
+        <div class="pulse-form-group">
+          <label class="pulse-form-label">Starts</label>
+          <%= render DatetimeInputComponent.new(
+            field_name: "starts_at",
+            timezone_field_name: "starts_at_timezone",
+            require_future: false,
+            default_timezone: @current_collective.timezone.name,
+            utc_value: @commitment.starts_at&.iso8601,
+          ) %>
+        </div>
+        <div class="pulse-form-group">
+          <label class="pulse-form-label">Ends</label>
+          <%= render DatetimeInputComponent.new(
+            field_name: "ends_at",
+            timezone_field_name: "ends_at_timezone",
+            require_future: false,
+            default_timezone: @current_collective.timezone.name,
+            utc_value: @commitment.ends_at&.iso8601,
+          ) %>
+        </div>
+        <div class="pulse-form-group">
+          <label class="pulse-form-label">Location <span class="pulse-form-label-optional">(optional)</span></label>
+          <%= form.text_field :location, placeholder: "Where will this happen?", value: @commitment.location, class: "pulse-form-input" %>
+        </div>
+      </section>
+      <% end %>
+
       <% unless @current_collective.private_workspace? %>
       <section class="pulse-settings-section">
         <h2 class="pulse-section-title">Critical Mass</h2>

--- a/test/controllers/commitments_controller_test.rb
+++ b/test/controllers/commitments_controller_test.rb
@@ -165,6 +165,58 @@ class CommitmentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to @commitment.path
   end
 
+  # The settings form posts top-level fields (form_with(url:), no model) with
+  # per-input timezones, same shape as the create form's event fields.
+  test "creator can update calendar event schedule via settings (form path)" do
+    sign_in_as(@user, tenant: @tenant)
+    event = create_calendar_event
+
+    post "/collectives/#{@collective.handle}/c/#{event.truncated_id}/settings", params: {
+      starts_at: "2030-06-01T18:00",
+      starts_at_timezone: "UTC",
+      ends_at: "2030-06-01T20:00",
+      ends_at_timezone: "UTC",
+      location: "The park",
+    }
+
+    event.reload
+    assert_equal Time.utc(2030, 6, 1, 18, 0), event.starts_at
+    assert_equal Time.utc(2030, 6, 1, 20, 0), event.ends_at
+    assert_equal "The park", event.location
+    assert_redirected_to event.path
+  end
+
+  test "calendar event schedule update rejects end before start" do
+    sign_in_as(@user, tenant: @tenant)
+    event = create_calendar_event
+    original_starts_at = event.reload.starts_at
+
+    post "/collectives/#{@collective.handle}/c/#{event.truncated_id}/settings", params: {
+      starts_at: "2030-06-01T18:00",
+      starts_at_timezone: "UTC",
+      ends_at: "2030-06-01T17:00",
+      ends_at_timezone: "UTC",
+    }
+
+    assert_redirected_to "#{event.path}/settings"
+    assert flash[:alert].present?
+    assert_equal original_starts_at, event.reload.starts_at
+  end
+
+  test "schedule params are ignored for non-calendar commitments" do
+    sign_in_as(@user, tenant: @tenant)
+
+    post "/collectives/#{@collective.handle}/c/#{@commitment.truncated_id}/settings", params: {
+      title: "Still an action",
+      starts_at: "2030-06-01T18:00",
+      starts_at_timezone: "UTC",
+    }
+
+    @commitment.reload
+    assert_equal "Still an action", @commitment.title
+    assert_nil @commitment.starts_at
+  end
+
   # === Join Tests ===
 
   test "user can join commitment" do
@@ -387,5 +439,26 @@ class CommitmentsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(@user, tenant: @tenant)
     get "/collectives/#{@collective.handle}/c/#{@commitment.truncated_id}/participants.html", params: { limit: 10 }
     assert_response :success
+  end
+
+  private
+
+  def create_calendar_event
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    Commitment.create!(
+      tenant: @tenant,
+      collective: @collective,
+      created_by: @user,
+      title: "Test Event",
+      subtype: "calendar_event",
+      critical_mass: 1,
+      deadline: 1.week.from_now,
+      starts_at: 1.week.from_now,
+      ends_at: 1.week.from_now + 1.hour
+    )
+  ensure
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
   end
 end


### PR DESCRIPTION
Fixes #321

## Problem

The commitment settings page had no way to change a calendar event's date after creation. `ApiHelper#update_commitment_settings` already supported `starts_at`/`ends_at`/`location` (so the markdown/agent path worked), but:

- the HTML settings form had no schedule fields, and
- `CommitmentsController#update_settings` built its helper params from a fixed list (title/description/critical_mass/deadline), dropping event fields even if submitted.

## Changes

- **Settings form**: for calendar events, adds a Schedule section with Starts/Ends datetime inputs (prefilled from the record via `DatetimeInputComponent`'s `utc_value`) and a Location field.
- **Controller**: passes `starts_at`/`ends_at`/`location` through to the ApiHelper with the same per-input-timezone parsing the create form uses; only for calendar events.
- **Error handling**: `update_settings` now rescues `RecordInvalid` and redirects back to the settings page with the validation message (previously an invalid edit — e.g. end before start, now reachable from the form — would 500).

## Tests

Added controller tests for the form-shaped (top-level params) path: successful schedule update, end-before-start rejection, and schedule params being ignored on non-calendar commitments. Ran the commitments controller suite locally in Docker: 28 runs, 0 failures.