### PR TITLE
Clear the iOS home indicator with the bottom tab bar

### DIFF
--- a/app/assets/stylesheets/pulse/_base.css
+++ b/app/assets/stylesheets/pulse/_base.css
@@ -20,6 +20,10 @@ body {
   min-height: 100vh;
   -webkit-tap-highlight-color: transparent;
   overscroll-behavior-y: contain;
+  /* viewport-fit=cover extends the page under the notch in landscape;
+     keep in-flow content out of the ears. Zero in portrait. */
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 }
 
 img {

--- a/app/assets/stylesheets/pulse/_layout.css
+++ b/app/assets/stylesheets/pulse/_layout.css
@@ -12,7 +12,7 @@
   --pulse-tab-bar-height: 0px;
 }
 
-/* App Shell: persistent collective rail + the rest of the app */
+/* App Shell */
 .pulse-app-shell {
   display: flex;
   flex: 1;

--- a/app/assets/stylesheets/pulse/_places_sheet.css
+++ b/app/assets/stylesheets/pulse/_places_sheet.css
@@ -59,6 +59,10 @@
   top: 0;
   bottom: 0;
   left: 0;
+  /* Full-height fixed panel: keep the last rows above the home indicator
+     and the row contents out of the notch ear in landscape. */
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
   width: min(320px, 85vw);
   background: var(--color-canvas-default);
   border-right: 1px solid var(--color-border-default);

--- a/app/assets/stylesheets/pulse/_tab_bar.css
+++ b/app/assets/stylesheets/pulse/_tab_bar.css
@@ -25,6 +25,10 @@
     right: 0;
     height: calc(var(--pulse-tab-bar-height) + env(safe-area-inset-bottom));
     padding-bottom: env(safe-area-inset-bottom);
+    /* Fixed elements ignore the body's ear padding — clear the notch
+       ourselves in landscape. */
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
     background: var(--color-canvas-default);
     border-top: 1px solid var(--color-border-default);
     /* Below the places sheet backdrop (200) so the open sheet covers it. */

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <title><%= @page_title || 'Harmonic' %></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <%# viewport-fit=cover: without it iOS reports every safe-area inset as 0,
+        so the tab bar's env(safe-area-inset-bottom) clearance above the home
+        indicator evaluates to nothing (#395). %>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta charset="UTF-8">
     <link rel="icon" type="image/png" href="/<%= @current_app %>-favicon-32x32.png" sizes="32x32">
     <link rel="icon" type="image/png" href="/<%= @current_app %>-favicon-16x16.png" sizes="16x16">

--- a/app/views/pwa/offline.html.erb
+++ b/app/views/pwa/offline.html.erb
@@ -6,7 +6,7 @@
   <head>
     <title>Offline — Harmonic</title>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <style>
       /* Values mirror root_variables.css (light/dark) — this page must be
          self-contained, so the palette is inlined rather than linked. */

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -52,6 +52,16 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "layout viewport meta opts into safe-area insets" do
+    sign_in_as(@user, tenant: @tenant)
+    get "/"
+    assert_response :success
+
+    # Without viewport-fit=cover, iOS reports every env(safe-area-inset-*)
+    # as 0 and the tab bar's home-indicator clearance evaluates to nothing.
+    assert_select "meta[name='viewport'][content*='viewport-fit=cover']"
+  end
+
   test "layout renders the places sheet with a toggle in the header and in the tab bar" do
     sign_in_as(@user, tenant: @tenant)
     get "/"


### PR DESCRIPTION
Fixes #395

## Problem

On iOS the bottom tab bar sits flush against the bottom edge of the screen, under the home indicator, making the nav hard to use.

## Cause

The tab bar CSS already pads itself with `env(safe-area-inset-bottom)` — but without `viewport-fit=cover` in the viewport meta, iOS reports every safe-area inset as `0`, so the clearance evaluated to nothing.

## Fix

- Add `viewport-fit=cover` to the viewport meta (app layout + offline fallback page). The status bar style stays `default`, so the top inset is unaffected.
- Cover also extends the page under the notch in landscape, so the elements it newly exposes get insets too:
  - body side-padding keeps in-flow content out of the notch ears (zero in portrait),
  - the fixed-position tab bar and places sheet clear the notch/home indicator themselves, since fixed elements ignore body padding.

Pinned by a layout test asserting the meta tag. (`env()` values can't be exercised in a desktop browser, so the meta is the load-bearing assertion.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)