### PR TITLE
Support multi-day calendar events from the create form

### DIFF
--- a/app/javascript/controllers/duration_select_controller.test.ts
+++ b/app/javascript/controllers/duration_select_controller.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import DurationSelectController from "./duration_select_controller"
+import { waitForController } from "../test/setup"
+
+describe("DurationSelectController", () => {
+  let application: Application
+
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    application = Application.start()
+    application.register("duration-select", DurationSelectController)
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+  })
+
+  function render(selected: string) {
+    document.body.innerHTML = `
+      <div data-controller="duration-select">
+        <select name="duration_minutes" data-duration-select-target="select" data-action="change->duration-select#toggle">
+          <option value="60"${selected === "60" ? " selected" : ""}>1 hour</option>
+          <option value=""${selected === "" ? " selected" : ""}>Custom end time (multi-day)</option>
+        </select>
+        <div data-duration-select-target="customFields" style="display: none;">
+          <input type="datetime-local" name="ends_at">
+        </div>
+      </div>
+    `
+  }
+
+  it("hides custom end fields when a preset duration is selected", async () => {
+    render("60")
+    await waitForController()
+
+    const fields = document.querySelector("[data-duration-select-target='customFields']") as HTMLElement
+    expect(fields.style.display).toBe("none")
+  })
+
+  it("shows custom end fields when the custom option is selected", async () => {
+    render("60")
+    await waitForController()
+
+    const select = document.querySelector("select") as HTMLSelectElement
+    select.value = ""
+    select.dispatchEvent(new Event("change"))
+
+    const fields = document.querySelector("[data-duration-select-target='customFields']") as HTMLElement
+    expect(fields.style.display).toBe("")
+  })
+
+  it("shows custom end fields on connect if custom is preselected", async () => {
+    render("")
+    await waitForController()
+
+    const fields = document.querySelector("[data-duration-select-target='customFields']") as HTMLElement
+    expect(fields.style.display).toBe("")
+  })
+})

--- a/app/javascript/controllers/duration_select_controller.ts
+++ b/app/javascript/controllers/duration_select_controller.ts
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Duration select with a "Custom end time" escape hatch (empty option value).
+// Preset durations let the server derive ends_at from starts_at +
+// duration_minutes; picking the custom option reveals an explicit ends_at
+// datetime input, which the server uses when duration_minutes is blank.
+// This is what makes multi-day events creatable from the form.
+export default class DurationSelectController extends Controller {
+  static targets = ["select", "customFields"]
+
+  declare readonly selectTarget: HTMLSelectElement
+  declare readonly customFieldsTarget: HTMLElement
+
+  connect(): void {
+    this.toggle()
+  }
+
+  toggle(): void {
+    const custom = this.selectTarget.value === ""
+    this.customFieldsTarget.style.display = custom ? "" : "none"
+  }
+}

--- a/app/javascript/controllers/index.ts
+++ b/app/javascript/controllers/index.ts
@@ -82,6 +82,7 @@ import SummaryToggleController from "./summary_toggle_controller"
 import CommitmentSubtypeController from "./commitment_subtype_controller"
 import DecisionSubtypeController from "./decision_subtype_controller"
 import DialogController from "./dialog_controller"
+import DurationSelectController from "./duration_select_controller"
 import TabsController from "./tabs_controller"
 import WebhookTestController from "./webhook_test_controller"
 import WebPushController from "./web_push_controller"
@@ -103,6 +104,7 @@ application.register("cooldown-button", CooldownButtonController)
 application.register("countdown", CountdownController)
 application.register("datetime-input", DatetimeInputController)
 application.register("deadline-options", DeadlineOptionsController)
+application.register("duration-select", DurationSelectController)
 application.register("decision", DecisionController)
 application.register("commitment-subtype", CommitmentSubtypeController)
 application.register("decision-subtype", DecisionSubtypeController)

--- a/app/views/commitments/new.html.erb
+++ b/app/views/commitments/new.html.erb
@@ -64,23 +64,37 @@
           default_timezone: @current_collective.timezone.name,
         ) %>
       </div>
-      <div class="pulse-form-group">
-        <label class="pulse-form-label">Duration</label>
-        <%
-          duration_options = [
-            ["30 minutes", 30],
-            ["1 hour", 60],
-            ["1.5 hours", 90],
-            ["2 hours", 120],
-            ["3 hours", 180],
-            ["4 hours", 240],
-            ["8 hours", 480],
-            ["1 day", 1440],
-          ]
-        %>
-        <%= select_tag "duration_minutes",
-          options_for_select(duration_options, 60),
-          class: "pulse-form-input pulse-form-input-inline" %>
+      <div data-controller="duration-select">
+        <div class="pulse-form-group">
+          <label class="pulse-form-label">Duration</label>
+          <%
+            duration_options = [
+              ["30 minutes", 30],
+              ["1 hour", 60],
+              ["1.5 hours", 90],
+              ["2 hours", 120],
+              ["3 hours", 180],
+              ["4 hours", 240],
+              ["8 hours", 480],
+              ["1 day", 1440],
+              ["Custom end time (multi-day)", ""],
+            ]
+          %>
+          <%= select_tag "duration_minutes",
+            options_for_select(duration_options, 60),
+            class: "pulse-form-input pulse-form-input-inline",
+            data: { duration_select_target: "select", action: "change->duration-select#toggle" } %>
+        </div>
+        <div class="pulse-form-group" data-duration-select-target="customFields" style="display: none;">
+          <label class="pulse-form-label">Ends</label>
+          <%= render DatetimeInputComponent.new(
+            field_name: "ends_at",
+            timezone_field_name: "ends_at_timezone",
+            default_offset: "8d",
+            require_future: true,
+            default_timezone: @current_collective.timezone.name,
+          ) %>
+        </div>
       </div>
       <div class="pulse-form-group">
         <label class="pulse-form-label">Location <span class="pulse-form-label-optional">(optional)</span></label>

--- a/test/controllers/commitments_controller_test.rb
+++ b/test/controllers/commitments_controller_test.rb
@@ -272,6 +272,32 @@ class CommitmentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Room C", commitment.location
   end
 
+  # The "Custom end time (multi-day)" duration option submits a blank
+  # duration_minutes plus an explicit ends_at, which is how the form creates
+  # events spanning more than a day.
+  test "create multi-day calendar event with custom end time (form path)" do
+    sign_in_as(@user, tenant: @tenant)
+
+    starts = 1.week.from_now.change(min: 0, sec: 0)
+    ends = starts + 3.days
+
+    post "/collectives/#{@collective.handle}/commit", params: {
+      title: "Multi-day retreat",
+      subtype: "calendar_event",
+      critical_mass: 1,
+      starts_at: starts.strftime("%Y-%m-%dT%H:%M"),
+      starts_at_timezone: "UTC",
+      duration_minutes: "",
+      ends_at: ends.strftime("%Y-%m-%dT%H:%M"),
+      ends_at_timezone: "UTC",
+      deadline_option: "no_deadline",
+    }
+
+    commitment = Commitment.unscoped.find_by(title: "Multi-day retreat", collective: @collective)
+    assert_not_nil commitment, "Expected event to be created. Flash: #{flash.inspect}"
+    assert_in_delta 3.days.to_f, commitment.ends_at - commitment.starts_at, 1.0
+  end
+
   test "create calendar event commitment with form-shaped params" do
     sign_in_as(@user, tenant: @tenant)
 


### PR DESCRIPTION
Fixes #319

## Problem

The Commitment model and API already support arbitrary `ends_at` values (and the markdown path accepts `ends_at` directly), but the HTML create form only offered a fixed duration select capped at "1 day" — so multi-day events couldn't be created from the UI.

## Changes

- Adds a **"Custom end time (multi-day)"** option (blank value) to the duration select. Selecting it reveals an explicit "Ends" datetime input (`DatetimeInputComponent`, default one day after the default start).
- New `duration-select` Stimulus controller toggles the custom field's visibility; registered in `index.ts`.
- No server changes needed: `CommitmentsController#create` already uses `ends_at` (with its per-input timezone) when `duration_minutes` is blank, and the `ends_at > starts_at` model validation covers bad input.

## Tests

- Vitest: 3 tests for the new controller (hidden for presets, shown on custom, shown on connect when preselected).
- Rails: form-shaped controller test posting `duration_minutes: ""` + a 3-days-later `ends_at`, asserting the multi-day event is created.
- Full commitments controller suite green locally (26 runs); `tsc --noEmit` clean.