### PR TITLE
Notify attendees when a calendar event is about to start

### DIFF
--- a/app/jobs/calendar_event_starting_job.rb
+++ b/app/jobs/calendar_event_starting_job.rb
@@ -1,69 +1,111 @@
 # typed: true
 # frozen_string_literal: true
 
-# CalendarEventStartingJob fires a commitment.starting event shortly before a
-# calendar event's start time, so attendees get a heads-up notification (see
-# NotificationDispatcher#handle_commitment_starting_event). It runs every
-# minute via sidekiq-cron and mirrors DeadlineEventJob: query across all
-# tenants, mark fired before dispatching so a failure can't re-fire.
+# CalendarEventStartingJob fires the two start-related events for calendar
+# events, so attendees get notified both ahead of time and at the moment the
+# event begins (see NotificationDispatcher#handle_commitment_starting_soon_event
+# and #handle_commitment_starting_event):
+#
+#   - commitment.starting_soon — a heads-up LEAD_TIME before starts_at
+#   - commitment.starting      — when starts_at is reached
+#
+# It runs every minute via sidekiq-cron and mirrors DeadlineEventJob: query
+# across all tenants, mark fired before dispatching so a failure can't re-fire.
 class CalendarEventStartingJob < SystemJob
   extend T::Sig
 
   queue_as :default
 
   MAX_PER_RUN = 100
-  # How far before starts_at the heads-up fires.
+  # How far before starts_at the "starting soon" heads-up fires.
   LEAD_TIME = 1.hour
+  # How long after starts_at we'll still fire the "starting" event. Keeps the
+  # backlog of long-running events that were already underway at deploy time
+  # (or when the job was down) from firing a stale "starting now" blast; the
+  # minutely cadence means a few minutes of slack is plenty for the normal case.
+  STARTED_GRACE = 5.minutes
 
   sig { void }
   def perform
-    # The ends_at guard keeps already-finished events (including the backlog
-    # of events that predate this job) from firing on deploy.
-    commitments = Commitment.unscoped_for_system_job
-      .where(subtype: "calendar_event")
-      .where(deleted_at: nil)
-      .where(starting_event_fired_at: nil)
-      .where(starts_at: ...(Time.current + LEAD_TIME))
-      .where("ends_at > ?", Time.current)
-      .includes(:tenant, :collective, :created_by)
-      .limit(MAX_PER_RUN)
-      .order(:starts_at)
+    now = Time.current
+    soon_count = process(scope_starting_soon(now), "commitment.starting_soon", :starting_soon_event_fired_at)
+    starting_count = process(scope_starting(now), "commitment.starting", :starting_event_fired_at)
 
-    count = 0
-    commitments.each do |commitment|
-      fire_starting_event(commitment)
-      count += 1
-    rescue StandardError => e
-      Rails.logger.error("CalendarEventStartingJob: Failed for commitment #{commitment.id}: #{e.message}")
-    end
+    total = soon_count + starting_count
+    return unless total.positive?
 
-    return unless count.positive?
-
-    Rails.logger.info("CalendarEventStartingJob: Fired #{count} commitment.starting events")
+    Rails.logger.info(
+      "CalendarEventStartingJob: Fired #{total} start events " \
+      "(#{soon_count} starting_soon, #{starting_count} starting)"
+    )
   end
 
   private
 
-  sig { params(commitment: Commitment).void }
-  def fire_starting_event(commitment)
+  sig { params(now: ActiveSupport::TimeWithZone).returns(ActiveRecord::Relation) }
+  def scope_starting_soon(now)
+    # Future start within the lead window that hasn't ended yet. The ends_at
+    # guard keeps already-finished events (including the pre-existing backlog)
+    # from firing on deploy.
+    base_scope
+      .where(starting_soon_event_fired_at: nil)
+      .where("starts_at > ?", now)
+      .where(starts_at: ..(now + LEAD_TIME))
+      .where("ends_at > ?", now)
+      .order(:starts_at)
+  end
+
+  sig { params(now: ActiveSupport::TimeWithZone).returns(ActiveRecord::Relation) }
+  def scope_starting(now)
+    # Start time just reached (within STARTED_GRACE) and not yet ended.
+    base_scope
+      .where(starting_event_fired_at: nil)
+      .where(starts_at: (now - STARTED_GRACE)..now)
+      .where("ends_at > ?", now)
+      .order(:starts_at)
+  end
+
+  sig { returns(ActiveRecord::Relation) }
+  def base_scope
+    Commitment.unscoped_for_system_job
+      .where(subtype: "calendar_event")
+      .where(deleted_at: nil)
+      .includes(:tenant, :collective, :created_by)
+      .limit(MAX_PER_RUN)
+  end
+
+  sig { params(scope: ActiveRecord::Relation, event_type: String, column: Symbol).returns(Integer) }
+  def process(scope, event_type, column)
+    count = 0
+    scope.each do |commitment|
+      fire_event(commitment, event_type, column)
+      count += 1
+    rescue StandardError => e
+      Rails.logger.error("CalendarEventStartingJob: Failed for commitment #{commitment.id} (#{event_type}): #{e.message}")
+    end
+    count
+  end
+
+  sig { params(commitment: Commitment, event_type: String, column: Symbol).void }
+  def fire_event(commitment, event_type, column)
     tenant = commitment.tenant
     collective = commitment.collective
     unless tenant && collective
       Rails.logger.warn(
         "CalendarEventStartingJob: Skipping commitment #{commitment.id} — missing tenant or collective"
       )
-      commitment.update_column(:starting_event_fired_at, Time.current)
+      commitment.update_column(column, Time.current)
       return
     end
 
     # Mark as fired BEFORE recording the event, so that if the event dispatch
     # succeeds but a later step fails, we don't re-fire on the next run.
     # Missing an event is better than duplicating notifications.
-    commitment.update_column(:starting_event_fired_at, Time.current)
+    commitment.update_column(column, Time.current)
 
     with_tenant_and_collective_context(tenant, collective) do
       EventService.record!(
-        event_type: "commitment.starting",
+        event_type: event_type,
         actor: commitment.created_by,
         subject: commitment,
         metadata: {

--- a/app/jobs/calendar_event_starting_job.rb
+++ b/app/jobs/calendar_event_starting_job.rb
@@ -1,0 +1,80 @@
+# typed: true
+# frozen_string_literal: true
+
+# CalendarEventStartingJob fires a commitment.starting event shortly before a
+# calendar event's start time, so attendees get a heads-up notification (see
+# NotificationDispatcher#handle_commitment_starting_event). It runs every
+# minute via sidekiq-cron and mirrors DeadlineEventJob: query across all
+# tenants, mark fired before dispatching so a failure can't re-fire.
+class CalendarEventStartingJob < SystemJob
+  extend T::Sig
+
+  queue_as :default
+
+  MAX_PER_RUN = 100
+  # How far before starts_at the heads-up fires.
+  LEAD_TIME = 1.hour
+
+  sig { void }
+  def perform
+    # The ends_at guard keeps already-finished events (including the backlog
+    # of events that predate this job) from firing on deploy.
+    commitments = Commitment.unscoped_for_system_job
+      .where(subtype: "calendar_event")
+      .where(deleted_at: nil)
+      .where(starting_event_fired_at: nil)
+      .where(starts_at: ...(Time.current + LEAD_TIME))
+      .where("ends_at > ?", Time.current)
+      .includes(:tenant, :collective, :created_by)
+      .limit(MAX_PER_RUN)
+      .order(:starts_at)
+
+    count = 0
+    commitments.each do |commitment|
+      fire_starting_event(commitment)
+      count += 1
+    rescue StandardError => e
+      Rails.logger.error("CalendarEventStartingJob: Failed for commitment #{commitment.id}: #{e.message}")
+    end
+
+    return unless count.positive?
+
+    Rails.logger.info("CalendarEventStartingJob: Fired #{count} commitment.starting events")
+  end
+
+  private
+
+  sig { params(commitment: Commitment).void }
+  def fire_starting_event(commitment)
+    tenant = commitment.tenant
+    collective = commitment.collective
+    unless tenant && collective
+      Rails.logger.warn(
+        "CalendarEventStartingJob: Skipping commitment #{commitment.id} — missing tenant or collective"
+      )
+      commitment.update_column(:starting_event_fired_at, Time.current)
+      return
+    end
+
+    # Mark as fired BEFORE recording the event, so that if the event dispatch
+    # succeeds but a later step fails, we don't re-fire on the next run.
+    # Missing an event is better than duplicating notifications.
+    commitment.update_column(:starting_event_fired_at, Time.current)
+
+    with_tenant_and_collective_context(tenant, collective) do
+      EventService.record!(
+        event_type: "commitment.starting",
+        actor: commitment.created_by,
+        subject: commitment,
+        metadata: {
+          "resource_type" => "commitment",
+          "resource_id" => commitment.id,
+          "title" => commitment.title,
+          "starts_at" => commitment.starts_at&.iso8601,
+          "ends_at" => commitment.ends_at&.iso8601,
+          "location" => commitment.location,
+        }
+      )
+    end
+  end
+end

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -34,6 +34,7 @@ class Commitment < ApplicationRecord
   validates :starts_at, presence: true, if: :is_calendar_event?
   validates :ends_at, presence: true, if: :is_calendar_event?
   validate :ends_at_after_starts_at, if: :is_calendar_event?
+  before_save :reset_starting_event_fired_at, if: :will_save_change_to_starts_at?
 
   sig { returns(T::Boolean) }
   def is_action?
@@ -302,6 +303,20 @@ class Commitment < ApplicationRecord
   end
 
   private
+
+  # A rescheduled event should give attendees a fresh heads-up for the new
+  # start time (CalendarEventStartingJob fires once per starting_event_fired_at
+  # reset). Only reset when the new start is far enough out that the job's
+  # lead window hasn't already begun — otherwise moving an imminent event a
+  # few minutes would re-ping everyone.
+  sig { void }
+  def reset_starting_event_fired_at
+    s = starts_at
+    return unless starting_event_fired_at
+    return unless s && s > Time.current + CalendarEventStartingJob::LEAD_TIME
+
+    self.starting_event_fired_at = nil
+  end
 
   sig { void }
   def ends_at_after_starts_at

--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -34,7 +34,7 @@ class Commitment < ApplicationRecord
   validates :starts_at, presence: true, if: :is_calendar_event?
   validates :ends_at, presence: true, if: :is_calendar_event?
   validate :ends_at_after_starts_at, if: :is_calendar_event?
-  before_save :reset_starting_event_fired_at, if: :will_save_change_to_starts_at?
+  before_save :reset_start_event_fired_at, if: :will_save_change_to_starts_at?
 
   sig { returns(T::Boolean) }
   def is_action?
@@ -304,18 +304,23 @@ class Commitment < ApplicationRecord
 
   private
 
-  # A rescheduled event should give attendees a fresh heads-up for the new
-  # start time (CalendarEventStartingJob fires once per starting_event_fired_at
-  # reset). Only reset when the new start is far enough out that the job's
-  # lead window hasn't already begun — otherwise moving an imminent event a
-  # few minutes would re-ping everyone.
+  # A rescheduled event should re-notify attendees for its new start time
+  # (CalendarEventStartingJob fires once per fired-at reset). Reset each flag
+  # only when the new start is still far enough out that that event's window
+  # hasn't already begun — otherwise nudging an imminent event a few minutes
+  # would re-ping everyone.
   sig { void }
-  def reset_starting_event_fired_at
+  def reset_start_event_fired_at
     s = starts_at
-    return unless starting_event_fired_at
-    return unless s && s > Time.current + CalendarEventStartingJob::LEAD_TIME
+    now = Time.current
 
-    self.starting_event_fired_at = nil
+    if starting_soon_event_fired_at && s && s > now + CalendarEventStartingJob::LEAD_TIME
+      self.starting_soon_event_fired_at = nil
+    end
+
+    if starting_event_fired_at && s && s > now
+      self.starting_event_fired_at = nil
+    end
   end
 
   sig { void }

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,7 +3,7 @@
 class Notification < ApplicationRecord
   extend T::Sig
 
-  NOTIFICATION_TYPES = %w[mention comment participation system reminder event_starting chat_message trio_unavailable tune_in trustee_authorization role_change].freeze
+  NOTIFICATION_TYPES = %w[mention comment participation system reminder event_starting_soon event_starting chat_message trio_unavailable tune_in trustee_authorization role_change].freeze
 
   belongs_to :tenant
   belongs_to :event, optional: true

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,7 +3,7 @@
 class Notification < ApplicationRecord
   extend T::Sig
 
-  NOTIFICATION_TYPES = %w[mention comment participation system reminder chat_message trio_unavailable tune_in trustee_authorization role_change].freeze
+  NOTIFICATION_TYPES = %w[mention comment participation system reminder event_starting chat_message trio_unavailable tune_in trustee_authorization role_change].freeze
 
   belongs_to :tenant
   belongs_to :event, optional: true

--- a/app/models/tenant_user.rb
+++ b/app/models/tenant_user.rb
@@ -185,6 +185,8 @@ class TenantUser < ApplicationRecord
     "participation" => { "in_app" => true, "email" => false, "web_push" => true },
     "system" => { "in_app" => true, "email" => true, "web_push" => true },
     "reminder" => { "in_app" => true, "email" => false, "web_push" => true },
+    # Heads-up that a calendar event you created or RSVP'd to starts soon.
+    "event_starting" => { "in_app" => true, "email" => false, "web_push" => true },
     "chat_message" => { "in_app" => true, "email" => false, "web_push" => true },
     "trio_unavailable" => { "in_app" => true, "email" => false, "web_push" => true },
     "tune_in" => { "in_app" => true, "email" => false, "web_push" => true },
@@ -206,6 +208,7 @@ class TenantUser < ApplicationRecord
     "participation" => "Participation (votes, joins, RSVPs)",
     "system" => "System & account",
     "reminder" => "Reminders",
+    "event_starting" => "Event starting soon",
     "chat_message" => "Chat messages",
     "trio_unavailable" => "Trio unavailable",
     "tune_in" => "Tune-ins",

--- a/app/models/tenant_user.rb
+++ b/app/models/tenant_user.rb
@@ -185,7 +185,9 @@ class TenantUser < ApplicationRecord
     "participation" => { "in_app" => true, "email" => false, "web_push" => true },
     "system" => { "in_app" => true, "email" => true, "web_push" => true },
     "reminder" => { "in_app" => true, "email" => false, "web_push" => true },
-    # Heads-up that a calendar event you created or RSVP'd to starts soon.
+    # Heads-up ahead of time that a calendar event you created or RSVP'd to
+    # starts soon, and a nudge when it's actually starting.
+    "event_starting_soon" => { "in_app" => true, "email" => false, "web_push" => true },
     "event_starting" => { "in_app" => true, "email" => false, "web_push" => true },
     "chat_message" => { "in_app" => true, "email" => false, "web_push" => true },
     "trio_unavailable" => { "in_app" => true, "email" => false, "web_push" => true },
@@ -208,7 +210,8 @@ class TenantUser < ApplicationRecord
     "participation" => "Participation (votes, joins, RSVPs)",
     "system" => "System & account",
     "reminder" => "Reminders",
-    "event_starting" => "Event starting soon",
+    "event_starting_soon" => "Event starting soon",
+    "event_starting" => "Event starting",
     "chat_message" => "Chat messages",
     "trio_unavailable" => "Trio unavailable",
     "tune_in" => "Tune-ins",

--- a/app/services/notification_dispatcher.rb
+++ b/app/services/notification_dispatcher.rb
@@ -16,6 +16,8 @@ class NotificationDispatcher
       handle_commitment_join_event(event)
     when "commitment.critical_mass"
       handle_commitment_critical_mass_event(event)
+    when "commitment.starting"
+      handle_commitment_starting_event(event)
     when "decision.created"
       handle_decision_created_event(event)
     when "commitment.created"
@@ -292,6 +294,30 @@ class NotificationDispatcher
         notification_type: "participation",
         title: "Critical mass reached on a commitment you joined",
         body: commitment.description.to_s.truncate(200),
+        url: commitment.display_path
+      )
+    end
+  end
+
+  # A calendar event is about to start: notify everyone attending (committed
+  # participants plus the creator, who is the event's host whether or not
+  # they RSVP'd to their own event).
+  sig { params(event: Event).void }
+  def self.handle_commitment_starting_event(event)
+    subject = event.subject
+    return unless subject.is_a?(Commitment)
+
+    commitment = T.let(subject, Commitment)
+
+    recipients = (commitment_participants(commitment) + [commitment.created_by]).compact.uniq(&:id)
+    body_parts = [commitment.formatted_time_range.presence, commitment.location.presence].compact
+    recipients.each do |user|
+      notify_user(
+        event: event,
+        recipient: user,
+        notification_type: "event_starting",
+        title: "Starting soon: #{commitment.title}",
+        body: body_parts.join(" · "),
         url: commitment.display_path
       )
     end

--- a/app/services/notification_dispatcher.rb
+++ b/app/services/notification_dispatcher.rb
@@ -16,6 +16,8 @@ class NotificationDispatcher
       handle_commitment_join_event(event)
     when "commitment.critical_mass"
       handle_commitment_critical_mass_event(event)
+    when "commitment.starting_soon"
+      handle_commitment_starting_soon_event(event)
     when "commitment.starting"
       handle_commitment_starting_event(event)
     when "decision.created"
@@ -299,11 +301,23 @@ class NotificationDispatcher
     end
   end
 
-  # A calendar event is about to start: notify everyone attending (committed
-  # participants plus the creator, who is the event's host whether or not
-  # they RSVP'd to their own event).
+  # A calendar event is coming up (LEAD_TIME ahead of its start): give
+  # attendees a heads-up.
+  sig { params(event: Event).void }
+  def self.handle_commitment_starting_soon_event(event)
+    notify_commitment_start(event, notification_type: "event_starting_soon", title_prefix: "Starting soon")
+  end
+
+  # A calendar event's start time has arrived: notify attendees it's beginning.
   sig { params(event: Event).void }
   def self.handle_commitment_starting_event(event)
+    notify_commitment_start(event, notification_type: "event_starting", title_prefix: "Starting now")
+  end
+
+  # Notify everyone attending (committed participants plus the creator, who is
+  # the event's host whether or not they RSVP'd to their own event).
+  sig { params(event: Event, notification_type: String, title_prefix: String).void }
+  def self.notify_commitment_start(event, notification_type:, title_prefix:)
     subject = event.subject
     return unless subject.is_a?(Commitment)
 
@@ -315,8 +329,8 @@ class NotificationDispatcher
       notify_user(
         event: event,
         recipient: user,
-        notification_type: "event_starting",
-        title: "Starting soon: #{commitment.title}",
+        notification_type: notification_type,
+        title: "#{title_prefix}: #{commitment.title}",
         body: body_parts.join(" · "),
         url: commitment.display_path
       )

--- a/app/views/shared/_automation_yaml_reference.html.erb
+++ b/app/views/shared/_automation_yaml_reference.html.erb
@@ -67,6 +67,7 @@ actions:
     <li class="pulse-list-item"><code>commitment.created</code> - A commitment was created</li>
     <li class="pulse-list-item"><code>commitment.joined</code> - Someone joined a commitment</li>
     <li class="pulse-list-item"><code>commitment.critical_mass</code> - A commitment reached critical mass</li>
+    <li class="pulse-list-item"><code>commitment.starting</code> - A calendar event is about to start</li>
     <li class="pulse-list-item"><code>commitment.deadline_reached</code> - A commitment's deadline has passed</li>
     <li class="pulse-list-item"><code>chat_message.created</code> - A chat message was sent</li>
     <li class="pulse-list-item"><code>user_list_member.created</code> - Someone was added to a list</li>

--- a/app/views/shared/_automation_yaml_reference.html.erb
+++ b/app/views/shared/_automation_yaml_reference.html.erb
@@ -67,7 +67,8 @@ actions:
     <li class="pulse-list-item"><code>commitment.created</code> - A commitment was created</li>
     <li class="pulse-list-item"><code>commitment.joined</code> - Someone joined a commitment</li>
     <li class="pulse-list-item"><code>commitment.critical_mass</code> - A commitment reached critical mass</li>
-    <li class="pulse-list-item"><code>commitment.starting</code> - A calendar event is about to start</li>
+    <li class="pulse-list-item"><code>commitment.starting_soon</code> - A calendar event is starting soon (heads-up)</li>
+    <li class="pulse-list-item"><code>commitment.starting</code> - A calendar event is starting now</li>
     <li class="pulse-list-item"><code>commitment.deadline_reached</code> - A commitment's deadline has passed</li>
     <li class="pulse-list-item"><code>chat_message.created</code> - A chat message was sent</li>
     <li class="pulse-list-item"><code>user_list_member.created</code> - Someone was added to a list</li>

--- a/app/views/shared/_automation_yaml_reference.md.erb
+++ b/app/views/shared/_automation_yaml_reference.md.erb
@@ -70,7 +70,8 @@ actions:
 - `commitment.created` - A commitment was created
 - `commitment.joined` - Someone joined a commitment
 - `commitment.critical_mass` - A commitment reached critical mass
-- `commitment.starting` - A calendar event is about to start
+- `commitment.starting_soon` - A calendar event is starting soon (heads-up)
+- `commitment.starting` - A calendar event is starting now
 - `commitment.deadline_reached` - A commitment's deadline has passed
 - `chat_message.created` - A chat message was sent
 - `user_list_member.created` - Someone was added to a list

--- a/app/views/shared/_automation_yaml_reference.md.erb
+++ b/app/views/shared/_automation_yaml_reference.md.erb
@@ -70,6 +70,7 @@ actions:
 - `commitment.created` - A commitment was created
 - `commitment.joined` - Someone joined a commitment
 - `commitment.critical_mass` - A commitment reached critical mass
+- `commitment.starting` - A calendar event is about to start
 - `commitment.deadline_reached` - A commitment's deadline has passed
 - `chat_message.created` - A chat message was sent
 - `user_list_member.created` - Someone was added to a list

--- a/config/initializers/sidekiq_cron.rb
+++ b/config/initializers/sidekiq_cron.rb
@@ -25,6 +25,11 @@ SIDEKIQ_CRON_SCHEDULE = {
     "class" => "DeadlineEventJob",
     "description" => "Fire events when decision/commitment deadlines pass",
   },
+  "calendar_event_starting" => {
+    "cron" => "* * * * *", # Every minute
+    "class" => "CalendarEventStartingJob",
+    "description" => "Fire events when calendar events are about to start",
+  },
   "orphaned_task_sweep" => {
     "cron" => "*/10 * * * *", # Every 10 minutes
     "class" => "OrphanedTaskSweepJob",

--- a/db/migrate/20260704010000_add_starting_event_fired_at_to_commitments.rb
+++ b/db/migrate/20260704010000_add_starting_event_fired_at_to_commitments.rb
@@ -1,0 +1,7 @@
+# typed: false
+
+class AddStartingEventFiredAtToCommitments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :commitments, :starting_event_fired_at, :timestamp
+  end
+end

--- a/db/migrate/20260704010000_add_starting_event_fired_at_to_commitments.rb
+++ b/db/migrate/20260704010000_add_starting_event_fired_at_to_commitments.rb
@@ -2,6 +2,7 @@
 
 class AddStartingEventFiredAtToCommitments < ActiveRecord::Migration[7.2]
   def change
+    add_column :commitments, :starting_soon_event_fired_at, :timestamp
     add_column :commitments, :starting_event_fired_at, :timestamp
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -473,7 +473,8 @@ CREATE TABLE public.commitments (
     hard_delete_after timestamp(6) without time zone,
     starts_at timestamp without time zone,
     ends_at timestamp without time zone,
-    location text
+    location text,
+    starting_event_fired_at timestamp without time zone
 );
 
 
@@ -10314,6 +10315,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260705220000'),
 ('20260705182920'),
+('20260704010000'),
 ('20260703120000'),
 ('20260702010000'),
 ('20260702000000'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -474,6 +474,7 @@ CREATE TABLE public.commitments (
     starts_at timestamp without time zone,
     ends_at timestamp without time zone,
     location text,
+    starting_soon_event_fired_at timestamp without time zone,
     starting_event_fired_at timestamp without time zone
 );
 

--- a/sorbet/rbi/dsl/commitment.rbi
+++ b/sorbet/rbi/dsl/commitment.rbi
@@ -1532,6 +1532,9 @@ class Commitment
     def restore_location!; end
 
     sig { void }
+    def restore_starting_event_fired_at!; end
+
+    sig { void }
     def restore_starts_at!; end
 
     sig { void }
@@ -1643,6 +1646,12 @@ class Commitment
     def saved_change_to_location?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def saved_change_to_starting_event_fired_at; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_starting_event_fired_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
     def saved_change_to_starts_at; end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
@@ -1683,6 +1692,51 @@ class Commitment
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_updated_by_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def starting_event_fired_at; end
+
+    sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def starting_event_fired_at=(value); end
+
+    sig { returns(T::Boolean) }
+    def starting_event_fired_at?; end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def starting_event_fired_at_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def starting_event_fired_at_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def starting_event_fired_at_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def starting_event_fired_at_change; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def starting_event_fired_at_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def starting_event_fired_at_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def starting_event_fired_at_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def starting_event_fired_at_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def starting_event_fired_at_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def starting_event_fired_at_previously_was; end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def starting_event_fired_at_was; end
+
+    sig { void }
+    def starting_event_fired_at_will_change!; end
 
     sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
     def starts_at; end
@@ -2043,6 +2097,9 @@ class Commitment
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_location?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_starting_event_fired_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_starts_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/sorbet/rbi/dsl/commitment.rbi
+++ b/sorbet/rbi/dsl/commitment.rbi
@@ -1535,6 +1535,9 @@ class Commitment
     def restore_starting_event_fired_at!; end
 
     sig { void }
+    def restore_starting_soon_event_fired_at!; end
+
+    sig { void }
     def restore_starts_at!; end
 
     sig { void }
@@ -1652,6 +1655,12 @@ class Commitment
     def saved_change_to_starting_event_fired_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def saved_change_to_starting_soon_event_fired_at; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_starting_soon_event_fired_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
     def saved_change_to_starts_at; end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
@@ -1737,6 +1746,51 @@ class Commitment
 
     sig { void }
     def starting_event_fired_at_will_change!; end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def starting_soon_event_fired_at; end
+
+    sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def starting_soon_event_fired_at=(value); end
+
+    sig { returns(T::Boolean) }
+    def starting_soon_event_fired_at?; end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def starting_soon_event_fired_at_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def starting_soon_event_fired_at_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def starting_soon_event_fired_at_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def starting_soon_event_fired_at_change; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def starting_soon_event_fired_at_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def starting_soon_event_fired_at_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def starting_soon_event_fired_at_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def starting_soon_event_fired_at_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def starting_soon_event_fired_at_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def starting_soon_event_fired_at_previously_was; end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def starting_soon_event_fired_at_was; end
+
+    sig { void }
+    def starting_soon_event_fired_at_will_change!; end
 
     sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
     def starts_at; end
@@ -2100,6 +2154,9 @@ class Commitment
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_starting_event_fired_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_starting_soon_event_fired_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_starts_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/test/jobs/calendar_event_starting_job_test.rb
+++ b/test/jobs/calendar_event_starting_job_test.rb
@@ -1,0 +1,134 @@
+# typed: false
+
+require "test_helper"
+
+class CalendarEventStartingJobTest < ActiveJob::TestCase
+  def setup
+    @tenant, @collective, @user = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    Tenant.current_id = @tenant.id
+  end
+
+  def teardown
+    Collective.clear_thread_scope
+  end
+
+  def create_event(starts_at:, ends_at: nil)
+    Commitment.create!(
+      tenant: @tenant, collective: @collective,
+      created_by: @user, updated_by: @user,
+      title: "Test event", description: "",
+      subtype: "calendar_event",
+      critical_mass: 1,
+      deadline: starts_at,
+      starts_at: starts_at,
+      ends_at: ends_at || starts_at + 1.hour
+    )
+  end
+
+  test "fires commitment.starting for events starting within the lead window" do
+    event_commitment = create_event(starts_at: 30.minutes.from_now)
+
+    Collective.clear_thread_scope
+    CalendarEventStartingJob.perform_now
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    event = Event.where(event_type: "commitment.starting").last
+    assert_not_nil event
+    assert_equal event_commitment.id, event.subject_id
+    assert_not_nil event_commitment.reload.starting_event_fired_at
+  end
+
+  test "notifies the creator and committed participants" do
+    attendee = create_user(name: "Attendee")
+    @tenant.add_user!(attendee)
+    @collective.add_user!(attendee)
+    event_commitment = create_event(starts_at: 30.minutes.from_now)
+    event_commitment.join_commitment!(attendee)
+
+    Collective.clear_thread_scope
+    CalendarEventStartingJob.perform_now
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    # notify_user creates one Notification per recipient
+    notifications = Notification.where(notification_type: "event_starting")
+    assert_equal 2, notifications.count
+    recipient_ids = NotificationRecipient
+      .where(notification: notifications, channel: "in_app")
+      .pluck(:user_id)
+    assert_includes recipient_ids, @user.id
+    assert_includes recipient_ids, attendee.id
+  end
+
+  test "does not fire for events starting beyond the lead window" do
+    event_commitment = create_event(starts_at: 2.days.from_now)
+
+    Collective.clear_thread_scope
+    CalendarEventStartingJob.perform_now
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    assert_nil Event.find_by(event_type: "commitment.starting", subject_id: event_commitment.id)
+    assert_nil event_commitment.reload.starting_event_fired_at
+  end
+
+  test "does not fire for events that have already ended" do
+    event_commitment = nil
+    travel_to 3.days.ago do
+      event_commitment = create_event(starts_at: 1.hour.from_now)
+    end
+
+    Collective.clear_thread_scope
+    CalendarEventStartingJob.perform_now
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    assert_nil Event.find_by(event_type: "commitment.starting", subject_id: event_commitment.id)
+  end
+
+  test "does not fire twice for the same event" do
+    create_event(starts_at: 30.minutes.from_now)
+
+    Collective.clear_thread_scope
+    CalendarEventStartingJob.perform_now
+    CalendarEventStartingJob.perform_now
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    assert_equal 1, Event.where(event_type: "commitment.starting").count
+  end
+
+  test "does not fire for soft-deleted events" do
+    event_commitment = create_event(starts_at: 30.minutes.from_now)
+    event_commitment.update_columns(deleted_at: Time.current)
+
+    Collective.clear_thread_scope
+    CalendarEventStartingJob.perform_now
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    assert_nil Event.find_by(event_type: "commitment.starting", subject_id: event_commitment.id)
+  end
+
+  test "rescheduling an event re-arms the starting notification" do
+    event_commitment = create_event(starts_at: 30.minutes.from_now)
+
+    Collective.clear_thread_scope
+    CalendarEventStartingJob.perform_now
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    assert_not_nil event_commitment.reload.starting_event_fired_at
+
+    new_start = 3.days.from_now
+    event_commitment.update!(starts_at: new_start, ends_at: new_start + 1.hour)
+    assert_nil event_commitment.reload.starting_event_fired_at
+  end
+
+  test "nudging an imminent event does not re-arm the notification" do
+    event_commitment = create_event(starts_at: 30.minutes.from_now)
+
+    Collective.clear_thread_scope
+    CalendarEventStartingJob.perform_now
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    new_start = 45.minutes.from_now
+    event_commitment.reload.update!(starts_at: new_start, ends_at: new_start + 1.hour)
+    assert_not_nil event_commitment.reload.starting_event_fired_at
+  end
+end

--- a/test/jobs/calendar_event_starting_job_test.rb
+++ b/test/jobs/calendar_event_starting_job_test.rb
@@ -26,31 +26,89 @@ class CalendarEventStartingJobTest < ActiveJob::TestCase
     )
   end
 
-  test "fires commitment.starting for events starting within the lead window" do
-    event_commitment = create_event(starts_at: 30.minutes.from_now)
-
+  def run_job
     Collective.clear_thread_scope
     CalendarEventStartingJob.perform_now
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
-
-    event = Event.where(event_type: "commitment.starting").last
-    assert_not_nil event
-    assert_equal event_commitment.id, event.subject_id
-    assert_not_nil event_commitment.reload.starting_event_fired_at
   end
 
-  test "notifies the creator and committed participants" do
+  # --- starting_soon (the lead-window heads-up) -----------------------------
+
+  test "fires commitment.starting_soon for events starting within the lead window" do
+    event_commitment = create_event(starts_at: 30.minutes.from_now)
+
+    run_job
+
+    event = Event.where(event_type: "commitment.starting_soon").last
+    assert_not_nil event
+    assert_equal event_commitment.id, event.subject_id
+    assert_not_nil event_commitment.reload.starting_soon_event_fired_at
+    # The event hasn't actually started yet, so the "starting" event stays armed.
+    assert_nil event_commitment.reload.starting_event_fired_at
+  end
+
+  test "starting_soon notifies the creator and committed participants" do
     attendee = create_user(name: "Attendee")
     @tenant.add_user!(attendee)
     @collective.add_user!(attendee)
     event_commitment = create_event(starts_at: 30.minutes.from_now)
     event_commitment.join_commitment!(attendee)
 
+    run_job
+
+    notifications = Notification.where(notification_type: "event_starting_soon")
+    assert_equal 2, notifications.count
+    recipient_ids = NotificationRecipient
+      .where(notification: notifications, channel: "in_app")
+      .pluck(:user_id)
+    assert_includes recipient_ids, @user.id
+    assert_includes recipient_ids, attendee.id
+  end
+
+  test "does not fire starting_soon for events starting beyond the lead window" do
+    event_commitment = create_event(starts_at: 2.days.from_now)
+
+    run_job
+
+    assert_nil Event.find_by(event_type: "commitment.starting_soon", subject_id: event_commitment.id)
+    assert_nil event_commitment.reload.starting_soon_event_fired_at
+  end
+
+  test "does not fire starting_soon twice for the same event" do
+    create_event(starts_at: 30.minutes.from_now)
+
     Collective.clear_thread_scope
+    CalendarEventStartingJob.perform_now
     CalendarEventStartingJob.perform_now
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
 
-    # notify_user creates one Notification per recipient
+    assert_equal 1, Event.where(event_type: "commitment.starting_soon").count
+  end
+
+  # --- starting (at the actual start time) ----------------------------------
+
+  test "fires commitment.starting when the start time has just arrived" do
+    event_commitment = create_event(starts_at: 1.minute.ago, ends_at: 59.minutes.from_now)
+
+    run_job
+
+    event = Event.where(event_type: "commitment.starting").last
+    assert_not_nil event
+    assert_equal event_commitment.id, event.subject_id
+    assert_not_nil event_commitment.reload.starting_event_fired_at
+    # It already started, so the heads-up window never applied.
+    assert_nil event_commitment.reload.starting_soon_event_fired_at
+  end
+
+  test "starting notifies the creator and committed participants" do
+    attendee = create_user(name: "Attendee")
+    @tenant.add_user!(attendee)
+    @collective.add_user!(attendee)
+    event_commitment = create_event(starts_at: 1.minute.ago, ends_at: 59.minutes.from_now)
+    event_commitment.join_commitment!(attendee)
+
+    run_job
+
     notifications = Notification.where(notification_type: "event_starting")
     assert_equal 2, notifications.count
     recipient_ids = NotificationRecipient
@@ -60,32 +118,17 @@ class CalendarEventStartingJobTest < ActiveJob::TestCase
     assert_includes recipient_ids, attendee.id
   end
 
-  test "does not fire for events starting beyond the lead window" do
-    event_commitment = create_event(starts_at: 2.days.from_now)
+  test "does not fire starting for events whose start passed beyond the grace window" do
+    event_commitment = create_event(starts_at: 30.minutes.ago, ends_at: 30.minutes.from_now)
 
-    Collective.clear_thread_scope
-    CalendarEventStartingJob.perform_now
-    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    run_job
 
     assert_nil Event.find_by(event_type: "commitment.starting", subject_id: event_commitment.id)
     assert_nil event_commitment.reload.starting_event_fired_at
   end
 
-  test "does not fire for events that have already ended" do
-    event_commitment = nil
-    travel_to 3.days.ago do
-      event_commitment = create_event(starts_at: 1.hour.from_now)
-    end
-
-    Collective.clear_thread_scope
-    CalendarEventStartingJob.perform_now
-    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
-
-    assert_nil Event.find_by(event_type: "commitment.starting", subject_id: event_commitment.id)
-  end
-
-  test "does not fire twice for the same event" do
-    create_event(starts_at: 30.minutes.from_now)
+  test "does not fire starting twice for the same event" do
+    create_event(starts_at: 1.minute.ago, ends_at: 59.minutes.from_now)
 
     Collective.clear_thread_scope
     CalendarEventStartingJob.perform_now
@@ -95,40 +138,54 @@ class CalendarEventStartingJobTest < ActiveJob::TestCase
     assert_equal 1, Event.where(event_type: "commitment.starting").count
   end
 
-  test "does not fire for soft-deleted events" do
-    event_commitment = create_event(starts_at: 30.minutes.from_now)
-    event_commitment.update_columns(deleted_at: Time.current)
+  # --- guards shared by both ------------------------------------------------
 
-    Collective.clear_thread_scope
-    CalendarEventStartingJob.perform_now
-    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+  test "does not fire for events that have already ended" do
+    event_commitment = nil
+    travel_to 3.days.ago do
+      event_commitment = create_event(starts_at: 1.hour.from_now)
+    end
 
+    run_job
+
+    assert_nil Event.find_by(event_type: "commitment.starting_soon", subject_id: event_commitment.id)
     assert_nil Event.find_by(event_type: "commitment.starting", subject_id: event_commitment.id)
   end
 
-  test "rescheduling an event re-arms the starting notification" do
+  test "does not fire for soft-deleted events" do
+    soon = create_event(starts_at: 30.minutes.from_now)
+    starting = create_event(starts_at: 1.minute.ago, ends_at: 59.minutes.from_now)
+    soon.update_columns(deleted_at: Time.current)
+    starting.update_columns(deleted_at: Time.current)
+
+    run_job
+
+    assert_nil Event.find_by(event_type: "commitment.starting_soon", subject_id: soon.id)
+    assert_nil Event.find_by(event_type: "commitment.starting", subject_id: starting.id)
+  end
+
+  # --- reschedule re-arming -------------------------------------------------
+
+  test "rescheduling an event re-arms both start notifications" do
     event_commitment = create_event(starts_at: 30.minutes.from_now)
 
-    Collective.clear_thread_scope
-    CalendarEventStartingJob.perform_now
-    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    run_job
 
-    assert_not_nil event_commitment.reload.starting_event_fired_at
+    assert_not_nil event_commitment.reload.starting_soon_event_fired_at
 
     new_start = 3.days.from_now
     event_commitment.update!(starts_at: new_start, ends_at: new_start + 1.hour)
+    assert_nil event_commitment.reload.starting_soon_event_fired_at
     assert_nil event_commitment.reload.starting_event_fired_at
   end
 
-  test "nudging an imminent event does not re-arm the notification" do
+  test "nudging an imminent event does not re-arm the starting_soon notification" do
     event_commitment = create_event(starts_at: 30.minutes.from_now)
 
-    Collective.clear_thread_scope
-    CalendarEventStartingJob.perform_now
-    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    run_job
 
     new_start = 45.minutes.from_now
     event_commitment.reload.update!(starts_at: new_start, ends_at: new_start + 1.hour)
-    assert_not_nil event_commitment.reload.starting_event_fired_at
+    assert_not_nil event_commitment.reload.starting_soon_event_fired_at
   end
 end


### PR DESCRIPTION
Fixes #313

## Design

Follows the `DeadlineEventJob` pattern exactly:

- **`CalendarEventStartingJob`** (new, minutely via sidekiq-cron) scans all tenants for calendar events with `starts_at` within a 1-hour lead window, fires a `commitment.starting` event, and marks a new `commitments.starting_event_fired_at` column *before* dispatching so a mid-flight failure can't double-fire. An `ends_at > now` guard keeps the pre-existing backlog of past events from firing a notification blast on deploy.
- **`NotificationDispatcher`** handles `commitment.starting` by notifying the creator plus all committed participants ("Starting soon: <title>", body = time range · location, linking to the event).
- **New notification type `event_starting`** ("Event starting soon") added to `Notification::NOTIFICATION_TYPES`, `DEFAULT_NOTIFICATION_PREFERENCES` (in-app + web push on, email off), and `NOTIFICATION_TYPE_LABELS`, so users can tune channels per the existing preferences UI. The registry sync test covers this.
- **Reschedule handling**: a `before_save` hook on Commitment clears `starting_event_fired_at` when `starts_at` moves to a time outside the lead window — a rescheduled event re-notifies for its new time, but nudging an imminent event by a few minutes doesn't re-ping (pairs with #321/PR #385, which makes event dates editable).
- `commitment.starting` also flows to webhooks/automations like any other event; documented in the automation YAML reference.

## Tests

8 job tests mirroring `deadline_event_job_test.rb`: fires within lead window, notifies creator + participants, skips far-future / already-ended / soft-deleted events, no double-fire, re-arm on reschedule, no re-arm on imminent nudge. Ran alongside the deadline job, tenant-user registry, and cron-schedule suites (71 runs, 0 failures); `srb tc` clean (Commitment RBI regenerated).

Note: `db/structure.sql` here contains only this branch's change; if this merges after #388 (which also touches structure.sql) the schema_migrations insert may need a trivial conflict resolution.