### PR TITLE
Fix collective representation lookup scoped out by differing collective context (#402)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -324,8 +324,15 @@ class ApplicationController < ActionController::Base
 
     # Look up the RepresentationSession by ID
     # Support both full UUID and 8-char truncated_id
+    #
+    # Bypass the collective default scope (RepresentationSession is
+    # MightNotBelongToCollective). A collective session carries the represented
+    # collective's id, so under the default scope it is filtered out whenever the
+    # request's collective context differs from that collective (e.g. acting on a
+    # public page or another collective) -> "Invalid representation session ID".
+    # tenant_scoped_only mirrors the browser path (resolve_browser_representation).
     column = session_id.length == 8 ? "truncated_id" : "id"
-    rep_session = RepresentationSession.find_by(column => session_id, tenant_id: current_tenant.id)
+    rep_session = RepresentationSession.tenant_scoped_only(current_tenant.id).find_by(column => session_id)
 
     # Validate: session exists
     unless rep_session

--- a/test/integration/api_collective_representation_test.rb
+++ b/test/integration/api_collective_representation_test.rb
@@ -150,6 +150,51 @@ class ApiCollectiveRepresentationTest < ActionDispatch::IntegrationTest
   end
 
   # ---------------------------------------------------------------------------
+  # Acting under the session across collective contexts (#402)
+  #
+  # resolve_api_representation looked the session up under the collective default
+  # scope. RepresentationSession is MightNotBelongToCollective, so a *collective*
+  # session (collective_id = the represented collective) is scoped out whenever
+  # the request's Collective.current_id is anything else -> the lookup returns
+  # nil and the caller gets "Invalid representation session ID".
+  #
+  # The start/end tests above never hit this: they act on the represented
+  # collective's own /represent path, where the current-collective context
+  # matches and the default scope happens to include the row. The bug only
+  # surfaces when acting under the session on a DIFFERENT collective context
+  # (a second collective, or the public space) — exactly what an agent does when
+  # it starts a session to post an announcement somewhere other than the
+  # collective's own page.
+  # ---------------------------------------------------------------------------
+
+  test "collective session resolves when acting on a different collective's context" do
+    grant_representative_role!
+    session_id = start_session!
+
+    # A second collective forces a different Collective.current_id on the request.
+    # The acting identity (the represented collective's identity_user) is a member
+    # so the target page authorizes cleanly once representation resolves.
+    other = create_collective(tenant: @tenant, created_by: @alice,
+                              handle: "api-crep-other-#{SecureRandom.hex(4)}")
+    other.add_user!(@alice)
+    other.add_user!(@collective.identity_user)
+    other.enable_api!
+
+    get other.path, headers: @headers.merge(
+      "X-Representation-Session-ID" => session_id,
+      "X-Representing-Collective" => @collective.handle,
+    )
+
+    assert_response :success,
+                    "collective session must resolve regardless of the request's collective " \
+                    "context, but got #{response.status}: #{response.body[0..300]}"
+    refute_includes response.body, "Invalid representation session ID",
+                     "the session lookup must not be scoped out by the differing collective context"
+    assert_includes response.body, "acting on behalf of",
+                    "the response should reflect that the caller is acting under the collective session"
+  end
+
+  # ---------------------------------------------------------------------------
   # Nested-session guard is DB-backed, not header-dependent (#365 review, #1)
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Collective representation over the API/MCP interface fails with `Invalid representation session ID` whenever you act under the session on a page outside the represented collective — starting and ending the session work, but acting under it does not.

Fixes #402.

## Root cause

`resolve_api_representation` (`application_controller.rb`) looked the session up under the **collective default scope**:

```ruby
RepresentationSession.find_by(column => session_id, tenant_id: current_tenant.id)
```

`RepresentationSession` includes `MightNotBelongToCollective`, whose `default_scope` narrows to `collective_id IN (Collective.current_id, NULL)` when a collective context is set. A collective session carries the represented collective's id, so on any request whose `Collective.current_id` differs (a different collective, or the public space) the row is scoped out → `find_by` returns nil → `Invalid representation session ID`.

The browser path (`resolve_browser_representation`, `:458`) already sidesteps this with `RepresentationSession.tenant_scoped_only(current_tenant.id).find_by(...)`. The API path did not.

## Why existing tests missed it

`api_collective_representation_test.rb` and the collective cases in `api_representation_test.rb` only ever declare the session while acting on the represented collective's **own** path (start/end on `/collectives/:handle/represent`, or `get @collective.path`). Under that matching context the default scope includes the row, so the lookup succeeds and the bug is masked.

## Fix

Mirror the browser path — look the session up via `tenant_scoped_only`, bypassing the collective default scope. One line, plus a regression test that acts under a collective session on a **second** collective's context (reproduces the 403 before the fix).

## Testing

- New test `collective session resolves when acting on a different collective's context` — fails with `403 Invalid representation session ID` on the old code, passes with the fix.
- `test/integration/api_collective_representation_test.rb` — 12 runs, 0 failures.
- `test/integration/api_representation_test.rb` (user + collective rep, same lookup line) — 31 runs, 0 failures.

## Impact

Unblocks collective representation over MCP — e.g. an agent starting a session to post an announcement as a collective, which is how this surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
