### PR TITLE
Make critical mass optional on commitments

### DIFF
--- a/app/components/feed_item_component.html.erb
+++ b/app/components/feed_item_component.html.erb
@@ -148,20 +148,28 @@
           </div>
         <% end %>
       <% else %>
-        <div class="pulse-commitment-progress">
-          <div class="pulse-progress-bar">
-            <div class="pulse-progress-fill" style="width: <%= progress_percent %>%"></div>
+        <% verb = is_policy_commitment? ? "signed" : "committed" %>
+        <% if critical_mass > 0 %>
+          <div class="pulse-commitment-progress">
+            <div class="pulse-progress-bar">
+              <div class="pulse-progress-fill" style="width: <%= progress_percent %>%"></div>
+            </div>
+            <div class="pulse-progress-label">
+              <span><%= participant_count %> of <%= critical_mass %> <%= verb %></span>
+              <% if remaining > 0 %>
+                <span><%= remaining %> more needed</span>
+              <% else %>
+                <span>Critical mass reached!</span>
+              <% end %>
+            </div>
           </div>
-          <div class="pulse-progress-label">
-            <% verb = is_policy_commitment? ? "signed" : "committed" %>
-            <span><%= participant_count %> of <%= critical_mass %> <%= verb %></span>
-            <% if remaining > 0 %>
-              <span><%= remaining %> more needed</span>
-            <% else %>
-              <span>Critical mass reached!</span>
-            <% end %>
+        <% else %>
+          <div class="pulse-commitment-progress">
+            <div class="pulse-progress-label">
+              <span><%= participant_count %> <%= verb %></span>
+            </div>
           </div>
-        </div>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/components/feed_item_component.rb
+++ b/app/components/feed_item_component.rb
@@ -240,7 +240,8 @@ class FeedItemComponent < ViewComponent::Base
   def critical_mass
     return 0 unless @item.is_a?(Commitment)
 
-    T.must(@item.critical_mass)
+    # 0 stands in for "no critical mass" — the template branches on > 0.
+    @item.critical_mass || 0
   end
 
   sig { returns(Integer) }

--- a/app/controllers/commitments_controller.rb
+++ b/app/controllers/commitments_controller.rb
@@ -260,11 +260,15 @@ class CommitmentsController < ApplicationController
     return render "404", status: :not_found unless @commitment
     return render "shared/403", status: :forbidden unless @commitment.can_edit_settings?(@current_user)
 
-    # Check for lowering critical mass
-    if model_params[:critical_mass].present?
-      cm_is_lower = model_params[:critical_mass].to_i < @commitment.critical_mass.to_i
-      if cm_is_lower && @commitment.participant_count > 0
-        flash[:alert] = "You cannot lower the critical mass after participants have joined."
+    # Check for lowering/removing critical mass. Clearing the field counts as
+    # lowering — a critical-mass rule can't be removed once people joined
+    # under it.
+    if @commitment.participant_count > 0
+      cm_param = model_params[:critical_mass]
+      clearing = cm_param == "" && @commitment.has_critical_mass?
+      lowering = cm_param.present? && cm_param.to_i < @commitment.critical_mass.to_i
+      if clearing || lowering
+        flash[:alert] = "You cannot lower or remove the critical mass after participants have joined."
         redirect_to @commitment.path
         return
       end
@@ -297,7 +301,7 @@ class CommitmentsController < ApplicationController
     end
     @commitment = api_helper(params: helper_params).update_commitment_settings
     # Handle close_at_critical_mass option (HTML form specific)
-    if params[:deadline_option] == "close_at_critical_mass"
+    if params[:deadline_option] == "close_at_critical_mass" && @commitment.has_critical_mass?
       @commitment.limit = @commitment.critical_mass
       @commitment.close_if_limit_reached
       @commitment.save!

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -28,7 +28,11 @@ class Commitment < ApplicationRecord
   has_many :participants, class_name: "CommitmentParticipant", dependent: :destroy
   validates :title, presence: true, length: { maximum: MAX_TITLE_LENGTH }
   validates :description, length: { maximum: MAX_DESCRIPTION_LENGTH }
-  validates :critical_mass, presence: true, numericality: { greater_than: 0 }
+  # Optional: critical mass is not relevant to every commitment (a task
+  # someone just needs to do, an event happening regardless of RSVPs, a
+  # policy in effect regardless of signatories). nil means "no critical
+  # mass" — the commitment simply collects participants.
+  validates :critical_mass, numericality: { greater_than: 0 }, allow_nil: true
   validates :deadline, presence: true
   validates :subtype, inclusion: { in: SUBTYPES }
   validates :starts_at, presence: true, if: :is_calendar_event?
@@ -186,8 +190,17 @@ class Commitment < ApplicationRecord
     ""
   end
 
+  sig { returns(T::Boolean) }
+  def has_critical_mass?
+    !critical_mass.nil?
+  end
+
   sig { returns(String) }
   def status_message
+    unless has_critical_mass?
+      return closed? ? "Closed." : "Open"
+    end
+
     # critical mass achieved
     return "Critical mass achieved." if critical_mass_achieved?
     # critical mass not achieved
@@ -227,12 +240,18 @@ class Commitment < ApplicationRecord
 
   sig { returns(Integer) }
   def remaining_needed_for_critical_mass
-    [T.must(critical_mass) - participant_count, 0].max
+    cm = critical_mass
+    return 0 unless cm
+
+    [cm - participant_count, 0].max
   end
 
   sig { returns(T::Boolean) }
   def critical_mass_achieved?
-    participant_count >= T.must(critical_mass)
+    cm = critical_mass
+    return false unless cm
+
+    participant_count >= cm
   end
 
   sig { returns(T::Boolean) }
@@ -242,7 +261,9 @@ class Commitment < ApplicationRecord
 
   sig { returns(T::Boolean) }
   def close_at_critical_mass?
-    limit == critical_mass
+    # The nil-guard matters: with no critical mass and no limit, nil == nil
+    # must not read as "closes at critical mass".
+    !!(critical_mass && limit == critical_mass)
   end
 
   sig { returns(T::Boolean) }
@@ -288,6 +309,7 @@ class Commitment < ApplicationRecord
   sig { returns(Integer) }
   def progress_percentage
     return 100 if critical_mass_achieved?
+    return 0 unless has_critical_mass?
 
     [(participant_count.to_f / critical_mass.to_f * 100).round, 100].min
   end

--- a/app/services/actions_helper.rb
+++ b/app/services/actions_helper.rb
@@ -467,12 +467,12 @@ class ActionsHelper
     # Commitment actions
     "create_commitment" => {
       description: "Create a new commitment (action, calendar_event, or policy)",
-      params_string: "(title, description, critical_mass, [deadline, subtype, starts_at, ends_at, location])",
+      params_string: "(title, description, [critical_mass, deadline, subtype, starts_at, ends_at, location])",
       params: [
         { name: "title", type: "string", description: "The title of the commitment" },
         { name: "description", type: "string", description: "Additional context for the commitment" },
-        { name: "critical_mass", type: "integer",
-          description: "Minimum participants/attendees/signatories needed for the commitment to take effect", },
+        { name: "critical_mass", type: "integer", required: false,
+          description: "Minimum participants/attendees/signatories needed for the commitment to take effect. Optional — omit when a minimum isn't relevant.", },
         { name: "deadline", type: "datetime", required: false,
           description: "When the commitment closes (RSVP deadline for calendar events). Optional — omit it to close manually; for calendar events it defaults to the event start. Accepts ISO 8601, a Unix timestamp, or relative time like 7d, 3h, or 1w.", },
         { name: "subtype", type: "string", required: false,
@@ -495,7 +495,7 @@ class ActionsHelper
         { name: "description", type: "string", required: false,
           description: "Additional context for the commitment", },
         { name: "critical_mass", type: "integer", required: false,
-          description: "Minimum participants/attendees/signatories needed for the commitment to take effect", },
+          description: "Minimum participants/attendees/signatories needed for the commitment to take effect. Pass 'none' to remove (only while no one has joined).", },
         { name: "deadline", type: "datetime", required: false,
           description: "When the commitment closes (RSVP deadline for calendar events). Accepts ISO 8601, a Unix timestamp, or relative time like 7d, 3h, or 1w.", },
         { name: "starts_at", type: "datetime", required: false,

--- a/app/services/api_helper.rb
+++ b/app/services/api_helper.rb
@@ -238,8 +238,8 @@ class ApiHelper
         attrs[:deadline] = subtype == "calendar_event" ? attrs[:starts_at].presence || 100.years.from_now : 100.years.from_now
       end
       commitment = Commitment.create!(attrs)
-      # Handle close_at_critical_mass option
-      if [true, "true"].include?(params[:close_at_critical_mass])
+      # Handle close_at_critical_mass option (meaningless without a critical mass)
+      if [true, "true"].include?(params[:close_at_critical_mass]) && commitment.has_critical_mass?
         commitment.limit = commitment.critical_mass
         commitment.save!
       end
@@ -1195,13 +1195,24 @@ class ApiHelper
       commitment.title = params[:title] if params[:title].present?
       commitment.description = params[:description] if params[:description].present?
 
-      if params[:critical_mass].present? && !current_collective.private_workspace?
-        new_cm = params[:critical_mass].to_i
-        if new_cm < commitment.critical_mass.to_i && commitment.participant_count > 0
-          raise "Cannot lower critical mass after participants have joined"
-        end
+      unless current_collective.private_workspace?
+        cm_param = params[:critical_mass]
+        if cm_param.to_s == "none" || (params.key?(:critical_mass) && cm_param == "")
+          # Clearing counts as lowering: once participants have joined under a
+          # critical-mass rule, it can't be removed out from under them.
+          if commitment.has_critical_mass? && commitment.participant_count > 0
+            raise "Cannot remove critical mass after participants have joined"
+          end
 
-        commitment.critical_mass = new_cm
+          commitment.critical_mass = nil
+        elsif cm_param.present?
+          new_cm = cm_param.to_i
+          if new_cm < commitment.critical_mass.to_i && commitment.participant_count > 0
+            raise "Cannot lower critical mass after participants have joined"
+          end
+
+          commitment.critical_mass = new_cm
+        end
       end
 
       commitment.deadline = parse_datetime_param(params[:deadline]) if params[:deadline].present?

--- a/app/views/commitments/_status.html.erb
+++ b/app/views/commitments/_status.html.erb
@@ -1,13 +1,21 @@
-<div class="pulse-participation-progress">
-  <div class="pulse-progress-bar">
-    <% bar_class = (@commitment.closed? && !@commitment.critical_mass_achieved?) ? 'pulse-progress-fill-inactive' : '' %>
-    <div class="pulse-progress-fill <%= bar_class %>" style="width: <%= [@commitment.progress_percentage, 100].min %>%"></div>
+<% if @commitment.has_critical_mass? %>
+  <div class="pulse-participation-progress">
+    <div class="pulse-progress-bar">
+      <% bar_class = (@commitment.closed? && !@commitment.critical_mass_achieved?) ? 'pulse-progress-fill-inactive' : '' %>
+      <div class="pulse-progress-fill <%= bar_class %>" style="width: <%= [@commitment.progress_percentage, 100].min %>%"></div>
+    </div>
+    <div class="pulse-progress-label">
+      <span><%= @commitment.participant_count %> of <%= @commitment.critical_mass %> <%= @commitment.metric_name %> needed</span>
+      <span><%= @commitment.progress_percentage.round %>%</span>
+    </div>
   </div>
-  <div class="pulse-progress-label">
-    <span><%= @commitment.participant_count %> of <%= @commitment.critical_mass %> <%= @commitment.metric_name %> needed</span>
-    <span><%= @commitment.progress_percentage.round %>%</span>
+  <% if @commitment.critical_mass_achieved? %>
+    <p class="pulse-critical-mass-achieved">Critical mass achieved!</p>
+  <% end %>
+<% else %>
+  <div class="pulse-participation-progress">
+    <div class="pulse-progress-label">
+      <span><%= @commitment.participant_count %> <%= @commitment.metric_name %></span>
+    </div>
   </div>
-</div>
-<% if @commitment.critical_mass_achieved? %>
-  <p class="pulse-critical-mass-achieved">Critical mass achieved!</p>
 <% end %>

--- a/app/views/commitments/new.html.erb
+++ b/app/views/commitments/new.html.erb
@@ -127,9 +127,10 @@
         <div class="pulse-form-group">
           <div class="pulse-inline-field">
             <span>At least</span>
-            <%= form.number_field :critical_mass, value: 1, min: 1, class: 'pulse-form-input pulse-form-input-narrow' %>
+            <%= form.number_field :critical_mass, value: nil, min: 1, class: 'pulse-form-input pulse-form-input-narrow' %>
             <span data-commitment-subtype-target="criticalMassSuffix"><%= critical_mass_suffix %></span>
           </div>
+          <p class="pulse-form-hint">Optional — leave blank if a minimum isn't relevant.</p>
         </div>
       <% end %>
     </section>

--- a/app/views/commitments/new.md.erb
+++ b/app/views/commitments/new.md.erb
@@ -10,8 +10,8 @@ All subtypes require:
 
 * A `title` describing the commitment.
 * An optional `description` (markdown).
-* A `critical_mass` (minimum participants) required for the commitment to take effect.
-* A `deadline` by which critical mass must be reached.
+* An optional `critical_mass` (minimum participants) required for the commitment to take effect. Omit it when a minimum isn't relevant.
+* A `deadline` by which the commitment closes (and by which critical mass, if set, must be reached).
 
 <% if @current_collective.id == @current_tenant.main_collective_id %>
 **Visibility:** This commitment will be publicly visible.

--- a/app/views/commitments/settings.html.erb
+++ b/app/views/commitments/settings.html.erb
@@ -75,19 +75,25 @@
       <section class="pulse-settings-section">
         <h2 class="pulse-section-title">Critical Mass</h2>
         <div class="pulse-notice">
-          <p>
-            <% if @commitment.participant_count > 0 %>
-              <strong>Lowering</strong> critical mass is no longer allowed because the current participant count (<%= @commitment.participant_count %>) is greater than zero.
-            <% else %>
-              <strong>Lowering</strong> critical mass below <%= @commitment.critical_mass %> is only allowed if the current participant count is zero.
-            <% end %>
-          </p>
-          <p>
-            <strong>Raising</strong> critical mass is always allowed but <strong>cannot be undone</strong> if the participant count is above zero.
-          </p>
+          <% if @commitment.has_critical_mass? %>
+            <p>
+              <% if @commitment.participant_count > 0 %>
+                <strong>Lowering or removing</strong> critical mass is no longer allowed because the current participant count (<%= @commitment.participant_count %>) is greater than zero.
+              <% else %>
+                <strong>Lowering</strong> critical mass below <%= @commitment.critical_mass %> — or removing it by leaving the field blank — is only allowed if the current participant count is zero.
+              <% end %>
+            </p>
+            <p>
+              <strong>Raising</strong> critical mass is always allowed but <strong>cannot be undone</strong> if the participant count is above zero.
+            </p>
+          <% else %>
+            <p>
+              This commitment has <strong>no critical mass</strong> — it takes effect regardless of how many join. Enter a number to require a minimum.
+            </p>
+          <% end %>
         </div>
         <p class="pulse-form-row">
-          At least <%= form.number_field :critical_mass, value: @commitment.critical_mass, class: "pulse-form-input", style: 'width:64px;' %> participant(s) required for this commitment to take effect.
+          At least <%= form.number_field :critical_mass, value: @commitment.critical_mass, min: 1, class: "pulse-form-input", style: 'width:64px;' %> participant(s) required for this commitment to take effect.
         </p>
       </section>
       <% end %>

--- a/app/views/commitments/settings.md.erb
+++ b/app/views/commitments/settings.md.erb
@@ -15,7 +15,7 @@ Current settings for <%= type_label.downcase %> **<%= @commitment.title %>**:
 |---------|-------|
 | Title | <%= @commitment.title %> |
 | Description | <%= @commitment.description || "(none)" %> |
-| Critical Mass | <%= @commitment.critical_mass %> |
+| Critical Mass | <%= @commitment.critical_mass || "(none)" %> |
 | Deadline | <%= @commitment.deadline %> |
 <% if @commitment.is_calendar_event? %>
 | Starts at | <%= @commitment.starts_at %> |

--- a/app/views/commitments/show.md.erb
+++ b/app/views/commitments/show.md.erb
@@ -48,15 +48,19 @@ This commitment has been deleted<%= " by the author" if @commitment.deleted_by_i
 
 ## Status
 
+<% noun = @commitment.metric_name.singularize -%>
+<% if @commitment.has_critical_mass? -%>
 Progress bar: `<%= '#' * (@commitment.progress_percentage / 2) %><%= '_' * ((100 - @commitment.progress_percentage) / 2) %>` <%= @commitment.progress_percentage %>%
 
-<% noun = @commitment.metric_name.singularize -%>
 __<%= @commitment.participant_count %>__ of __<%= @commitment.critical_mass %>__ <%= noun.pluralize(@commitment.critical_mass) %> needed to reach critical mass.
 <% unless @commitment.critical_mass_achieved? -%>
 __<%= @commitment.remaining_needed_for_critical_mass %>__ more <%= noun.pluralize(@commitment.remaining_needed_for_critical_mass) %> needed.
 <% end -%>
 <% if @commitment.critical_mass_achieved? -%>
 Critical mass achieved! 🎉
+<% end -%>
+<% else -%>
+__<%= @commitment.participant_count %>__ <%= noun.pluralize(@commitment.participant_count) %>. No critical mass required.
 <% end -%>
 
 ## <%= @commitment.metric_name.capitalize %>

--- a/app/views/pulse/_feed_item_commitment.html.erb
+++ b/app/views/pulse/_feed_item_commitment.html.erb
@@ -1,19 +1,29 @@
 <%
   participant_count = item.participant_count
   critical_mass = item.critical_mass
-  progress_percent = [(participant_count.to_f / critical_mass * 100).to_i, 100].min
-  remaining = [critical_mass - participant_count, 0].max
 %>
-<div class="pulse-commitment-progress">
-  <div class="pulse-progress-bar">
-    <div class="pulse-progress-fill" style="width: <%= progress_percent %>%"></div>
+<% if critical_mass %>
+  <%
+    progress_percent = [(participant_count.to_f / critical_mass * 100).to_i, 100].min
+    remaining = [critical_mass - participant_count, 0].max
+  %>
+  <div class="pulse-commitment-progress">
+    <div class="pulse-progress-bar">
+      <div class="pulse-progress-fill" style="width: <%= progress_percent %>%"></div>
+    </div>
+    <div class="pulse-progress-label">
+      <span><%= participant_count %> of <%= critical_mass %> committed</span>
+      <% if remaining > 0 %>
+        <span><%= remaining %> more needed</span>
+      <% else %>
+        <span>Critical mass reached!</span>
+      <% end %>
+    </div>
   </div>
-  <div class="pulse-progress-label">
-    <span><%= participant_count %> of <%= critical_mass %> committed</span>
-    <% if remaining > 0 %>
-      <span><%= remaining %> more needed</span>
-    <% else %>
-      <span>Critical mass reached!</span>
-    <% end %>
+<% else %>
+  <div class="pulse-commitment-progress">
+    <div class="pulse-progress-label">
+      <span><%= participant_count %> committed</span>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/shared/_automation_yaml_reference.html.erb
+++ b/app/views/shared/_automation_yaml_reference.html.erb
@@ -178,7 +178,7 @@ actions:
     params:
       title: "Follow up on {{subject.title}}"
       description: "Auto-generated"  # Optional
-      critical_mass: 3               # Optional (default: 1)
+      critical_mass: 3               # Optional (default: none — no minimum)
       deadline: "2024-12-31"         # Optional
       limit: 10                      # Optional max participants</code></pre>
 

--- a/app/views/shared/_automation_yaml_reference.md.erb
+++ b/app/views/shared/_automation_yaml_reference.md.erb
@@ -191,7 +191,7 @@ actions:
     params:
       title: "Follow up on {{subject.title}}"
       description: "Auto-generated"  # Optional
-      critical_mass: 3               # Optional (default: 1)
+      critical_mass: 3               # Optional (default: none — no minimum)
       deadline: "2024-12-31"         # Optional
       limit: 10                      # Optional max participants
 ```

--- a/test/controllers/commitments_controller_test.rb
+++ b/test/controllers/commitments_controller_test.rb
@@ -217,6 +217,48 @@ class CommitmentsControllerTest < ActionDispatch::IntegrationTest
     assert_nil @commitment.starts_at
   end
 
+  # === Optional Critical Mass ===
+
+  test "create commitment without critical mass (blank form field)" do
+    sign_in_as(@user, tenant: @tenant)
+
+    post "/collectives/#{@collective.handle}/commit", params: {
+      title: "Just a task",
+      description: "No minimum needed.",
+      critical_mass: "",
+      subtype: "action",
+      deadline_option: "no_deadline",
+    }
+
+    commitment = Commitment.unscoped.find_by(title: "Just a task", collective: @collective)
+    assert_not_nil commitment, "Expected commitment to be created. Flash: #{flash.inspect}"
+    assert_nil commitment.critical_mass
+  end
+
+  test "creator can remove critical mass while no one has joined" do
+    sign_in_as(@user, tenant: @tenant)
+
+    post "/collectives/#{@collective.handle}/c/#{@commitment.truncated_id}/settings", params: {
+      critical_mass: "",
+    }
+
+    assert_redirected_to @commitment.path
+    assert_nil @commitment.reload.critical_mass
+  end
+
+  test "creator cannot remove critical mass after participants have joined" do
+    sign_in_as(@user, tenant: @tenant)
+    @commitment.join_commitment!(@user)
+
+    post "/collectives/#{@collective.handle}/c/#{@commitment.truncated_id}/settings", params: {
+      critical_mass: "",
+    }
+
+    assert_redirected_to @commitment.path
+    assert flash[:alert].present?
+    assert_equal 5, @commitment.reload.critical_mass
+  end
+
   # === Join Tests ===
 
   test "user can join commitment" do

--- a/test/models/commitment_test.rb
+++ b/test/models/commitment_test.rb
@@ -512,7 +512,7 @@ class CommitmentTest < ActiveSupport::TestCase
   # instead of "join", and the metric is "signatories" instead of
   # "participants".
 
-  test "Policy commitment requires deadline and critical_mass like actions" do
+  test "Policy commitment requires deadline like actions (critical_mass optional)" do
     tenant = create_tenant
     user = create_user
     collective = create_collective(tenant: tenant, created_by: user)
@@ -528,7 +528,7 @@ class CommitmentTest < ActiveSupport::TestCase
 
     assert_not commitment.valid?
     assert_includes commitment.errors[:deadline], "can't be blank"
-    assert_includes commitment.errors[:critical_mass], "can't be blank"
+    assert_empty commitment.errors[:critical_mass]
   end
 
   test "Policy commitment closes when deadline passes" do
@@ -730,5 +730,49 @@ class CommitmentTest < ActiveSupport::TestCase
     assert_equal "Room A", json[:location]
     assert json[:starts_at].present?
     assert json[:ends_at].present?
+  end
+
+  # === Optional critical mass ===
+
+  test "Commitment is valid without a critical mass" do
+    tenant = create_tenant
+    user = create_user
+    collective = create_collective(tenant: tenant, created_by: user)
+
+    commitment = Commitment.create!(
+      tenant: tenant, collective: collective, created_by: user, updated_by: user,
+      title: "No minimum needed",
+      deadline: 1.week.from_now
+    )
+
+    assert commitment.persisted?
+    assert_nil commitment.critical_mass
+    assert_not commitment.has_critical_mass?
+  end
+
+  test "critical mass semantics with no critical mass set" do
+    tenant = create_tenant
+    user = create_user
+    collective = create_collective(tenant: tenant, created_by: user)
+
+    commitment = Commitment.create!(
+      tenant: tenant, collective: collective, created_by: user, updated_by: user,
+      title: "No minimum needed",
+      deadline: 1.week.from_now
+    )
+
+    assert_not commitment.critical_mass_achieved?
+    assert_equal 0, commitment.remaining_needed_for_critical_mass
+    assert_equal 0, commitment.progress_percentage
+    # nil limit == nil critical_mass must not read as "closes at critical mass"
+    assert_not commitment.close_at_critical_mass?
+    assert_equal "Open", commitment.status_message
+
+    commitment.join_commitment!(user)
+    assert_equal 1, commitment.participant_count
+    assert_not commitment.critical_mass_achieved?
+
+    commitment.deadline = 1.minute.ago
+    assert_equal "Closed.", commitment.status_message
   end
 end


### PR DESCRIPTION
Fixes #328

## Semantics

`critical_mass` may now be `nil`, meaning "no minimum" — the commitment simply collects participants and takes effect regardless of how many join. With no critical mass:

- `critical_mass_achieved?` is false, `remaining_needed_for_critical_mass` and `progress_percentage` are 0, and `status_message` is just Open/Closed.
- `close_at_critical_mass?` is explicitly guarded so `nil limit == nil critical_mass` doesn't read as "closes at critical mass".
- The `commitment.critical_mass` event never fires (`committed_count == nil` is never true — no change needed there).

## UI

- **Create form**: the field now defaults to blank with an "Optional — leave blank if a minimum isn't relevant" hint (private workspaces still pin it to 1 server-side).
- **Settings**: leaving the field blank removes the critical mass. Removal counts as lowering, so it's blocked once participants have joined — enforced both in the HTML pre-check and in `ApiHelper#update_commitment_settings` (agents/API can also pass `critical_mass: none`).
- **Status partial, feed cards (`FeedItemComponent`, pulse feed partial), markdown show view**: display a plain participant count instead of "X of Y needed" when no critical mass is set. These previously crashed on nil (`T.must`, division by nil).
- The "close at critical mass" deadline option is ignored when there's no critical mass (create + settings).
- Action definitions and automation YAML reference updated ("default: 1" there was stale — omitting critical_mass previously failed validation).

## Not changed

- The `critical-mass-achieved:` search filter keeps its existing participant-count heuristic (it has a standing TODO); nil-CM commitments match neither `true` nor `false`, same as any commitment with 0 participants before.
- Private-workspace commitments still get critical_mass 1 at create.

## Tests

New model tests (valid without CM, nil-CM semantics incl. the `close_at_critical_mass?` nil-guard) and controller tests (create with blank field, remove via settings, removal blocked after join). Updated one policy test that asserted the old presence validation. Ran commitment model + controller suites, markdown UI, private workspace, and feed component integration suites locally (289 runs total, 0 failures); `srb tc` clean.