### PR TITLE
Let the public space stay navigable during representation (#383)

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,8 +3,6 @@
 class HomeController < ApplicationController
   include FeedPage
 
-  before_action :redirect_representing
-
   def index
     @page_title = 'Home'
     @page_scope = "visibility:public"
@@ -59,12 +57,6 @@ class HomeController < ApplicationController
   end
 
   private
-
-  def redirect_representing
-    if current_representation_session
-      return redirect_to "/representing"
-    end
-  end
 
   # The default home view's reminder authors: the tuned-in list plus the
   # viewer, minus block-related users.

--- a/test/integration/representation_session_test.rb
+++ b/test/integration/representation_session_test.rb
@@ -112,6 +112,21 @@ class RepresentationSessionIntegrationTest < ActionDispatch::IntegrationTest
   # Actions While Representing
   # ====================
 
+  test "can navigate the public space (home) while representing a collective" do
+    @collective.collective_members.find_by(user: @user).add_role!('representative')
+    sign_in_with_representation_reverification(@user)
+
+    post "/collectives/#{@collective.handle}/represent", params: { understand: 'true' }
+    follow_redirect!
+
+    # The public space (main collective, root prefix) must be navigable while
+    # representing the collective — posting a public announcement as the
+    # collective starts here (Harmonic#383).
+    get "/"
+    assert_response :success
+    assert_equal "/", path
+  end
+
   test "creating note while representing attributes it to identity user" do
     @collective.collective_members.find_by(user: @user).add_role!('representative')
     sign_in_with_representation_reverification(@user)

--- a/test/integration/representation_test.rb
+++ b/test/integration/representation_test.rb
@@ -122,6 +122,20 @@ class RepresentationTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "can navigate the public space (home) while representing" do
+    sign_in_as(@parent, tenant: @tenant)
+    start_representing
+
+    # The public space is the main collective, served at the root prefix.
+    # Navigating to it during representation must render, not bounce back to
+    # /representing (Harmonic#383).
+    get "/"
+    assert_response :success
+
+    get "/about"
+    assert_response :success
+  end
+
   test "creating content while representing attributes it to the represented user" do
     sign_in_as(@parent, tenant: @tenant)
     start_representing


### PR DESCRIPTION
Fixes #383.

## Problem

While a representation session was active, navigating to the **public space** — the main collective, served at the root prefix (`/`, `/about`, etc.) — bounced straight to `/representing`. So you couldn't view the public home feed or reach the public note composer to post an announcement *as the collective*.

## Root cause

`HomeController` carried its own `before_action :redirect_representing` that redirected to `/representing` whenever `current_representation_session` was present. This was the only such guard on public content — public notes, decisions, and search at the root prefix were already reachable during representation; only the home pages were not.

(The scoping guard in `ApplicationController#current_representation_session` at ~:729 is effectively vestigial here — `@current_representation_session` is already memoized by the `current_user` before_action, so the reader early-returns before that guard runs. Left untouched to keep this change focused.)

## Fix

Drop the `redirect_representing` before_action. Landing on `/representing` when a session *starts* is handled by explicit redirects in the representation flow controllers (`users#represent`, `representation_sessions`, `trustee_grants`), so this only affects navigating *back* to the public space mid-session — which is exactly what should be allowed.

Account/settings pages stay protected: they were never gated by this home-only redirect, and the represented identity's account surface is unaffected by this change.

## Tests

Regression coverage added for both representation modes:
- `representation_test.rb` — user representation can `GET /` and `/about`.
- `representation_session_test.rb` — collective representation can `GET /`.

Ran locally (docker dev): `representation_test.rb`, `representation_session_test.rb`, `home_controller_test.rb` — all green (60 runs, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)