### PR TITLE
Allow creating decisions/commitments without a deadline via MCP (#411)

### DIFF
--- a/app/services/actions_helper.rb
+++ b/app/services/actions_helper.rb
@@ -383,7 +383,8 @@ class ActionsHelper
         { name: "question", type: "string", description: "The question being decided" },
         { name: "description", type: "string", description: "Additional context for the decision" },
         { name: "options_open", type: "boolean", description: "Whether participants can add options" },
-        { name: "deadline", type: "datetime", description: "When the decision closes" },
+        { name: "deadline", type: "datetime", required: false,
+          description: "When the decision closes. Optional — omit it to close the decision manually.", },
         { name: "subtype", type: "string", required: false, description: "Decision subtype: 'vote' (default), 'executive', or 'lottery'" },
         { name: "decision_maker", type: "string", required: false,
           description: "For executive decisions: handle (e.g. '@dan') or user ID of the decision maker (defaults to creator)", },
@@ -466,14 +467,14 @@ class ActionsHelper
     # Commitment actions
     "create_commitment" => {
       description: "Create a new commitment (action, calendar_event, or policy)",
-      params_string: "(title, description, critical_mass, deadline, [subtype, starts_at, ends_at, location])",
+      params_string: "(title, description, critical_mass, [deadline, subtype, starts_at, ends_at, location])",
       params: [
         { name: "title", type: "string", description: "The title of the commitment" },
         { name: "description", type: "string", description: "Additional context for the commitment" },
         { name: "critical_mass", type: "integer",
           description: "Minimum participants/attendees/signatories needed for the commitment to take effect", },
-        { name: "deadline", type: "datetime",
-          description: "When the commitment closes (RSVP deadline for calendar events)", },
+        { name: "deadline", type: "datetime", required: false,
+          description: "When the commitment closes (RSVP deadline for calendar events). Optional — omit it to close manually; for calendar events it defaults to the event start.", },
         { name: "subtype", type: "string", required: false,
           description: "One of: action (default), calendar_event, policy", },
         { name: "starts_at", type: "datetime", required: false,

--- a/app/services/api_helper.rb
+++ b/app/services/api_helper.rb
@@ -189,7 +189,10 @@ class ApiHelper
         description: params[:description],
         subtype: params[:subtype] || "vote",
         options_open: params[:options_open] || true,
-        deadline: params[:deadline],
+        # Deadline is optional. Omitting it means the decision is closed manually,
+        # represented by a far-future deadline (see requires_manual_close?) — the
+        # same convention as the HTML form's "no deadline" option.
+        deadline: params[:deadline].presence || 100.years.from_now,
         created_by: current_user,
       }
       decision_maker_param = params[:decision_maker] || params[:decision_maker_id]
@@ -217,7 +220,7 @@ class ApiHelper
         title: params[:title],
         description: params[:description],
         subtype: subtype,
-        deadline: params[:deadline],
+        deadline: params[:deadline].presence,
         critical_mass: current_collective.private_workspace? ? 1 : params[:critical_mass],
         created_by: current_user,
       }
@@ -225,6 +228,13 @@ class ApiHelper
         attrs[:starts_at] = params[:starts_at]
         attrs[:ends_at] = params[:ends_at]
         attrs[:location] = params[:location].presence
+      end
+      # Deadline is optional. When omitted, calendar events fall back to their
+      # start time (the RSVP deadline for an event), matching the HTML form;
+      # everything else gets a far-future deadline meaning "close manually"
+      # (see requires_manual_close?).
+      if attrs[:deadline].blank?
+        attrs[:deadline] = subtype == "calendar_event" ? attrs[:starts_at].presence || 100.years.from_now : 100.years.from_now
       end
       commitment = Commitment.create!(attrs)
       # Handle close_at_critical_mass option

--- a/test/services/api_helper_test.rb
+++ b/test/services/api_helper_test.rb
@@ -90,6 +90,70 @@ class ApiHelperTest < ActiveSupport::TestCase
     assert_equal @user, decision.created_by
   end
 
+  test "ApiHelper.create_decision without a deadline is closed manually" do
+    params = {
+      question: "What is the best approach?",
+      description: "No deadline supplied.",
+    }
+    api_helper = ApiHelper.new(
+      current_user: @user,
+      current_collective: @collective,
+      current_tenant: @tenant,
+      current_representation_session: nil,
+      current_resource_model: Decision,
+      current_resource: nil,
+      params: params,
+      request: {}
+    )
+    decision = api_helper.create_decision
+    assert decision.persisted?
+    assert decision.requires_manual_close?, "a deadline-less decision should require manual close"
+  end
+
+  test "ApiHelper.create_commitment creates a commitment" do
+    params = {
+      title: "Ship the feature",
+      description: "Coordinate the release.",
+      critical_mass: 2,
+      deadline: Time.current + 1.week,
+    }
+    api_helper = ApiHelper.new(
+      current_user: @user,
+      current_collective: @collective,
+      current_tenant: @tenant,
+      current_representation_session: nil,
+      current_resource_model: Commitment,
+      current_resource: nil,
+      params: params,
+      request: {}
+    )
+    commitment = api_helper.create_commitment
+    assert commitment.persisted?
+    assert_equal params[:title], commitment.title
+    assert_equal @user, commitment.created_by
+  end
+
+  test "ApiHelper.create_commitment without a deadline is closed manually" do
+    params = {
+      title: "Ongoing policy",
+      description: "No deadline supplied.",
+      critical_mass: 2,
+    }
+    api_helper = ApiHelper.new(
+      current_user: @user,
+      current_collective: @collective,
+      current_tenant: @tenant,
+      current_representation_session: nil,
+      current_resource_model: Commitment,
+      current_resource: nil,
+      params: params,
+      request: {}
+    )
+    commitment = api_helper.create_commitment
+    assert commitment.persisted?
+    assert commitment.requires_manual_close?, "a deadline-less commitment should require manual close"
+  end
+
   test "resolve_user normalizes handle case and @-prefix" do
     # Stored handles are parameterized (lowercase, slug). Agent-supplied
     # values can arrive as `@Alice`, `Alice`, or `alice` — all must resolve


### PR DESCRIPTION
Closes #411.

**Bug:** Creating a decision or commitment through MCP required a `deadline`, even though the HTML forms let you omit it.

**Cause:** The HTML `deadline_option: "no_deadline"` maps to a far-future deadline (`100.years.from_now`) that the app reads back as "close manually" (`requires_manual_close?` → deadline > 50 years out). The MCP `create_decision`/`create_commitment` actions passed `params[:deadline]` straight to the model, so omitting it hit `validates :deadline, presence: true` and failed.

**Fix:** In the MCP create path, default a blank deadline to the same far-future sentinel the HTML path uses. Calendar events fall back to their `starts_at` (the RSVP deadline), matching the HTML form. `deadline` is now marked optional in the `create_decision`/`create_commitment` action definitions.

Tests: added no-deadline cases for both `create_decision` and `create_commitment` (assert `requires_manual_close?`), plus a happy-path `create_commitment` test that was missing. `test/services/api_helper_test.rb` green locally (44 runs, 0 failures).

Related to #410 (relative-time shorthand for deadlines) — separate PR; the two touch adjacent lines in these create methods, so whichever lands second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)