### PR TITLE
Fix #392: iOS autozoom on feed bar query field

### DIFF
--- a/app/assets/stylesheets/pulse/_responsive.css
+++ b/app/assets/stylesheets/pulse/_responsive.css
@@ -94,11 +94,12 @@
 
   /* iOS Safari zooms the viewport on focus when input font-size < 16px.
      Force every text-entry control to at least 16px on mobile so focusing
-     never triggers an autozoom. Element selectors with :not() keep enough
-     specificity to override class-based sizes like .header-search-input. */
+     never triggers an autozoom. !important because this is an invariant,
+     not a default: any class-based size (e.g. a 13px query field) outranks
+     bare element selectors and would silently reintroduce the zoom. */
   input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),
   textarea,
   select {
-    font-size: 16px;
+    font-size: 16px !important;
   }
 }

--- a/e2e/tests/pulse/mobile-input-zoom.spec.ts
+++ b/e2e/tests/pulse/mobile-input-zoom.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "../../fixtures/test-fixtures"
+
+// iOS Safari zooms the viewport when a focused text control's computed
+// font-size is under 16px. The guard lives in _responsive.css; these specs
+// pin it against class-based font-size overrides (issue #392: the feed bar's
+// textarea regressed because its 13px class outranked the bare `textarea`
+// element selector).
+
+const fontSize = async (locator: import("@playwright/test").Locator) =>
+  parseFloat(await locator.evaluate((el) => getComputedStyle(el).fontSize))
+
+test.describe("Mobile input font-size (iOS autozoom guard)", () => {
+  test("feed bar query textarea is at least 16px on mobile", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage
+    await page.setViewportSize({ width: 375, height: 667 })
+    await page.goto("/")
+
+    const input = page.locator("textarea.pulse-feed-bar-input")
+    await expect(input).toBeVisible()
+    expect(await fontSize(input)).toBeGreaterThanOrEqual(16)
+  })
+
+  test("feed bar query textarea keeps its compact size on desktop", async ({
+    authenticatedPage,
+  }) => {
+    const page = authenticatedPage
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await page.goto("/")
+
+    const input = page.locator("textarea.pulse-feed-bar-input")
+    await expect(input).toBeVisible()
+    expect(await fontSize(input)).toBeLessThan(16)
+  })
+})


### PR DESCRIPTION
Fixes #392.

## Root cause

The mobile ≥16px font-size guard in `_responsive.css` protects text controls from iOS Safari's focus autozoom (triggered when computed font-size < 16px). The `input` selector carries four `:not([type=...])` attribute selectors (specificity 0-4-1), but `textarea` and `select` sat bare at 0-0-1 — so any class-based font-size outranked them.

#381 converted the feed bar's query field from `<input>` to `<textarea class="pulse-feed-bar-input">` (so long queries wrap). As an input it was protected; as a textarea, its 13px class beat the bare guard, and every feed page's query field started autozooming on iOS.

## Fix

Make the guard `font-size: 16px !important`. It is an invariant (no text control under 16px on mobile), not a default — any class-based size would silently reintroduce the zoom otherwise. Audited the stylesheets: no text-entry control is styled above 16px anywhere, so nothing gets shrunk.

## Tests

New e2e spec (`mobile-input-zoom.spec.ts`) pins the computed font-size of the feed bar textarea: ≥16px at 375px viewport (red at 13px before the fix), and still compact (<16px) at desktop width so the override provably stays inside the mobile media query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)