### PR TITLE
Update AI agents page copy (#406)

### DIFF
--- a/app/views/ai_agents/index.html.erb
+++ b/app/views/ai_agents/index.html.erb
@@ -36,15 +36,15 @@
     %>
 
     <p class="pulse-muted" style="margin-bottom: 24px;">
-      AI Agents in Harmonic are identities for AI agents managed by you, the primary agent.
+      AI Agents in Harmonic are distinct identities for AI agents that you manage as their principal.
     </p>
     <p class="pulse-muted" style="margin-bottom: 24px;">
       <% if internal_enabled && external_enabled %>
-        AI Agents can be powered externally through the API or internally using Harmonic's agent runners.
+        AI Agents can be powered internally by Harmonic's agent runners, or externally on your own infrastructure. Either way, they interact with Harmonic through the API and the MCP interface.
       <% elsif internal_enabled %>
         AI Agents are powered by Harmonic's agent runners and can run automated tasks on your behalf.
       <% else %>
-        AI Agents are powered by your own infrastructure and interact with Harmonic through the API.
+        AI Agents are powered by your own infrastructure and interact with Harmonic through the API and the MCP interface.
       <% end %>
     </p>
 

--- a/app/views/ai_agents/new.html.erb
+++ b/app/views/ai_agents/new.html.erb
@@ -40,7 +40,7 @@
         <strong>No credit balance</strong> — <a href="/billing">Add funds</a> before running tasks.
       </div>
     <% end %>
-    <p>AI Agents are identities for AI agents managed by you, the primary agent.</p>
+    <p>AI Agents are distinct identities for AI agents that you manage as their principal.</p>
 
     <%# turbo: false — this form triggers a Stripe Checkout redirect for non-admin users
         on tenants with stripe_billing enabled. Turbo Drive's cross-origin handling has


### PR DESCRIPTION
Closes #406.

The AI agents index and new pages still called the human user the "primary agent." We now use **principal**, and agents can be internal (Harmonic's agent runners) or external (your own infrastructure), interacting through both the API and the MCP interface.

Changes:
- `ai_agents/index.html.erb` — "primary agent" → "principal"; external/both blurb now mentions the MCP interface alongside the API.
- `ai_agents/new.html.erb` — same "primary agent" → "principal" fix.

Copy-only; no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)