### PR TITLE
Fix push notifications silently dying on iOS

### DIFF
--- a/app/controllers/web_push_subscriptions_controller.rb
+++ b/app/controllers/web_push_subscriptions_controller.rb
@@ -19,15 +19,26 @@ class WebPushSubscriptionsController < ApplicationController
     return head :forbidden unless current_user.human?
 
     subscription_params = params.require(:subscription)
-    subscription = WebPushSubscription.upsert_for!(
+    attrs = {
       user: current_user,
       endpoint: subscription_params.require(:endpoint),
       p256dh_key: subscription_params.require(:keys).require(:p256dh),
       auth_key: subscription_params.require(:keys).require(:auth),
-      request: request
-    )
+      request: request,
+    }
 
-    render json: { id: subscription.id, device_label: subscription.device_label }, status: :created
+    # resync = the page-load background refresh, not a user action: it keeps
+    # last_seen_at honest and registers rotated endpoints, but must not
+    # revive a revoked subscription (that takes an explicit re-enable).
+    if params[:resync].present?
+      subscription = WebPushSubscription.refresh_for!(**attrs)
+      return head :no_content if subscription.nil?
+
+      render json: { id: subscription.id, device_label: subscription.device_label }, status: :ok
+    else
+      subscription = WebPushSubscription.upsert_for!(**attrs)
+      render json: { id: subscription.id, device_label: subscription.device_label }, status: :created
+    end
   end
 
   # DELETE /u/:handle/settings/push-subscriptions/:subscription_id

--- a/app/javascript/application.ts
+++ b/app/javascript/application.ts
@@ -5,5 +5,7 @@ import "./polling_trigger_event"
 // image_cropper functionality is now in controllers/image_cropper_controller.ts
 import "./password_reset_form"
 import { registerServiceWorker } from "./pwa/register"
+import { wirePushResync } from "./pwa/resync"
 
 registerServiceWorker()
+wirePushResync()

--- a/app/javascript/pwa/push.test.ts
+++ b/app/javascript/pwa/push.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { clickAction, notificationOptions, parsePayload, shouldShowNotification } from "./push"
+import { clickAction, notificationOptions, parsePayload } from "./push"
 
 const ORIGIN = "https://app.harmonic.local"
 
@@ -36,37 +36,6 @@ describe("notificationOptions", () => {
     expect(options.icon).toBe("/icon.png")
     expect(options.badge).toBe("/badge.png")
     expect(options.data.url).toBe(`${ORIGIN}/n/abc`)
-  })
-})
-
-describe("shouldShowNotification", () => {
-  const focused = { focused: true }
-  const blurred = { focused: false }
-
-  it("shows when no window is open", () => {
-    expect(shouldShowNotification(`${ORIGIN}/n/abc`, [], ORIGIN)).toBe(true)
-  })
-
-  it("shows when windows are open but none is focused", () => {
-    expect(shouldShowNotification(`${ORIGIN}/n/abc`, [blurred, blurred], ORIGIN)).toBe(true)
-  })
-
-  it("suppresses a same-origin notification when a window is focused", () => {
-    // The user is actively in the app on this tenant; the in-app channel
-    // (bell badge, chat view) is already showing the content.
-    expect(shouldShowNotification(`${ORIGIN}/n/abc`, [blurred, focused], ORIGIN)).toBe(false)
-  })
-
-  it("shows a cross-origin notification even when a window is focused", () => {
-    // Delivery is origin-agnostic: tenant B's notification can arrive at
-    // tenant A's service worker. A focused tenant-A window says nothing
-    // about whether the user can see tenant B's content.
-    expect(shouldShowNotification("https://other.harmonic.local/n/abc", [focused], ORIGIN)).toBe(true)
-  })
-
-  it("suppresses url-less and unparseable-url notifications when focused", () => {
-    expect(shouldShowNotification(undefined, [focused], ORIGIN)).toBe(false)
-    expect(shouldShowNotification("::not a url::", [focused], ORIGIN)).toBe(false)
   })
 })
 

--- a/app/javascript/pwa/push.ts
+++ b/app/javascript/pwa/push.ts
@@ -46,33 +46,6 @@ export function notificationOptions(payload: PushPayload): PushNotificationOptio
   }
 }
 
-// Decide whether an incoming push should surface an OS notification, given
-// the open windows on this origin. When the user has a window focused they
-// are actively in the app, and the in-app channel (bell badge, chat view) is
-// already showing the content — a banner on top of that is noise, worst for
-// chat, which pushes per message. Chrome's userVisibleOnly requirement has an
-// explicit carve-out for skipping the notification while a window is focused.
-//
-// Cross-origin targets always show: delivery is origin-agnostic, so another
-// tenant's notification can arrive at this service worker, and a focused
-// window here says nothing about whether the user can see that content.
-// Url-less payloads originate from this origin's server, so they follow the
-// same-origin rule.
-export function shouldShowNotification(
-  targetUrl: string | undefined,
-  clients: { focused: boolean }[],
-  origin: string,
-): boolean {
-  if (!clients.some((client) => client.focused)) return true
-  if (!targetUrl) return false
-
-  try {
-    return new URL(targetUrl).origin !== origin
-  } catch {
-    return false
-  }
-}
-
 export type ClickAction =
   | { type: "focus"; index: number }
   | { type: "focus-navigate"; index: number }

--- a/app/javascript/pwa/resync.test.ts
+++ b/app/javascript/pwa/resync.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest"
+import { resyncPushSubscription, type ResyncDeps } from "./resync"
+
+const VAPID_KEY = "BPd6HDwGDrqBnbmZhZuT1Yc6mkWSHFJZfmiJqZUxWQZfQzD-Zh0aJutFYc9O2ZguJALhx1nlWJDjxqGmFvDf0Zs"
+
+function fakeSubscription(overrides: { applicationServerKey?: Uint8Array } = {}) {
+  return {
+    toJSON: () => ({ endpoint: "https://push.example.com/send/abc", keys: { p256dh: "k", auth: "a" } }),
+    options: overrides.applicationServerKey ? { applicationServerKey: overrides.applicationServerKey.buffer } : {},
+  } as unknown as PushSubscription
+}
+
+function deps(overrides: Partial<ResyncDeps> = {}): ResyncDeps & { posts: Array<{ url: string; body: unknown }> } {
+  const posts: Array<{ url: string; body: unknown }> = []
+  return {
+    posts,
+    postUrl: "/u/ada/settings/push-subscriptions",
+    vapidPublicKey: VAPID_KEY,
+    permission: "granted" as NotificationPermission,
+    getSubscription: async () => fakeSubscription(),
+    subscribe: async () => fakeSubscription(),
+    post: async (url: string, body: unknown) => {
+      posts.push({ url, body })
+      return true
+    },
+    ...overrides,
+  }
+}
+
+describe("resyncPushSubscription", () => {
+  it("re-posts the browser's subscription with the resync flag", async () => {
+    const d = deps()
+
+    expect(await resyncPushSubscription(d)).toBe("synced")
+    expect(d.posts).toHaveLength(1)
+    expect(d.posts[0].url).toBe("/u/ada/settings/push-subscriptions")
+    expect(d.posts[0].body).toEqual({
+      subscription: { endpoint: "https://push.example.com/send/abc", keys: { p256dh: "k", auth: "a" } },
+      resync: true,
+    })
+  })
+
+  it("re-subscribes when permission is granted but the subscription is gone", async () => {
+    // The self-heal for iOS silently revoking a subscription: the standing
+    // permission grant is the consent; minting a fresh transport identifier
+    // under it restores what the user asked for.
+    const subscribeFn = vi.fn(async () => fakeSubscription())
+    const d = deps({ getSubscription: async () => null, subscribe: subscribeFn })
+
+    expect(await resyncPushSubscription(d)).toBe("resubscribed")
+    expect(subscribeFn).toHaveBeenCalledOnce()
+    expect(d.posts).toHaveLength(1)
+  })
+
+  it("does nothing without permission", async () => {
+    const d = deps({ permission: "default" as NotificationPermission })
+
+    expect(await resyncPushSubscription(d)).toBe("skipped")
+    expect(d.posts).toHaveLength(0)
+  })
+
+  it("does nothing without a post URL or VAPID key", async () => {
+    expect(await resyncPushSubscription(deps({ postUrl: null }))).toBe("skipped")
+    expect(await resyncPushSubscription(deps({ vapidPublicKey: null }))).toBe("skipped")
+  })
+
+  it("leaves a subscription minted with a different VAPID key alone", async () => {
+    // Key rotation is repaired by the explicit re-enable flow (unsubscribe +
+    // fresh subscribe); the background resync must not churn it every load.
+    const d = deps({ getSubscription: async () => fakeSubscription({ applicationServerKey: new Uint8Array([9, 9, 9]) }) })
+
+    expect(await resyncPushSubscription(d)).toBe("skipped")
+    expect(d.posts).toHaveLength(0)
+  })
+
+  it("reports errors without throwing", async () => {
+    expect(await resyncPushSubscription(deps({ post: async () => false }))).toBe("error")
+    expect(
+      await resyncPushSubscription(
+        deps({ getSubscription: async () => null, subscribe: async () => { throw new Error("no") } }),
+      ),
+    ).toBe("error")
+  })
+
+  it("posts an existing subscription whose key cannot be read", async () => {
+    // Older browsers expose no options.applicationServerKey — trust it, as
+    // the subscribe flow does.
+    const d = deps({ getSubscription: async () => fakeSubscription() })
+
+    expect(await resyncPushSubscription(d)).toBe("synced")
+    expect(d.posts).toHaveLength(1)
+  })
+})

--- a/app/javascript/pwa/resync.ts
+++ b/app/javascript/pwa/resync.ts
@@ -1,0 +1,90 @@
+// Background push-subscription resync, run once per page load.
+//
+// The server only hears about a subscription when the user clicks "Enable on
+// this device" — after that, the two sides drift silently: last_seen_at goes
+// stale, the push service can rotate the endpoint, and iOS can revoke the
+// subscription outright without telling anyone (issue #397). Re-posting the
+// browser's subscription on every load keeps the server's row honest, and
+// when permission is still granted but the subscription is gone, re-creating
+// it restores what the user asked for — the standing permission grant is the
+// consent. The server side treats a resync as a refresh, never a re-enable:
+// it won't revive a row the user (or an admin) revoked.
+//
+// Browser APIs and the network are injected so the flow can be unit tested;
+// wirePushResync builds the real ones from the layout's meta tags.
+
+import { fetchWithCsrf } from "../utils/csrf"
+import { mintedWithKey, urlBase64ToUint8Array } from "./subscribe"
+
+export type ResyncResult = "synced" | "resubscribed" | "skipped" | "error"
+
+export interface ResyncDeps {
+  postUrl: string | null | undefined
+  vapidPublicKey: string | null | undefined
+  permission: NotificationPermission
+  getSubscription: () => Promise<PushSubscription | null>
+  subscribe: (options: { userVisibleOnly: boolean; applicationServerKey: Uint8Array<ArrayBuffer> }) => Promise<PushSubscription>
+  post: (url: string, body: unknown) => Promise<boolean>
+}
+
+export async function resyncPushSubscription(deps: ResyncDeps): Promise<ResyncResult> {
+  if (!deps.postUrl || !deps.vapidPublicKey) return "skipped"
+  if (deps.permission !== "granted") return "skipped"
+
+  try {
+    const currentKey = urlBase64ToUint8Array(deps.vapidPublicKey)
+    let subscription = await deps.getSubscription()
+    // A subscription minted with a rotated VAPID key can't deliver, but
+    // replacing it is the explicit re-enable flow's job — churning it on
+    // every load would fight that flow.
+    if (subscription && !mintedWithKey(subscription, currentKey)) return "skipped"
+
+    let result: ResyncResult = "synced"
+    if (!subscription) {
+      subscription = await deps.subscribe({ userVisibleOnly: true, applicationServerKey: currentKey })
+      result = "resubscribed"
+    }
+
+    const posted = await deps.post(deps.postUrl, { subscription: subscription.toJSON(), resync: true })
+    return posted ? result : "error"
+  } catch (error) {
+    console.warn("Push subscription resync failed:", error)
+    return "error"
+  }
+}
+
+export function wirePushResync(): void {
+  if (!("serviceWorker" in navigator) || !("PushManager" in window) || !("Notification" in window)) return
+
+  const meta = (name: string): string | undefined =>
+    (document.querySelector(`meta[name='${name}']`) as HTMLMetaElement | null)?.content
+  // No subscription URL means push isn't available here (flag off, VAPID
+  // unconfigured, signed out, or not a human user).
+  const postUrl = meta("push-subscription-url")
+  if (!postUrl) return
+
+  window.addEventListener("load", () => {
+    void (async () => {
+      // .ready rather than getRegistration(): on a cold load the register()
+      // call is still in flight, and getRegistration would resolve to
+      // nothing. The subscription URL only renders when the service-worker
+      // flag is on, so ready settles.
+      const registration = await navigator.serviceWorker.ready
+      await resyncPushSubscription({
+        postUrl,
+        vapidPublicKey: meta("vapid-public-key"),
+        permission: Notification.permission,
+        getSubscription: () => registration.pushManager.getSubscription(),
+        subscribe: (options) => registration.pushManager.subscribe(options),
+        post: async (url, body) => {
+          const response = await fetchWithCsrf(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          })
+          return response.ok
+        },
+      })
+    })()
+  })
+}

--- a/app/javascript/pwa/service_worker.test.ts
+++ b/app/javascript/pwa/service_worker.test.ts
@@ -36,6 +36,37 @@ async function fire(listeners: Map<string, Listener>, type: string): Promise<voi
   await Promise.all(waits)
 }
 
+describe("push", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it("shows the notification even when a window is focused", async () => {
+    // iOS counts a push that produces no visible notification as a strike
+    // and silently revokes the subscription after three (issue #397). A
+    // focused-window carve-out is never safe there — suspended PWA clients
+    // can keep reporting focused: true — so every push shows.
+    const { scope, listeners } = stubScope()
+    scope.clients.matchAll = vi.fn(async () => [
+      { url: "https://app.harmonic.local/", focused: true },
+    ]) as never
+    await import("./service_worker")
+
+    const waits: Promise<unknown>[] = []
+    listeners.get("push")!({
+      waitUntil: (promise: Promise<unknown>) => waits.push(promise),
+      data: { json: () => ({ title: "Ping", url: "https://app.harmonic.local/n/abc" }) },
+    })
+    await Promise.all(waits)
+
+    expect(scope.registration.showNotification).toHaveBeenCalledWith(
+      "Ping",
+      expect.objectContaining({ data: { url: "https://app.harmonic.local/n/abc" } }),
+    )
+  })
+})
+
 describe("service worker lifecycle", () => {
   afterEach(() => {
     vi.unstubAllGlobals()

--- a/app/javascript/pwa/service_worker.ts
+++ b/app/javascript/pwa/service_worker.ts
@@ -3,7 +3,7 @@
 // `self.CACHE_VERSION = "<git sha>"` line — per-deploy cache busting.
 
 import { respondCacheFirst, respondNetworkFirst } from "./handlers"
-import { clickAction, notificationOptions, parsePayload, shouldShowNotification } from "./push"
+import { clickAction, notificationOptions, parsePayload } from "./push"
 import { cacheName, classify, OFFLINE_PATH, staleCacheNames, type RequestSummary } from "./strategies"
 
 interface WindowClientLike {
@@ -89,12 +89,14 @@ sw.addEventListener("push", (event: PushEventLike) => {
 
   event.waitUntil(
     (async () => {
-      const clients = await sw.clients.matchAll({ type: "window", includeUncontrolled: true })
-      if (shouldShowNotification(payload.url, clients, sw.location.origin)) {
-        await sw.registration.showNotification(payload.title, notificationOptions(payload))
-      }
+      // Always show — no focused-window carve-out. iOS counts a push that
+      // produces no visible notification as a strike and silently revokes
+      // the subscription after three, and suspended iOS PWA clients can
+      // keep reporting focused: true, so any suppression path eventually
+      // kills push delivery on the device (issue #397).
+      await sw.registration.showNotification(payload.title, notificationOptions(payload))
       // iOS surfaces the app badge on the home-screen icon; harmless no-op
-      // elsewhere. Badge even when the banner is suppressed.
+      // elsewhere.
       await sw.navigator?.setAppBadge?.().catch(() => undefined)
     })(),
   )

--- a/app/javascript/pwa/subscribe.ts
+++ b/app/javascript/pwa/subscribe.ts
@@ -24,7 +24,7 @@ export function urlBase64ToUint8Array(base64: string): Uint8Array<ArrayBuffer> {
 // the current one (sends come back 401 Unauthorized). An unreadable key
 // (older browsers expose no options.applicationServerKey) is kept — churning
 // a working subscription is worse than trusting it.
-function mintedWithKey(subscription: PushSubscription, key: Uint8Array): boolean {
+export function mintedWithKey(subscription: PushSubscription, key: Uint8Array): boolean {
   const existing = subscription.options?.applicationServerKey
   if (!existing) return true
   const bytes = new Uint8Array(existing)

--- a/app/models/web_push_subscription.rb
+++ b/app/models/web_push_subscription.rb
@@ -58,6 +58,27 @@ class WebPushSubscription < ApplicationRecord
     subscription
   end
 
+  # Like upsert_for!, but for the background resync on page load: stamps
+  # last_seen_at (and any rotated keys) on the row this browser holds, and
+  # registers an endpoint the server has never seen. Unlike upsert_for! it
+  # never revives a revoked row — re-enabling is an explicit user action,
+  # and the resync must not undo a revocation. Returns nil in that case.
+  sig do
+    params(
+      user: User,
+      endpoint: String,
+      p256dh_key: String,
+      auth_key: String,
+      request: T.untyped
+    ).returns(T.nilable(WebPushSubscription))
+  end
+  def self.refresh_for!(user:, endpoint:, p256dh_key:, auth_key:, request: nil)
+    existing = find_by(user: user, endpoint: endpoint)
+    return nil if existing && !existing.active?
+
+    upsert_for!(user: user, endpoint: endpoint, p256dh_key: p256dh_key, auth_key: auth_key, request: request)
+  end
+
   sig { returns(T::Boolean) }
   def active?
     revoked_at.nil?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,9 @@
     <% end %>
     <% if @current_tenant&.web_push_available? %>
       <meta name="vapid-public-key" content="<%= ENV["VAPID_PUBLIC_KEY"] %>">
+      <% if @current_user&.human? %>
+        <meta name="push-subscription-url" content="<%= @current_user.path %>/settings/push-subscriptions">
+      <% end %>
     <% end %>
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)">

--- a/test/controllers/web_push_subscriptions_controller_test.rb
+++ b/test/controllers/web_push_subscriptions_controller_test.rb
@@ -72,6 +72,52 @@ class WebPushSubscriptionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 0, WebPushSubscription.count
   end
 
+  test "resync refreshes an active subscription's last_seen_at" do
+    sign_in_as(@user, tenant: @tenant)
+    subscription = WebPushSubscription.upsert_for!(
+      user: @user, endpoint: "https://push.example.com/send/abc123", p256dh_key: "k", auth_key: "a"
+    )
+    subscription.update!(last_seen_at: 2.days.ago)
+
+    post "/u/#{@handle}/settings/push-subscriptions", params: subscription_params.merge(resync: true), as: :json
+
+    assert_response :success
+    assert_in_delta Time.current, subscription.reload.last_seen_at, 5.seconds
+  end
+
+  test "resync registers an endpoint the server has never seen" do
+    # The browser can hold a subscription the server doesn't know about
+    # (push-service rotation, self-heal after iOS dropped the old one).
+    sign_in_as(@user, tenant: @tenant)
+
+    assert_difference -> { WebPushSubscription.where(user: @user).count }, 1 do
+      post "/u/#{@handle}/settings/push-subscriptions", params: subscription_params.merge(resync: true), as: :json
+    end
+    assert_response :success
+  end
+
+  test "resync does not revive a revoked subscription" do
+    sign_in_as(@user, tenant: @tenant)
+    subscription = WebPushSubscription.upsert_for!(
+      user: @user, endpoint: "https://push.example.com/send/abc123", p256dh_key: "k", auth_key: "a"
+    )
+    subscription.revoke!(reason: "user")
+
+    post "/u/#{@handle}/settings/push-subscriptions", params: subscription_params.merge(resync: true), as: :json
+
+    assert_response :no_content
+    assert_not subscription.reload.active?
+  end
+
+  test "the layout advertises the resync endpoint to the client" do
+    sign_in_as(@user, tenant: @tenant)
+
+    get "/"
+
+    assert_response :success
+    assert_select "meta[name='push-subscription-url'][content='/u/#{@handle}/settings/push-subscriptions']", count: 1
+  end
+
   test "destroy revokes the subscription" do
     sign_in_as(@user, tenant: @tenant)
     subscription = WebPushSubscription.upsert_for!(

--- a/test/models/web_push_subscription_test.rb
+++ b/test/models/web_push_subscription_test.rb
@@ -51,6 +51,43 @@ class WebPushSubscriptionTest < ActiveSupport::TestCase
     assert_nil resubscribed.revoked_reason
   end
 
+  test "refresh_for! stamps last_seen_at and keys on an active row" do
+    subscription = subscribe!
+    subscription.update!(last_seen_at: 2.days.ago)
+
+    refreshed = WebPushSubscription.refresh_for!(
+      user: @user, endpoint: ENDPOINT, p256dh_key: "rotated-p256dh", auth_key: "rotated-auth"
+    )
+
+    assert_equal subscription.id, refreshed.id
+    assert_in_delta Time.current, refreshed.last_seen_at, 5.seconds
+    assert_equal "rotated-p256dh", refreshed.p256dh_key
+  end
+
+  test "refresh_for! creates a row for an endpoint the server has never seen" do
+    refreshed = WebPushSubscription.refresh_for!(
+      user: @user, endpoint: ENDPOINT, p256dh_key: "p256dh-key", auth_key: "auth-key"
+    )
+
+    assert refreshed.active?
+    assert_equal 1, WebPushSubscription.where(user: @user).count
+  end
+
+  test "refresh_for! never revives a revoked row" do
+    # Re-enabling is an explicit user action (the settings button →
+    # upsert_for!); the background resync must not undo a revocation.
+    subscription = subscribe!
+    subscription.revoke!(reason: "user")
+
+    result = WebPushSubscription.refresh_for!(
+      user: @user, endpoint: ENDPOINT, p256dh_key: "p256dh-key", auth_key: "auth-key"
+    )
+
+    assert_nil result
+    assert_not subscription.reload.active?
+    assert_equal "user", subscription.revoked_reason
+  end
+
   test "the same endpoint can belong to multiple users" do
     other_user = create_user
 


### PR DESCRIPTION
Fixes #397

## What happened

Push worked for about a day after enabling, then stopped. Settings showed the device still listed (last seen 1 day ago) *and* the "Enable on this device" button — contradictory on its face.

## Root cause

iOS counts a push that produces no visible notification as a strike and **silently revokes the subscription after three**. The service worker's focused-window suppression (shipped with push in 1.37.0) skipped the banner whenever a window client reported `focused: true` — and suspended iOS PWA clients can keep reporting `focused: true` from the app switcher. So pushes delivered while the app was backgrounded were suppressed strikes; after three, iOS killed the browser-side subscription with no signal to anyone. The server row stayed active (nothing had 410'd), `last_seen_at` was only ever stamped at subscribe time, and the Enable button was truthfully reporting that the browser no longer held a subscription.

## Fix (two commits)

**1. Always show the notification.** No focused-window carve-out. Chrome permits one, but the platforms can't be told apart reliably from inside a service worker (iPadOS reports a Mac UA), and an occasionally redundant banner is a far cheaper failure than silent subscription death.

**2. Resync on page load.** The layout advertises the subscription endpoint in a `push-subscription-url` meta tag, and every page load re-posts the browser's subscription:
- keeps `last_seen_at` honest (it previously froze at subscribe time),
- registers endpoints the server has never seen (push-service rotation),
- when permission is still granted but the subscription is gone — the exact iOS-revocation state — silently re-subscribes. The standing permission grant is the consent for that repair.

Guardrails:
- A resync is a refresh, never a re-enable: `WebPushSubscription.refresh_for!` returns nil for revoked rows, so disabling a device from anywhere stays disabled until an explicit re-enable.
- Subscriptions minted with a rotated VAPID key are left alone — replacing those is the explicit re-enable flow's job; churning them on every load would fight it.

## After deploy

Affected devices self-heal on next app open if iOS kept the permission grant; otherwise one tap of "Enable on this device."

## Tests

Red-green throughout: SW test pinning that a focused window no longer suppresses the banner; vitest coverage of the resync flow (sync / resubscribe / skip / error paths); model tests for `refresh_for!` semantics; controller tests for the `resync` param including the revoked-row no-revive case and the layout meta tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)