### PR TITLE
Add media: search filter (image / text-only) (#363)

### DIFF
--- a/app/services/search_query.rb
+++ b/app/services/search_query.rb
@@ -159,7 +159,7 @@ class SearchQuery
   # of any of these suppresses the People section entirely; the viewer's
   # query string is clearly looking for content.
   PEOPLE_INCOMPATIBLE_PARAM_KEYS = [
-    :type, :exclude_types, :subtypes, :exclude_subtypes, :status, :creator_handles, :exclude_creator_handles, :read_by_handles, :exclude_read_by_handles, :voter_handles, :exclude_voter_handles, :participant_handles, :exclude_participant_handles, :mentions_handles, :exclude_mentions_handles, :replying_to_handles, :exclude_replying_to_handles, :my_filters, :exclude_my_filters, :critical_mass_achieved, :min_links, :max_links, :min_backlinks, :max_backlinks, :min_comments, :max_comments, :min_readers, :max_readers, :min_voters, :max_voters, :min_participants, :max_participants, :after_date, :before_date, :visibility, :exclude_visibility,
+    :type, :exclude_types, :subtypes, :exclude_subtypes, :status, :creator_handles, :exclude_creator_handles, :read_by_handles, :exclude_read_by_handles, :voter_handles, :exclude_voter_handles, :participant_handles, :exclude_participant_handles, :mentions_handles, :exclude_mentions_handles, :replying_to_handles, :exclude_replying_to_handles, :my_filters, :exclude_my_filters, :critical_mass_achieved, :min_links, :max_links, :min_backlinks, :max_backlinks, :min_comments, :max_comments, :min_readers, :max_readers, :min_voters, :max_voters, :min_participants, :max_participants, :after_date, :before_date, :visibility, :exclude_visibility, :media,
   ].freeze
 
   sig { returns(T::Array[User]) }
@@ -585,6 +585,7 @@ class SearchQuery
     apply_list_filter
     apply_integer_filters
     apply_boolean_filters
+    apply_media_filter
     apply_sorting
 
     # Eager load associations to avoid N+1 queries when grouping or displaying results
@@ -1265,6 +1266,26 @@ class SearchQuery
                   # Commitments that have NOT reached critical mass
                   T.must(@relation)
                     .where(item_type: "Commitment")
+                end
+  end
+
+  sig { void }
+  def apply_media_filter
+    # media:image     → items with at least one embedded image (MediaItem)
+    # media:text-only → items with no embedded images
+    media = @params[:media]
+    return if media.blank?
+
+    # MediaItem is polymorphic on (mediable_type, mediable_id), which line up
+    # with search_index's (item_type, item_id). The mediable index covers this.
+    exists = "SELECT 1 FROM media_items mi
+              WHERE mi.mediable_type = search_index.item_type
+              AND mi.mediable_id = search_index.item_id
+              AND mi.tenant_id = search_index.tenant_id"
+    @relation = if media == "text-only"
+                  T.must(@relation).where("NOT EXISTS (#{exists})")
+                else # "image"
+                  T.must(@relation).where("EXISTS (#{exists})")
                 end
   end
 

--- a/app/services/search_query_parser.rb
+++ b/app/services/search_query_parser.rb
@@ -66,6 +66,11 @@ class SearchQueryParser
     "subtype" => { values: Note::SUBTYPES + Decision::SUBTYPES + Commitment::SUBTYPES, multi: true },
     "status" => { values: ["open", "closed"], multi: false },
 
+    # Content filters
+    # media:image   → items with at least one embedded image
+    # media:text-only → items with no embedded images
+    "media" => { values: ["image", "text-only"], multi: false },
+
     # Boolean filters
     "critical-mass-achieved" => { values: ["true", "false"], multi: false },
 
@@ -317,6 +322,9 @@ class SearchQueryParser
     # Boolean filters
     params[:critical_mass_achieved] = build_boolean_param("critical-mass-achieved")
 
+    # Content filters
+    params[:media] = build_media_param
+
     # Integer filters (min/max)
     params[:min_links] = build_integer_param("min-links")
     params[:max_links] = build_integer_param("max-links")
@@ -437,6 +445,15 @@ class SearchQueryParser
 
     # Last value wins
     values.last == "true"
+  end
+
+  sig { returns(T.nilable(String)) }
+  def build_media_param
+    values = @operators["media"]
+    return nil if values.blank?
+
+    # Last value wins
+    values.last
   end
 
   sig { params(key: String).returns(T.nilable(Integer)) }

--- a/app/views/help/search.md.erb
+++ b/app/views/help/search.md.erb
@@ -28,6 +28,7 @@ Use operators in your query to filter, sort, and group results.
 | `type:` | note, decision, commitment | `type:note` |
 | `subtype:` | post, reminder, table, comment, statement, summary, vote, lottery, executive, action, calendar_event, policy | `subtype:reminder` |
 | `status:` | open, closed | `status:open` |
+| `media:` | image, text-only | `media:image` |
 | `creator:` | @handle | `creator:@alice` |
 | `read-by:` | @handle | `read-by:@alice` |
 | `voter:` | @handle | `voter:@alice` |

--- a/test/services/search_query_parser_test.rb
+++ b/test/services/search_query_parser_test.rb
@@ -106,6 +106,24 @@ class SearchQueryParserTest < ActiveSupport::TestCase
     assert_equal ["comment"], result[:exclude_subtypes]
   end
 
+  # media: operator
+
+  test "media:image sets media filter" do
+    result = SearchQueryParser.new("media:image").parse
+    assert_equal "image", result[:media]
+  end
+
+  test "media:text-only sets media filter" do
+    result = SearchQueryParser.new("media:text-only").parse
+    assert_equal "text-only", result[:media]
+  end
+
+  test "invalid media value treated as search text" do
+    result = SearchQueryParser.new("media:video").parse
+    assert_equal "media:video", result[:q]
+    assert_nil result[:media]
+  end
+
   # creator: operator
 
   test "creator:@alice sets creator handles" do

--- a/test/services/search_query_test.rb
+++ b/test/services/search_query_test.rb
@@ -1350,4 +1350,47 @@ class SearchQueryTest < ActiveSupport::TestCase
     # Ignored, not applied: results are not narrowed to exclude the viewer's notes.
     assert search.results.any?
   end
+
+  # media: filter
+
+  test "media:image returns only items with embedded images" do
+    attach_image_to(@note)
+
+    search = SearchQuery.new(
+      tenant: @tenant, collective: @collective, current_user: @user,
+      raw_query: "budget media:image cycle:all"
+    )
+
+    results = search.results
+    assert_equal [@note.id], results.map(&:item_id)
+  end
+
+  test "media:text-only excludes items with embedded images" do
+    attach_image_to(@note)
+
+    search = SearchQuery.new(
+      tenant: @tenant, collective: @collective, current_user: @user,
+      raw_query: "budget media:text-only cycle:all"
+    )
+
+    item_ids = search.results.map(&:item_id)
+    assert_not_includes item_ids, @note.id
+    assert_includes item_ids, @decision.id
+    assert_includes item_ids, @commitment.id
+  end
+
+  # A minimal valid PNG so MediaItem's magic-byte validation passes.
+  def valid_png_bytes
+    "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82".b
+  end
+
+  def attach_image_to(note)
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new(valid_png_bytes), filename: "a.png", content_type: "image/png"
+    )
+    MediaItem.create!(
+      tenant: @tenant, collective: @collective, mediable: note,
+      file: blob, created_by: @user, updated_by: @user
+    )
+  end
 end


### PR DESCRIPTION
Closes #363.

Adds a `media:` search operator so feeds and search can filter by whether an item carries embedded images:

- `media:image` — items with at least one embedded image (`MediaItem`)
- `media:text-only` — items with none

**Implementation:** an `EXISTS` / `NOT EXISTS` subquery against `media_items`, joined on the polymorphic `(mediable_type, mediable_id)` which line up with `search_index`'s `(item_type, item_id)`. No schema change or reindex needed — the existing `index_media_items_on_mediable` covers the lookup. `media:` is added to the people-incompatible keys (it filters items, not people), and the search help doc lists the operator.

Tests: parser cases (`media:image`, `media:text-only`, invalid value → search text) plus integration tests that attach a `MediaItem` and assert `media:image` returns only that item while `media:text-only` excludes it. `search_query_parser_test.rb` + `search_query_test.rb` green locally (204 runs, 0 failures); `srb tc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)