### PR TITLE
Billing UX: reuse saved cards across checkouts, honest empty-state copy

### DIFF
--- a/app/services/stripe_service.rb
+++ b/app/services/stripe_service.rb
@@ -73,6 +73,10 @@ class StripeService
           quantity: quantity,
         },
       ],
+      # Offer cards the customer already saved (e.g. via a credit top-up)
+      # instead of asking them to type the number again. "limited" includes
+      # cards Stripe saved automatically for subscription renewals.
+      saved_payment_method_options: { allow_redisplay_filters: ["always", "limited"] },
       success_url: success_url,
       cancel_url: cancel_url,
     )
@@ -275,6 +279,13 @@ class StripeService
       mode: "payment",
       line_items: [{ price: price.id, quantity: 1 }],
       metadata: { type: "credit_topup" },
+      # Offer cards saved via the identity subscription ("limited") or a prior
+      # top-up ("always"), and let the customer save a new card for next time —
+      # payment-mode checkouts don't save cards by default.
+      saved_payment_method_options: {
+        allow_redisplay_filters: ["always", "limited"],
+        payment_method_save: "enabled",
+      },
       success_url: success_url,
       cancel_url: cancel_url,
     )

--- a/app/views/billing/_inventory_table.html.erb
+++ b/app/views/billing/_inventory_table.html.erb
@@ -9,7 +9,7 @@
           <% if @current_user.counts_self_for_paid_human_features? %>
             $3/mo <span class="pulse-muted">(programmatic access)</span>
           <% else %>
-            <span style="color: var(--color-fg-muted);">free</span>
+            <span style="color: var(--color-fg-muted);">$0/mo</span>
           <% end %>
         </td>
       <% end %>

--- a/app/views/billing/show.html.erb
+++ b/app/views/billing/show.html.erb
@@ -31,7 +31,6 @@
 
       <section class="pulse-section" style="margin-bottom: 24px;">
         <h2 class="pulse-section-title">Your Subscription</h2>
-        <p class="pulse-muted" style="margin-bottom: 12px;">Your membership is free — each AI agent and additional collective costs $3/month.</p>
         <%= render partial: "billing/inventory_table", locals: { show_prices: true, show_actions: true } %>
       </section>
 
@@ -164,10 +163,10 @@
       <%# === No subscription needed — nothing billable yet (or fully exempt) === %>
       <section class="pulse-section" style="margin-bottom: 24px;">
         <div class="pulse-notice pulse-notice-success">
-          <span><%= octicon 'shield-check', height: 16 %> <strong>Nothing to pay</strong> — you have no billable items yet.</span>
+          <span><%= octicon 'shield-check', height: 16 %> <strong>Nothing to pay</strong> — you have no billable items.</span>
         </div>
         <p class="pulse-muted" style="margin-top: 12px;">
-          Your membership is free. Each AI agent and additional collective costs <strong>$3/month</strong> — you'll set up payment when you add your first one.
+          Billable items will show up here when created. AI agents cost <strong>$3/month</strong> each.
         </p>
       </section>
 
@@ -181,7 +180,7 @@
       <section class="pulse-section" style="margin-bottom: 24px;">
         <h2 class="pulse-section-title">Subscription required</h2>
         <p style="margin-bottom: 16px;">
-          You have AI agents or additional collectives that need an active subscription. Each costs <strong>$3/month</strong>.
+          You have billable items that need an active subscription. Each costs <strong>$3/month</strong>.
         </p>
 
         <%= render partial: "billing/inventory_table", locals: { show_prices: true } %>

--- a/app/views/billing/show.html.erb
+++ b/app/views/billing/show.html.erb
@@ -31,7 +31,7 @@
 
       <section class="pulse-section" style="margin-bottom: 24px;">
         <h2 class="pulse-section-title">Your Subscription</h2>
-        <p class="pulse-muted" style="margin-bottom: 12px;">Your account is free. AI agents and additional collectives cost $3/month each.</p>
+        <p class="pulse-muted" style="margin-bottom: 12px;">Your membership is free — each AI agent and additional collective costs $3/month.</p>
         <%= render partial: "billing/inventory_table", locals: { show_prices: true, show_actions: true } %>
       </section>
 
@@ -161,13 +161,13 @@
       </section>
 
     <% elsif @billable_quantity && @billable_quantity == 0 %>
-      <%# === No subscription needed — free account (or fully exempt) === %>
+      <%# === No subscription needed — nothing billable yet (or fully exempt) === %>
       <section class="pulse-section" style="margin-bottom: 24px;">
         <div class="pulse-notice pulse-notice-success">
-          <span><%= octicon 'shield-check', height: 16 %> <strong>Free account</strong> — No subscription required.</span>
+          <span><%= octicon 'shield-check', height: 16 %> <strong>Nothing to pay</strong> — you have no billable items yet.</span>
         </div>
         <p class="pulse-muted" style="margin-top: 12px;">
-          Joining is free. AI agents and additional collectives cost <strong>$3/month</strong> each — billing kicks in when you create one.
+          Your membership is free. Each AI agent and additional collective costs <strong>$3/month</strong> — you'll set up payment when you add your first one.
         </p>
       </section>
 

--- a/app/views/billing/show.md.erb
+++ b/app/views/billing/show.md.erb
@@ -7,11 +7,9 @@
 
 ## Your Subscription
 
-Membership is free — each AI agent and additional collective costs $3/month.
-
 | Item | Cost |
 |------|------|
-| <%= @current_user.display_name %> (you) | <%= @current_user.counts_self_for_paid_human_features? ? "$3/mo (programmatic access)" : "free" %> |
+| <%= @current_user.display_name %> (you) | <%= @current_user.counts_self_for_paid_human_features? ? "$3/mo (programmatic access)" : "$0/mo" %> |
 <% @active_agents&.each do |agent| %>
 | <%= agent.display_name %> (agent) | <%= agent.billing_exempt? ? "$0/mo (exempt)" : "$3/mo" %> |
 <% end %>
@@ -81,9 +79,9 @@ To add credits, visit `/billing` in your browser and use the "Add Funds" button.
 <% elsif @billable_quantity && @billable_quantity == 0 %>
 ## Status
 
-**Nothing to pay** — no billable items yet.
+**Nothing to pay** — no billable items.
 
-Membership is free. Each AI agent and additional collective costs $3/month — payment setup happens when the first one is added.
+Billable items will show up here when created. AI agents cost $3/month each.
 
 ## Your Resources
 
@@ -104,11 +102,11 @@ Not Set Up
 
 ## Subscription required
 
-You have AI agents or additional collectives that need an active subscription. Each costs **$3/month**.
+You have billable items that need an active subscription. Each costs **$3/month**.
 
 | Item | Cost |
 |------|------|
-| <%= @current_user.display_name %> (you) | <%= @current_user.counts_self_for_paid_human_features? ? "$3/mo (programmatic access)" : "free" %> |
+| <%= @current_user.display_name %> (you) | <%= @current_user.counts_self_for_paid_human_features? ? "$3/mo (programmatic access)" : "$0/mo" %> |
 <% @active_agents&.each do |agent| %>
 | <%= agent.display_name %> (agent) | <%= agent.billing_exempt? ? "$0/mo (exempt)" : "$3/mo" %> |
 <% end %>

--- a/app/views/billing/show.md.erb
+++ b/app/views/billing/show.md.erb
@@ -7,7 +7,7 @@
 
 ## Your Subscription
 
-Your account is free. AI agents and additional collectives cost $3/month each.
+Membership is free — each AI agent and additional collective costs $3/month.
 
 | Item | Cost |
 |------|------|
@@ -81,9 +81,9 @@ To add credits, visit `/billing` in your browser and use the "Add Funds" button.
 <% elsif @billable_quantity && @billable_quantity == 0 %>
 ## Status
 
-**Free account** — No subscription required.
+**Nothing to pay** — no billable items yet.
 
-Joining is free. AI agents and additional collectives cost $3/month each — billing kicks in when you create one.
+Membership is free. Each AI agent and additional collective costs $3/month — payment setup happens when the first one is added.
 
 ## Your Resources
 

--- a/test/controllers/billing_controller_test.rb
+++ b/test/controllers/billing_controller_test.rb
@@ -46,7 +46,7 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "show describes a fresh human as a 'Free account' with no subscription needed" do
+  test "show tells a fresh human there is nothing to pay yet" do
     # Fresh user — no AI agents, no non-main collectives.
     fresh_tenant = create_tenant(subdomain: "billing-free-#{SecureRandom.hex(4)}")
     enable_stripe_billing_flag!(fresh_tenant)
@@ -59,8 +59,10 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
     get "/billing"
 
     assert_response :success
-    assert_match(/free account/i, response.body,
-                 "expected 'Free account' framing for humans with no billable resources")
+    assert_match(/nothing to pay/i, response.body,
+                 "expected 'Nothing to pay' framing for humans with no billable resources")
+    assert_no_match(/free account/i, response.body,
+                    "'Free account' reads as a plan tier that includes agents — don't use it")
     assert_no_match(/Set Up Billing/, response.body,
                     "fresh humans should not see a Set Up Billing button")
   end
@@ -504,9 +506,9 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Set Up Billing"
   end
 
-  test "show displays free-account banner when no billable resources" do
+  test "show displays nothing-to-pay banner when no billable resources" do
     # Under humans-free, a user with no agents and no non-main collectives
-    # owned by them lands in the "free account" branch — same view branch
+    # owned by them lands in the "nothing to pay" branch — same view branch
     # the older billing-exempt test used to cover (now broadened beyond
     # admin-set exemption).
     @user.update!(billing_exempt: true)
@@ -516,7 +518,7 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
     get "/billing"
 
     assert_response :success
-    assert_includes response.body, "Free account"
+    assert_includes response.body, "Nothing to pay"
   end
 
   test "show displays exempt label on individual exempt resources" do

--- a/test/controllers/billing_controller_test.rb
+++ b/test/controllers/billing_controller_test.rb
@@ -48,9 +48,9 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
 
   test "show tells a fresh human there is nothing to pay yet" do
     # Fresh user — no AI agents, no non-main collectives.
-    fresh_tenant = create_tenant(subdomain: "billing-free-#{SecureRandom.hex(4)}")
+    fresh_tenant = create_tenant(subdomain: "billing-fresh-#{SecureRandom.hex(4)}")
     enable_stripe_billing_flag!(fresh_tenant)
-    fresh_user = create_user(email: "billing-free-#{SecureRandom.hex(4)}@example.com", name: "Billing Free")
+    fresh_user = create_user(email: "billing-fresh-#{SecureRandom.hex(4)}@example.com", name: "Billing Fresh")
     fresh_tenant.add_user!(fresh_user)
     fresh_tenant.create_main_collective!(created_by: fresh_user)
     host! "#{fresh_tenant.subdomain}.#{ENV['HOSTNAME']}"
@@ -61,8 +61,13 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match(/nothing to pay/i, response.body,
                  "expected 'Nothing to pay' framing for humans with no billable resources")
-    assert_no_match(/free account/i, response.body,
-                    "'Free account' reads as a plan tier that includes agents — don't use it")
+    assert_match(/billable items will show up here/i, response.body,
+                 "expected forward-looking framing instead of a plan-tier claim")
+    assert_no_match(/\bfree\b/i, response.body,
+                    "billing copy must not describe the account as free — the word invites " \
+                    "'free except when it's not' confusion")
+    assert_no_match(/collectives? cost/i, response.body,
+                    "collectives don't bill until automations are enabled — don't imply they cost money")
     assert_no_match(/Set Up Billing/, response.body,
                     "fresh humans should not see a Set Up Billing button")
   end

--- a/test/services/stripe_service_test.rb
+++ b/test/services/stripe_service_test.rb
@@ -104,6 +104,32 @@ class StripeServiceTest < ActiveSupport::TestCase
     assert_equal "1", item["quantity"]
   end
 
+  test "create_checkout_session offers previously saved cards" do
+    sc = StripeCustomer.create!(billable: @user, stripe_id: "cus_savedpm1")
+
+    captured_body = nil
+    stub_request(:post, "https://api.stripe.com/v1/checkout/sessions")
+      .with { |req| captured_body = Rack::Utils.parse_nested_query(req.body); true }
+      .to_return(
+        status: 200,
+        body: {
+          id: "cs_test",
+          object: "checkout.session",
+          url: "https://checkout.stripe.com/session/cs_test",
+        }.to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+    StripeService.create_checkout_session(
+      stripe_customer: sc,
+      success_url: "https://app.example.com/billing",
+      cancel_url: "https://app.example.com/billing",
+    )
+
+    filters = captured_body["saved_payment_method_options"]["allow_redisplay_filters"]
+    assert_equal ["always", "limited"], filters.values
+  end
+
   test "create_checkout_session includes checkout_session_id template in success_url" do
     sc = StripeCustomer.create!(billable: @user, stripe_id: "cus_url789")
 
@@ -1544,6 +1570,45 @@ class StripeServiceTest < ActiveSupport::TestCase
     assert_equal "https://checkout.stripe.com/session/cs_topup123", result
     assert_equal "payment", captured_body["mode"]
     assert_equal "credit_topup", captured_body["metadata"]["type"]
+  ensure
+    ENV.delete("STRIPE_CREDIT_PRODUCT_ID")
+  end
+
+  test "create_credit_topup_checkout offers previously saved cards and saves new ones" do
+    sc = StripeCustomer.create!(billable: @user, stripe_id: "cus_topup_saved")
+
+    ENV["STRIPE_CREDIT_PRODUCT_ID"] = "prod_credits_test"
+
+    stub_request(:post, "https://api.stripe.com/v1/prices")
+      .to_return(
+        status: 200,
+        body: { id: "price_dynamic_456", object: "price" }.to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+    captured_body = nil
+    stub_request(:post, "https://api.stripe.com/v1/checkout/sessions")
+      .with { |req| captured_body = Rack::Utils.parse_nested_query(req.body); true }
+      .to_return(
+        status: 200,
+        body: {
+          id: "cs_topup_saved",
+          object: "checkout.session",
+          url: "https://checkout.stripe.com/session/cs_topup_saved",
+        }.to_json,
+        headers: { "Content-Type" => "application/json" },
+      )
+
+    StripeService.create_credit_topup_checkout(
+      stripe_customer: sc,
+      amount_cents: 500,
+      success_url: "https://app.example.com/billing",
+      cancel_url: "https://app.example.com/billing",
+    )
+
+    opts = captured_body["saved_payment_method_options"]
+    assert_equal ["always", "limited"], opts["allow_redisplay_filters"].values
+    assert_equal "enabled", opts["payment_method_save"]
   ensure
     ENV.delete("STRIPE_CREDIT_PRODUCT_ID")
   end


### PR DESCRIPTION
## Summary

Two fixes from the first real end-to-end billing run on the sandbox tenant, plus a copy revision:

**Saved cards (`StripeService`)** — Paying the $3/mo identity subscription and then topping up LLM credits asked for the card twice, even though Stripe had it on file after the first checkout. Stripe Checkout doesn't offer saved cards unless asked:
- Both checkout sessions now pass `saved_payment_method_options` with `allow_redisplay_filters: ["always", "limited"]` (cards saved via subscription checkouts are stored as `limited`).
- The payment-mode top-up also sets `payment_method_save: "enabled"`, so a card entered during a top-up is reusable in either direction.

**Billing page copy** — The page greeted users with a green "Free account" banner, which reads as a plan tier that includes agents — so hitting the paywall when adding an agent felt like a contradiction. And the pricing line claimed collectives cost $3/month, which is wrong: collectives bill only when automations are enabled (uncommon).
- Empty state: "**Nothing to pay** — you have no billable items." + "Billable items will show up here when created. AI agents cost **$3/month** each."
- Removed the "membership is free" intro from the active-subscription section — the itemized table speaks for itself.
- "Subscription required" state says "billable items" instead of naming collectives.
- Self row shows "$0/mo" instead of "free", matching the exempt-row format.
- Applied to both the HTML and markdown (agent-facing) views.

The word "free" no longer appears anywhere on the billing page; the collective *tier* vocabulary ("free plan" badge/confirmations in collective settings) is intentionally untouched.

## Testing

- Red-green throughout: new webmock tests assert the `saved_payment_method_options` request params on both sessions; controller tests assert the new copy, reject `\bfree\b` anywhere on the page, and reject any "collectives cost" phrasing.
- `test/services/stripe_service_test.rb` (75 runs) and `test/controllers/billing_controller_test.rb` (49 runs) both pass; Sorbet + TS + pre-commit checks green.
- Post-deploy check worth doing: start a top-up on the sandbox tenant and confirm Checkout offers "Use card ending in …" — webmock verifies the params we send, not how Checkout renders them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)