### PR TITLE
Stripe AI Gateway production readiness: per-task routing, model mapping, pricing-plan billing

### DIFF
--- a/.claude/plans/stripe-ai-gateway-production-readiness.md
+++ b/.claude/plans/stripe-ai-gateway-production-readiness.md
@@ -51,7 +51,18 @@ Agent-runner went through a substantial refactor in mid-June (71aabfd2 and follo
 
 ### Phase 1 — Stripe-side verification (do first, blocks everything)
 
-> **Status 2026-07-05:** Access CONFIRMED — the harmonic.social Stripe account is in the LLM gateway private preview. Remaining Phase 1 items: create the restricted key (step 3), verify `STRIPE_CREDIT_PRODUCT_ID` (step 4), and make one successful raw call to `llm.stripe.com` (step 5). Also check what markup (if any) the gateway supports on passed-through token costs.
+> **Status 2026-07-05 (later): Phase 1 raw-call verification PASSED.** Test-mode `rk_test_` gateway key (Billing → Meter events: Write) accepted by `llm.stripe.com`, both with and without `X-Stripe-Customer-ID`. Exact working request:
+>
+> ```
+> curl https://llm.stripe.com/chat/completions \
+>   -H "Content-Type: application/json" \
+>   -H "Authorization: Bearer $STRIPE_GATEWAY_KEY" \
+>   -H "X-Stripe-Customer-ID: cus_UpZQeYlBN6ZYlf" \
+>   -d '{"model": "anthropic/claude-haiku-4.5",
+>        "messages": [{"role": "user", "content": "..."}], "max_tokens": 20}'
+> ```
+>
+> Returns HTTP 200, OpenAI-format JSON (`choices[0].message.content`, `usage.prompt_tokens`/`completion_tokens`) — matches what LLMClient.ts parses. Anthropic served via Vertex (`msg_vrtx_` ids). Model names must be the gateway's dotted form (`anthropic/claude-haiku-4.5`). Test customer for attribution checks: `cus_UpZQeYlBN6ZYlf` ("Gateway Verification Test", test mode). Markup: supported, set as a percentage on the Dashboard pricing plan. Remaining verification (dashboard): meter events visible for the test customer, usage lands on an upcoming invoice, credit grant offsets it (the prepaid-vs-postpaid question).
 
 1. Log into the Stripe dashboard for the harmonic.social account.
 2. Open Developers → API keys → Create restricted key. Confirm an "AI Gateway" permission row exists. If it doesn't, the rest of this plan parks until it does.

--- a/.claude/plans/stripe-ai-gateway-production-readiness.md
+++ b/.claude/plans/stripe-ai-gateway-production-readiness.md
@@ -62,7 +62,9 @@ Agent-runner went through a substantial refactor in mid-June (71aabfd2 and follo
 >        "messages": [{"role": "user", "content": "..."}], "max_tokens": 20}'
 > ```
 >
-> Returns HTTP 200, OpenAI-format JSON (`choices[0].message.content`, `usage.prompt_tokens`/`completion_tokens`) — matches what LLMClient.ts parses. Anthropic served via Vertex (`msg_vrtx_` ids). Model names must be the gateway's dotted form (`anthropic/claude-haiku-4.5`). Test customer for attribution checks: `cus_UpZQeYlBN6ZYlf` ("Gateway Verification Test", test mode). Markup: supported, set as a percentage on the Dashboard pricing plan. Remaining verification (dashboard): meter events visible for the test customer, usage lands on an upcoming invoice, credit grant offsets it (the prepaid-vs-postpaid question).
+> Returns HTTP 200, OpenAI-format JSON (`choices[0].message.content`, `usage.prompt_tokens`/`completion_tokens`) — matches what LLMClient.ts parses. Anthropic served via Vertex (`msg_vrtx_` ids). Model names must be the gateway's dotted form (`anthropic/claude-haiku-4.5`). Test customer for attribution checks: `cus_UpZQeYlBN6ZYlf` ("Gateway Verification Test", test mode). Markup: supported, set as a percentage on the Dashboard pricing plan.
+>
+> **Billing-model verification (same day):** meter events only bill customers subscribed to a *pricing plan*; the plan's "included usage" is delivered as promotional credit grants on the same `metered` scope our top-up grants use, so both pool into the balance `get_credit_balance` reads. The prepaid flow survives unchanged. New work identified: subscribe billed customers to the pricing plan at billing setup (`checkout_items[0][type]=pricing_plan_subscription_item`, preview API version header — verified working with the existing `STRIPE_API_KEY`), create the production pricing plan (markup lives there), and note that balance deduction from usage is aggregated periodically, not per-request.
 
 1. Log into the Stripe dashboard for the harmonic.social account.
 2. Open Developers → API keys → Create restricted key. Confirm an "AI Gateway" permission row exists. If it doesn't, the rest of this plan parks until it does.

--- a/.claude/plans/stripe-ai-gateway-production-readiness.md
+++ b/.claude/plans/stripe-ai-gateway-production-readiness.md
@@ -1,0 +1,131 @@
+# Stripe AI Gateway — Production Readiness
+
+> **Status 2026-07-05:** Phases 2–6 implemented on branch `stripe-gateway-routing` (6 commits): `StripeGatewayModelMapper` + fail-fast dispatch mapping, per-task `llm_gateway_mode` stream field (Rails decides; runner env var is fallback-only), structured `llm_request` logs + `billing:gateway_health` rake task, BILLING.md runbook + `.env.example` vars, and `test/manual/billing/gateway_enablement.manual_test.md`. Remaining: Phase 1 dashboard steps (restricted key, product ID check, raw `llm.stripe.com` call — Dan), merge, then Phase 6 smoke test execution and Phase 7 cutover.
+
+## Where we are
+
+The Layer 2 credit-billing implementation from the [original plan](completed/2026/04/STRIPE_AI_GATEWAY_BILLING.md) shipped in v1.6.0 (April 2026). The code is feature-complete on paper — `StripeService.create_credit_topup_checkout` / `create_credit_grant_from_checkout` / `get_credit_balance` all exist ([stripe_service.rb:262](../../app/services/stripe_service.rb#L262)); the webhook disambiguates subscription vs credit-topup; the billing controller has a `topup` action; the views render a balance + Add Funds dropdown; the dispatcher does a preflight balance check ([agent_runner_dispatch_service.rb:71](../../app/services/agent_runner_dispatch_service.rb#L71)); the agent-runner LLM client routes to `llm.stripe.com` and sends the `X-Stripe-Customer-ID` header when `LLM_GATEWAY_MODE=stripe_gateway` ([LLMClient.ts:82-97](../../agent-runner/src/services/LLMClient.ts#L82)).
+
+But it has never been turned on. Two months later, several gaps make a straight env-var flip unsafe.
+
+---
+
+## Production-blocking gaps
+
+### 1. Model names sent to Stripe are in LiteLLM format, not Stripe format
+
+The dispatcher publishes `model: ai_agent.agent_configuration["model"]` to the Redis stream ([agent_runner_dispatch_service.rb:152](../../app/services/agent_runner_dispatch_service.rb#L152)). The agent-runner forwards that string verbatim to the LLM endpoint ([LLMClient.ts:101](../../agent-runner/src/services/LLMClient.ts#L101)).
+
+Users pick model names from [litellm_config.yaml](../../config/litellm_config.yaml) — `default`, `claude-sonnet-4`, `claude-haiku-4`, `gpt-4o`, etc. Stripe's AI Gateway expects `provider/model` strings (e.g. `anthropic/claude-sonnet-4-5`, `openai/gpt-4o`). The original plan accounted for this with `StripeModelMapper`, which was deleted somewhere during the agent-runner TypeScript migration. **No translation layer exists today.** Any agent run with `stripe_gateway` mode on will currently 400 from Stripe.
+
+The default model is worse: `default` resolves to Arcee Trinity, which Stripe doesn't proxy at all. Even if we fix the format, switching the default tenant to gateway mode breaks every agent that hasn't explicitly chosen an Anthropic/OpenAI model.
+
+### 2. Gateway routing is global but billing is per-tenant
+
+`stripe_billing` is a per-tenant feature flag ([feature_flags.yml:64](../../config/feature_flags.yml#L64)). `LLM_GATEWAY_MODE` is a single process-wide env var read by both the Rails dispatcher and the agent-runner. The moment we set it to `stripe_gateway`, **every** tenant's agents route through Stripe — including tenants where `stripe_billing` is off and no `billing_customer` exists. For those, the dispatcher skips the preflight, no customer ID gets stamped, the request hits Stripe with a missing/empty `X-Stripe-Customer-ID`, and Stripe rejects it.
+
+For a single-billed-tenant deployment (harmonic.social) this is fine — but we should make the routing decision per-task, not per-process, so this isn't a foot-gun later. The cleanest fix: the agent-runner already receives `stripe_customer_stripe_id` per task in the Redis stream payload ([agent_runner_dispatch_service.rb:155](../../app/services/agent_runner_dispatch_service.rb#L155)). It should pick the gateway based on whether that field is populated, not on a global env var.
+
+### 3. Stripe AI Gateway availability was never re-verified
+
+Open question #1 in the original plan: "is `llm.stripe.com` GA, and is the `AI Gateway` restricted-key permission visible in Stripe's UI?" That was the deployment blocker in March 2026, and there's no commit, doc, or runbook note suggesting it's been confirmed. We need to actually create the restricted key with that scope and confirm it works against a small test call before going any further.
+
+### 4. No observability for gateway responses
+
+`LLMClient.ts` catches 402 and rephrases it as "Payment required. Please check your billing setup." ([LLMClient.ts:122-124](../../agent-runner/src/services/LLMClient.ts#L122)) — but nothing distinguishes that from any other LLM failure in logs/metrics. No Sentry breadcrumb, no counter for 402/429/success, no health check, no rake task. If we flip the switch and 5% of requests start 402'ing because of, say, a credit-grant race or an unmapped model, we won't notice until users complain.
+
+### 5. Untested integration since the MCP migration
+
+Agent-runner went through a substantial refactor in mid-June (71aabfd2 and follow-ups) — direct REST → /mcp for agent-acting calls. The `LLMClient` path was preserved, but the gateway flow has not been exercised end-to-end since. The `agent_runner_dispatch_service_test.rb:321` test toggles the env var but doesn't actually hit Stripe.
+
+### 6. Documentation and runbook gaps
+
+- `.env.example` doesn't mention `STRIPE_CREDIT_PRODUCT_ID` or `STRIPE_MAX_TOPUP_CENTS` — the dispatcher will `KeyError` if `STRIPE_CREDIT_PRODUCT_ID` is unset.
+- No deployment runbook documenting the order of operations (set key → set mode → smoke test).
+- No rollback procedure documented.
+- `docs/BILLING.md` describes Layer 2 as built but doesn't say it's off in prod.
+
+---
+
+## Plan
+
+### Phase 1 — Stripe-side verification (do first, blocks everything)
+
+> **Status 2026-07-05:** Access CONFIRMED — the harmonic.social Stripe account is in the LLM gateway private preview. Remaining Phase 1 items: create the restricted key (step 3), verify `STRIPE_CREDIT_PRODUCT_ID` (step 4), and make one successful raw call to `llm.stripe.com` (step 5). Also check what markup (if any) the gateway supports on passed-through token costs.
+
+1. Log into the Stripe dashboard for the harmonic.social account.
+2. Open Developers → API keys → Create restricted key. Confirm an "AI Gateway" permission row exists. If it doesn't, the rest of this plan parks until it does.
+3. Create the restricted key with: AI Gateway (write), Billing Credit Grants (write), Billing Credit Balance Summary (read), Checkout (write — already used). Save as `STRIPE_GATEWAY_KEY`.
+4. Verify `STRIPE_CREDIT_PRODUCT_ID` (`prod_UE7KI2m3xrm2eu` per `.env`) still exists and is named appropriately.
+5. From a dev container, hit `POST https://llm.stripe.com/chat/completions` with the new key against a known good Anthropic model (no customer ID — just confirm the endpoint accepts the key). Document the exact request that succeeded.
+
+### Phase 2 — Fix the model-name format gap
+
+Bring back the translation layer. Two options:
+
+**Option A (recommended): translate in Rails at dispatch time.** Add `StripeGatewayModelMapper` ([app/services/stripe_gateway_model_mapper.rb](../../app/services/stripe_gateway_model_mapper.rb)) that maps the LiteLLM-config names to Stripe gateway names. Translate inside `AgentRunnerDispatchService#publish_to_stream` *only when* the task will route through the gateway (see Phase 3). Unmapped models raise → task fails fast with "Model X is not available on the billing gateway. Choose Y." This is better than translating in TypeScript because the mapping table lives next to the rest of the Ruby billing logic and unit tests are cheaper.
+
+**Option B:** translate in `LLMClient.ts`. Slightly closer to the wire but splits config between Ruby (which knows the litellm name space) and TS (which would need to be kept in sync).
+
+Either way, decide the supported-model whitelist explicitly: Anthropic Claude family + OpenAI GPT-4o-class, at minimum. Arcee/Ollama/free-tier models are *not* available via gateway and must remain available only when the request routes to LiteLLM.
+
+Also: change the per-tenant default model from `default` (Arcee Trinity) to a Stripe-routable model **when `stripe_billing` is on for that tenant** — otherwise every new agent in that tenant lands on an unsupported model. Either pick a sensible cross-tenant default (`claude-sonnet-4`) or surface the choice in the AI agent form when billing is on. The form already accepts the model — it's the default that's wrong.
+
+### Phase 3 — Per-task gateway routing
+
+Replace the global env-var decision with a per-task decision:
+
+1. Rails: `AgentRunnerDispatchService` decides whether the task should route through Stripe. Today: `ENV.fetch("LLM_GATEWAY_MODE", "litellm") == "stripe_gateway"`. New: `tenant.feature_enabled?("stripe_billing") && billing_customer&.stripe_id.present?`.
+2. Add a new Redis-stream field: `llm_gateway_mode` (`"stripe_gateway"` or `"litellm"`), set per task.
+3. Agent-runner: `LLMClient` reads the mode from the task payload instead of from `Config`. The env var becomes a *default* for tasks that don't carry the field (and for legacy stream entries during rollout).
+4. The preflight balance check moves from "is env var set?" to "is `stripe_billing` on for this tenant AND does this agent have a billing customer?" — i.e. the same condition that routes the task. No skew possible.
+
+This change also fixes the documentation problem: `LLM_GATEWAY_MODE` stops being a global toggle and becomes deprecated. Drop it from production once everything is per-task.
+
+### Phase 4 — Observability
+
+Before flipping anyone in prod:
+
+1. Agent-runner `LLMClient`: emit structured log lines on every LLM response with `status_code`, `model`, `stripe_customer_present`, `gateway_mode`, `duration_ms`, `prompt_tokens`, `completion_tokens`. Distinct lines for 402/429/5xx vs success.
+2. Sentry: capture 402/5xx with breadcrumb including the same fields (no customer ID in the message body — only present/absent).
+3. Add a rake task `billing:gateway_health` that does: count agents-with-billing-customer, count of agents with zero balance, last-24h dispatch failures by error message. Cheap; runs from cron.
+4. Health endpoint or admin page widget that surfaces credit balance + last-known-good gateway response for the prod tenant.
+
+### Phase 5 — Documentation and runbook
+
+1. Update `.env.example` with `STRIPE_CREDIT_PRODUCT_ID` and `STRIPE_MAX_TOPUP_CENTS` (with comments referring to the Stripe dashboard).
+2. Add `docs/BILLING.md` section: "Layer 2 enablement runbook" — order: (a) set `STRIPE_GATEWAY_KEY` secret in prod env, (b) deploy, (c) verify health rake task passes, (d) enable `stripe_billing` for the target tenant, (e) confirm a known test agent runs and draws balance.
+3. Add a rollback section: revoke the restricted key in Stripe, flip `stripe_billing` off for the tenant, restart agent-runner — task routes fall back to LiteLLM, no in-flight requests get mid-flight 402.
+4. Drop `LLM_GATEWAY_MODE` from docs once Phase 3 lands.
+
+### Phase 6 — Staging smoke test
+
+Stand up an end-to-end scenario in staging (or against a feature-flagged dev tenant) that:
+
+1. Enables `stripe_billing` on the tenant.
+2. Creates a paying user, runs the credit top-up checkout flow, verifies the Credit Grant lands in Stripe.
+3. Creates an AI agent with a Stripe-supported model.
+4. Runs a task. Verifies request reaches `llm.stripe.com`, response is 200, credit balance drops, agent run succeeds.
+5. Drains the balance to ~$0, runs another task. Verifies preflight fails cleanly with the right error message and the UI matches.
+6. Re-runs after top-up. Verifies the recovery path.
+7. Confirms the LiteLLM fallback still works on a second tenant with `stripe_billing` off (regression check for Phase 3).
+
+Capture the smoke-test as `test/manual/billing/gateway_enablement.manual_test.md` so we can re-run it pre-cutover.
+
+### Phase 7 — Production cutover
+
+1. Set `STRIPE_GATEWAY_KEY` in prod env via the secret store.
+2. Deploy (Phase 2–4 code on main).
+3. Run `billing:gateway_health` — confirm green.
+4. Enable `stripe_billing` for the harmonic.social tenant.
+5. Run the test agent end-to-end. Check Stripe dashboard for the Credit Grant draw.
+6. Watch logs/Sentry for 24 hours. Rollback procedure is the documented one from Phase 5.
+
+---
+
+## Open questions
+
+1. **Who's the first paying tenant?** harmonic.social is the obvious answer, but we should confirm whether anyone else has the Layer 1 subscription on prod today that would be affected by the Phase 3 routing change. (None, based on a code-only read, but worth confirming against the prod DB.)
+2. **Should we set a non-zero minimum balance to dispatch?** Today preflight is "> 0 cents". If a multi-step task burns through $1 of balance mid-run, step N+1 gets a 402. The original plan flagged this as Open Question #4. Probably we accept this and document it in the user-facing copy ("top up before long agent runs"); not worth building a minimum-balance threshold yet.
+3. **What's the right top-up minimum?** Code says $1; UI dropdown can be more conservative. Decide before Phase 5 docs land.
+4. **Do we need a billing-admin tool to grant credits manually?** For comping or refunds. Not blocking, but easy to add a rake task / admin route now.

--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,11 @@ STRIPE_PRICE_ID=
 # Stripe Product ID (prod_... prefix) for prepaid LLM credit grants.
 # Required when any tenant has stripe_billing enabled — top-up checkout raises without it.
 STRIPE_CREDIT_PRODUCT_ID=
+# Pricing plan ID (bpp_... prefix) for the "Billing for LLM tokens" plan
+# (create via Dashboard -> Pricing plans; markup % is set there). Top-up
+# completion subscribes the customer to this plan; without it, gateway
+# dispatch is refused because usage would meter but never bill.
+STRIPE_PRICING_PLAN_ID=
 # Maximum single top-up amount in cents (default 50000 = $500)
 STRIPE_MAX_TOPUP_CENTS=50000
 # DEPRECATED fallback for the agent-runner only: tasks now carry llm_gateway_mode

--- a/.env.example
+++ b/.env.example
@@ -112,9 +112,13 @@ ALERT_EMAIL_RECIPIENTS=
 METRICS_AUTH_TOKEN=
 #
 # Stripe Billing & AI Gateway
-# Backend API key (restricted: customers, subscriptions, checkout, webhooks)
+# Backend restricted key. Permissions (see docs/BILLING.md for the full table):
+# Customers (write), Checkout Sessions (write), Subscriptions (write),
+# Invoices (write), Products (write), Credit grants (write),
+# Credit balance summary (read), Customer portal (write)
 STRIPE_API_KEY=
-# AI Gateway key (restricted: used as Bearer token for llm.stripe.com requests only)
+# AI Gateway restricted key, used only as the Bearer token for llm.stripe.com.
+# Permissions: Billing -> Meter events (write). Needed by Rails AND agent-runner.
 STRIPE_GATEWAY_KEY=
 # Webhook endpoint signature verification secret
 STRIPE_WEBHOOK_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -120,7 +120,14 @@ STRIPE_GATEWAY_KEY=
 STRIPE_WEBHOOK_SECRET=
 # Stripe Price ID (price_... prefix) — recurring $3/month account subscription
 STRIPE_PRICE_ID=
-# LLM gateway mode: litellm (default, local dev) or stripe_gateway (production billing)
+# Stripe Product ID (prod_... prefix) for prepaid LLM credit grants.
+# Required when any tenant has stripe_billing enabled — top-up checkout raises without it.
+STRIPE_CREDIT_PRODUCT_ID=
+# Maximum single top-up amount in cents (default 50000 = $500)
+STRIPE_MAX_TOPUP_CENTS=50000
+# DEPRECATED fallback for the agent-runner only: tasks now carry llm_gateway_mode
+# in the Redis stream payload (set by Rails per tenant), and this env var is used
+# solely for payloads published before that field existed.
 LLM_GATEWAY_MODE=litellm
 #
 # Agent Runner Service (see docs/AGENT_RUNNER.md)

--- a/agent-runner/src/config/Config.ts
+++ b/agent-runner/src/config/Config.ts
@@ -6,7 +6,9 @@ export interface AppConfig {
   readonly harmonicHostname: string;
   readonly agentRunnerSecret: string;
   readonly redisUrl: string;
-  readonly llmBaseUrl: string;
+  readonly litellmBaseUrl: string;
+  readonly stripeGatewayBaseUrl: string;
+  /** Fallback route for tasks whose payload carries no llm_gateway_mode. */
   readonly llmGatewayMode: "litellm" | "stripe_gateway";
   readonly stripeGatewayKey: string | undefined;
   readonly streamName: string;
@@ -38,9 +40,17 @@ export const ConfigLive = Layer.effect(
     const redisUrl = yield* optionalEnv("REDIS_URL", "redis://redis:6379");
     const llmGatewayMode = yield* optionalEnv("LLM_GATEWAY_MODE", "litellm");
     const harmonicInternalUrl = yield* optionalEnv("HARMONIC_INTERNAL_URL", "http://web:3000");
-    const llmBaseUrl = yield* optionalEnv(
-      "LLM_BASE_URL",
-      llmGatewayMode === "stripe_gateway" ? "https://llm.stripe.com" : "http://litellm:4000",
+    // LLM_BASE_URL historically overrode the single boot-mode endpoint; keep
+    // honoring it for whichever mode the env declares, with per-route
+    // overrides available via the explicit vars.
+    const llmBaseUrl = process.env["LLM_BASE_URL"];
+    const litellmBaseUrl = yield* optionalEnv(
+      "LITELLM_BASE_URL",
+      (llmGatewayMode === "litellm" ? llmBaseUrl : undefined) ?? "http://litellm:4000",
+    );
+    const stripeGatewayBaseUrl = yield* optionalEnv(
+      "STRIPE_GATEWAY_BASE_URL",
+      (llmGatewayMode === "stripe_gateway" ? llmBaseUrl : undefined) ?? "https://llm.stripe.com",
     );
     const stripeGatewayKey = process.env["STRIPE_GATEWAY_KEY"];
     const streamName = yield* optionalEnv("AGENT_TASKS_STREAM", "agent_tasks");
@@ -60,7 +70,8 @@ export const ConfigLive = Layer.effect(
       harmonicHostname,
       agentRunnerSecret,
       redisUrl,
-      llmBaseUrl,
+      litellmBaseUrl,
+      stripeGatewayBaseUrl,
       llmGatewayMode: llmGatewayMode as "litellm" | "stripe_gateway",
       stripeGatewayKey,
       streamName,

--- a/agent-runner/src/core/PromptBuilder.ts
+++ b/agent-runner/src/core/PromptBuilder.ts
@@ -30,6 +30,8 @@ export interface TaskPayload {
   readonly agentId: string;
   readonly tenantSubdomain: string;
   readonly stripeCustomerStripeId: string | undefined;
+  /** Set by Rails at dispatch; undefined for payloads published before the field existed. */
+  readonly llmGatewayMode: "litellm" | "stripe_gateway" | undefined;
   readonly mode: "task" | "chat_turn";
   readonly chatSessionId: string | undefined;
 }

--- a/agent-runner/src/services/AgentLoop.ts
+++ b/agent-runner/src/services/AgentLoop.ts
@@ -329,6 +329,7 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
           task.model,
           tools,
           task.stripeCustomerStripeId,
+          task.llmGatewayMode,
         ).pipe(
           Effect.map((r) => ({ ok: true as const, response: r })),
           Effect.catchAll((err) =>
@@ -593,6 +594,7 @@ const updateScratchpad = (
       task.model,
       [], // no tools for scratchpad
       task.stripeCustomerStripeId,
+      task.llmGatewayMode,
     );
 
     const usage = { inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens };

--- a/agent-runner/src/services/LLMClient.ts
+++ b/agent-runner/src/services/LLMClient.ts
@@ -6,6 +6,7 @@
 import { Context, Effect, Layer } from "effect";
 import { Config } from "../config/Config.js";
 import { LLMError } from "../errors/Errors.js";
+import { log } from "./Logger.js";
 import type { Message, ToolCall } from "../core/PromptBuilder.js";
 import type { ToolDefinition } from "../core/AgentContext.js";
 
@@ -117,15 +118,31 @@ export const LLMClientLive = Layer.effect(
           });
 
           const url = `${baseUrl}${endpoint}`;
+          const startedAt = Date.now();
           const response = await fetch(url, {
             method: "POST",
             headers,
             body,
             signal: AbortSignal.timeout(120_000),
           });
+          const durationMs = Date.now() - startedAt;
+
+          // Routing fields only — never the customer id itself.
+          const requestLogFields = {
+            gateway_mode: mode,
+            model: model ?? "default",
+            status_code: response.status,
+            duration_ms: durationMs,
+            stripe_customer_present: stripeCustomerId !== undefined,
+          };
 
           if (!response.ok) {
             const errorBody = await response.text().catch(() => "");
+            log.warn({
+              event: "llm_request_failed",
+              ...requestLogFields,
+              error_body: errorBody.slice(0, 200),
+            });
             if (response.status === 402) {
               throw new Error("Payment required. Please check your billing setup.");
             }
@@ -136,6 +153,12 @@ export const LLMClientLive = Layer.effect(
           }
 
           const data = await response.json() as CompletionResponse;
+          log.info({
+            event: "llm_request",
+            ...requestLogFields,
+            input_tokens: data.usage?.prompt_tokens ?? 0,
+            output_tokens: data.usage?.completion_tokens ?? 0,
+          });
           const choice = data.choices?.[0];
           const message = choice?.message;
 

--- a/agent-runner/src/services/LLMClient.ts
+++ b/agent-runner/src/services/LLMClient.ts
@@ -33,6 +33,7 @@ export interface LLMClientService {
     model: string | undefined,
     tools: readonly ToolDefinition[],
     stripeCustomerId: string | undefined,
+    gatewayMode?: "litellm" | "stripe_gateway",
   ) => Effect.Effect<LLMResponse, LLMError>;
 }
 
@@ -76,10 +77,12 @@ export const LLMClientLive = Layer.effect(
   Effect.gen(function* () {
     const config = yield* Config;
 
-    const chat: LLMClientService["chat"] = (messages, model, tools, stripeCustomerId) =>
+    const chat: LLMClientService["chat"] = (messages, model, tools, stripeCustomerId, gatewayMode) =>
       Effect.tryPromise({
         try: async () => {
-          const endpoint = config.llmGatewayMode === "stripe_gateway"
+          const mode = gatewayMode ?? config.llmGatewayMode;
+          const baseUrl = mode === "stripe_gateway" ? config.stripeGatewayBaseUrl : config.litellmBaseUrl;
+          const endpoint = mode === "stripe_gateway"
             ? "/chat/completions"
             : "/v1/chat/completions";
 
@@ -87,14 +90,17 @@ export const LLMClientLive = Layer.effect(
             "Content-Type": "application/json",
           };
 
-          if (config.llmGatewayMode === "stripe_gateway") {
+          if (mode === "stripe_gateway") {
             if (config.stripeGatewayKey === undefined) {
               throw new Error("STRIPE_GATEWAY_KEY is required in stripe_gateway mode");
             }
-            headers["Authorization"] = `Bearer ${config.stripeGatewayKey}`;
-            if (stripeCustomerId !== undefined) {
-              headers["X-Stripe-Customer-ID"] = stripeCustomerId;
+            if (stripeCustomerId === undefined) {
+              // Without the customer header the gateway would bill the platform
+              // account instead of the tenant — refuse rather than eat the cost.
+              throw new Error("stripe_gateway mode requires a stripe customer id for billing attribution");
             }
+            headers["Authorization"] = `Bearer ${config.stripeGatewayKey}`;
+            headers["X-Stripe-Customer-ID"] = stripeCustomerId;
           }
 
           const body = JSON.stringify({
@@ -110,7 +116,7 @@ export const LLMClientLive = Layer.effect(
             max_tokens: 4096,
           });
 
-          const url = `${config.llmBaseUrl}${endpoint}`;
+          const url = `${baseUrl}${endpoint}`;
           const response = await fetch(url, {
             method: "POST",
             headers,

--- a/agent-runner/src/services/TaskQueue.ts
+++ b/agent-runner/src/services/TaskQueue.ts
@@ -40,7 +40,7 @@ export interface TaskQueueService {
 
 export class TaskQueue extends Context.Tag("TaskQueue")<TaskQueue, TaskQueueService>() {}
 
-function parseStreamEntry(fields: string[]): TaskPayload | null {
+export function parseStreamEntry(fields: string[]): TaskPayload | null {
   const map = new Map<string, string>();
   for (let i = 0; i < fields.length; i += 2) {
     const key = fields[i];
@@ -71,6 +71,11 @@ function parseStreamEntry(fields: string[]): TaskPayload | null {
 
   const model = map.get("model");
   const stripeCustomerStripeId = map.get("stripe_customer_stripe_id");
+  const llmGatewayModeStr = map.get("llm_gateway_mode");
+  const llmGatewayMode =
+    llmGatewayModeStr === "stripe_gateway" || llmGatewayModeStr === "litellm"
+      ? llmGatewayModeStr
+      : undefined;
   const mode = map.get("mode");
   const chatSessionId = map.get("chat_session_id");
 
@@ -83,6 +88,7 @@ function parseStreamEntry(fields: string[]): TaskPayload | null {
     agentId,
     tenantSubdomain,
     stripeCustomerStripeId: stripeCustomerStripeId !== undefined && stripeCustomerStripeId !== "" ? stripeCustomerStripeId : undefined,
+    llmGatewayMode,
     mode: mode === "chat_turn" ? "chat_turn" : "task",
     chatSessionId: chatSessionId !== undefined && chatSessionId !== "" ? chatSessionId : undefined,
   };

--- a/agent-runner/test/config/Config.test.ts
+++ b/agent-runner/test/config/Config.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Effect } from "effect";
+import { Config, ConfigLive } from "../../src/config/Config.js";
+
+function loadConfig() {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      return yield* Config;
+    }).pipe(Effect.provide(ConfigLive)),
+  );
+}
+
+describe("Config LLM base URLs", () => {
+  beforeEach(() => {
+    vi.stubEnv("AGENT_RUNNER_SECRET", "test-secret");
+    vi.stubEnv("HARMONIC_HOSTNAME", "test.local");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("defaults both base URLs", async () => {
+    const config = await loadConfig();
+    expect(config.litellmBaseUrl).toBe("http://litellm:4000");
+    expect(config.stripeGatewayBaseUrl).toBe("https://llm.stripe.com");
+  });
+
+  it("honors LLM_BASE_URL for the litellm route when boot mode is litellm", async () => {
+    vi.stubEnv("LLM_BASE_URL", "http://custom-litellm:5000");
+    const config = await loadConfig();
+    expect(config.litellmBaseUrl).toBe("http://custom-litellm:5000");
+    expect(config.stripeGatewayBaseUrl).toBe("https://llm.stripe.com");
+  });
+
+  it("honors LLM_BASE_URL for the gateway route when boot mode is stripe_gateway", async () => {
+    vi.stubEnv("LLM_GATEWAY_MODE", "stripe_gateway");
+    vi.stubEnv("LLM_BASE_URL", "https://gateway-proxy.test");
+    const config = await loadConfig();
+    expect(config.stripeGatewayBaseUrl).toBe("https://gateway-proxy.test");
+    expect(config.litellmBaseUrl).toBe("http://litellm:4000");
+  });
+});

--- a/agent-runner/test/services/LLMClient.test.ts
+++ b/agent-runner/test/services/LLMClient.test.ts
@@ -3,12 +3,13 @@ import { Effect, Layer } from "effect";
 import { LLMClient, LLMClientLive } from "../../src/services/LLMClient.js";
 import { Config } from "../../src/config/Config.js";
 
-const ConfigTest = Layer.succeed(Config, {
+const baseConfig = {
   harmonicInternalUrl: "http://test:3000",
   harmonicHostname: "test.local",
   agentRunnerSecret: "test-secret",
   redisUrl: "redis://test:6379",
-  llmBaseUrl: "http://litellm:4000",
+  litellmBaseUrl: "http://litellm:4000",
+  stripeGatewayBaseUrl: "https://stripe.test",
   llmGatewayMode: "litellm" as const,
   stripeGatewayKey: undefined,
   streamName: "test_tasks",
@@ -16,7 +17,9 @@ const ConfigTest = Layer.succeed(Config, {
   consumerName: "test_consumer",
   maxConcurrentTasks: 10,
   streamMaxLen: 1000,
-});
+};
+
+const ConfigTest = Layer.succeed(Config, baseConfig);
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -106,5 +109,82 @@ describe("LLMClient", () => {
     });
 
     expect(result.reasoning).toBeUndefined();
+  });
+});
+
+const okBody = {
+  choices: [{ message: { content: "ok" }, finish_reason: "stop" }],
+  usage: { prompt_tokens: 1, completion_tokens: 1 },
+};
+
+function runChatWith(
+  config: Partial<typeof baseConfig>,
+  opts: { customerId?: string; gatewayMode?: "litellm" | "stripe_gateway" },
+) {
+  const fetchSpy = vi.fn(async () => jsonResponse(okBody));
+  vi.stubGlobal("fetch", fetchSpy);
+  const layer = Layer.succeed(Config, { ...baseConfig, ...config });
+  const program = Effect.gen(function* () {
+    const client = yield* LLMClient;
+    return yield* client.chat([], undefined, [], opts.customerId, opts.gatewayMode);
+  });
+  return Effect.runPromise(
+    program.pipe(Effect.provide(LLMClientLive.pipe(Layer.provide(layer)))),
+  ).then(() => fetchSpy);
+}
+
+describe("LLMClient per-task gateway routing", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("routes to the Stripe gateway when the task says stripe_gateway", async () => {
+    const fetchSpy = await runChatWith(
+      { stripeGatewayKey: "rk_test_123" },
+      { customerId: "cus_abc", gatewayMode: "stripe_gateway" },
+    );
+
+    const [url, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://stripe.test/chat/completions");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer rk_test_123");
+    expect(headers["X-Stripe-Customer-ID"]).toBe("cus_abc");
+  });
+
+  it("routes to LiteLLM when the task says litellm even if the config default is stripe_gateway", async () => {
+    const fetchSpy = await runChatWith(
+      { llmGatewayMode: "stripe_gateway", stripeGatewayKey: "rk_test_123" },
+      { gatewayMode: "litellm" },
+    );
+
+    const [url, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("http://litellm:4000/v1/chat/completions");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+
+  it("falls back to the config mode when the task carries no mode", async () => {
+    const fetchSpy = await runChatWith(
+      { llmGatewayMode: "stripe_gateway", stripeGatewayKey: "rk_test_123" },
+      { customerId: "cus_abc" },
+    );
+
+    const [url] = fetchSpy.mock.calls[0] as unknown as [string];
+    expect(url).toBe("https://stripe.test/chat/completions");
+  });
+
+  it("fails in stripe_gateway mode without a stripe customer id", async () => {
+    await expect(
+      runChatWith(
+        { stripeGatewayKey: "rk_test_123" },
+        { gatewayMode: "stripe_gateway" },
+      ),
+    ).rejects.toThrow(/customer/i);
+  });
+
+  it("fails in stripe_gateway mode without STRIPE_GATEWAY_KEY", async () => {
+    await expect(
+      runChatWith({}, { customerId: "cus_abc", gatewayMode: "stripe_gateway" }),
+    ).rejects.toThrow(/STRIPE_GATEWAY_KEY/);
   });
 });

--- a/agent-runner/test/services/LLMClient.test.ts
+++ b/agent-runner/test/services/LLMClient.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Effect, Layer } from "effect";
 import { LLMClient, LLMClientLive } from "../../src/services/LLMClient.js";
 import { Config } from "../../src/config/Config.js";
+import { log } from "../../src/services/Logger.js";
 
 const baseConfig = {
   harmonicInternalUrl: "http://test:3000",
@@ -119,9 +120,9 @@ const okBody = {
 
 function runChatWith(
   config: Partial<typeof baseConfig>,
-  opts: { customerId?: string; gatewayMode?: "litellm" | "stripe_gateway" },
+  opts: { customerId?: string; gatewayMode?: "litellm" | "stripe_gateway"; response?: Response },
 ) {
-  const fetchSpy = vi.fn(async () => jsonResponse(okBody));
+  const fetchSpy = vi.fn(async () => opts.response ?? jsonResponse(okBody));
   vi.stubGlobal("fetch", fetchSpy);
   const layer = Layer.succeed(Config, { ...baseConfig, ...config });
   const program = Effect.gen(function* () {
@@ -186,5 +187,62 @@ describe("LLMClient per-task gateway routing", () => {
     await expect(
       runChatWith({}, { customerId: "cus_abc", gatewayMode: "stripe_gateway" }),
     ).rejects.toThrow(/STRIPE_GATEWAY_KEY/);
+  });
+});
+
+describe("LLMClient request logging", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("logs a structured llm_request line without leaking the customer id", async () => {
+    const infoSpy = vi.spyOn(log, "info").mockImplementation(() => {});
+
+    await runChatWith(
+      { stripeGatewayKey: "rk_test_123" },
+      { customerId: "cus_abc", gatewayMode: "stripe_gateway" },
+    );
+
+    const entry = infoSpy.mock.calls
+      .map((c) => c[0] as Record<string, unknown>)
+      .find((f) => f["event"] === "llm_request");
+    expect(entry).toMatchObject({
+      event: "llm_request",
+      gateway_mode: "stripe_gateway",
+      status_code: 200,
+      stripe_customer_present: true,
+      model: "default",
+      input_tokens: 1,
+      output_tokens: 1,
+    });
+    expect(entry?.["duration_ms"]).toBeGreaterThanOrEqual(0);
+    expect(JSON.stringify(entry)).not.toContain("cus_abc");
+  });
+
+  it("logs the failure status when the gateway rejects the request", async () => {
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    await expect(
+      runChatWith(
+        { stripeGatewayKey: "rk_test_123" },
+        {
+          customerId: "cus_abc",
+          gatewayMode: "stripe_gateway",
+          response: new Response("insufficient credit", { status: 402 }),
+        },
+      ),
+    ).rejects.toThrow(/Payment required/);
+
+    const entry = warnSpy.mock.calls
+      .map((c) => c[0] as Record<string, unknown>)
+      .find((f) => f["event"] === "llm_request_failed");
+    expect(entry).toMatchObject({
+      event: "llm_request_failed",
+      gateway_mode: "stripe_gateway",
+      status_code: 402,
+      stripe_customer_present: true,
+    });
+    expect(JSON.stringify(entry)).not.toContain("cus_abc");
   });
 });

--- a/agent-runner/test/services/TaskQueue.test.ts
+++ b/agent-runner/test/services/TaskQueue.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { parseStreamEntry } from "../../src/services/TaskQueue.js";
+
+function fields(overrides: Record<string, string> = {}): string[] {
+  const base: Record<string, string> = {
+    task_run_id: "run-1",
+    encrypted_token: "enc-token",
+    task: "Do the thing",
+    max_steps: "10",
+    model: "anthropic/claude-sonnet-4-6",
+    agent_id: "agent-1",
+    tenant_subdomain: "test",
+    stripe_customer_stripe_id: "cus_abc",
+    mode: "task",
+    chat_session_id: "",
+    ...overrides,
+  };
+  return Object.entries(base).flat();
+}
+
+describe("parseStreamEntry gateway mode", () => {
+  it("parses llm_gateway_mode stripe_gateway", () => {
+    const task = parseStreamEntry(fields({ llm_gateway_mode: "stripe_gateway" }));
+    expect(task?.llmGatewayMode).toBe("stripe_gateway");
+  });
+
+  it("parses llm_gateway_mode litellm", () => {
+    const task = parseStreamEntry(fields({ llm_gateway_mode: "litellm" }));
+    expect(task?.llmGatewayMode).toBe("litellm");
+  });
+
+  it("leaves llmGatewayMode undefined when the field is absent (pre-upgrade payloads)", () => {
+    const task = parseStreamEntry(fields());
+    expect(task).not.toBeNull();
+    expect(task?.llmGatewayMode).toBeUndefined();
+  });
+
+  it("leaves llmGatewayMode undefined for unrecognized values", () => {
+    const task = parseStreamEntry(fields({ llm_gateway_mode: "bogus" }));
+    expect(task?.llmGatewayMode).toBeUndefined();
+  });
+});

--- a/app/services/agent_runner_dispatch_service.rb
+++ b/app/services/agent_runner_dispatch_service.rb
@@ -67,14 +67,31 @@ class AgentRunnerDispatchService
 
       # Stamp immutable billing attribution
       @task_run.update!(stripe_customer_id: billing_customer.id)
+    end
 
+    # Gateway routing is decided per task: billed agents go through the Stripe
+    # AI Gateway (prepaid credits), everyone else through LiteLLM. The runner
+    # reads this from the stream payload rather than its own env config.
+    gateway_mode = if tenant.feature_enabled?("stripe_billing") && !ai_agent.system? && billing_customer&.active?
+      "stripe_gateway"
+    else
+      "litellm"
+    end
+
+    model = ai_agent.agent_configuration&.dig("model") || ""
+    if gateway_mode == "stripe_gateway"
       # Pre-flight credit balance check
-      if ENV.fetch("LLM_GATEWAY_MODE", "litellm") == "stripe_gateway"
-        credit_balance = StripeService.get_credit_balance(billing_customer)
-        if credit_balance.nil? || credit_balance <= 0
-          fail_task!("Insufficient credit balance. Add funds at /billing before running agents.")
-          return
-        end
+      credit_balance = StripeService.get_credit_balance(T.must(billing_customer))
+      if credit_balance.nil? || credit_balance <= 0
+        fail_task!("Insufficient credit balance. Add funds at /billing before running agents.")
+        return
+      end
+
+      begin
+        model = StripeGatewayModelMapper.map(model)
+      rescue StripeGatewayModelMapper::UnmappedModelError => e
+        fail_task!(e.message)
+        return
       end
     end
 
@@ -95,7 +112,7 @@ class AgentRunnerDispatchService
 
     # Publish to Redis Stream with encrypted token
     begin
-      publish_to_stream(token, billing_customer)
+      publish_to_stream(token, billing_customer, model: model, gateway_mode: gateway_mode)
     rescue StandardError => e
       # Redis failure after token creation — clean up the token and fail the task
       # so it shows up on the admin page instead of lurking as "queued" forever.
@@ -139,8 +156,8 @@ class AgentRunnerDispatchService
     Rails.logger.error("[AgentRunnerDispatchService] Failed to broadcast chat error: #{e.message}")
   end
 
-  sig { params(token: ApiToken, billing_customer: T.nilable(StripeCustomer)).void }
-  def publish_to_stream(token, billing_customer)
+  sig { params(token: ApiToken, billing_customer: T.nilable(StripeCustomer), model: String, gateway_mode: String).void }
+  def publish_to_stream(token, billing_customer, model:, gateway_mode:)
     encrypted_token = AgentRunnerCrypto.encrypt(token.plaintext_token)
 
     redis = Redis.new(url: ENV["REDIS_URL"])
@@ -149,7 +166,8 @@ class AgentRunnerDispatchService
       encrypted_token: encrypted_token,
       task: @task_run.task,
       max_steps: @task_run.max_steps.to_s,
-      model: T.must(@task_run.ai_agent).agent_configuration&.dig("model") || "",
+      model: model,
+      llm_gateway_mode: gateway_mode,
       agent_id: T.must(@task_run.ai_agent).id,
       tenant_subdomain: T.must(@task_run.tenant).subdomain,
       stripe_customer_stripe_id: billing_customer&.stripe_id || "",

--- a/app/services/agent_runner_dispatch_service.rb
+++ b/app/services/agent_runner_dispatch_service.rb
@@ -80,6 +80,14 @@ class AgentRunnerDispatchService
 
     model = ai_agent.agent_configuration&.dig("model") || ""
     if gateway_mode == "stripe_gateway"
+      # Without a pricing-plan subscription, gateway usage is metered but never
+      # billed and credits never drain — refuse rather than give free usage.
+      # Topping up at /billing creates the subscription.
+      unless T.must(billing_customer).pricing_plan_subscription_id.present?
+        fail_task!("AI usage billing is not fully set up. Add credits at /billing to complete setup before running agents.")
+        return
+      end
+
       # Pre-flight credit balance check
       credit_balance = StripeService.get_credit_balance(T.must(billing_customer))
       if credit_balance.nil? || credit_balance <= 0

--- a/app/services/stripe_gateway_model_mapper.rb
+++ b/app/services/stripe_gateway_model_mapper.rb
@@ -1,0 +1,37 @@
+# typed: true
+# frozen_string_literal: true
+
+# Translates LiteLLM model aliases (what agents store in agent_configuration)
+# into the `provider/model` format the Stripe AI Gateway expects. Names the
+# gateway cannot proxy (local Ollama models, Arcee Trinity) raise so dispatch
+# fails fast with a clear error instead of a 400 at request time.
+class StripeGatewayModelMapper
+  extend T::Sig
+
+  class UnmappedModelError < StandardError; end
+
+  DEFAULT_MODEL = "anthropic/claude-sonnet-4-6"
+
+  # LiteLLM alias => Stripe gateway provider/model. Keep in sync with
+  # config/litellm_config.yaml so agents behave the same on either route.
+  MODEL_MAP = T.let({
+    "claude-sonnet-4" => "anthropic/claude-sonnet-4-6",
+    "claude-haiku-4" => "anthropic/claude-haiku-4-5-20251001",
+    "claude-opus-4" => "anthropic/claude-opus-4-7",
+    "gpt-4o" => "openai/gpt-4o",
+  }.freeze, T::Hash[String, String])
+
+  sig { params(model: T.nilable(String)).returns(String) }
+  def self.map(model)
+    return DEFAULT_MODEL if model.blank? || model == "default"
+
+    # Already provider-prefixed — trust the operator and pass it through;
+    # the gateway rejects unsupported models at request time.
+    return model if model.include?("/")
+
+    MODEL_MAP.fetch(model) do
+      raise UnmappedModelError, "Model \"#{model}\" is not available through the Stripe gateway. " \
+                                "Available models: #{MODEL_MAP.keys.join(", ")}."
+    end
+  end
+end

--- a/app/services/stripe_gateway_model_mapper.rb
+++ b/app/services/stripe_gateway_model_mapper.rb
@@ -10,14 +10,16 @@ class StripeGatewayModelMapper
 
   class UnmappedModelError < StandardError; end
 
-  DEFAULT_MODEL = "anthropic/claude-sonnet-4-6"
+  DEFAULT_MODEL = "anthropic/claude-sonnet-4.6"
 
-  # LiteLLM alias => Stripe gateway provider/model. Keep in sync with
-  # config/litellm_config.yaml so agents behave the same on either route.
+  # LiteLLM alias => Stripe gateway provider/model. Gateway names use dotted
+  # versions (claude-sonnet-4.6), unlike the dashed Anthropic API ids in
+  # config/litellm_config.yaml — see the supported-models list in Stripe's
+  # token-billing integration guide.
   MODEL_MAP = T.let({
-    "claude-sonnet-4" => "anthropic/claude-sonnet-4-6",
-    "claude-haiku-4" => "anthropic/claude-haiku-4-5-20251001",
-    "claude-opus-4" => "anthropic/claude-opus-4-7",
+    "claude-sonnet-4" => "anthropic/claude-sonnet-4.6",
+    "claude-haiku-4" => "anthropic/claude-haiku-4.5",
+    "claude-opus-4" => "anthropic/claude-opus-4.7",
     "gpt-4o" => "openai/gpt-4o",
   }.freeze, T::Hash[String, String])
 

--- a/app/services/stripe_service.rb
+++ b/app/services/stripe_service.rb
@@ -328,6 +328,20 @@ class StripeService
     nil
   end
 
+  # Operational snapshot of the AI gateway configuration and every active
+  # customer's prepaid credit balance. A nil balance means the Stripe API
+  # call failed for that customer (details in the error log).
+  sig { returns(T::Hash[Symbol, T.untyped]) }
+  def self.gateway_health
+    {
+      gateway_key_present: ENV["STRIPE_GATEWAY_KEY"].present?,
+      credit_product_configured: ENV["STRIPE_CREDIT_PRODUCT_ID"].present?,
+      active_customers: StripeCustomer.where(active: true).map do |customer|
+        { stripe_id: customer.stripe_id, credit_balance_cents: get_credit_balance(customer) }
+      end,
+    }
+  end
+
   # Create a Stripe Billing Portal session.
   # Returns the portal URL for redirect.
   sig { params(stripe_customer: StripeCustomer, return_url: String).returns(String) }

--- a/app/services/stripe_service.rb
+++ b/app/services/stripe_service.rb
@@ -309,6 +309,11 @@ class StripeService
       { idempotency_key: "credit_grant:#{checkout_session_id}" },
     )
     Rails.logger.info("[StripeService] Created credit grant of #{amount_cents} cents for customer #{stripe_customer.stripe_id} (session #{checkout_session_id})")
+
+    # Credits only drain if the customer is subscribed to the LLM-tokens
+    # pricing plan; a failure here is logged and dispatch blocks gateway
+    # usage until the next top-up retries it.
+    ensure_pricing_plan_subscription!(stripe_customer)
   end
 
   # Fetch the available credit balance for a Stripe customer.
@@ -328,6 +333,103 @@ class StripeService
     nil
   end
 
+  # Stripe's token-billing preview APIs (pricing plans, billing intents) are
+  # v2 JSON endpoints not yet wrapped by stripe-ruby resources.
+  PRICING_PLAN_API_VERSION = "2026-06-24.preview"
+
+  # Subscribe the customer to the LLM-tokens pricing plan (STRIPE_PRICING_PLAN_ID).
+  # Without this subscription, gateway usage is metered but never billed and
+  # prepaid credits never drain — so dispatch refuses gateway tasks until it exists.
+  # Idempotent via the stored pricing_plan_subscription_id. If the plan has an
+  # amount due at subscribe time, charges the customer's default payment method
+  # off-session. Returns false (logged) on missing config or Stripe errors;
+  # callers treat that as "credits granted but usage billing incomplete".
+  sig { params(stripe_customer: StripeCustomer).returns(T::Boolean) }
+  def self.ensure_pricing_plan_subscription!(stripe_customer)
+    return true if stripe_customer.pricing_plan_subscription_id.present?
+
+    plan_id = ENV["STRIPE_PRICING_PLAN_ID"]
+    if plan_id.blank?
+      Rails.logger.warn("[StripeService] STRIPE_PRICING_PLAN_ID not set; cannot subscribe #{stripe_customer.stripe_id} to the pricing plan")
+      return false
+    end
+
+    plan = v2_request(:get, "/v2/billing/pricing_plans/#{plan_id}")
+    profile = v2_request(:post, "/v2/billing/profiles", { customer: stripe_customer.stripe_id })
+    cadence = v2_request(:post, "/v2/billing/cadences", {
+      payer: { billing_profile: profile.fetch("id") },
+      billing_cycle: { type: "month", interval_count: 1 },
+    })
+    intent = v2_request(:post, "/v2/billing/intents", {
+      currency: "usd",
+      cadence: cadence.fetch("id"),
+      actions: [{
+        type: "subscribe",
+        subscribe: {
+          type: "pricing_plan_subscription_details",
+          pricing_plan_subscription_details: {
+            pricing_plan: plan_id,
+            pricing_plan_version: plan.fetch("live_version"),
+            component_configurations: [],
+          },
+        },
+      }],
+    })
+    reserved = v2_request(:post, "/v2/billing/intents/#{intent.fetch("id")}/reserve")
+
+    commit_params = {}
+    amount_due = reserved.dig("amount_details", "total").to_i
+    if amount_due.positive?
+      payment_method = default_payment_method_for(stripe_customer)
+      if payment_method.blank?
+        Rails.logger.error("[StripeService] No default payment method for #{stripe_customer.stripe_id}; cannot pay pricing plan subscription")
+        return false
+      end
+      payment_intent = Stripe::PaymentIntent.create(
+        amount: amount_due,
+        currency: "usd",
+        customer: stripe_customer.stripe_id,
+        payment_method: payment_method,
+        off_session: true,
+        confirm: true,
+      )
+      commit_params = { payment_intent: payment_intent.id }
+    end
+
+    v2_request(:post, "/v2/billing/intents/#{intent.fetch("id")}/commit", commit_params)
+
+    # The commit response doesn't reference the created subscription; find it
+    # via the cadence, which is unique to this call.
+    subscriptions = v2_request(:get, "/v2/billing/pricing_plan_subscriptions")
+    subscription = subscriptions.fetch("data", []).find { |s| s["billing_cadence"] == cadence.fetch("id") }
+    if subscription.nil?
+      Rails.logger.error("[StripeService] Committed billing intent #{intent.fetch("id")} but found no pricing plan subscription for cadence #{cadence.fetch("id")}")
+      return false
+    end
+
+    stripe_customer.update!(pricing_plan_subscription_id: subscription.fetch("id"))
+    Rails.logger.info("[StripeService] Subscribed #{stripe_customer.stripe_id} to pricing plan #{plan_id} (#{subscription.fetch("id")})")
+    true
+  rescue Stripe::StripeError => e
+    Rails.logger.error("[StripeService] Failed to subscribe #{stripe_customer.stripe_id} to pricing plan: #{e.message}")
+    false
+  end
+
+  sig { params(method: Symbol, path: String, params: T::Hash[Symbol, T.untyped]).returns(T::Hash[String, T.untyped]) }
+  def self.v2_request(method, path, params = {})
+    client = Stripe::StripeClient.new(T.must(Stripe.api_key))
+    response = client.raw_request(method, path, params: params, opts: { stripe_version: PRICING_PLAN_API_VERSION })
+    JSON.parse(response.http_body)
+  end
+  private_class_method :v2_request
+
+  sig { params(stripe_customer: StripeCustomer).returns(T.nilable(String)) }
+  def self.default_payment_method_for(stripe_customer)
+    customer = Stripe::Customer.retrieve(stripe_customer.stripe_id)
+    customer.invoice_settings&.default_payment_method
+  end
+  private_class_method :default_payment_method_for
+
   # Operational snapshot of the AI gateway configuration and every active
   # customer's prepaid credit balance. A nil balance means the Stripe API
   # call failed for that customer (details in the error log).
@@ -336,8 +438,13 @@ class StripeService
     {
       gateway_key_present: ENV["STRIPE_GATEWAY_KEY"].present?,
       credit_product_configured: ENV["STRIPE_CREDIT_PRODUCT_ID"].present?,
+      pricing_plan_configured: ENV["STRIPE_PRICING_PLAN_ID"].present?,
       active_customers: StripeCustomer.where(active: true).map do |customer|
-        { stripe_id: customer.stripe_id, credit_balance_cents: get_credit_balance(customer) }
+        {
+          stripe_id: customer.stripe_id,
+          credit_balance_cents: get_credit_balance(customer),
+          pricing_plan_subscribed: customer.pricing_plan_subscription_id.present?,
+        }
       end,
     }
   end

--- a/db/migrate/20260705182920_add_pricing_plan_subscription_to_stripe_customers.rb
+++ b/db/migrate/20260705182920_add_pricing_plan_subscription_to_stripe_customers.rb
@@ -1,0 +1,6 @@
+# typed: false
+class AddPricingPlanSubscriptionToStripeCustomers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :stripe_customers, :pricing_plan_subscription_id, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1729,7 +1729,8 @@ CREATE TABLE public.stripe_customers (
     stripe_subscription_id character varying,
     active boolean DEFAULT false NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    pricing_plan_subscription_id character varying
 );
 
 
@@ -10304,6 +10305,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260705182920'),
 ('20260702010000'),
 ('20260702000000'),
 ('20260701000000'),

--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -115,9 +115,11 @@ Visible at `/system-admin/agent-runner` (requires sys_admin role). Shows runner 
 | `HARMONIC_HOSTNAME` | Yes | — | Base domain for Host headers. Same value as Rails `HOSTNAME`. Agent-runner prepends the tenant subdomain (e.g., `harmonic.com` → `Host: tenant1.harmonic.com`) |
 | `HARMONIC_INTERNAL_URL` | No | `http://web:3000` | Direct TCP URL to Rails container |
 | `REDIS_URL` | No | `redis://redis:6379` | Redis connection |
-| `LLM_BASE_URL` | No | `http://litellm:4000` or `https://llm.stripe.com` | LLM API endpoint (defaults based on gateway mode) |
-| `LLM_GATEWAY_MODE` | No | `litellm` | `litellm` or `stripe_gateway` |
-| `STRIPE_GATEWAY_KEY` | No | — | Required in `stripe_gateway` mode |
+| `LITELLM_BASE_URL` | No | `http://litellm:4000` | LiteLLM endpoint |
+| `STRIPE_GATEWAY_BASE_URL` | No | `https://llm.stripe.com` | Stripe AI Gateway endpoint |
+| `LLM_BASE_URL` | No | — | Legacy override; applies to whichever route `LLM_GATEWAY_MODE` names |
+| `LLM_GATEWAY_MODE` | No | `litellm` | Fallback route for tasks whose payload predates the per-task `llm_gateway_mode` stream field. Rails decides routing per task; this only covers old queued payloads. |
+| `STRIPE_GATEWAY_KEY` | No | — | Required for any task routed through the Stripe gateway |
 | `MAX_CONCURRENT_TASKS` | No | `100` | Maximum concurrent task fibers |
 | `STREAM_MAX_LEN` | No | `10000` | Redis stream approximate max length |
 | `AGENT_TASKS_STREAM` | No | `agent_tasks` | Redis stream name |

--- a/docs/BILLING.md
+++ b/docs/BILLING.md
@@ -18,7 +18,7 @@ The unit price is **$3/month per billable identity**. A user has one Stripe subs
 
 **Why this shape.** A non-zero cost per identity discourages bad actors that rely on free or untraceable accounts (scam accounts, spam accounts, agents-fronting-as-humans). Humans without API access can join freely so the social layer doesn't have a price gate. Self-hosting remains an unrestricted alternative.
 
-**AI agent usage billing.** A separate prepaid credit balance covers LLM token usage when `LLM_GATEWAY_MODE=stripe_gateway`. Users top up via `/billing/topup` (requires an active subscription); the agent-runner deducts per LLM call, and task dispatch is blocked when the balance is empty. This is independent of the per-identity subscription.
+**AI agent usage billing.** A separate prepaid credit balance covers LLM token usage. Routing is decided per task at dispatch: agents whose tenant has `stripe_billing` enabled and whose owner has an active billing customer run through the Stripe AI Gateway (`llm.stripe.com`, billed against the prepaid balance); all other agents (including system agents like Trio) run through LiteLLM at the operator's cost. Users top up via `/billing/topup` (requires an active subscription); Stripe deducts per LLM call, and task dispatch is blocked when the balance is empty. This is independent of the per-identity subscription. See the enablement runbook below.
 
 ## Collective Tier State Machine
 
@@ -79,6 +79,27 @@ Two layers enforce billing at request time:
 - **Collective tier gate** (`Collective#tier_unlocks_paid_features?`) — short-circuits paid-feature access whenever the collective isn't on the paid tier. Used by `trio_enabled?`, `file_attachments_enabled?`, the automation dispatcher, the automation scheduler, the incoming-webhook receiver, and the per-toggle filter in collective settings updates. Always returns true for main collectives and for tenants without `stripe_billing` (self-hosted).
 
 Background workers (agent task execution, automation execution) have their own per-resource billing checks so suspended agents and pending resources don't run.
+
+## AI Gateway Enablement Runbook
+
+How LLM usage billing turns on for a production tenant. Prerequisite: the Stripe account is enrolled in the AI Gateway preview (`llm.stripe.com`).
+
+**Enable:**
+
+1. **Create the restricted key** in the Stripe dashboard with: AI Gateway (write), Credit Grants (write), Credit Balance Summary (read), Checkout Sessions (write). Set it as `STRIPE_GATEWAY_KEY` for both Rails and the agent-runner.
+2. **Create the credit product** (or verify the existing one) in the Stripe dashboard and set `STRIPE_CREDIT_PRODUCT_ID`. Top-up checkout raises `KeyError` without it.
+3. **Deploy** with both vars set. No behavior changes yet — routing stays on LiteLLM until a tenant qualifies.
+4. **Verify health:** `rails billing:gateway_health` should show both vars present and list active customers with balances.
+5. **Enable the flag:** `tenant.enable_feature_flag!("stripe_billing")` for the target tenant. From the next dispatch, that tenant's billed agents route through the gateway.
+6. **Smoke test:** top up a small amount at `/billing/topup`, run an agent task, confirm the balance dropped (`billing:gateway_health`) and the agent-runner logged `llm_request` lines with `"gateway_mode":"stripe_gateway"`.
+
+**Model names.** Agents store LiteLLM aliases (`claude-sonnet-4`, `claude-haiku-4`, ...). At dispatch, `StripeGatewayModelMapper` translates them to the gateway's `provider/model` format; agents with no configured model get the mapper's default. Models the gateway cannot proxy (local Ollama, Arcee Trinity) fail the task at dispatch with an explanatory error — update the agent's model or route the tenant back to LiteLLM.
+
+**Rollback** (gateway outage, unexpected charges, key compromise):
+
+1. `tenant.disable_feature_flag!("stripe_billing")` — new dispatches route to LiteLLM immediately. Note the blast radius: this disables *all* billing gates for the tenant (subscriptions, paid tiers), not just gateway routing. Acceptable for an incident; restore the flag once resolved.
+2. If the key is compromised: revoke it in the Stripe dashboard and unset `STRIPE_GATEWAY_KEY`; in-flight gateway tasks fail with a clear error and can be re-run.
+3. Already-purchased credits are unaffected — they sit on the customer's Stripe balance until routing is restored.
 
 ## Design Notes
 

--- a/docs/BILLING.md
+++ b/docs/BILLING.md
@@ -84,9 +84,32 @@ Background workers (agent task execution, automation execution) have their own p
 
 How LLM usage billing turns on for a production tenant. Prerequisite: the Stripe account is enrolled in the AI Gateway preview (`llm.stripe.com`).
 
+**Restricted key permissions.** Two keys, minimal scopes. Every permission maps to a specific code path — when adding a new Stripe API call, extend the matching key's permissions and this table.
+
+`STRIPE_GATEWAY_KEY` — used exclusively as the Bearer token for `llm.stripe.com` requests (agent-runner):
+
+| Permission | Access | Used by |
+|------------|--------|---------|
+| Billing → Meter events | Write | Every gateway LLM call (the gateway records token usage as meter events) |
+
+`STRIPE_API_KEY` — all `Stripe::*` API calls from Rails:
+
+| Permission | Access | Used by |
+|------------|--------|---------|
+| Customers | Write | `find_or_create_customer` (billing setup), email sync on user email change |
+| Checkout Sessions | Write | Subscription setup, collective upgrade, credit top-up; `retrieve` on the checkout return path |
+| Subscriptions | Write | Quantity sync (`Subscription.retrieve`, `SubscriptionItem.update`), cancel-at-zero-quantity |
+| Invoices | Write | Proration invoice create/pay, upcoming-invoice preview, finalizing the final invoice on cancel |
+| Products (incl. Prices) | Write | Ad-hoc `Price.create` per credit top-up checkout |
+| Credit grants | Write | Credit grant creation on top-up completion |
+| Credit balance summary | Read | Dispatch preflight balance check, `billing:gateway_health`, billing page |
+| Customer portal | Write | `/billing/portal` session creation |
+
+Webhook verification (`/stripe/webhooks`) uses `STRIPE_WEBHOOK_SECRET` for signature checks — no key permission involved.
+
 **Enable:**
 
-1. **Create the restricted key** in the Stripe dashboard with: AI Gateway (write), Credit Grants (write), Credit Balance Summary (read), Checkout Sessions (write). Set it as `STRIPE_GATEWAY_KEY` for both Rails and the agent-runner.
+1. **Create the restricted keys** in the Stripe dashboard per the tables above. `STRIPE_GATEWAY_KEY` goes to both Rails and the agent-runner; `STRIPE_API_KEY` to Rails only.
 2. **Create the credit product** (or verify the existing one) in the Stripe dashboard and set `STRIPE_CREDIT_PRODUCT_ID`. Top-up checkout raises `KeyError` without it.
 3. **Deploy** with both vars set. No behavior changes yet — routing stays on LiteLLM until a tenant qualifies.
 4. **Verify health:** `rails billing:gateway_health` should show both vars present and list active customers with balances.

--- a/docs/BILLING.md
+++ b/docs/BILLING.md
@@ -20,6 +20,8 @@ The unit price is **$3/month per billable identity**. A user has one Stripe subs
 
 **AI agent usage billing.** A separate prepaid credit balance covers LLM token usage. Routing is decided per task at dispatch: agents whose tenant has `stripe_billing` enabled and whose owner has an active billing customer run through the Stripe AI Gateway (`llm.stripe.com`, billed against the prepaid balance); all other agents (including system agents like Trio) run through LiteLLM at the operator's cost. Users top up via `/billing/topup` (requires an active subscription); Stripe deducts per LLM call, and task dispatch is blocked when the balance is empty. This is independent of the per-identity subscription. See the enablement runbook below.
 
+Under the hood this uses Stripe's token billing (pricing plans + meter events): the first top-up also subscribes the customer to the LLM-tokens pricing plan (`STRIPE_PRICING_PLAN_ID`), which is what turns metered usage into billing — usage draws down credit grants (top-ups plus any included-usage credits the plan grants), and overage past the balance invoices at cycle end with the plan's markup. Dispatch refuses gateway tasks for customers without the plan subscription so usage can never run unbilled.
+
 ## Collective Tier State Machine
 
 Every collective has a `tier` column with three states. Paid features (automations, Trio AI assistant, file attachments) require the paid tier.
@@ -104,6 +106,8 @@ How LLM usage billing turns on for a production tenant. Prerequisite: the Stripe
 | Credit grants | Write | Credit grant creation on top-up completion |
 | Credit balance summary | Read | Dispatch preflight balance check, `billing:gateway_health`, billing page |
 | Customer portal | Write | `/billing/portal` session creation |
+| PaymentIntents | Write | Off-session charge when the pricing-plan subscription has an amount due at subscribe time |
+| Billing (v2 preview: profiles, cadences, intents, pricing plans) | Write | `ensure_pricing_plan_subscription!` — the token-billing preview endpoints; verified working under the restricted key's Billing scopes in test mode, re-verify on the live key |
 
 Webhook verification (`/stripe/webhooks`) uses `STRIPE_WEBHOOK_SECRET` for signature checks — no key permission involved.
 
@@ -111,10 +115,12 @@ Webhook verification (`/stripe/webhooks`) uses `STRIPE_WEBHOOK_SECRET` for signa
 
 1. **Create the restricted keys** in the Stripe dashboard per the tables above. `STRIPE_GATEWAY_KEY` goes to both Rails and the agent-runner; `STRIPE_API_KEY` to Rails only.
 2. **Create the credit product** (or verify the existing one) in the Stripe dashboard and set `STRIPE_CREDIT_PRODUCT_ID`. Top-up checkout raises `KeyError` without it.
-3. **Deploy** with both vars set. No behavior changes yet — routing stays on LiteLLM until a tenant qualifies.
-4. **Verify health:** `rails billing:gateway_health` should show both vars present and list active customers with balances.
-5. **Enable the flag:** `tenant.enable_feature_flag!("stripe_billing")` for the target tenant. From the next dispatch, that tenant's billed agents route through the gateway.
-6. **Smoke test:** top up a small amount at `/billing/topup`, run an agent task, confirm the balance dropped (`billing:gateway_health`) and the agent-runner logged `llm_request` lines with `"gateway_mode":"stripe_gateway"`.
+3. **Create the pricing plan** (Dashboard → Pricing plans → Create → "Billing for LLM tokens" template): select the models to offer and set the markup percentage. Set its `bpp_...` id as `STRIPE_PRICING_PLAN_ID`.
+4. **Ask Stripe to enable zero-balance rejection** (token-billing-team@stripe.com) so the gateway itself refuses requests once a customer's balance is empty — our dispatch preflight checks at task start, not per LLM call, and balance deduction is aggregated periodically rather than real-time.
+5. **Deploy** with the vars set. No behavior changes yet — routing stays on LiteLLM until a tenant qualifies.
+6. **Verify health:** `rails billing:gateway_health` should show all three vars present and list active customers with balances and subscription status.
+7. **Enable the flag:** `tenant.enable_feature_flag!("stripe_billing")` for the target tenant. From the next dispatch, that tenant's billed agents route through the gateway.
+8. **Smoke test:** top up a small amount at `/billing/topup` (this also creates the pricing-plan subscription), run an agent task, confirm the balance dropped (`billing:gateway_health`) and the agent-runner logged `llm_request` lines with `"gateway_mode":"stripe_gateway"`.
 
 **Model names.** Agents store LiteLLM aliases (`claude-sonnet-4`, `claude-haiku-4`, ...). At dispatch, `StripeGatewayModelMapper` translates them to the gateway's `provider/model` format; agents with no configured model get the mapper's default. Models the gateway cannot proxy (local Ollama, Arcee Trinity) fail the task at dispatch with an explanatory error — update the agent's model or route the tenant back to LiteLLM.
 

--- a/lib/tasks/billing.rake
+++ b/lib/tasks/billing.rake
@@ -1,0 +1,18 @@
+# typed: false
+# frozen_string_literal: true
+
+namespace :billing do
+  desc "Report Stripe AI Gateway config status and active customers' credit balances"
+  task gateway_health: :environment do
+    report = StripeService.gateway_health
+
+    puts "STRIPE_GATEWAY_KEY:       #{report[:gateway_key_present] ? 'present' : 'MISSING'}"
+    puts "STRIPE_CREDIT_PRODUCT_ID: #{report[:credit_product_configured] ? 'present' : 'MISSING'}"
+    puts "Active billing customers: #{report[:active_customers].size}"
+    report[:active_customers].each do |customer|
+      balance = customer[:credit_balance_cents]
+      display = balance.nil? ? "BALANCE LOOKUP FAILED" : format("$%.2f", balance / 100.0)
+      puts "  #{customer[:stripe_id]}: #{display}"
+    end
+  end
+end

--- a/lib/tasks/billing.rake
+++ b/lib/tasks/billing.rake
@@ -8,11 +8,13 @@ namespace :billing do
 
     puts "STRIPE_GATEWAY_KEY:       #{report[:gateway_key_present] ? 'present' : 'MISSING'}"
     puts "STRIPE_CREDIT_PRODUCT_ID: #{report[:credit_product_configured] ? 'present' : 'MISSING'}"
+    puts "STRIPE_PRICING_PLAN_ID:   #{report[:pricing_plan_configured] ? 'present' : 'MISSING'}"
     puts "Active billing customers: #{report[:active_customers].size}"
     report[:active_customers].each do |customer|
       balance = customer[:credit_balance_cents]
       display = balance.nil? ? "BALANCE LOOKUP FAILED" : format("$%.2f", balance / 100.0)
-      puts "  #{customer[:stripe_id]}: #{display}"
+      plan = customer[:pricing_plan_subscribed] ? "" : " [NO PRICING PLAN SUBSCRIPTION]"
+      puts "  #{customer[:stripe_id]}: #{display}#{plan}"
     end
   end
 end

--- a/sorbet/rbi/dsl/stripe_customer.rbi
+++ b/sorbet/rbi/dsl/stripe_customer.rbi
@@ -181,6 +181,7 @@ class StripeCustomer
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         block: T.proc.params(object: ::StripeCustomer).void
       ).void
@@ -191,10 +192,11 @@ class StripeCustomer
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol
       ).returns(T::Enumerator[::StripeCustomer])
     end
-    def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
+    def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
 
     sig do
       params(
@@ -202,6 +204,7 @@ class StripeCustomer
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         block: T.proc.params(object: T::Array[::StripeCustomer]).void
       ).void
@@ -212,10 +215,11 @@ class StripeCustomer
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol
       ).returns(T::Enumerator[T::Enumerator[::StripeCustomer]])
     end
-    def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
+    def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
 
     sig do
       params(
@@ -297,6 +301,7 @@ class StripeCustomer
         finish: T.untyped,
         load: T.untyped,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         use_ranges: T.untyped,
         block: T.proc.params(object: PrivateRelation).void
@@ -309,11 +314,12 @@ class StripeCustomer
         finish: T.untyped,
         load: T.untyped,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         use_ranges: T.untyped
       ).returns(::ActiveRecord::Batches::BatchEnumerator)
     end
-    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, use_ranges: nil, &block); end
+    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, cursor: primary_key, order: :asc, use_ranges: nil, &block); end
 
     sig { params(record: T.untyped).returns(T::Boolean) }
     def include?(record); end
@@ -877,6 +883,51 @@ class StripeCustomer
     sig { void }
     def id_will_change!; end
 
+    sig { returns(T.nilable(::String)) }
+    def pricing_plan_subscription_id; end
+
+    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+    def pricing_plan_subscription_id=(value); end
+
+    sig { returns(T::Boolean) }
+    def pricing_plan_subscription_id?; end
+
+    sig { returns(T.nilable(::String)) }
+    def pricing_plan_subscription_id_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def pricing_plan_subscription_id_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def pricing_plan_subscription_id_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def pricing_plan_subscription_id_change; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def pricing_plan_subscription_id_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def pricing_plan_subscription_id_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def pricing_plan_subscription_id_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def pricing_plan_subscription_id_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def pricing_plan_subscription_id_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def pricing_plan_subscription_id_previously_was; end
+
+    sig { returns(T.nilable(::String)) }
+    def pricing_plan_subscription_id_was; end
+
+    sig { void }
+    def pricing_plan_subscription_id_will_change!; end
+
     sig { void }
     def restore_active!; end
 
@@ -894,6 +945,9 @@ class StripeCustomer
 
     sig { void }
     def restore_id_value!; end
+
+    sig { void }
+    def restore_pricing_plan_subscription_id!; end
 
     sig { void }
     def restore_stripe_id!; end
@@ -939,6 +993,12 @@ class StripeCustomer
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_id_value?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def saved_change_to_pricing_plan_subscription_id; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_pricing_plan_subscription_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([::String, ::String])) }
     def saved_change_to_stripe_id; end
@@ -1110,6 +1170,9 @@ class StripeCustomer
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_id_value?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_pricing_plan_subscription_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_stripe_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/test/manual/billing/gateway_enablement.manual_test.md
+++ b/test/manual/billing/gateway_enablement.manual_test.md
@@ -11,8 +11,8 @@ End-to-end verification that prepaid LLM credits flow correctly: top-up → agen
 ## Prerequisites
 
 - Stripe account enrolled in the AI Gateway preview (`llm.stripe.com`)
-- `STRIPE_GATEWAY_KEY` and `STRIPE_CREDIT_PRODUCT_ID` set on Rails and agent-runner (see docs/BILLING.md runbook)
-- `rails billing:gateway_health` shows both vars present
+- `STRIPE_GATEWAY_KEY`, `STRIPE_CREDIT_PRODUCT_ID`, and `STRIPE_PRICING_PLAN_ID` set (see docs/BILLING.md runbook)
+- `rails billing:gateway_health` shows all three vars present
 - Tenant A: `stripe_billing` enabled, a user with an active subscription and one internal AI agent
 - Tenant B: `stripe_billing` NOT enabled, with one internal AI agent (regression control)
 
@@ -27,7 +27,9 @@ End-to-end verification that prepaid LLM credits flow correctly: top-up → agen
 ### Checklist
 
 - [ ] Checkout completes and redirects back to `/billing`
-- [ ] Balance shows the granted amount (`credit_balance_cents` matches the top-up)
+- [ ] Balance shows the granted amount plus any included-usage credits from the pricing plan
+- [ ] No `[NO PRICING PLAN SUBSCRIPTION]` marker for the customer (the top-up subscribed them)
+- [ ] Stripe dashboard shows the customer subscribed to the pricing plan
 
 ## Test 2: Agent run bills the gateway
 
@@ -41,7 +43,8 @@ End-to-end verification that prepaid LLM credits flow correctly: top-up → agen
 
 - [ ] Task completes successfully
 - [ ] Log lines show `"gateway_mode":"stripe_gateway"`, `"stripe_customer_present":true`, and a `provider/model`-format model name
-- [ ] Balance dropped by roughly the expected token cost
+- [ ] Meter events for the run appear in the Stripe dashboard (Usage-based billing → Meters) within seconds
+- [ ] Balance drops by roughly the expected token cost (deduction is aggregated periodically — allow up to an hour, not instant)
 
 ## Test 3: Drain to zero fails cleanly
 

--- a/test/manual/billing/gateway_enablement.manual_test.md
+++ b/test/manual/billing/gateway_enablement.manual_test.md
@@ -1,0 +1,94 @@
+---
+passing: false
+last_verified: null
+verified_by: null
+---
+
+# Test: Stripe AI Gateway Enablement
+
+End-to-end verification that prepaid LLM credits flow correctly: top-up → agent run → balance deduction → clean failure at zero → recovery, plus a LiteLLM regression check. Run this on staging (or a test-mode tenant) before the production cutover, and again after cutover with a small real amount.
+
+## Prerequisites
+
+- Stripe account enrolled in the AI Gateway preview (`llm.stripe.com`)
+- `STRIPE_GATEWAY_KEY` and `STRIPE_CREDIT_PRODUCT_ID` set on Rails and agent-runner (see docs/BILLING.md runbook)
+- `rails billing:gateway_health` shows both vars present
+- Tenant A: `stripe_billing` enabled, a user with an active subscription and one internal AI agent
+- Tenant B: `stripe_billing` NOT enabled, with one internal AI agent (regression control)
+
+## Test 1: Top-up
+
+### Steps
+
+1. As Tenant A's user, go to `/billing/topup` and purchase a small credit amount (e.g. $5)
+2. Complete Stripe Checkout
+3. Run `rails billing:gateway_health`
+
+### Checklist
+
+- [ ] Checkout completes and redirects back to `/billing`
+- [ ] Balance shows the granted amount (`credit_balance_cents` matches the top-up)
+
+## Test 2: Agent run bills the gateway
+
+### Steps
+
+1. Run a short task with Tenant A's agent
+2. Watch agent-runner logs for `llm_request` lines
+3. Run `rails billing:gateway_health` after completion
+
+### Checklist
+
+- [ ] Task completes successfully
+- [ ] Log lines show `"gateway_mode":"stripe_gateway"`, `"stripe_customer_present":true`, and a `provider/model`-format model name
+- [ ] Balance dropped by roughly the expected token cost
+
+## Test 3: Drain to zero fails cleanly
+
+### Steps
+
+1. Run agent tasks until the balance reaches zero (or revoke the remaining credit grant in the Stripe dashboard)
+2. Attempt another agent task
+
+### Checklist
+
+- [ ] Task fails at dispatch with "Insufficient credit balance. Add funds at /billing before running agents."
+- [ ] No `llm_request` line with `stripe_gateway` appears for the failed task (it never reached the gateway)
+- [ ] The failure is visible to the user (task run page / chat error)
+
+## Test 4: Top-up recovery
+
+### Steps
+
+1. Top up again at `/billing/topup`
+2. Re-run the agent task
+
+### Checklist
+
+- [ ] Task dispatches and completes without operator intervention
+
+## Test 5: Unmappable model fails at dispatch
+
+### Steps
+
+1. Set Tenant A's agent model to a LiteLLM-only name (e.g. `llama3`)
+2. Attempt an agent task
+3. Restore the agent's model afterward
+
+### Checklist
+
+- [ ] Task fails at dispatch naming the model and listing available ones
+- [ ] After restoring a mapped model, tasks run again
+
+## Test 6: LiteLLM regression (Tenant B)
+
+### Steps
+
+1. Run a task with Tenant B's agent
+2. Watch agent-runner logs
+
+### Checklist
+
+- [ ] Task completes via LiteLLM (`"gateway_mode":"litellm"` in `llm_request` lines)
+- [ ] No Stripe balance change for any customer
+- [ ] System agent (Trio) tasks on Tenant A also log `"gateway_mode":"litellm"`

--- a/test/services/agent_runner_dispatch_service_test.rb
+++ b/test/services/agent_runner_dispatch_service_test.rb
@@ -175,7 +175,7 @@ class AgentRunnerDispatchServiceTest < ActiveSupport::TestCase
     assert_not_nil entry, "task should be dispatched: #{@task_run.reload.error}"
     fields = entry[1]
     assert_equal "stripe_gateway", fields["llm_gateway_mode"]
-    assert_equal "anthropic/claude-sonnet-4-6", fields["model"]
+    assert_equal "anthropic/claude-sonnet-4.6", fields["model"]
     assert_equal "cus_test123", fields["stripe_customer_stripe_id"]
     redis.close
   end

--- a/test/services/agent_runner_dispatch_service_test.rb
+++ b/test/services/agent_runner_dispatch_service_test.rb
@@ -225,6 +225,22 @@ class AgentRunnerDispatchServiceTest < ActiveSupport::TestCase
     redis.close
   end
 
+  test "fails task when billing customer has no pricing plan subscription" do
+    setup_active_billing!(pricing_plan_subscription_id: nil)
+
+    redis = Redis.new(url: ENV["REDIS_URL"])
+    StripeService.stub :get_credit_balance, ->(_) { 500 } do
+      AgentRunnerDispatchService.dispatch(@task_run)
+    end
+
+    @task_run.reload
+    assert_equal "failed", @task_run.status
+    assert_includes @task_run.error, "usage billing"
+    entry = redis.xrange("agent_tasks").find { |_id, fields| fields["task_run_id"] == @task_run.id }
+    assert_nil entry, "task without usage billing must not reach the stream"
+    redis.close
+  end
+
   test "fails task when credit balance is zero" do
     setup_active_billing!
 
@@ -344,12 +360,13 @@ class AgentRunnerDispatchServiceTest < ActiveSupport::TestCase
     tenant.enable_feature_flag!("stripe_billing")
   end
 
-  def setup_active_billing!
+  def setup_active_billing!(pricing_plan_subscription_id: "bpps_test123")
     enable_stripe_billing_flag!(@tenant)
     billing_customer = StripeCustomer.create!(
       billable: @ai_agent,
       stripe_id: "cus_test123",
       active: true,
+      pricing_plan_subscription_id: pricing_plan_subscription_id,
     )
     @ai_agent.update!(stripe_customer_id: billing_customer.id)
   end

--- a/test/services/agent_runner_dispatch_service_test.rb
+++ b/test/services/agent_runner_dispatch_service_test.rb
@@ -150,18 +150,91 @@ class AgentRunnerDispatchServiceTest < ActiveSupport::TestCase
   end
 
   test "stamps stripe_customer_id when billing active" do
-    enable_stripe_billing_flag!(@tenant)
-    billing_customer = StripeCustomer.create!(
-      billable: @ai_agent,
-      stripe_id: "cus_test123",
-      active: true,
-    )
-    @ai_agent.update!(stripe_customer_id: billing_customer.id)
+    setup_active_billing!
 
-    AgentRunnerDispatchService.dispatch(@task_run)
+    StripeService.stub :get_credit_balance, ->(_) { 500 } do
+      AgentRunnerDispatchService.dispatch(@task_run)
+    end
 
     @task_run.reload
-    assert_equal billing_customer.id, @task_run.stripe_customer_id
+    assert_equal @ai_agent.billing_customer.id, @task_run.stripe_customer_id
+  end
+
+  # === Per-task gateway routing ===
+
+  test "publishes stripe_gateway mode with mapped model when billing active" do
+    setup_active_billing!
+    @ai_agent.update!(agent_configuration: { "mode" => "internal", "model" => "claude-sonnet-4" })
+
+    redis = Redis.new(url: ENV["REDIS_URL"])
+    StripeService.stub :get_credit_balance, ->(_) { 500 } do
+      AgentRunnerDispatchService.dispatch(@task_run)
+    end
+
+    entry = redis.xrange("agent_tasks").find { |_id, fields| fields["task_run_id"] == @task_run.id }
+    assert_not_nil entry, "task should be dispatched: #{@task_run.reload.error}"
+    fields = entry[1]
+    assert_equal "stripe_gateway", fields["llm_gateway_mode"]
+    assert_equal "anthropic/claude-sonnet-4-6", fields["model"]
+    assert_equal "cus_test123", fields["stripe_customer_stripe_id"]
+    redis.close
+  end
+
+  test "publishes stripe_gateway mode with default model when agent has none configured" do
+    setup_active_billing!
+
+    redis = Redis.new(url: ENV["REDIS_URL"])
+    StripeService.stub :get_credit_balance, ->(_) { 500 } do
+      AgentRunnerDispatchService.dispatch(@task_run)
+    end
+
+    entry = redis.xrange("agent_tasks").find { |_id, fields| fields["task_run_id"] == @task_run.id }
+    assert_not_nil entry, "task should be dispatched: #{@task_run.reload.error}"
+    assert_equal StripeGatewayModelMapper::DEFAULT_MODEL, entry[1]["model"]
+    redis.close
+  end
+
+  test "publishes litellm mode with unmapped model when stripe_billing is off" do
+    @ai_agent.update!(agent_configuration: { "mode" => "internal", "model" => "claude-sonnet-4" })
+
+    redis = Redis.new(url: ENV["REDIS_URL"])
+    AgentRunnerDispatchService.dispatch(@task_run)
+
+    entry = redis.xrange("agent_tasks").find { |_id, fields| fields["task_run_id"] == @task_run.id }
+    assert_not_nil entry
+    fields = entry[1]
+    assert_equal "litellm", fields["llm_gateway_mode"]
+    assert_equal "claude-sonnet-4", fields["model"]
+    redis.close
+  end
+
+  test "fails task when agent model cannot be mapped for the gateway" do
+    setup_active_billing!
+    @ai_agent.update!(agent_configuration: { "mode" => "internal", "model" => "llama3" })
+
+    redis = Redis.new(url: ENV["REDIS_URL"])
+    StripeService.stub :get_credit_balance, ->(_) { 500 } do
+      AgentRunnerDispatchService.dispatch(@task_run)
+    end
+
+    @task_run.reload
+    assert_equal "failed", @task_run.status
+    assert_includes @task_run.error, "llama3"
+    entry = redis.xrange("agent_tasks").find { |_id, fields| fields["task_run_id"] == @task_run.id }
+    assert_nil entry, "unmappable task must not reach the stream"
+    redis.close
+  end
+
+  test "fails task when credit balance is zero" do
+    setup_active_billing!
+
+    StripeService.stub :get_credit_balance, ->(_) { 0 } do
+      AgentRunnerDispatchService.dispatch(@task_run)
+    end
+
+    @task_run.reload
+    assert_equal "failed", @task_run.status
+    assert_includes @task_run.error, "Insufficient credit balance"
   end
 
   test "fails task for external agent" do
@@ -271,6 +344,16 @@ class AgentRunnerDispatchServiceTest < ActiveSupport::TestCase
     tenant.enable_feature_flag!("stripe_billing")
   end
 
+  def setup_active_billing!
+    enable_stripe_billing_flag!(@tenant)
+    billing_customer = StripeCustomer.create!(
+      billable: @ai_agent,
+      stripe_id: "cus_test123",
+      active: true,
+    )
+    @ai_agent.update!(stripe_customer_id: billing_customer.id)
+  end
+
   # === System agent (Trio) billing exemption ===
 
   test "dispatches task for system agent without billing setup" do
@@ -309,7 +392,7 @@ class AgentRunnerDispatchServiceTest < ActiveSupport::TestCase
     assert_nil task_run.stripe_customer_id
   end
 
-  test "skips credit balance check for system agent in stripe_gateway mode" do
+  test "system agent routes through litellm and skips credit balance check" do
     enable_stripe_billing_flag!(@tenant)
     @tenant.create_main_collective!(created_by: @user)
     trio = TrioSeeder.ensure_for(T.must(@tenant.main_collective))
@@ -318,23 +401,18 @@ class AgentRunnerDispatchServiceTest < ActiveSupport::TestCase
       task: "Hello", max_steps: 10, status: "queued",
     )
 
-    previous_mode = ENV["LLM_GATEWAY_MODE"]
-    ENV["LLM_GATEWAY_MODE"] = "stripe_gateway"
-    begin
-      # StripeService.get_credit_balance must not be called for system agents.
-      # If it were, this stub would raise.
-      StripeService.stub :get_credit_balance, ->(_) { raise "should not be called for system agent" } do
-        AgentRunnerDispatchService.dispatch(task_run)
-      end
-    ensure
-      if previous_mode.nil?
-        ENV.delete("LLM_GATEWAY_MODE")
-      else
-        ENV["LLM_GATEWAY_MODE"] = previous_mode
-      end
+    redis = Redis.new(url: ENV["REDIS_URL"])
+    # StripeService.get_credit_balance must not be called for system agents.
+    # If it were, this stub would raise.
+    StripeService.stub :get_credit_balance, ->(_) { raise "should not be called for system agent" } do
+      AgentRunnerDispatchService.dispatch(task_run)
     end
 
     task_run.reload
     assert_equal "queued", task_run.status
+    entry = redis.xrange("agent_tasks").find { |_id, fields| fields["task_run_id"] == task_run.id }
+    assert_not_nil entry
+    assert_equal "litellm", entry[1]["llm_gateway_mode"]
+    redis.close
   end
 end

--- a/test/services/stripe_gateway_model_mapper_test.rb
+++ b/test/services/stripe_gateway_model_mapper_test.rb
@@ -1,0 +1,35 @@
+# typed: false
+require "test_helper"
+
+class StripeGatewayModelMapperTest < ActiveSupport::TestCase
+  test "maps LiteLLM claude names to Stripe provider/model format" do
+    assert_equal "anthropic/claude-sonnet-4-6", StripeGatewayModelMapper.map("claude-sonnet-4")
+    assert_equal "anthropic/claude-haiku-4-5-20251001", StripeGatewayModelMapper.map("claude-haiku-4")
+    assert_equal "anthropic/claude-opus-4-7", StripeGatewayModelMapper.map("claude-opus-4")
+  end
+
+  test "maps gpt-4o to openai provider format" do
+    assert_equal "openai/gpt-4o", StripeGatewayModelMapper.map("gpt-4o")
+  end
+
+  test "maps blank and default to the gateway default model" do
+    assert_equal "anthropic/claude-sonnet-4-6", StripeGatewayModelMapper.map(nil)
+    assert_equal "anthropic/claude-sonnet-4-6", StripeGatewayModelMapper.map("")
+    assert_equal "anthropic/claude-sonnet-4-6", StripeGatewayModelMapper.map("default")
+  end
+
+  test "passes through names already in provider/model format" do
+    assert_equal "anthropic/claude-sonnet-4-6", StripeGatewayModelMapper.map("anthropic/claude-sonnet-4-6")
+    assert_equal "openai/gpt-4o-mini", StripeGatewayModelMapper.map("openai/gpt-4o-mini")
+  end
+
+  test "raises UnmappedModelError for models the gateway cannot proxy" do
+    error = assert_raises(StripeGatewayModelMapper::UnmappedModelError) do
+      StripeGatewayModelMapper.map("trinity-large-thinking")
+    end
+    assert_includes error.message, "trinity-large-thinking"
+
+    assert_raises(StripeGatewayModelMapper::UnmappedModelError) { StripeGatewayModelMapper.map("llama3") }
+    assert_raises(StripeGatewayModelMapper::UnmappedModelError) { StripeGatewayModelMapper.map("deepseek-r1") }
+  end
+end

--- a/test/services/stripe_gateway_model_mapper_test.rb
+++ b/test/services/stripe_gateway_model_mapper_test.rb
@@ -3,9 +3,9 @@ require "test_helper"
 
 class StripeGatewayModelMapperTest < ActiveSupport::TestCase
   test "maps LiteLLM claude names to Stripe provider/model format" do
-    assert_equal "anthropic/claude-sonnet-4-6", StripeGatewayModelMapper.map("claude-sonnet-4")
-    assert_equal "anthropic/claude-haiku-4-5-20251001", StripeGatewayModelMapper.map("claude-haiku-4")
-    assert_equal "anthropic/claude-opus-4-7", StripeGatewayModelMapper.map("claude-opus-4")
+    assert_equal "anthropic/claude-sonnet-4.6", StripeGatewayModelMapper.map("claude-sonnet-4")
+    assert_equal "anthropic/claude-haiku-4.5", StripeGatewayModelMapper.map("claude-haiku-4")
+    assert_equal "anthropic/claude-opus-4.7", StripeGatewayModelMapper.map("claude-opus-4")
   end
 
   test "maps gpt-4o to openai provider format" do
@@ -13,13 +13,13 @@ class StripeGatewayModelMapperTest < ActiveSupport::TestCase
   end
 
   test "maps blank and default to the gateway default model" do
-    assert_equal "anthropic/claude-sonnet-4-6", StripeGatewayModelMapper.map(nil)
-    assert_equal "anthropic/claude-sonnet-4-6", StripeGatewayModelMapper.map("")
-    assert_equal "anthropic/claude-sonnet-4-6", StripeGatewayModelMapper.map("default")
+    assert_equal "anthropic/claude-sonnet-4.6", StripeGatewayModelMapper.map(nil)
+    assert_equal "anthropic/claude-sonnet-4.6", StripeGatewayModelMapper.map("")
+    assert_equal "anthropic/claude-sonnet-4.6", StripeGatewayModelMapper.map("default")
   end
 
   test "passes through names already in provider/model format" do
-    assert_equal "anthropic/claude-sonnet-4-6", StripeGatewayModelMapper.map("anthropic/claude-sonnet-4-6")
+    assert_equal "anthropic/claude-sonnet-4.6", StripeGatewayModelMapper.map("anthropic/claude-sonnet-4.6")
     assert_equal "openai/gpt-4o-mini", StripeGatewayModelMapper.map("openai/gpt-4o-mini")
   end
 

--- a/test/services/stripe_service_test.rb
+++ b/test/services/stripe_service_test.rb
@@ -1615,10 +1615,124 @@ class StripeServiceTest < ActiveSupport::TestCase
     assert_equal 0, result
   end
 
+  # === ensure_pricing_plan_subscription! ===
+
+  PLAN_ID = "bpp_test_plan123"
+  PLAN_VERSION = "bppv_test_version123"
+
+  def with_pricing_plan_env
+    original = ENV["STRIPE_PRICING_PLAN_ID"]
+    ENV["STRIPE_PRICING_PLAN_ID"] = PLAN_ID
+    yield
+  ensure
+    original.nil? ? ENV.delete("STRIPE_PRICING_PLAN_ID") : ENV["STRIPE_PRICING_PLAN_ID"] = original
+  end
+
+  def stub_pricing_plan_subscription_flow(reserve_total: "0")
+    stub_request(:get, "https://api.stripe.com/v2/billing/pricing_plans/#{PLAN_ID}")
+      .to_return(status: 200, body: { id: PLAN_ID, live_version: PLAN_VERSION }.to_json, headers: { "Content-Type" => "application/json" })
+    stub_request(:post, "https://api.stripe.com/v2/billing/profiles")
+      .to_return(status: 200, body: { id: "bilp_test_1" }.to_json, headers: { "Content-Type" => "application/json" })
+    stub_request(:post, "https://api.stripe.com/v2/billing/cadences")
+      .to_return(status: 200, body: { id: "bc_test_1" }.to_json, headers: { "Content-Type" => "application/json" })
+    stub_request(:post, "https://api.stripe.com/v2/billing/intents")
+      .to_return(status: 200, body: { id: "bilint_test_1", status: "drafted" }.to_json, headers: { "Content-Type" => "application/json" })
+    stub_request(:post, "https://api.stripe.com/v2/billing/intents/bilint_test_1/reserve")
+      .to_return(status: 200, body: { id: "bilint_test_1", status: "reserved", amount_details: { total: reserve_total } }.to_json,
+                 headers: { "Content-Type" => "application/json" })
+    stub_request(:post, "https://api.stripe.com/v2/billing/intents/bilint_test_1/commit")
+      .to_return(status: 200, body: { id: "bilint_test_1", status: "committed" }.to_json, headers: { "Content-Type" => "application/json" })
+    stub_request(:get, %r{https://api.stripe.com/v2/billing/pricing_plan_subscriptions.*})
+      .to_return(status: 200, body: { data: [{ id: "bpps_test_new1", billing_cadence: "bc_test_1" },
+                                             { id: "bpps_test_other", billing_cadence: "bc_test_other" }] }.to_json,
+                 headers: { "Content-Type" => "application/json" })
+  end
+
+  test "ensure_pricing_plan_subscription! subscribes and stores the subscription id (zero due)" do
+    sc = StripeCustomer.create!(billable: @user, stripe_id: "cus_plan1", active: true)
+    stub_pricing_plan_subscription_flow(reserve_total: "0")
+
+    result = with_pricing_plan_env { StripeService.ensure_pricing_plan_subscription!(sc) }
+
+    assert result
+    assert_equal "bpps_test_new1", sc.reload.pricing_plan_subscription_id
+    assert_not_requested :post, "https://api.stripe.com/v1/payment_intents"
+    assert_requested(:post, "https://api.stripe.com/v2/billing/intents/bilint_test_1/commit") do |req|
+      !req.body.include?("payment_intent")
+    end
+  end
+
+  test "ensure_pricing_plan_subscription! charges off-session when the plan has an amount due" do
+    sc = StripeCustomer.create!(billable: @user, stripe_id: "cus_plan2", active: true)
+    stub_pricing_plan_subscription_flow(reserve_total: "300")
+    stub_request(:get, "https://api.stripe.com/v1/customers/cus_plan2")
+      .to_return(status: 200, body: { id: "cus_plan2", invoice_settings: { default_payment_method: "pm_default1" } }.to_json,
+                 headers: { "Content-Type" => "application/json" })
+    stub_request(:post, "https://api.stripe.com/v1/payment_intents")
+      .to_return(status: 200, body: { id: "pi_test_1", status: "succeeded" }.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = with_pricing_plan_env { StripeService.ensure_pricing_plan_subscription!(sc) }
+
+    assert result
+    assert_equal "bpps_test_new1", sc.reload.pricing_plan_subscription_id
+    assert_requested(:post, "https://api.stripe.com/v1/payment_intents") do |req|
+      req.body.include?("amount=300") && req.body.include?("off_session=true") && req.body.include?("pm_default1")
+    end
+    assert_requested(:post, "https://api.stripe.com/v2/billing/intents/bilint_test_1/commit") do |req|
+      req.body.include?("pi_test_1")
+    end
+  end
+
+  test "ensure_pricing_plan_subscription! is a no-op when already subscribed" do
+    sc = StripeCustomer.create!(billable: @user, stripe_id: "cus_plan3", active: true, pricing_plan_subscription_id: "bpps_existing")
+
+    result = with_pricing_plan_env { StripeService.ensure_pricing_plan_subscription!(sc) }
+
+    assert result
+    assert_equal "bpps_existing", sc.reload.pricing_plan_subscription_id
+  end
+
+  test "ensure_pricing_plan_subscription! returns false when the plan id is not configured" do
+    sc = StripeCustomer.create!(billable: @user, stripe_id: "cus_plan4", active: true)
+    original = ENV["STRIPE_PRICING_PLAN_ID"]
+    ENV.delete("STRIPE_PRICING_PLAN_ID")
+    begin
+      assert_not StripeService.ensure_pricing_plan_subscription!(sc)
+    ensure
+      ENV["STRIPE_PRICING_PLAN_ID"] = original unless original.nil?
+    end
+    assert_nil sc.reload.pricing_plan_subscription_id
+  end
+
+  test "create_credit_grant_from_checkout also subscribes the customer to the pricing plan" do
+    sc = StripeCustomer.create!(billable: @user, stripe_id: "cus_grant_plan", active: true)
+    stub_request(:post, "https://api.stripe.com/v1/billing/credit_grants")
+      .to_return(status: 200, body: { id: "credgr_test" }.to_json, headers: { "Content-Type" => "application/json" })
+    stub_pricing_plan_subscription_flow(reserve_total: "0")
+
+    with_pricing_plan_env do
+      StripeService.create_credit_grant_from_checkout(stripe_customer: sc, amount_cents: 500, checkout_session_id: "cs_plan_wire")
+    end
+
+    assert_requested(:post, "https://api.stripe.com/v1/billing/credit_grants")
+    assert_equal "bpps_test_new1", sc.reload.pricing_plan_subscription_id
+  end
+
+  test "ensure_pricing_plan_subscription! returns false on Stripe errors without storing" do
+    sc = StripeCustomer.create!(billable: @user, stripe_id: "cus_plan5", active: true)
+    stub_request(:get, "https://api.stripe.com/v2/billing/pricing_plans/#{PLAN_ID}")
+      .to_return(status: 500, body: { error: { message: "boom" } }.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = with_pricing_plan_env { StripeService.ensure_pricing_plan_subscription!(sc) }
+
+    assert_not result
+    assert_nil sc.reload.pricing_plan_subscription_id
+  end
+
   # === gateway_health ===
 
   test "gateway_health reports config presence and per-customer balances" do
-    StripeCustomer.create!(billable: @user, stripe_id: "cus_health1", active: true)
+    StripeCustomer.create!(billable: @user, stripe_id: "cus_health1", active: true, pricing_plan_subscription_id: "bpps_health1")
     inactive_user = User.create!(name: "Inactive", email: "inactive-#{SecureRandom.hex(4)}@example.com")
     StripeCustomer.create!(billable: inactive_user, stripe_id: "cus_inactive", active: false)
 
@@ -1642,7 +1756,7 @@ class StripeServiceTest < ActiveSupport::TestCase
     ENV["STRIPE_GATEWAY_KEY"] = "rk_test_gateway"
     ENV["STRIPE_CREDIT_PRODUCT_ID"] = "prod_test_credit"
     begin
-      report = StripeService.gateway_health
+      report = with_pricing_plan_env { StripeService.gateway_health }
     ensure
       original_key.nil? ? ENV.delete("STRIPE_GATEWAY_KEY") : ENV["STRIPE_GATEWAY_KEY"] = original_key
       original_product.nil? ? ENV.delete("STRIPE_CREDIT_PRODUCT_ID") : ENV["STRIPE_CREDIT_PRODUCT_ID"] = original_product
@@ -1650,11 +1764,13 @@ class StripeServiceTest < ActiveSupport::TestCase
 
     assert report[:gateway_key_present]
     assert report[:credit_product_configured]
+    assert report[:pricing_plan_configured]
     customer_ids = report[:active_customers].map { |c| c[:stripe_id] }
     assert_includes customer_ids, "cus_health1"
     assert_not_includes customer_ids, "cus_inactive"
-    balance = report[:active_customers].find { |c| c[:stripe_id] == "cus_health1" }
-    assert_equal 1200, balance[:credit_balance_cents]
+    health1 = report[:active_customers].find { |c| c[:stripe_id] == "cus_health1" }
+    assert_equal 1200, health1[:credit_balance_cents]
+    assert health1[:pricing_plan_subscribed]
   end
 
   test "gateway_health reports missing config" do
@@ -1671,6 +1787,7 @@ class StripeServiceTest < ActiveSupport::TestCase
 
     assert_not report[:gateway_key_present]
     assert_not report[:credit_product_configured]
+    assert_not report[:pricing_plan_configured]
     assert_equal [], report[:active_customers]
   end
 

--- a/test/services/stripe_service_test.rb
+++ b/test/services/stripe_service_test.rb
@@ -1615,6 +1615,65 @@ class StripeServiceTest < ActiveSupport::TestCase
     assert_equal 0, result
   end
 
+  # === gateway_health ===
+
+  test "gateway_health reports config presence and per-customer balances" do
+    StripeCustomer.create!(billable: @user, stripe_id: "cus_health1", active: true)
+    inactive_user = User.create!(name: "Inactive", email: "inactive-#{SecureRandom.hex(4)}@example.com")
+    StripeCustomer.create!(billable: inactive_user, stripe_id: "cus_inactive", active: false)
+
+    stub_request(:get, %r{https://api.stripe.com/v1/billing/credit_balance_summary.*})
+      .to_return(
+        status: 200,
+        body: {
+          object: "billing.credit_balance_summary",
+          balances: [
+            {
+              available_balance: { type: "monetary", monetary: { value: 1200, currency: "usd" } },
+              ledger_balance: { type: "monetary", monetary: { value: 1200, currency: "usd" } },
+            },
+          ],
+        }.to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+    original_key = ENV["STRIPE_GATEWAY_KEY"]
+    original_product = ENV["STRIPE_CREDIT_PRODUCT_ID"]
+    ENV["STRIPE_GATEWAY_KEY"] = "rk_test_gateway"
+    ENV["STRIPE_CREDIT_PRODUCT_ID"] = "prod_test_credit"
+    begin
+      report = StripeService.gateway_health
+    ensure
+      original_key.nil? ? ENV.delete("STRIPE_GATEWAY_KEY") : ENV["STRIPE_GATEWAY_KEY"] = original_key
+      original_product.nil? ? ENV.delete("STRIPE_CREDIT_PRODUCT_ID") : ENV["STRIPE_CREDIT_PRODUCT_ID"] = original_product
+    end
+
+    assert report[:gateway_key_present]
+    assert report[:credit_product_configured]
+    customer_ids = report[:active_customers].map { |c| c[:stripe_id] }
+    assert_includes customer_ids, "cus_health1"
+    assert_not_includes customer_ids, "cus_inactive"
+    balance = report[:active_customers].find { |c| c[:stripe_id] == "cus_health1" }
+    assert_equal 1200, balance[:credit_balance_cents]
+  end
+
+  test "gateway_health reports missing config" do
+    original_key = ENV["STRIPE_GATEWAY_KEY"]
+    original_product = ENV["STRIPE_CREDIT_PRODUCT_ID"]
+    ENV.delete("STRIPE_GATEWAY_KEY")
+    ENV.delete("STRIPE_CREDIT_PRODUCT_ID")
+    begin
+      report = StripeService.gateway_health
+    ensure
+      ENV["STRIPE_GATEWAY_KEY"] = original_key unless original_key.nil?
+      ENV["STRIPE_CREDIT_PRODUCT_ID"] = original_product unless original_product.nil?
+    end
+
+    assert_not report[:gateway_key_present]
+    assert_not report[:credit_product_configured]
+    assert_equal [], report[:active_customers]
+  end
+
   test "get_credit_balance returns nil on Stripe error" do
     sc = StripeCustomer.create!(billable: @user, stripe_id: "cus_balerr")
 


### PR DESCRIPTION
## Summary

Makes the Layer 2 prepaid LLM-credit system (built in v1.6.0, never enabled) production-ready end to end, per `.claude/plans/stripe-ai-gateway-production-readiness.md`. All Stripe-side behavior was verified live in test mode against the token-billing private preview, including two successful `llm.stripe.com` calls and a full API-driven pricing-plan subscription.

### Routing (per task, not per deploy)
- Rails decides each task's LLM route at dispatch: billed agents (tenant has `stripe_billing` + active billing customer) go through the Stripe AI Gateway; everyone else (including system agents) through LiteLLM. The decision rides a new `llm_gateway_mode` Redis-stream field.
- The agent-runner picks endpoint/base URL/auth headers per call; `LLM_GATEWAY_MODE` env is now only a fallback for pre-upgrade payloads. Gateway calls without a customer id are refused (an unattributed call succeeds on Stripe's side but bills nobody).

### Model mapping
- `StripeGatewayModelMapper` translates LiteLLM aliases to the gateway's dotted `provider/model` names (`claude-sonnet-4` → `anthropic/claude-sonnet-4.6`), verified against the gateway's supported-models list. Unmappable models (Ollama, Arcee Trinity) fail the task at dispatch with a clear error instead of a 400 at request time.

### Billing completeness (usage can never run unbilled)
- Gateway usage only bills customers subscribed to Stripe's LLM-tokens pricing plan (verified: meter events without one float unbilled). Top-up completion now ensures that subscription via the v2 preview APIs (profile → cadence → billing intent → reserve → commit, charging the default payment method off-session when the plan has an amount due) and stores it on `StripeCustomer#pricing_plan_subscription_id`.
- Dispatch refuses gateway tasks for customers without the subscription.
- The plan's included-usage credits and our top-up credit grants pool into the same balance the existing preflight reads — the prepaid UX survives unchanged.

### Observability & ops
- Structured `llm_request` / `llm_request_failed` runner logs (gateway mode, model, status, duration, tokens — never the customer id).
- `rails billing:gateway_health`: config presence + per-customer balance and subscription status.
- `docs/BILLING.md`: enablement runbook, rollback path, exact restricted-key permission tables for both Stripe keys.
- Staging/prod smoke-test checklist in `test/manual/billing/gateway_enablement.manual_test.md`.

## Deploy gate

Before deploying, confirm no prod tenant other than the intended one already has `stripe_billing` enabled with active billing customers — such tenants' agents would flip to gateway routing and fail dispatch (insufficient balance / missing plan subscription) until they top up.

## Test plan

- [x] 103 Rails test runs green (dispatch service, model mapper, StripeService incl. v2 subscription flow via webmock)
- [x] 227 agent-runner tests green; `tsc` clean; Sorbet clean
- [x] Live test-mode verification: raw gateway calls, checkout-based and API-based pricing-plan subscription, credit grant + balance pooling
- [ ] Staging smoke test per `test/manual/billing/gateway_enablement.manual_test.md` (needs deployed env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)