### PR TITLE
Notify members when granted a collective role (#340)

### DIFF
--- a/app/controllers/collectives_controller.rb
+++ b/app/controllers/collectives_controller.rb
@@ -689,6 +689,20 @@ class CollectivesController < ApplicationController
       return render_action_error({ action_name: 'update_member_roles', resource: @current_collective, error: e.message })
     end
 
+    # Notify the member when they gain a role, so they learn about the new
+    # standing and who granted it (issue #340). Revocations are silent, and a
+    # self-grant (an admin editing their own roles) notifies no one — the
+    # dispatcher drops actor == recipient.
+    if grant
+      EventService.record!(
+        event_type: "collective_member.role_granted",
+        actor: @current_user,
+        subject: member,
+        metadata: { "role" => role },
+        collective_id: @current_collective.id
+      )
+    end
+
     render_action_success({
       action_name: 'update_member_roles',
       resource: @current_collective,

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,7 +3,7 @@
 class Notification < ApplicationRecord
   extend T::Sig
 
-  NOTIFICATION_TYPES = %w[mention comment participation system reminder chat_message trio_unavailable tune_in trustee_authorization].freeze
+  NOTIFICATION_TYPES = %w[mention comment participation system reminder chat_message trio_unavailable tune_in trustee_authorization role_change].freeze
 
   belongs_to :tenant
   belongs_to :event, optional: true

--- a/app/models/tenant_user.rb
+++ b/app/models/tenant_user.rb
@@ -191,6 +191,9 @@ class TenantUser < ApplicationRecord
     # Trustee authorization lifecycle (offered/accepted/declined/revoked).
     # In-app by default, matching most types; users can opt into email.
     "trustee_authorization" => { "in_app" => true, "email" => false, "web_push" => true },
+    # Being granted a collective role (admin/representative/summarizer). A
+    # meaningful change in standing, so email defaults on like system/mention.
+    "role_change" => { "in_app" => true, "email" => true, "web_push" => true },
   }.freeze, T::Hash[String, T::Hash[String, T::Boolean]])
 
   # User-facing labels for each notification type, in display order. Keys must
@@ -207,6 +210,7 @@ class TenantUser < ApplicationRecord
     "trio_unavailable" => "Trio unavailable",
     "tune_in" => "Tune-ins",
     "trustee_authorization" => "Trustee authorizations",
+    "role_change" => "Role changes",
   }.freeze, T::Hash[String, String])
 
   # Delivery channels a user can toggle per notification type.

--- a/app/services/notification_dispatcher.rb
+++ b/app/services/notification_dispatcher.rb
@@ -24,8 +24,51 @@ class NotificationDispatcher
       handle_option_created_event(event)
     when "user_list_member.created"
       handle_member_added_event(event)
+    when "collective_member.role_granted"
+      handle_role_granted_event(event)
     when /^agent\./
       handle_agent_event(event)
+    end
+  end
+
+  # Notify a member that they were granted a collective role (admin,
+  # representative, or summarizer), naming who granted it (issue #340).
+  sig { params(event: Event).void }
+  def self.handle_role_granted_event(event)
+    membership = event.subject
+    return unless membership.is_a?(CollectiveMember)
+
+    recipient = membership.user
+    collective = membership.collective
+    return if collective.nil?
+    # Don't notify an admin who edited their own roles.
+    return if event.actor_id && recipient.id == event.actor_id
+
+    role = event.metadata.is_a?(Hash) ? event.metadata["role"].to_s : ""
+    return if role.blank?
+
+    granter = T.unsafe(event).actor
+    granter_name = granter&.display_name || "An admin"
+    title = "#{granter_name} made you #{role_phrase(role)} of #{collective.name}"
+
+    notify_user(
+      event: event,
+      recipient: recipient,
+      notification_type: "role_change",
+      title: title,
+      url: "#{collective.path}/members"
+    )
+  end
+
+  # "an admin" / "a representative" / "a summarizer" — falls back to a bare
+  # "the <role> role" for any future role that doesn't read well with an article.
+  sig { params(role: String).returns(String) }
+  def self.role_phrase(role)
+    case role
+    when "admin" then "an admin"
+    when "representative" then "a representative"
+    when "summarizer" then "a summarizer"
+    else "the #{role} role"
     end
   end
 

--- a/test/services/notification_dispatcher_test.rb
+++ b/test/services/notification_dispatcher_test.rb
@@ -854,4 +854,47 @@ class NotificationDispatcherTest < ActiveSupport::TestCase
     event = Event.where(event_type: "commitment.deadline_reached", subject: commitment).last
     assert_nil Notification.where(event: event).last
   end
+
+  # Role-change notifications (issue #340)
+
+  test "handle_role_granted_event notifies the member and names the granter" do
+    tenant, collective, admin = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+
+    member_user = create_user(email: "newrep@example.com", name: "New Rep")
+    tenant.add_user!(member_user)
+    collective.add_user!(member_user)
+    membership = CollectiveMember.find_by(collective: collective, user: member_user)
+
+    event = EventService.record!(
+      event_type: "collective_member.role_granted",
+      actor: admin,
+      subject: membership,
+      metadata: { "role" => "representative" },
+      collective_id: collective.id
+    )
+
+    notification = Notification.where(event: event).last
+    assert_not_nil notification, "Expected a role_change notification"
+    assert_equal "role_change", notification.notification_type
+    assert_includes notification.title, "a representative"
+    assert_includes notification.title, admin.display_name
+    assert_equal member_user, notification.notification_recipients.first.user
+  end
+
+  test "handle_role_granted_event does not notify on a self-grant" do
+    tenant, collective, admin = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    membership = CollectiveMember.find_by(collective: collective, user: admin)
+
+    assert_no_difference -> { Notification.count } do
+      EventService.record!(
+        event_type: "collective_member.role_granted",
+        actor: admin,
+        subject: membership,
+        metadata: { "role" => "admin" },
+        collective_id: collective.id
+      )
+    end
+  end
 end


### PR DESCRIPTION
Closes #340.

When an admin grants a member a role (admin, representative, or summarizer), the member now receives a notification that names the role and who granted it.

**Changes:**
- New `role_change` notification type, added to `Notification::NOTIFICATION_TYPES` and the `TenantUser` preference matrix + labels. Email defaults on (a change in standing, like system/mention notifications). The existing registry-sync test keeps the three lists aligned.
- `execute_update_member_roles` records a `collective_member.role_granted` event on grant. Revocations stay silent (the issue is about being *given* a role).
- `NotificationDispatcher.handle_role_granted_event` notifies the member, skipping self-grants (an admin editing their own roles). Title reads like "Dan Allison made you a representative of Team Alpha" and links to the collective members page.

Because the role update runs through the standard action pipeline in the controller, this covers both the HTML form and the MCP `update_member_roles` action.

Tests: dispatcher tests for the grant notification (asserts type, granter name, role phrase, recipient) and the self-grant no-op. `notification_dispatcher_test.rb`, `tenant_user_test.rb` (registry sync), and `collectives_controller_test.rb` green locally; `srb tc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)