### PR TITLE
Bottom tab bar: the rail's mobile mirror

### DIFF
--- a/app/assets/stylesheets/pulse.css
+++ b/app/assets/stylesheets/pulse.css
@@ -8,6 +8,7 @@
  *= require pulse/_layout
  *= require pulse/_rail
  *= require pulse/_places_sheet
+ *= require pulse/_tab_bar
  *= require pulse/_components
  *= require pulse/_markdown_editor
  *= require pulse/_sidebar

--- a/app/assets/stylesheets/pulse/_layout.css
+++ b/app/assets/stylesheets/pulse/_layout.css
@@ -8,6 +8,9 @@
 :root {
   --pulse-sidebar-width: 280px;
   --pulse-rail-width: 72px;
+  /* The mobile bottom tab bar's height — 0 on desktop, set by
+     _tab_bar.css under its mobile media query. */
+  --pulse-tab-bar-height: 0px;
 }
 
 /* App Shell: persistent collective rail + the rest of the app */

--- a/app/assets/stylesheets/pulse/_places_sheet.css
+++ b/app/assets/stylesheets/pulse/_places_sheet.css
@@ -1,38 +1,10 @@
 /* Pulse Places Sheet
  *
  * The mobile place switcher: the rail's destinations as labeled rows in a
- * slide-over panel, opened from a header toggle. Desktop widths hide both
- * (the rail is the desktop projection of the same destinations — see the
- * form-factors section of docs/NAVIGATION_DESIGN.md).
+ * slide-over panel, opened from the tab bar's Places tab. Desktop widths
+ * hide both (the rail is the desktop projection of the same destinations
+ * — see the form-factors section of docs/NAVIGATION_DESIGN.md).
  */
-
-.pulse-places-toggle {
-  display: none;
-  position: relative;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border: none;
-  background: none;
-  color: var(--color-fg-muted);
-  cursor: pointer;
-}
-
-.pulse-places-toggle .octicon {
-  fill: currentColor;
-}
-
-/* Aggregate unread dot: any place has activity. */
-.pulse-places-toggle-dot {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--color-accent-fg);
-}
 
 .pulse-places-backdrop {
   position: fixed;
@@ -150,10 +122,4 @@
   height: 1px;
   background: var(--color-border-default);
   margin: 6px 12px;
-}
-
-@media (max-width: 768px) {
-  .pulse-places-toggle {
-    display: flex;
-  }
 }

--- a/app/assets/stylesheets/pulse/_tab_bar.css
+++ b/app/assets/stylesheets/pulse/_tab_bar.css
@@ -1,0 +1,142 @@
+/* Mobile bottom tab bar
+ *
+ * The persistent destinations at phone widths, ordered outward→inward:
+ * globe, places, search, inbox, you (docs/NAVIGATION_DESIGN.md "Form
+ * factors"). Desktop unfolds the same set into the rail and header — CSS
+ * shows exactly one projection per width, so the bar and the rail never
+ * coexist. --pulse-tab-bar-height is 0 on desktop (set in _layout.css)
+ * and real height here; content clearance derives from the variable.
+ */
+
+.pulse-tab-bar {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  :root {
+    --pulse-tab-bar-height: 56px;
+  }
+
+  .pulse-tab-bar {
+    display: flex;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: calc(var(--pulse-tab-bar-height) + env(safe-area-inset-bottom));
+    padding-bottom: env(safe-area-inset-bottom);
+    background: var(--color-canvas-default);
+    border-top: 1px solid var(--color-border-default);
+    /* Below the places sheet backdrop (200) so the open sheet covers it. */
+    z-index: 150;
+  }
+
+  .pulse-tab-bar-item {
+    position: relative;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--color-fg-muted);
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .pulse-tab-bar-item .octicon {
+    fill: currentColor;
+  }
+
+  .pulse-tab-bar-item.active {
+    color: var(--color-fg-default);
+  }
+
+  .pulse-tab-bar-label {
+    font-size: 10px;
+    line-height: 1;
+  }
+
+  /* The You tab: a positioned wrapper so its menu can anchor above it. */
+  .pulse-tab-bar-you {
+    justify-content: stretch;
+  }
+
+  /* The You menu opens upward, CSS-anchored to the tab (the controller's
+     openUp mode skips its JS positioning). */
+  .pulse-tab-bar-you .top-menu {
+    position: absolute;
+    bottom: calc(100% + 4px);
+    top: auto;
+    right: 4px;
+  }
+
+  .pulse-tab-bar-you-button {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    width: 100%;
+    padding: 0;
+    border: none;
+    background: none;
+    color: inherit;
+    cursor: pointer;
+  }
+
+  .pulse-tab-bar-you-button .profile-pic,
+  .pulse-tab-bar-you-button img {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+  }
+
+  /* Same pill as the rail badges, anchored to the tab icon's corner. */
+  .pulse-tab-bar-badge {
+    position: absolute;
+    top: 4px;
+    left: calc(50% + 4px);
+    background-color: var(--color-accent-fg);
+    color: white;
+    font-size: 10px;
+    font-weight: bold;
+    min-width: 16px;
+    height: 16px;
+    line-height: 16px;
+    text-align: center;
+    border-radius: 8px;
+    padding: 0 4px;
+  }
+
+  /* Aggregate unread dot on the Places tab. */
+  .pulse-tab-bar-dot {
+    position: absolute;
+    top: 6px;
+    left: calc(50% + 8px);
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--color-accent-fg);
+  }
+
+  /* Content clears the fixed bar. */
+  .pulse-app-shell,
+  .pulse-motto-footer {
+    margin-bottom: calc(var(--pulse-tab-bar-height) + env(safe-area-inset-bottom));
+  }
+
+  /* The header slims: search, inbox, and the avatar menu live in the bar
+     now. They stay in the DOM (the notification poller runs from the
+     header cluster) — only hidden. The contextual "+" create button
+     keeps its top-bar slot (creation takes no tab). */
+  .top-right-display > .header-search-wrapper,
+  .top-right-display > div:has(> .notification-icon),
+  .top-right-display > div[data-controller="top-right-menu"] {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/pulse/_tab_bar.css
+++ b/app/assets/stylesheets/pulse/_tab_bar.css
@@ -42,22 +42,13 @@
     padding: 0;
     border: none;
     background: none;
-    color: var(--color-fg-muted);
+    color: var(--color-fg-default);
     text-decoration: none;
     cursor: pointer;
   }
 
   .pulse-tab-bar-item .octicon {
     fill: currentColor;
-  }
-
-  .pulse-tab-bar-item.active {
-    color: var(--color-fg-default);
-  }
-
-  .pulse-tab-bar-label {
-    font-size: 10px;
-    line-height: 1;
   }
 
   /* The You tab: a positioned wrapper so its menu can anchor above it. */
@@ -99,7 +90,7 @@
   /* Same pill as the rail badges, anchored to the tab icon's corner. */
   .pulse-tab-bar-badge {
     position: absolute;
-    top: 4px;
+    top: 8px;
     left: calc(50% + 4px);
     background-color: var(--color-accent-fg);
     color: white;
@@ -116,7 +107,7 @@
   /* Aggregate unread dot on the Places tab. */
   .pulse-tab-bar-dot {
     position: absolute;
-    top: 6px;
+    top: 12px;
     left: calc(50% + 8px);
     width: 8px;
     height: 8px;

--- a/app/assets/stylesheets/pulse/_tab_bar.css
+++ b/app/assets/stylesheets/pulse/_tab_bar.css
@@ -29,6 +29,20 @@
     border-top: 1px solid var(--color-border-default);
     /* Below the places sheet backdrop (200) so the open sheet covers it. */
     z-index: 150;
+    /* Auto-hide in lockstep with the top header (same controller and
+       timing, opposite direction). */
+    transition: transform 0.25s ease;
+    will-change: transform;
+  }
+
+  .pulse-tab-bar--hidden {
+    transform: translateY(100%);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pulse-tab-bar {
+      transition: none;
+    }
   }
 
   .pulse-tab-bar-item {

--- a/app/controllers/pulse_controller.rb
+++ b/app/controllers/pulse_controller.rb
@@ -17,7 +17,9 @@ class PulseController < ApplicationController
     workspace = @current_collective.private_workspace?
     @page_scope = workspace ? "visibility:private" : "collective:#{@current_collective.handle}"
 
-    resolve_feed_query("cycle:this-week -subtype:comment")
+    # Workspaces get no default query: the private zone is the only
+    # filter — there is no curation layer over your own space.
+    resolve_feed_query(workspace ? "" : "cycle:this-week -subtype:comment")
     fixed = { collective_handle: @current_collective.handle }
     fixed[:visibility] = "private" if workspace
     # cycle "all" as the base: a cleared query means all time, not the

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,11 @@
 # typed: false
 
 module ApplicationHelper
+  # Badge display rules shared with the rail/sheet components — the tab
+  # bar's inbox badge renders with the same text/style contract the
+  # rail-badges controller maintains client-side.
+  include UnreadBadgeDisplay
+
   # Generate consistent avatar initials from a name
   # Returns up to 2 uppercase characters
   def avatar_initials(name)

--- a/app/javascript/controllers/auto_hide_header_controller.ts
+++ b/app/javascript/controllers/auto_hide_header_controller.ts
@@ -1,16 +1,20 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Auto-hiding top header.
+// Auto-hiding chrome bars.
 //
-// Hides the app header (translated off-screen via a CSS class) when the user
+// Hides the element (translated off-screen via a CSS class) when the user
 // scrolls down, and reveals it again when they scroll up or return to the top
-// of the page. Attaches to <header class="pulse-top-header"> in the layout.
+// of the page. Drives both the top header and the mobile bottom tab bar —
+// one instance each, so they move in lockstep:
 //
 //   <header class="pulse-top-header"
 //           data-controller="auto-hide-header"
 //           data-auto-hide-header-hidden-class="pulse-top-header--hidden">
+//   <nav class="pulse-tab-bar"
+//        data-controller="rail-badges auto-hide-header"
+//        data-auto-hide-header-hidden-class="pulse-tab-bar--hidden">
 //
-// The reveal-on-scroll-up behaviour keeps the header one flick away without it
+// The reveal-on-scroll-up behaviour keeps the chrome one flick away without it
 // eating vertical space while reading, which matters most on small screens.
 export default class AutoHideHeaderController extends Controller<HTMLElement> {
   static classes = ["hidden"]

--- a/app/javascript/controllers/rail_badges_controller.test.ts
+++ b/app/javascript/controllers/rail_badges_controller.test.ts
@@ -15,6 +15,9 @@ describe("RailBadgesController", () => {
         <a href="/collectives/team-b" data-place-path="/collectives/team-b">
           <span class="pulse-rail-badge" data-collective-id="bbb-222" style="display: none"></span>
         </a>
+        <a href="/notifications">
+          <span class="pulse-tab-bar-badge" data-total-badge style="display: none"></span>
+        </a>
       </nav>
     `
     const application = Application.start()
@@ -86,6 +89,20 @@ describe("RailBadgesController", () => {
 
     await vi.waitFor(() => expect(chatBadge().textContent).toBe("5"))
     expect(chatBadge().closest("a")?.getAttribute("href")).toBe("/chat")
+  })
+
+  it("fills the total-count badge from the broadcast's count", async () => {
+    window.dispatchEvent(
+      new CustomEvent("notifications:counts", { detail: { count: 7, byCollective: {}, chat: 0 } }),
+    )
+
+    const totalBadge = document.querySelector("[data-total-badge]") as HTMLElement
+    await vi.waitFor(() => {
+      expect(totalBadge.textContent).toBe("7")
+      expect(totalBadge.style.display).toBe("")
+    })
+    // Its anchor is not a place entry — the href never swaps.
+    expect(totalBadge.closest("a")?.getAttribute("href")).toBe("/notifications")
   })
 
   it("fills and clears the aggregated chat badge", async () => {

--- a/app/javascript/controllers/rail_badges_controller.ts
+++ b/app/javascript/controllers/rail_badges_controller.ts
@@ -35,6 +35,12 @@ export default class RailBadgesController extends Controller<HTMLElement> {
     if (chatBadge) {
       this.updateBadge(chatBadge, detail?.chat ?? 0)
     }
+
+    // Total unread count — the tab bar's inbox badge.
+    const totalBadge = this.element.querySelector<HTMLElement>("[data-total-badge]")
+    if (totalBadge) {
+      this.updateBadge(totalBadge, detail?.count ?? 0)
+    }
   }
 
   private updateBadge(badge: HTMLElement, count: number): void {

--- a/app/javascript/controllers/top_right_menu_controller.ts
+++ b/app/javascript/controllers/top_right_menu_controller.ts
@@ -2,11 +2,18 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class TopRightMenuController extends Controller {
   static targets = ["button", "menu", "quickAppendInput"]
+  // openUp: the menu opens above the button instead of below — for
+  // instances anchored to the bottom tab bar. Positioning is pure CSS
+  // (bottom: 100% inside the positioned wrapper); measuring here would
+  // read offsetParent while the menu is display:none, which resolves to
+  // <body> and mispositions on scrolled pages.
+  static values = { openUp: { type: Boolean, default: false } }
 
   declare readonly buttonTarget: HTMLElement
   declare readonly menuTarget: HTMLElement
   declare readonly quickAppendInputTarget: HTMLInputElement
   declare readonly hasQuickAppendInputTarget: boolean
+  declare openUpValue: boolean
 
   connect(): void {
     this.menuTarget.style.display = "none"
@@ -25,11 +32,13 @@ export default class TopRightMenuController extends Controller {
   }
 
   toggleMenu(): void {
-    const rect = this.buttonTarget.getBoundingClientRect()
-    const offsetParent = (this.menuTarget.offsetParent || document.body) as HTMLElement
-    const parentRect = offsetParent.getBoundingClientRect()
-    this.menuTarget.style.top = `${rect.bottom - parentRect.top}px`
-    this.menuTarget.style.right = `${parentRect.right - rect.right}px`
+    if (!this.openUpValue) {
+      const rect = this.buttonTarget.getBoundingClientRect()
+      const offsetParent = (this.menuTarget.offsetParent || document.body) as HTMLElement
+      const parentRect = offsetParent.getBoundingClientRect()
+      this.menuTarget.style.top = `${rect.bottom - parentRect.top}px`
+      this.menuTarget.style.right = `${parentRect.right - rect.right}px`
+    }
     this.menuTarget.style.display = this.menuTarget.style.display === "none" ? "block" : "none"
   }
 }

--- a/app/views/help/markdown_ui.md.erb
+++ b/app/views/help/markdown_ui.md.erb
@@ -63,7 +63,7 @@ scope: collective:my-team
 | `/` (home) | `visibility:public` | `list:tuned_in -subtype:comment` |
 | `/collectives/:handle` (feed) | `collective:handle` | `cycle:this-week -subtype:comment` |
 | `/collectives/:handle/dashboard` | `collective:handle` | — |
-| `/workspace/:handle` (feed) | `visibility:private` | `cycle:this-week -subtype:comment` |
+| `/workspace/:handle` (feed) | `visibility:private` | — |
 | `/workspace/:handle/dashboard` | `visibility:private` | — |
 | `/u/:handle` | `visibility:public creator:@handle` | — |
 | `/lists/:id` | `visibility:public list:id` | — |

--- a/app/views/layouts/_bottom_tab_bar.html.erb
+++ b/app/views/layouts/_bottom_tab_bar.html.erb
@@ -2,7 +2,11 @@
     the persistent destinations, ordered left→right as outward→inward —
     globe, places, search, inbox, you. Desktop unfolds this same set into
     the rail and header; CSS shows exactly one projection per width. %>
-<nav class="pulse-tab-bar" aria-label="Primary" data-controller="rail-badges">
+<%# Hides on scroll-down / reveals on scroll-up in lockstep with the top
+    header — same controller, same threshold, opposite translate. %>
+<nav class="pulse-tab-bar" aria-label="Primary"
+     data-controller="rail-badges auto-hide-header"
+     data-auto-hide-header-hidden-class="pulse-tab-bar--hidden">
   <a href="/" class="pulse-tab-bar-item<%= ' active' if request.path == '/' %>" aria-label="Home"
      <% if request.path == "/" %>aria-current="page"<% end %>>
     <%= octicon "globe", height: 22 %>

--- a/app/views/layouts/_bottom_tab_bar.html.erb
+++ b/app/views/layouts/_bottom_tab_bar.html.erb
@@ -1,0 +1,52 @@
+<%# Mobile bottom tab bar (docs/NAVIGATION_DESIGN.md "Form factors"):
+    the persistent destinations, ordered left→right as outward→inward —
+    globe, places, search, inbox, you. Desktop unfolds this same set into
+    the rail and header; CSS shows exactly one projection per width. %>
+<nav class="pulse-tab-bar" aria-label="Primary" data-controller="rail-badges">
+  <a href="/" class="pulse-tab-bar-item<%= ' active' if request.path == '/' %>"
+     <% if request.path == "/" %>aria-current="page"<% end %>>
+    <%= octicon "globe", height: 22 %>
+    <span class="pulse-tab-bar-label">Home</span>
+  </a>
+
+  <button type="button" class="pulse-tab-bar-item pulse-tab-bar-places"
+          data-places-sheet-target="toggle"
+          data-action="click->places-sheet#toggle"
+          aria-expanded="false">
+    <%= octicon "apps", height: 22 %>
+    <span class="pulse-tab-bar-label">Places</span>
+    <span class="pulse-tab-bar-dot" data-places-sheet-target="dot"
+          style="<%= 'display: none' unless rail_unread_counts.values.any?(&:positive?) || rail_chat_unread_count.positive? %>"></span>
+  </button>
+
+  <a href="/search" class="pulse-tab-bar-item<%= ' active' if request.path.start_with?('/search') %>"
+     <% if request.path.start_with?("/search") %>aria-current="page"<% end %>>
+    <%= octicon "search", height: 22 %>
+    <span class="pulse-tab-bar-label">Search</span>
+  </a>
+
+  <a href="/notifications" class="pulse-tab-bar-item<%= ' active' if request.path.start_with?('/notifications') %>"
+     <% if request.path.start_with?("/notifications") %>aria-current="page"<% end %>>
+    <%= octicon "inbox", height: 22 %>
+    <span class="pulse-tab-bar-label">Inbox</span>
+    <span class="pulse-tab-bar-badge" data-total-badge
+          style="<%= count_badge_style(@unread_notification_count.to_i) %>"><%= count_badge_text(@unread_notification_count.to_i) %></span>
+  </a>
+
+  <% unless @current_representation_session %>
+    <div class="pulse-tab-bar-item pulse-tab-bar-you"
+         data-controller="top-right-menu"
+         data-top-right-menu-open-up-value="true">
+      <button type="button" class="pulse-tab-bar-you-button"
+              data-top-right-menu-target="button"
+              data-action="click->top-right-menu#toggleMenu"
+              aria-haspopup="menu">
+        <%= profile_pic(@current_user) %>
+        <span class="pulse-tab-bar-label">You</span>
+      </button>
+      <div data-top-right-menu-target="menu" class="top-menu" style="display:none;">
+        <%= render "layouts/user_menu" %>
+      </div>
+    </div>
+  <% end %>
+</nav>

--- a/app/views/layouts/_bottom_tab_bar.html.erb
+++ b/app/views/layouts/_bottom_tab_bar.html.erb
@@ -3,32 +3,28 @@
     globe, places, search, inbox, you. Desktop unfolds this same set into
     the rail and header; CSS shows exactly one projection per width. %>
 <nav class="pulse-tab-bar" aria-label="Primary" data-controller="rail-badges">
-  <a href="/" class="pulse-tab-bar-item<%= ' active' if request.path == '/' %>"
+  <a href="/" class="pulse-tab-bar-item<%= ' active' if request.path == '/' %>" aria-label="Home"
      <% if request.path == "/" %>aria-current="page"<% end %>>
     <%= octicon "globe", height: 22 %>
-    <span class="pulse-tab-bar-label">Home</span>
   </a>
 
   <button type="button" class="pulse-tab-bar-item pulse-tab-bar-places"
           data-places-sheet-target="toggle"
           data-action="click->places-sheet#toggle"
-          aria-expanded="false">
+          aria-expanded="false" aria-label="Places">
     <%= octicon "apps", height: 22 %>
-    <span class="pulse-tab-bar-label">Places</span>
     <span class="pulse-tab-bar-dot" data-places-sheet-target="dot"
           style="<%= 'display: none' unless rail_unread_counts.values.any?(&:positive?) || rail_chat_unread_count.positive? %>"></span>
   </button>
 
-  <a href="/search" class="pulse-tab-bar-item<%= ' active' if request.path.start_with?('/search') %>"
+  <a href="/search" class="pulse-tab-bar-item<%= ' active' if request.path.start_with?('/search') %>" aria-label="Search"
      <% if request.path.start_with?("/search") %>aria-current="page"<% end %>>
     <%= octicon "search", height: 22 %>
-    <span class="pulse-tab-bar-label">Search</span>
   </a>
 
-  <a href="/notifications" class="pulse-tab-bar-item<%= ' active' if request.path.start_with?('/notifications') %>"
+  <a href="/notifications" class="pulse-tab-bar-item<%= ' active' if request.path.start_with?('/notifications') %>" aria-label="Inbox"
      <% if request.path.start_with?("/notifications") %>aria-current="page"<% end %>>
     <%= octicon "inbox", height: 22 %>
-    <span class="pulse-tab-bar-label">Inbox</span>
     <span class="pulse-tab-bar-badge" data-total-badge
           style="<%= count_badge_style(@unread_notification_count.to_i) %>"><%= count_badge_text(@unread_notification_count.to_i) %></span>
   </a>
@@ -40,9 +36,8 @@
       <button type="button" class="pulse-tab-bar-you-button"
               data-top-right-menu-target="button"
               data-action="click->top-right-menu#toggleMenu"
-              aria-haspopup="menu">
+              aria-haspopup="menu" aria-label="You">
         <%= profile_pic(@current_user) %>
-        <span class="pulse-tab-bar-label">You</span>
       </button>
       <div data-top-right-menu-target="menu" class="top-menu" style="display:none;">
         <%= render "layouts/user_menu" %>

--- a/app/views/layouts/_top_right_menu.html.erb
+++ b/app/views/layouts/_top_right_menu.html.erb
@@ -49,61 +49,7 @@
       <%= profile_pic(@current_user) %>
     </div>
     <div data-top-right-menu-target="menu" class="top-menu" style="display:none;">
-      <ul>
-        <li>
-          <%= octicon 'person' %>
-          <a href="<%= @current_user.path %>">Profile</a>
-        </li>
-        <li>
-          <%= octicon 'list-unordered' %>
-          <a href="<%= @current_user.path %>/lists">Your lists</a>
-        </li>
-        <li>
-          <%= octicon 'comment-discussion' %>
-          <a href="/chat">Chat</a>
-        </li>
-        <% if @current_tenant&.any_ai_agents_enabled? %>
-          <li>
-            <%= octicon 'command-palette' %>
-            <a href="/ai-agents">AI Agents</a>
-          </li>
-        <% end %>
-        <li>
-          <%= octicon 'people' %>
-          <a href="/collectives">Collectives</a>
-        </li>
-        <li>
-          <%= octicon 'globe' %>
-          <a href="/subdomains">Subdomains</a>
-        </li>
-        <li>
-          <%= octicon 'gear' %>
-          <a href="<%= @current_user.path %>/settings">Settings</a>
-          <% if (pending_grants = @current_user.pending_trustee_grant_requests.count) > 0 %>
-            <span class="notification-badge-count" style="position:relative;top:-2px;margin-left:4px;"><%= pending_grants %></span>
-          <% end %>
-        </li>
-        <li>
-          <%= octicon 'question' %>
-          <a href="/help">Help</a>
-        </li>
-        <% if @current_tenant.is_admin?(@current_user) %>
-          <li>
-            <a href="/admin">
-              <%= octicon 'tools' %> Admin
-            </a>
-          </li>
-        <% end %>
-        <li>
-          <hr style="height:0;margin:0;border:none;border-top:1px solid var(--color-border-default);" />
-        </li>
-        <li>
-          <%= octicon 'sign-out' %>
-          <%= button_to "Sign Out", logout_path, method: :delete, style: "display:inline;",
-                params: { push_endpoint: "" },
-                form: { data: { controller: "logout", action: "submit->logout#prepare" } } %>
-        </li>
-      </ul>
+      <%= render "layouts/user_menu" %>
     </div>
   </div>
 <% else %>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -6,16 +6,16 @@
     <%= octicon 'person' %>
     <a href="<%= @current_user.path %>">Profile</a>
   </li>
-  <li>
-    <%= octicon 'list-unordered' %>
-    <a href="<%= @current_user.path %>/lists">Your lists</a>
-  </li>
   <% if @current_tenant&.any_ai_agents_enabled? %>
     <li>
       <%= octicon 'command-palette' %>
       <a href="/ai-agents">AI Agents</a>
     </li>
   <% end %>
+  <li>
+    <%= octicon 'list-unordered' %>
+    <a href="<%= @current_user.path %>/lists">Lists</a>
+  </li>
   <li>
     <%= octicon 'globe' %>
     <a href="/subdomains">Subdomains</a>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -10,20 +10,12 @@
     <%= octicon 'list-unordered' %>
     <a href="<%= @current_user.path %>/lists">Your lists</a>
   </li>
-  <li>
-    <%= octicon 'comment-discussion' %>
-    <a href="/chat">Chat</a>
-  </li>
   <% if @current_tenant&.any_ai_agents_enabled? %>
     <li>
       <%= octicon 'command-palette' %>
       <a href="/ai-agents">AI Agents</a>
     </li>
   <% end %>
-  <li>
-    <%= octicon 'people' %>
-    <a href="/collectives">Collectives</a>
-  </li>
   <li>
     <%= octicon 'globe' %>
     <a href="/subdomains">Subdomains</a>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -1,0 +1,58 @@
+<%# The signed-in user's menu items — rendered inside the header avatar
+    dropdown (desktop) and the tab bar's You tab (mobile). Both wrap it in
+    their own top-right-menu controller instance. %>
+<ul>
+  <li>
+    <%= octicon 'person' %>
+    <a href="<%= @current_user.path %>">Profile</a>
+  </li>
+  <li>
+    <%= octicon 'list-unordered' %>
+    <a href="<%= @current_user.path %>/lists">Your lists</a>
+  </li>
+  <li>
+    <%= octicon 'comment-discussion' %>
+    <a href="/chat">Chat</a>
+  </li>
+  <% if @current_tenant&.any_ai_agents_enabled? %>
+    <li>
+      <%= octicon 'command-palette' %>
+      <a href="/ai-agents">AI Agents</a>
+    </li>
+  <% end %>
+  <li>
+    <%= octicon 'people' %>
+    <a href="/collectives">Collectives</a>
+  </li>
+  <li>
+    <%= octicon 'globe' %>
+    <a href="/subdomains">Subdomains</a>
+  </li>
+  <li>
+    <%= octicon 'gear' %>
+    <a href="<%= @current_user.path %>/settings">Settings</a>
+    <% if (pending_grants = @current_user.pending_trustee_grant_requests.count) > 0 %>
+      <span class="notification-badge-count" style="position:relative;top:-2px;margin-left:4px;"><%= pending_grants %></span>
+    <% end %>
+  </li>
+  <li>
+    <%= octicon 'question' %>
+    <a href="/help">Help</a>
+  </li>
+  <% if @current_tenant.is_admin?(@current_user) %>
+    <li>
+      <a href="/admin">
+        <%= octicon 'tools' %> Admin
+      </a>
+    </li>
+  <% end %>
+  <li>
+    <hr style="height:0;margin:0;border:none;border-top:1px solid var(--color-border-default);" />
+  </li>
+  <li>
+    <%= octicon 'sign-out' %>
+    <%= button_to "Sign Out", logout_path, method: :delete, style: "display:inline;",
+          params: { push_endpoint: "" },
+          form: { data: { controller: "logout", action: "submit->logout#prepare" } } %>
+  </li>
+</ul>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -6,6 +6,12 @@
     <%= octicon 'person' %>
     <a href="<%= @current_user.path %>">Profile</a>
   </li>
+  <% if (workspace = @current_user.private_workspace) %>
+    <li>
+      <%= octicon 'lock' %>
+      <a href="<%= workspace.path %>">Workspace</a>
+    </li>
+  <% end %>
   <% if @current_tenant&.any_ai_agents_enabled? %>
     <li>
       <%= octicon 'command-palette' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,16 +41,6 @@
       <header class="pulse-top-header"
               data-controller="auto-hide-header"
               data-auto-hide-header-hidden-class="pulse-top-header--hidden">
-        <% if @current_user %>
-          <button type="button" class="pulse-places-toggle"
-                  data-places-sheet-target="toggle"
-                  data-action="click->places-sheet#toggle"
-                  aria-expanded="false" aria-label="Places">
-            <%= octicon "three-bars", height: 20 %>
-            <span class="pulse-places-toggle-dot" data-places-sheet-target="dot"
-                  style="<%= 'display: none' unless rail_unread_counts.values.any?(&:positive?) || rail_chat_unread_count.positive? %>"></span>
-          </button>
-        <% end %>
         <a href="/" class="pulse-logo">
           <i class="tri-logo-icon icon-sm"></i>
           <span>Harmonic</span>
@@ -117,6 +107,9 @@
         </main>
       <% end %>
     </div>
+    <% if @current_user && !@hide_header %>
+      <%= render "layouts/bottom_tab_bar" %>
+    <% end %>
     <p class="pulse-motto-footer"
       title="These words appear on every page in Harmonic as a tuning fork to facilitate social attunement between agents within Harmonic, both human and AI. Our social agency is strengthened by our mutual commitment to ethical behavior, motivated by Love ❤️."
     >

--- a/app/views/pulse/feed.html.erb
+++ b/app/views/pulse/feed.html.erb
@@ -20,10 +20,15 @@
         <% end %>
       <% elsif default_feed_view? %>
         <div class="pulse-feed-empty">
-          <p>Nothing here this week.</p>
-          <p class="pulse-body-text-muted">
-            <%= link_to "Show all time", "#{@current_collective.path}?q=" %>
-          </p>
+          <% if @feed_default_query.present? %>
+            <p>Nothing here this week.</p>
+            <p class="pulse-body-text-muted">
+              <%= link_to "Show all time", "#{@current_collective.path}?q=" %>
+            </p>
+          <% else %>
+            <%# Workspaces: no default query, so the default view IS all time. %>
+            <p>Nothing here yet.</p>
+          <% end %>
         </div>
       <% else %>
         <div class="pulse-feed-empty">

--- a/docs/NAVIGATION_DESIGN.md
+++ b/docs/NAVIGATION_DESIGN.md
@@ -201,7 +201,9 @@ Decisions and rationale:
   own query (list activity; the profile Posts/Activity tabs already
   did). An earlier draft special-cased `my:notified` to lift a hidden
   exclusion; rejected — defaults carry the curation, queries carry
-  nothing invisible.
+  nothing invisible. **Private workspaces have no default query at
+  all**: `visibility:private` is the only filter — there is no curation
+  layer over your own space.
 - **Refinements live in the URL** (`/collectives/x?q=type:decision`), so
   filtered views are shareable and the back button works. The canonical
   page URL (no `q`) always shows the default view. Markdown frontmatter

--- a/docs/NAVIGATION_DESIGN.md
+++ b/docs/NAVIGATION_DESIGN.md
@@ -301,12 +301,26 @@ chrome to reshape per form factor without forking the model.
 
 ### Increments (each independently shippable, none undone by the next)
 
-1. **Bottom tab bar** — the sheet gets its tab; Inbox/Search/You move
-   down; the top bar slims to a place label.
-2. **Sidebar → place header**, paced by how much of the sidebar
-   feeds-are-queries continues to absorb.
+1. **Sidebar → place header**, paced by how much of the sidebar
+   feeds-are-queries continues to absorb. This also owes the top bar its
+   place label — with the control cluster gone on mobile, the slimmed
+   bar still shows the logo, not "where am I".
 
 Shipped from this list:
+
+- **Bottom tab bar** (built): `[Home(globe)][Places][Search][Inbox][You]`
+  under 768px, the rail's mirror — CSS shows exactly one of the two per
+  width (`--pulse-tab-bar-height` is the layout hook, 0 on desktop).
+  Places carries the aggregate dot and toggles the sheet (the header
+  toggle is gone); Inbox carries the total count (`[data-total-badge]`,
+  fed by the same `notifications:counts` broadcast); You opens the
+  avatar menu upward (shared `layouts/_user_menu` partial, rendered in
+  both the header dropdown and the bar — the You-menu positioning is
+  pure CSS because measuring a `display:none` menu's offsetParent
+  resolves to `<body>` and breaks on scrolled pages). On mobile the
+  header hides search/inbox/avatar (they stay in the DOM — the
+  notification poller lives in the header cluster) and keeps the
+  contextual `+`; creation takes no tab.
 
 - **Badge click-through + clearing affordance** (open question 3, built):
   reminder-notification attribution, the `my:` filter namespace

--- a/e2e/tests/collectives/places-sheet.spec.ts
+++ b/e2e/tests/collectives/places-sheet.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "../../fixtures/test-fixtures"
 
 test.describe("Places Sheet", () => {
-  test("opens from the header toggle on mobile and lists places by name", async ({
+  test("opens from the tab bar's Places tab on mobile and lists places by name", async ({
     authenticatedPage,
   }) => {
     const page = authenticatedPage
@@ -9,7 +9,7 @@ test.describe("Places Sheet", () => {
 
     await page.goto("/")
 
-    const toggle = page.locator(".pulse-places-toggle")
+    const toggle = page.locator(".pulse-tab-bar-places")
     await expect(toggle).toBeVisible()
 
     const sheet = page.locator(".pulse-places-sheet")
@@ -29,14 +29,37 @@ test.describe("Places Sheet", () => {
     await expect(sheet).toBeHidden()
   })
 
-  test("the toggle is hidden on desktop where the rail serves instead", async ({
+  test("the tab bar is hidden on desktop where the rail serves instead", async ({
     authenticatedPage,
   }) => {
     const page = authenticatedPage
 
     await page.goto("/")
 
-    await expect(page.locator(".pulse-places-toggle")).toBeHidden()
+    await expect(page.locator(".pulse-tab-bar")).toBeHidden()
     await expect(page.locator(".pulse-rail")).toBeVisible()
+  })
+
+  test("the tab bar shows its five destinations on mobile and the rail hides", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage
+    await page.setViewportSize({ width: 375, height: 667 })
+
+    await page.goto("/")
+
+    const bar = page.locator(".pulse-tab-bar")
+    await expect(bar).toBeVisible()
+    await expect(page.locator(".pulse-rail")).toBeHidden()
+    await expect(bar.locator("a[href='/']")).toBeVisible()
+    await expect(bar.locator(".pulse-tab-bar-places")).toBeVisible()
+    await expect(bar.locator("a[href='/search']")).toBeVisible()
+    await expect(bar.locator("a[href='/notifications']")).toBeVisible()
+    await expect(bar.locator(".pulse-tab-bar-you-button")).toBeVisible()
+
+    // You opens the user menu upward.
+    await bar.locator(".pulse-tab-bar-you-button").click()
+    await expect(bar.locator(".top-menu")).toBeVisible()
+    await expect(bar.locator(".top-menu a[href='/help']")).toBeVisible()
   })
 })

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -91,6 +91,18 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "the user menu links to the user's private workspace" do
+    sign_in_as(@user, tenant: @tenant)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    workspace = @user.private_workspace
+    Tenant.clear_thread_scope
+    assert workspace, "expected add_user! to have created a private workspace"
+
+    get "/"
+    assert_response :success
+    assert_select ".pulse-tab-bar [data-controller='top-right-menu'] a[href='#{workspace.path}']", text: "Workspace"
+  end
+
   test "the tab bar's inbox badge renders the unread count server-side" do
     Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
     notification = Notification.create!(tenant: @tenant, event: nil, notification_type: "reminder", title: "Badge probe")

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -77,9 +77,10 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     assert_select ".pulse-tab-bar" do
-      # Outward → inward: globe, places, search, inbox, you.
+      # Outward → inward: globe, places, search, inbox, you. Bare icons —
+      # aria-labels carry the names.
       assert_select "a[href='/'] .octicon-globe"
-      assert_select "button[data-action*='places-sheet#toggle']", text: /Places/
+      assert_select "button[data-action*='places-sheet#toggle'][aria-label='Places']"
       assert_select "a[href='/search']"
       assert_select "a[href='/notifications'] .pulse-tab-bar-badge"
       # You: the avatar menu, same items as the header menu.

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -52,18 +52,61 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "layout renders the places sheet and its header toggle for signed-in users" do
+  test "layout renders the places sheet, toggled from the tab bar's Places tab" do
     sign_in_as(@user, tenant: @tenant)
     get "/"
     assert_response :success
 
     assert_select "body[data-controller~='places-sheet']"
-    assert_select ".pulse-places-toggle[data-places-sheet-target='toggle'][aria-expanded='false']"
+    # The sheet's toggle lives in the bottom tab bar now; the old header
+    # toggle is gone.
+    assert_select ".pulse-places-toggle", false
+    assert_select ".pulse-tab-bar button[data-places-sheet-target='toggle'][aria-expanded='false']" do
+      assert_select "[data-places-sheet-target='dot']"
+    end
     assert_select ".pulse-places-sheet[aria-hidden='true']" do
       assert_select "a[href='/']", text: /Public space/
       assert_select "a[href='/chat']", text: /Chat/
       assert_select "a[href='/collectives']", text: /Create or join a collective/
     end
+  end
+
+  test "layout renders the bottom tab bar with its five destinations for signed-in users" do
+    sign_in_as(@user, tenant: @tenant)
+    get "/"
+    assert_response :success
+
+    assert_select ".pulse-tab-bar" do
+      # Outward → inward: globe, places, search, inbox, you.
+      assert_select "a[href='/'] .octicon-globe"
+      assert_select "button[data-action*='places-sheet#toggle']", text: /Places/
+      assert_select "a[href='/search']"
+      assert_select "a[href='/notifications'] .pulse-tab-bar-badge"
+      # You: the avatar menu, same items as the header menu.
+      assert_select "[data-controller='top-right-menu']" do
+        assert_select "a[href='#{@user.path}']", text: "Profile"
+        assert_select "button[type=submit]", text: "Sign Out"
+      end
+    end
+  end
+
+  test "the tab bar's inbox badge renders the unread count server-side" do
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    notification = Notification.create!(tenant: @tenant, event: nil, notification_type: "reminder", title: "Badge probe")
+    NotificationRecipient.create!(notification: notification, user: @user, channel: "in_app", status: "delivered", tenant: @tenant)
+    Tenant.clear_thread_scope
+
+    sign_in_as(@user, tenant: @tenant)
+    get "/"
+    assert_response :success
+    assert_select ".pulse-tab-bar a[href='/notifications'] .pulse-tab-bar-badge[data-total-badge]", text: "1"
+  end
+
+  test "anonymous pages render no tab bar" do
+    get "/login"
+    follow_redirect!
+    assert_response :success
+    assert_select ".pulse-tab-bar", false
   end
 
   test "rail chat badge renders its unread count server-side on first paint" do

--- a/test/controllers/pulse_controller_test.rb
+++ b/test/controllers/pulse_controller_test.rb
@@ -249,6 +249,11 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select ".pulse-feed-bar-scope code", text: "visibility:private"
     assert_includes response.body, "private workspace feed probe"
+    # Workspaces get no default query — the private zone is the only
+    # filter; there is no curation layer over your own space.
+    assert_select "textarea[name='q']" do |fields|
+      assert_equal "", fields.first.text.strip
+    end
   end
 
   test "dashboard-only sidebar sections hide on the feed" do

--- a/test/integration/private_workspace_test.rb
+++ b/test/integration/private_workspace_test.rb
@@ -53,8 +53,12 @@ class PrivateWorkspaceTest < ActionDispatch::IntegrationTest
     get "/whoami"
     assert_response :success
     workspace = @alice.private_workspace
-    # The workspace name appears in "Your Workspace" section but NOT in "Your Collectives"
-    collectives_section = response.body.split("Your Collectives").last
+    # The workspace name appears in "Your Workspace" section but NOT in
+    # "Your Collectives". Scope to the page content — the layout chrome
+    # (the user menu in the header and tab bar) intentionally links to
+    # your own workspace on every page.
+    main_content = response.body[%r{<main.*</main>}m].to_s
+    collectives_section = main_content.split("Your Collectives").last
     refute_includes collectives_section, workspace.handle
   end
 
@@ -230,10 +234,14 @@ class PrivateWorkspaceTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     workspace = @alice.private_workspace
-    refute_includes response.body, workspace.handle,
+    # The index listing must not include the workspace. The layout chrome
+    # (the user menu in the header and tab bar) intentionally links to
+    # your own workspace on every page, so scope to the page content.
+    main_content = response.body[%r{<main.*</main>}m].to_s
+    refute_includes main_content, workspace.handle,
       "Collectives index should not include private workspace"
     # But should show the regular collective
-    assert_includes response.body, @collective.name
+    assert_includes main_content, @collective.name
   end
 
   # =========================================================================


### PR DESCRIPTION
The bottom tab bar from the form-factors design (docs/NAVIGATION_DESIGN.md): five persistent destinations under 768px, ordered left→right as outward→inward — **[Home(globe)] [Places] [Search] [Inbox] [You]**. The rail and the bar never coexist: CSS shows one projection per width, with `--pulse-tab-bar-height` as the layout hook (0 on desktop; content and footer clearance derive from it, mirroring `--pulse-rail-width`).

## The tabs

- **Home** — the globe, linking to `/`. Bare icons in the default foreground color; `aria-label`s carry the names.
- **Places** — toggles the places sheet and carries the aggregate unread dot. The old header hamburger toggle is deleted: the bar replaces it at the only width it ever showed.
- **Search** — `/search`.
- **Inbox** — `/notifications` with the total unread count: server-rendered first paint from the existing layout ivar, kept live by the rail-badges controller's new `[data-total-badge]` handling off the same `notifications:counts` broadcast.
- **You** — the avatar menu, opening upward. Menu items are extracted to a shared `layouts/_user_menu` partial rendered by both the header dropdown and the bar, each with its own `top-right-menu` controller instance. Upward positioning is pure CSS (`bottom: 100%` inside the positioned tab): measuring a `display:none` menu's `offsetParent` resolves to `<body>`, which offset the menu by the page's scroll height. Hidden during representation sessions, matching the header.

## Header on mobile

Search, the inbox icon, and the avatar hide under 768px (hidden, not removed — the notification poller lives in that cluster). The contextual `+` keeps its top-bar slot: creation takes no tab, per the doc. The top bar's place label comes with the sidebar→place-header increment.

## You-menu changes riding along

- **Chat** and **Collectives** dropped from the user menu — both live in the place chrome now (rail / sheet / bar).
- **Workspace** added under Profile: the nav redesign's first doorway to the private zone ("private enters from the right" — the rightmost tab is the right edge). Lock icon + the page's fixed `visibility:private` scope carry the privacy; guarded for users without a workspace.
- "Your lists" → **Lists**; AI Agents ordered above it.

## Workspace feeds: no default query

`visibility:private` is the only filter — no cycle window, no comment exclusion; there is no curation layer over your own space. The default-view empty state stops saying "this week" when there is no default query (the default view already IS all time), and the `/help/markdown-ui` scope table shows "—".

## Auto-hide

The bar hides on scroll-down and reveals on scroll-up in lockstep with the top header — the same `auto-hide-header` controller, one instance per bar, same threshold and timing, opposite translate. Inherits reveal-on-focus and `prefers-reduced-motion` handling.

## Tests

Layout tests for the five destinations, the sheet toggling from the bar, the server-rendered inbox count, the Workspace link, no bar for anonymous pages, and the header toggle's removal; vitest for the total-count badge; the places-sheet e2e specs updated for the bar (plus a new five-destinations + You-menu spec); workspace-feed test pins the empty default query. Verified in the browser at 375px and 1280px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
