### PR TITLE
Keep upcoming calendar events in the feed's cycle window

### DIFF
--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -53,6 +53,8 @@ class SearchIndexer
       created_at: @item.created_at,
       updated_at: @item.updated_at,
       deadline: deadline,
+      starts_at: @item.is_a?(Commitment) ? @item.starts_at : nil,
+      ends_at: @item.is_a?(Commitment) ? @item.ends_at : nil,
       created_by_id: @item.created_by_id,
       updated_by_id: @item.updated_by_id,
       link_count: link_count,

--- a/app/services/search_query.rb
+++ b/app/services/search_query.rb
@@ -894,10 +894,17 @@ class SearchQuery
     return if cycle_obj.blank?
 
     # Match the pattern from Cycle#resources:
-    # created_at < end_date AND deadline > start_date
+    # created_at < end_date AND deadline > start_date.
+    # Calendar events additionally stay in the window until the event itself
+    # has ended: their deadline is the RSVP cutoff, which can pass long
+    # before the event happens, and an upcoming event shouldn't vanish from
+    # the feed (#320). ends_at is only populated for calendar events.
     @relation = T.must(@relation)
       .where(search_index: { created_at: ...cycle_obj.end_date })
-      .where("search_index.deadline > ?", cycle_obj.start_date)
+      .where(
+        "search_index.deadline > :cycle_start OR search_index.ends_at > :cycle_start",
+        cycle_start: cycle_obj.start_date
+      )
   end
 
   sig { void }

--- a/db/migrate/20260704000000_add_event_times_to_search_index.rb
+++ b/db/migrate/20260704000000_add_event_times_to_search_index.rb
@@ -1,0 +1,24 @@
+# typed: false
+
+class AddEventTimesToSearchIndex < ActiveRecord::Migration[7.2]
+  def up
+    add_column :search_index, :starts_at, :timestamp
+    add_column :search_index, :ends_at, :timestamp
+
+    # Backfill calendar-event rows from their commitments so existing events
+    # get the widened feed window without waiting for a full reindex.
+    execute <<-SQL.squish
+      UPDATE search_index si
+      SET starts_at = c.starts_at, ends_at = c.ends_at
+      FROM commitments c
+      WHERE si.item_type = 'Commitment'
+        AND si.item_id = c.id
+        AND c.subtype = 'calendar_event'
+    SQL
+  end
+
+  def down
+    remove_column :search_index, :starts_at
+    remove_column :search_index, :ends_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1172,7 +1172,9 @@ CREATE TABLE public.search_index (
     is_pinned boolean DEFAULT false,
     sort_key bigint NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 )
 PARTITION BY HASH (tenant_id);
 
@@ -1225,7 +1227,9 @@ CREATE TABLE public.search_index_p0 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1258,7 +1262,9 @@ CREATE TABLE public.search_index_p1 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1291,7 +1297,9 @@ CREATE TABLE public.search_index_p10 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1324,7 +1332,9 @@ CREATE TABLE public.search_index_p11 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1357,7 +1367,9 @@ CREATE TABLE public.search_index_p12 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1390,7 +1402,9 @@ CREATE TABLE public.search_index_p13 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1423,7 +1437,9 @@ CREATE TABLE public.search_index_p14 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1456,7 +1472,9 @@ CREATE TABLE public.search_index_p15 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1489,7 +1507,9 @@ CREATE TABLE public.search_index_p2 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1522,7 +1542,9 @@ CREATE TABLE public.search_index_p3 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1555,7 +1577,9 @@ CREATE TABLE public.search_index_p4 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1588,7 +1612,9 @@ CREATE TABLE public.search_index_p5 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1621,7 +1647,9 @@ CREATE TABLE public.search_index_p6 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1654,7 +1682,9 @@ CREATE TABLE public.search_index_p7 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1687,7 +1717,9 @@ CREATE TABLE public.search_index_p8 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -1720,7 +1752,9 @@ CREATE TABLE public.search_index_p9 (
     is_pinned boolean DEFAULT false,
     sort_key bigint DEFAULT nextval('public.search_index_sort_key_seq'::regclass) NOT NULL,
     subtype character varying,
-    replying_to_id uuid
+    replying_to_id uuid,
+    starts_at timestamp without time zone,
+    ends_at timestamp without time zone
 );
 
 
@@ -10314,6 +10348,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260705220000'),
 ('20260705182920'),
+('20260704000000'),
 ('20260703120000'),
 ('20260702010000'),
 ('20260702000000'),

--- a/test/services/search_indexer_test.rb
+++ b/test/services/search_indexer_test.rb
@@ -53,6 +53,24 @@ class SearchIndexerTest < ActiveSupport::TestCase
     assert_equal commitment.title, search_index.title
     assert_equal commitment.description, search_index.body
     assert_equal commitment.truncated_id, search_index.truncated_id
+    assert_nil search_index.starts_at
+    assert_nil search_index.ends_at
+  end
+
+  test "reindex records event times for calendar events" do
+    starts = 3.days.from_now
+    event = Commitment.create!(
+      tenant: @tenant, collective: @collective, created_by: @user,
+      title: "Team offsite", subtype: "calendar_event",
+      critical_mass: 1,
+      deadline: starts, starts_at: starts, ends_at: starts + 2.hours
+    )
+
+    SearchIndexer.reindex(event)
+
+    search_index = SearchIndex.find_by(item_type: "Commitment", item_id: event.id)
+    assert_in_delta starts.to_f, search_index.starts_at.to_f, 1.0
+    assert_in_delta (starts + 2.hours).to_f, search_index.ends_at.to_f, 1.0
   end
 
   test "reindex creates search index for comments with subtype and replying_to_id" do

--- a/test/services/search_query_test.rb
+++ b/test/services/search_query_test.rb
@@ -1393,4 +1393,42 @@ class SearchQueryTest < ActiveSupport::TestCase
       file: blob, created_by: @user, updated_by: @user
     )
   end
+
+  # === Cycle window vs calendar events (issue #320) ===
+
+  test "upcoming calendar event stays in the cycle window after its RSVP deadline passes" do
+    event = Commitment.create!(
+      tenant: @tenant, collective: @collective, created_by: @user,
+      title: "Upcoming retreat", subtype: "calendar_event",
+      critical_mass: 1,
+      deadline: 2.weeks.ago, # RSVP cutoff already passed
+      starts_at: 3.days.from_now, ends_at: 3.days.from_now + 2.hours
+    )
+    SearchIndexer.reindex(event)
+
+    search = SearchQuery.new(
+      tenant: @tenant, collective: @collective, current_user: @user,
+      raw_query: "cycle:this-week"
+    )
+
+    ids = search.results.map(&:item_id)
+    assert_includes ids, event.id, "event with passed RSVP deadline but future ends_at should stay in the feed window"
+  end
+
+  test "standard commitment whose deadline passed before the cycle drops out of the window" do
+    stale = Commitment.create!(
+      tenant: @tenant, collective: @collective, created_by: @user,
+      title: "Old closed commitment", critical_mass: 1,
+      deadline: 2.weeks.ago
+    )
+    SearchIndexer.reindex(stale)
+
+    search = SearchQuery.new(
+      tenant: @tenant, collective: @collective, current_user: @user,
+      raw_query: "cycle:this-week"
+    )
+
+    ids = search.results.map(&:item_id)
+    assert_not_includes ids, stale.id
+  end
 end


### PR DESCRIPTION
Fixes #320

## Diagnosis

The main collective feed (`pulse#feed`) is search-backed with a default `cycle:this-week` window, applied in `SearchQuery#apply_time_window` as `created_at < cycle_end AND deadline > cycle_start` for every item type. For calendar events the `deadline` is the **RSVP cutoff**, which can pass long before the event happens. Once the cutoff fell before the current cycle's start, the still-upcoming event dropped out of the feed entirely — reachable only via search (`cycle:all`) or direct URL, exactly as reported.

The dashboard side already special-cases this (`Cycle#commitments` buckets calendar events by `starts_at`); the search-backed feed had no equivalent because the search index didn't carry event times.

## Changes

- **Migration**: adds `starts_at`/`ends_at` to `search_index`, and backfills both columns for existing calendar-event rows inline (so the fix applies on deploy without a full reindex).
- **SearchIndexer**: writes `starts_at`/`ends_at` for commitments (nil for notes/decisions and non-event commitments).
- **SearchQuery#apply_time_window**: the window becomes `created_at < cycle_end AND (deadline > cycle_start OR ends_at > cycle_start)` — an event stays in the feed until it has actually ended. Since `ends_at` is only populated for calendar events, other types keep the exact old behavior.

## Not changed (possible follow-up)

The `status:open/closed` search filter still keys off `deadline` alone, so an upcoming event whose RSVP closed counts as "closed". If you want `open` to mean "not yet ended" for events, that's a small follow-up on the same columns.

## Tests

- SearchQuery: an upcoming event with a passed RSVP deadline stays in `cycle:this-week`; a standard commitment whose deadline passed before the cycle still drops out.
- SearchIndexer: event times recorded for calendar events, nil otherwise.
- Full search query + indexer suites green locally (87 runs); `srb tc` clean.