### PR TITLE
Add a mobile header back button for PWA use (#322)

### DIFF
--- a/app/assets/stylesheets/pulse/_layout.css
+++ b/app/assets/stylesheets/pulse/_layout.css
@@ -108,16 +108,16 @@
   font-size: 16px;
 }
 
-/* Desktop: center the logo relative to the window. space-between would
-   center it between the places toggle and the right cluster, which reads
-   as off-center against the full width. */
-@media (min-width: 769px) {
-  .pulse-top-header .pulse-logo {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-  }
+/* Center the logo relative to the window at every width. In-flow, space-between
+   would center it between the left control and the right cluster, which reads
+   as off-center against the full width. Absolute positioning lifts it out of
+   flow so the left slot (places toggle on desktop, back button on mobile #322)
+   and the right cluster flank a truly centered logo. */
+.pulse-top-header .pulse-logo {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 /* Logo uses .tri-logo-icon.icon-sm (28px) - see _components.css */
@@ -126,6 +126,41 @@
   display: flex;
   align-items: center;
   gap: 16px;
+  /* Pin the right cluster right regardless of what occupies the left slot:
+     the logo is out of flow and the left control may be absent (no history,
+     logged out), which would otherwise let space-between pull this leftward. */
+  margin-left: auto;
+}
+
+/* Mobile back button (#322). Hidden by default at every width — the
+   history-back controller adds pulse-back-btn--visible only when there is
+   in-app history, and the reveal rule below is scoped to mobile, so it never
+   shows on desktop or without JS. */
+.pulse-back-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: none;
+  border-radius: var(--border-radius-default);
+  color: var(--color-fg-default);
+  cursor: pointer;
+}
+
+.pulse-back-btn:hover {
+  background: var(--color-canvas-subtle);
+}
+
+.pulse-back-btn .octicon {
+  fill: currentColor;
+}
+
+@media (max-width: 768px) {
+  .pulse-back-btn.pulse-back-btn--visible {
+    display: flex;
+  }
 }
 
 .pulse-top-header-right .pulse-action-btn {

--- a/app/javascript/controllers/history_back_controller.test.ts
+++ b/app/javascript/controllers/history_back_controller.test.ts
@@ -36,4 +36,31 @@ describe("HistoryBackController", () => {
     expect(backSpy).toHaveBeenCalledTimes(1)
     expect(ev.defaultPrevented).toBe(true)
   })
+
+  describe("reveal-when-history", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it("adds the revealed class when there is history to go back to", async () => {
+      vi.stubGlobal("history", { length: 2, back: () => {} })
+      await mount('data-history-back-revealed-class="is-visible"')
+      const link = document.querySelector(".btn") as HTMLAnchorElement
+      expect(link.classList.contains("is-visible")).toBe(true)
+    })
+
+    it("leaves the control hidden when there is no earlier entry", async () => {
+      vi.stubGlobal("history", { length: 1, back: () => {} })
+      await mount('data-history-back-revealed-class="is-visible"')
+      const link = document.querySelector(".btn") as HTMLAnchorElement
+      expect(link.classList.contains("is-visible")).toBe(false)
+    })
+
+    it("does not touch classes when no revealed class is configured", async () => {
+      vi.stubGlobal("history", { length: 5, back: () => {} })
+      await mount()
+      const link = document.querySelector(".btn") as HTMLAnchorElement
+      expect(link.className).toBe("btn")
+    })
+  })
 })

--- a/app/javascript/controllers/history_back_controller.ts
+++ b/app/javascript/controllers/history_back_controller.ts
@@ -7,9 +7,36 @@ import { Controller } from "@hotwired/stimulus"
 //   <a href="/somewhere" class="pulse-btn"
 //      data-controller="history-back"
 //      data-action="click->history-back#back">Cancel</a>
-export default class extends Controller {
+//
+// Optionally configure a "revealed" class to keep the control hidden until
+// there is in-app history to return to. Used by the mobile header back button
+// (#322), which has nothing to go back to on a fresh PWA launch:
+//
+//   <button class="pulse-back-btn"
+//           data-controller="history-back"
+//           data-history-back-revealed-class="pulse-back-btn--visible"
+//           data-action="click->history-back#back">…</button>
+//
+// The element's own CSS hides it by default; the class is only added when
+// window.history has an earlier entry, so no-JS users never see a dead button.
+export default class extends Controller<HTMLElement> {
+  static classes = ["revealed"]
+
+  declare readonly revealedClass: string
+  declare readonly hasRevealedClass: boolean
+
+  connect(): void {
+    if (this.hasRevealedClass && this.canGoBack()) {
+      this.element.classList.add(this.revealedClass)
+    }
+  }
+
   back(event: Event): void {
     event.preventDefault()
     window.history.back()
+  }
+
+  private canGoBack(): boolean {
+    return window.history.length > 1
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,6 +47,18 @@
       <header class="pulse-top-header"
               data-controller="auto-hide-header"
               data-auto-hide-header-hidden-class="pulse-top-header--hidden">
+        <%# Mobile back control (#322). A PWA in standalone display has no
+            browser chrome, so the header carries its own back affordance in the
+            upper-left slot the places toggle vacates below 768px. The
+            history-back controller reveals it only when there is in-app history
+            to return to, so a fresh launch shows nothing to go back to. %>
+        <button type="button" class="pulse-back-btn"
+                data-controller="history-back"
+                data-history-back-revealed-class="pulse-back-btn--visible"
+                data-action="click->history-back#back"
+                aria-label="Go back">
+          <%= octicon "arrow-left", height: 20 %>
+        </button>
         <% if @current_user %>
           <%# Desktop trigger for the places sheet — the tab bar's Places
               tab covers mobile, so this one is CSS-hidden under 768px. %>


### PR DESCRIPTION
Closes #322.

## Problem
Installed as a PWA in standalone display, Harmonic has no browser chrome — so no back button. On mobile the places toggle lives in the bottom tab bar, leaving the header's upper-left slot empty.

## Change
- **Back arrow in the upper-left on mobile**, centered logo (matching desktop). The right cluster now uses `margin-left: auto` so it stays right-aligned whether or not a left-slot control is present, and the logo is absolutely centered at every width.
- **Only appears when there's history to go back to.** The existing `history-back` Stimulus controller gains an optional `revealed` class that it adds in `connect()` only when `window.history.length > 1`. The button is `display:none` by default, and the reveal rule is scoped to `max-width: 768px`, so it never shows on desktop, on a fresh launch, or without JS (no dead affordance).

## Notes
- Reuses the CSP-safe `history-back` controller (no inline `javascript:history.back()`).
- Existing `history-back` usages (the report Cancel link) are unaffected — they configure no `revealed` class.

## Testing
- `npm test` — `history_back_controller.test.ts` extended with reveal/hide/no-op-when-unconfigured cases; 4 tests pass.
- `npm run typecheck` clean.
- Both run in the baked test image with the edited files overlaid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)