### PR TITLE
Add pure my: aliases to the search DSL (#373)

### DIFF
--- a/app/services/search_query.rb
+++ b/app/services/search_query.rb
@@ -41,7 +41,14 @@ class SearchQuery
     @current_user = current_user
     @raw_query = raw_query
     @fixed_params = fixed_params
+    @my_filters_unresolvable = T.let(false, T::Boolean)
     @params = build_params(params)
+
+    # Pure my: aliases (my:notes, my:voted, …) are sugar over existing
+    # operators scoped to the viewer. Expand them first so they behave
+    # exactly as if the viewer had typed the underlying operators —
+    # including being clamped by a page's fixed scope below.
+    expand_my_aliases
 
     # Page scope: fixed params win over anything the query says, loudly.
     apply_fixed_params(fixed_params)
@@ -591,9 +598,131 @@ class SearchQuery
     return if @current_user.present?
     return if Array(@params[:my_filters]).blank? && Array(@params[:exclude_my_filters]).blank?
 
+    warn_my_requires_user
+    @my_filters_unresolvable = true
+  end
+
+  # The shared "no viewer → no results" warning, deduped so a query mixing
+  # viewer-state values and aliases only reports it once.
+  sig { void }
+  def warn_my_requires_user
     @warnings ||= []
-    T.must(@warnings) << "my: filters need a signed-in user — showing no results"
-    @my_filters_unresolvable = T.let(true, T.nilable(T::Boolean))
+    msg = "my: filters need a signed-in user — showing no results"
+    T.must(@warnings) << msg unless T.must(@warnings).include?(msg)
+  end
+
+  # my: values that carry their own query logic (see apply_my_filters).
+  # Everything else in the namespace is a pure alias handled below.
+  MY_VIEWER_STATE_VALUES = T.let(%w[notified unread read].freeze, T::Array[String])
+
+  # Pure my: aliases expand into the params of existing operators, scoped
+  # to the viewer's own handle — so creator:/type:/subtype:/voter:/
+  # participant:/mentions:/list: remain the single implementation and the
+  # my: prefix is just a discoverable, viewer-relative shorthand (#373).
+  # Values that carry real logic (notified/unread/read) are left in
+  # my_filters for apply_my_filters.
+  sig { void }
+  def expand_my_aliases
+    warn_negated_my_aliases
+
+    aliases = Array(@params[:my_filters]) - MY_VIEWER_STATE_VALUES
+    return if aliases.blank?
+
+    # Keep only the viewer-state values under my_filters; the rest expand
+    # into other params below.
+    remaining = Array(@params[:my_filters]) & MY_VIEWER_STATE_VALUES
+    if remaining.present?
+      @params[:my_filters] = remaining
+    else
+      @params.delete(:my_filters)
+    end
+
+    handle = viewer_handle
+    # Without a viewer handle (anonymous, or no handle in this tenant) the
+    # aliases can't be scoped to anyone. Fail closed rather than dropping
+    # the viewer constraint and leaking everyone's items.
+    if handle.blank?
+      warn_my_requires_user
+      @my_filters_unresolvable = true
+      return
+    end
+
+    aliases.each { |value| apply_my_alias(value, handle) }
+  end
+
+  # Negating a compound alias (-my:notes = NOT(creator:me AND type:note))
+  # isn't a pure expansion, so aliases can't be negated. Warn and drop them
+  # rather than silently matching everything.
+  sig { void }
+  def warn_negated_my_aliases
+    negated_aliases = Array(@params[:exclude_my_filters]) - MY_VIEWER_STATE_VALUES
+    return if negated_aliases.blank?
+
+    @warnings ||= []
+    negated_aliases.each do |value|
+      T.must(@warnings) << "-my:#{value} is not supported (my: aliases can't be negated); ignored"
+    end
+    remaining = Array(@params[:exclude_my_filters]) & MY_VIEWER_STATE_VALUES
+    if remaining.present?
+      @params[:exclude_my_filters] = remaining
+    else
+      @params.delete(:exclude_my_filters)
+    end
+  end
+
+  sig { params(value: String, handle: String).void }
+  def apply_my_alias(value, handle)
+    case value
+    when "mentions"
+      merge_handle_param(:mentions_handles, handle)
+    when "notes"
+      merge_handle_param(:creator_handles, handle)
+      merge_type("note")
+    when "decisions"
+      merge_handle_param(:creator_handles, handle)
+      merge_type("decision")
+    when "commitments"
+      merge_handle_param(:creator_handles, handle)
+      merge_type("commitment")
+    when "posts"
+      merge_handle_param(:creator_handles, handle)
+      merge_subtype("post")
+    when "voted"
+      merge_handle_param(:voter_handles, handle)
+    when "committed"
+      merge_handle_param(:participant_handles, handle)
+    when "rsvps"
+      merge_handle_param(:participant_handles, handle)
+      merge_subtype("calendar_event")
+    when "mutuals"
+      # list: is single-valued (last wins); don't clobber an explicit list:.
+      @params[:list_id_or_alias] ||= "mutuals"
+    end
+  end
+
+  sig { params(key: Symbol, handle: String).void }
+  def merge_handle_param(key, handle)
+    @params[key] = (Array(@params[key]) + [handle]).uniq
+  end
+
+  sig { params(subtype: String).void }
+  def merge_subtype(subtype)
+    @params[:subtypes] = (Array(@params[:subtypes]) + [subtype]).uniq
+  end
+
+  # @params[:type] is a comma-joined string (see the parser's type param).
+  sig { params(type: String).void }
+  def merge_type(type)
+    existing = @params[:type].to_s.split(",").map(&:strip).compact_blank
+    @params[:type] = (existing + [type]).uniq.join(",")
+  end
+
+  sig { returns(T.nilable(String)) }
+  def viewer_handle
+    return @viewer_handle if defined?(@viewer_handle)
+
+    handle = @current_user && @tenant.tenant_users.find_by(user_id: T.must(@current_user).id)&.handle
+    @viewer_handle = T.let(handle, T.nilable(String))
   end
 
   sig { returns(T::Array[String]) }

--- a/app/services/search_query_parser.rb
+++ b/app/services/search_query_parser.rb
@@ -38,11 +38,21 @@ class SearchQueryParser
     "visibility" => { values: ["public", "shared", "private"], multi: true },
 
     # User filters
-    # Viewer-state filters: the viewer's own state per item (notification
-    # queue, read confirmations), unlike creator:/list: which resolve to
-    # authors. Requires a signed-in user — SearchQuery warns and matches
+    # The my: namespace filters on the current user's own relationship to
+    # items. Two kinds of value share the one prefix for discoverability:
+    #   - Viewer-state filters (notified/unread/read): the viewer's own
+    #     state per item (notification queue, read confirmations), unlike
+    #     creator:/list: which resolve to authors. These carry their own
+    #     query logic — see SearchQuery#apply_my_filters.
+    #   - Pure aliases (the rest): sugar that SearchQuery expands into
+    #     existing operators scoped to the viewer's handle, so those
+    #     operators stay the single implementation (issue #373).
+    # Either way requires a signed-in user — SearchQuery warns and matches
     # nothing otherwise.
-    "my" => { values: ["notified", "unread", "read"], multi: true },
+    "my" => {
+      values: %w[notified unread read mentions notes decisions commitments posts voted committed rsvps mutuals],
+      multi: true,
+    },
 
     "creator" => { pattern: HANDLE_PATTERN, multi: true },
     "read-by" => { pattern: HANDLE_PATTERN, multi: true },

--- a/app/views/help/search.md.erb
+++ b/app/views/help/search.md.erb
@@ -54,6 +54,26 @@ unread-count badge. `my:unread`/`my:read` are about read *confirmations*
 (the social act), not notifications; only notes can be unread, so
 `my:unread` never matches decisions or commitments.
 
+The rest of the namespace is shorthand: each value expands to an existing
+operator scoped to you, so it composes with everything else the same way.
+
+| Value | Expands to | Meaning |
+|-------|-----------|---------|
+| `my:notes` | `creator:@you type:note` | Notes you created |
+| `my:decisions` | `creator:@you type:decision` | Decisions you created |
+| `my:commitments` | `creator:@you type:commitment` | Commitments you created |
+| `my:posts` | `creator:@you subtype:post` | Posts you created |
+| `my:voted` | `voter:@you` | Decisions you voted on |
+| `my:committed` | `participant:@you` | Commitments you joined |
+| `my:rsvps` | `participant:@you subtype:calendar_event` | Calendar events you're attending |
+| `my:mentions` | `mentions:@you` | Items that mention you |
+| `my:mutuals` | `list:mutuals` | Items from people you're mutuals with |
+
+Because these are pure aliases, they compose like their underlying
+operators (which combine with AND): `my:voted my:committed` matches items
+that are *both*, not either. Aliases can't be negated — write the
+underlying operator (e.g. `-creator:@you`) instead.
+
 ### Numeric Filters
 
 Use `min-` and `max-` prefixes with these fields:

--- a/test/services/search_query_parser_test.rb
+++ b/test/services/search_query_parser_test.rb
@@ -698,6 +698,13 @@ class SearchQueryParserTest < ActiveSupport::TestCase
     assert_equal ["unread", "read"], result[:my_filters]
   end
 
+  test "my: parses the pure-alias values" do
+    # Parsing only collects the raw values under my_filters; SearchQuery is
+    # what expands aliases into the underlying operators (issue #373).
+    result = SearchQueryParser.new("my:notes,voted,mutuals").parse
+    assert_equal ["notes", "voted", "mutuals"], result[:my_filters]
+  end
+
   test "negated my: values parse into the exclusion param" do
     result = SearchQueryParser.new("-my:read").parse
     assert_equal ["read"], result[:exclude_my_filters]
@@ -710,5 +717,6 @@ class SearchQueryParserTest < ActiveSupport::TestCase
     assert_equal 1, result[:warnings].size
     assert_includes result[:warnings].first, "my:bogus"
     assert_includes result[:warnings].first, "notified, unread, read"
+    assert_includes result[:warnings].first, "notes, decisions, commitments"
   end
 end

--- a/test/services/search_query_test.rb
+++ b/test/services/search_query_test.rb
@@ -1211,4 +1211,143 @@ class SearchQueryTest < ActiveSupport::TestCase
     assert_not_includes results, ["Note", @note.id]
     assert_includes results, ["Decision", @decision.id]
   end
+
+  # my: — pure aliases that expand into existing operators scoped to the
+  # viewer's own handle (issue #373).
+
+  def set_status(user, item, **flags)
+    status = UserItemStatus.find_or_initialize_for(
+      tenant_id: @tenant.id, user_id: user.id,
+      item_type: item.class.name, item_id: item.id
+    )
+    status.update!(**flags)
+  end
+
+  test "my:notes returns the viewer's notes and nothing else" do
+    author = add_member("Author")
+    my_note = create_note(tenant: @tenant, collective: @collective, created_by: author, text: "Author note")
+    other_note = create_note(tenant: @tenant, collective: @collective, created_by: @user, text: "Someone else note")
+    [my_note, other_note].each { |n| SearchIndexer.reindex(n) }
+
+    results = my_search(author, "my:notes").results.map { |r| [r.item_type, r.item_id] }
+    assert_includes results, ["Note", my_note.id]
+    assert_not_includes results, ["Note", other_note.id]
+    # Author's own decisions/commitments are excluded — my:notes is type-scoped.
+    assert results.all? { |type, _| type == "Note" }
+  end
+
+  test "my:decisions and my:commitments are type-scoped to the viewer's items" do
+    author = add_member("Maker")
+    decision = create_decision(tenant: @tenant, collective: @collective, created_by: author, question: "Author decision?")
+    commitment = create_commitment(tenant: @tenant, collective: @collective, created_by: author, title: "Author commitment")
+    [decision, commitment].each { |i| SearchIndexer.reindex(i) }
+
+    decisions = my_search(author, "my:decisions").results.map { |r| [r.item_type, r.item_id] }
+    assert_equal [["Decision", decision.id]], decisions
+
+    commitments = my_search(author, "my:commitments").results.map { |r| [r.item_type, r.item_id] }
+    assert_equal [["Commitment", commitment.id]], commitments
+  end
+
+  test "my:posts narrows to the viewer's post-subtype notes" do
+    author = add_member("Poster")
+    # Notes default to the "post" subtype; use a non-post note as the contrast.
+    post = create_note(tenant: @tenant, collective: @collective, created_by: author, subtype: "post", text: "A post")
+    reminder = create_note(tenant: @tenant, collective: @collective, created_by: author, subtype: "reminder", text: "Not a post")
+    [post, reminder].each { |n| SearchIndexer.reindex(n) }
+
+    results = my_search(author, "my:posts").results.map(&:item_id)
+    assert_includes results, post.id
+    assert_not_includes results, reminder.id
+  end
+
+  test "my:voted expands to voter:@self" do
+    voter = add_member("Voter")
+    set_status(voter, @decision, has_voted: true, voted_at: Time.current)
+
+    results = my_search(voter, "my:voted").results.map { |r| [r.item_type, r.item_id] }
+    assert_equal [["Decision", @decision.id]], results
+    # Equivalent to the underlying operator.
+    handle = @tenant.tenant_users.find_by(user_id: voter.id).handle
+    equivalent = my_search(voter, "voter:@#{handle}").results.map { |r| [r.item_type, r.item_id] }
+    assert_equal equivalent, results
+  end
+
+  test "my:committed expands to participant:@self" do
+    participant = add_member("Joiner")
+    set_status(participant, @commitment, is_participating: true, participated_at: Time.current)
+
+    results = my_search(participant, "my:committed").results.map { |r| [r.item_type, r.item_id] }
+    assert_equal [["Commitment", @commitment.id]], results
+  end
+
+  test "my:rsvps narrows participation to calendar events" do
+    attendee = add_member("Attendee")
+    event = create_commitment(tenant: @tenant, collective: @collective, created_by: @user, title: "Launch party")
+    event.update!(subtype: "calendar_event", starts_at: 1.day.from_now, ends_at: 2.days.from_now)
+    SearchIndexer.reindex(event)
+    set_status(attendee, event, is_participating: true, participated_at: Time.current)
+    set_status(attendee, @commitment, is_participating: true, participated_at: Time.current)
+
+    results = my_search(attendee, "my:rsvps").results.map(&:item_id)
+    assert_includes results, event.id
+    # The plain (non-calendar) commitment is excluded by subtype.
+    assert_not_includes results, @commitment.id
+  end
+
+  test "my:mentions expands to mentions:@self" do
+    mentioned = add_member("Mentioned")
+    set_status(mentioned, @note, is_mentioned: true)
+
+    results = my_search(mentioned, "my:mentions").results.map { |r| [r.item_type, r.item_id] }
+    assert_equal [["Note", @note.id]], results
+  end
+
+  test "my:mutuals expands to list:mutuals" do
+    @tenant.update!(main_collective: @collective)
+    mutual = add_member("Mutual")
+    stranger = add_member("Stranger")
+    # Reciprocal tune-in makes `mutual` a mutual of @user.
+    UserListMember.create!(
+      tenant: @tenant, collective: @collective,
+      user_list: @user.primary_user_list_in!(@tenant), user: mutual, added_by: @user
+    )
+    UserListMember.create!(
+      tenant: @tenant, collective: @collective,
+      user_list: mutual.primary_user_list_in!(@tenant), user: @user, added_by: mutual
+    )
+    mutual_note = create_note(tenant: @tenant, collective: @collective, created_by: mutual, text: "Mutual note")
+    stranger_note = create_note(tenant: @tenant, collective: @collective, created_by: stranger, text: "Stranger note")
+    [mutual_note, stranger_note].each { |n| SearchIndexer.reindex(n) }
+
+    ids = SearchQuery.new(tenant: @tenant, current_user: @user, raw_query: "my:mutuals cycle:all").results.pluck(:item_id)
+    assert_includes ids, mutual_note.id
+    assert_not_includes ids, stranger_note.id
+  end
+
+  test "a my: alias composes with a remaining viewer-state value" do
+    author = add_member("Mixed")
+    unread_note = create_note(tenant: @tenant, collective: @collective, created_by: author, text: "Unread by reader")
+    SearchIndexer.reindex(unread_note)
+    # `my:notes` scopes to the author; `my:unread` keeps notes they haven't
+    # confirmed read. The author confirm-reads their own notes on create, so
+    # the combination is empty for the author's own notes.
+    assert_empty my_search(author, "my:notes my:unread").results
+  end
+
+  test "my: aliases warn and match nothing for anonymous viewers" do
+    search = SearchQuery.new(tenant: @tenant, collective: nil, current_user: nil, raw_query: "my:notes cycle:all")
+
+    assert_empty search.results
+    assert search.warnings.any? { |w| w.include?("signed-in user") }
+  end
+
+  test "negated my: aliases warn and are ignored" do
+    viewer = add_member("Negator")
+
+    search = my_search(viewer, "-my:notes")
+    assert search.warnings.any? { |w| w.include?("-my:notes") && w.include?("can't be negated") }
+    # Ignored, not applied: results are not narrowed to exclude the viewer's notes.
+    assert search.results.any?
+  end
 end


### PR DESCRIPTION
Implements the **pure aliases** from #373 — the viewer-relative `my:` values that expand to existing operators. Per Dan's scoping, the new-resolution-logic values (`my:represented`, `my:lists`, `my:agents`, `my:bookmarks`) are **not** included here.

## What

Adds these `my:` values alongside the existing viewer-state ones (`notified`/`unread`/`read`):

| Alias | Expands to |
|-------|-----------|
| `my:mentions` | `mentions:@you` |
| `my:notes` | `creator:@you type:note` |
| `my:decisions` | `creator:@you type:decision` |
| `my:commitments` | `creator:@you type:commitment` |
| `my:posts` | `creator:@you subtype:post` |
| `my:voted` | `voter:@you` |
| `my:committed` | `participant:@you` |
| `my:rsvps` | `participant:@you subtype:calendar_event` |
| `my:mutuals` | `list:mutuals` |

## How

- **Parser** (`SearchQueryParser`): the new values join the `my` operator's allowed set. The parser only collects them under `my_filters` — it can't expand, since it doesn't know the viewer's handle.
- **Executor** (`SearchQuery#expand_my_aliases`): expands aliases into the underlying operator params, scoped to the viewer's tenant handle, so `creator:`/`type:`/`subtype:`/`voter:`/`participant:`/`mentions:`/`list:` stay the single implementation (per #373's "expand rather than duplicate" note). Expansion runs **before** fixed-param enforcement, so aliases are clamped by a page's fixed scope exactly like typed operators.

## Behavior notes

- **Composition**: because they're pure aliases, they compose like their operators — which combine with AND. `my:voted my:committed` matches items that are *both*, not either. Documented in `/help/search`.
- **Negation**: negating a compound alias (`-my:notes` = `NOT(creator:me AND type:note)`) isn't a pure expansion, so negated aliases **warn and are ignored** — the help points users at the underlying operator (`-creator:@you`).
- **Anonymous / no-handle viewers**: fail closed (no results) with the same "needs sign-in" warning as the viewer-state values, rather than dropping the viewer constraint and leaking everyone's items.

## Tests

- Parser: alias values parse into `my_filters`; the invalid-value warning now names them.
- Executor: one test per alias (notes/decisions/commitments/posts/voted/committed/rsvps/mentions/mutuals), plus mixing an alias with a viewer-state value, anonymous fail-closed, and negated-alias-warns.
- Full `search_query_test.rb` (83) + `search_query_parser_test.rb` (116) + `feed_search_bar_component_test.rb` (6) green; `srb tc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)