### PR TITLE
Drop cycle:this-week from the collective feed default (#430)

### DIFF
--- a/app/controllers/pulse_controller.rb
+++ b/app/controllers/pulse_controller.rb
@@ -10,8 +10,8 @@ class PulseController < ApplicationController
 
   # The collective's default page: a feed — a search fixed to this
   # collective (private workspaces are additionally fixed to the private
-  # zone), with the current week as the default query. The cycle
-  # dashboard (#show) lives at /dashboard.
+  # zone). The default query only hides comments; it spans all cycles.
+  # The cycle dashboard (#show) lives at /dashboard.
   def feed
     @page_title = @current_collective.name
     workspace = @current_collective.private_workspace?
@@ -19,7 +19,7 @@ class PulseController < ApplicationController
 
     # Workspaces get no default query: the private zone is the only
     # filter — there is no curation layer over your own space.
-    resolve_feed_query(workspace ? "" : "cycle:this-week -subtype:comment")
+    resolve_feed_query(workspace ? "" : "-subtype:comment")
     fixed = { collective_handle: @current_collective.handle }
     fixed[:visibility] = "private" if workspace
     # cycle "all" as the base: a cleared query means all time, not the

--- a/app/javascript/controllers/feed_bar_input_controller.test.ts
+++ b/app/javascript/controllers/feed_bar_input_controller.test.ts
@@ -11,7 +11,7 @@ describe("FeedBarInputController", () => {
       <form>
         <textarea name="q" rows="1"
                   data-controller="feed-bar-input"
-                  data-action="input->feed-bar-input#resize keydown->feed-bar-input#keydown">cycle:this-week -subtype:comment</textarea>
+                  data-action="input->feed-bar-input#resize keydown->feed-bar-input#keydown">-subtype:comment</textarea>
       </form>
     `
     document.querySelector("form")?.addEventListener("submit", (e) => {

--- a/app/views/help/collectives.md.erb
+++ b/app/views/help/collectives.md.erb
@@ -35,7 +35,7 @@ To start a representation session, go to the collective's represent page at `{co
 
 ## URL Pattern
 
-- Collective home: `/collectives/{handle}` — a feed of the collective's content, filterable with [search syntax](/help/search); defaults to `cycle:this-week`
+- Collective home: `/collectives/{handle}` — a feed of the collective's content, filterable with [search syntax](/help/search); defaults to `-subtype:comment` (all cycles, comments hidden)
 - Cycle dashboard: `/collectives/{handle}/dashboard`
 - Collective settings: `/collectives/{handle}/settings`
 - Members: `/collectives/{handle}/members`

--- a/app/views/help/cycles.md.erb
+++ b/app/views/help/cycles.md.erb
@@ -23,7 +23,7 @@ To send a heartbeat, navigate to the collective home page and use the `send_hear
 
 ## Navigating Cycles
 
-The collective's dashboard shows the current cycle by default. You can browse previous cycles to see past activity. (The collective's home page is a feed defaulting to `cycle:this-week` — refine or clear its filters to cross cycles.)
+The collective's dashboard shows the current cycle by default. You can browse previous cycles to see past activity. (The collective's home page is a feed spanning all cycles by default — add a `cycle:` filter to narrow it to one.)
 
 ## URL Pattern
 

--- a/app/views/help/markdown_ui.md.erb
+++ b/app/views/help/markdown_ui.md.erb
@@ -61,14 +61,14 @@ scope: collective:my-team
 | Page | Scope | Default query |
 |------|-------|---------------|
 | `/` (home) | `visibility:public` | `list:tuned_in -subtype:comment` |
-| `/collectives/:handle` (feed) | `collective:handle` | `cycle:this-week -subtype:comment` |
+| `/collectives/:handle` (feed) | `collective:handle` | `-subtype:comment` |
 | `/collectives/:handle/dashboard` | `collective:handle` | — |
 | `/workspace/:handle` (feed) | `visibility:private` | — |
 | `/workspace/:handle/dashboard` | `visibility:private` | — |
 | `/u/:handle` | `visibility:public creator:@handle` | — |
 | `/lists/:id` | `visibility:public list:id` | — |
 
-A `query:` attribute carries the page's current refinements on top of the scope. Pages with a default query (home's `list:tuned_in` — the people you tune in to, plus yourself; the collective feed's `cycle:this-week`; both minus comments) apply it when `?q` is absent; pass `?q=` to refine, or an empty `?q=` to browse everything in scope, comments included. On `/search`, `query:` is the whole search (there is no fixed scope). Pages without a feed have neither key.
+A `query:` attribute carries the page's current refinements on top of the scope. Pages with a default query (home's `list:tuned_in` — the people you tune in to, plus yourself; the collective feed spans all cycles; both minus comments) apply it when `?q` is absent; pass `?q=` to refine, or an empty `?q=` to browse everything in scope, comments included. On `/search`, `query:` is the whole search (there is no fixed scope). Pages without a feed have neither key.
 
 ## Actions
 

--- a/docs/NAVIGATION_DESIGN.md
+++ b/docs/NAVIGATION_DESIGN.md
@@ -170,7 +170,7 @@ Filters come in three tiers, and the UI must make the tier visible:
 | Tier | Example | Rendering | Editable? |
 |---|---|---|---|
 | **Fixed** (the page scope) | `collective:my-team` on `/collectives/my-team` | Muted token inside the field, not editable | No — it *is* the page |
-| **Default** | `cycle:this-week -subtype:comment` on a collective home | Ordinary query text | Yes — remove or replace freely |
+| **Default** | `-subtype:comment` on a collective home | Ordinary query text | Yes — remove or replace freely |
 | **User** | anything typed | Query text | Yes |
 
 Decisions and rationale:
@@ -187,8 +187,8 @@ Decisions and rationale:
   button); the word "search" is reserved for `/search`. Two affordances,
   two verbs.
 - **Defaults are real query text, owned by the user.** A page may ship
-  defaults (`cycle:this-week` keeps a collective home focused on the
-  current cycle); once the page loads, defaults are indistinguishable from
+  defaults (`-subtype:comment` keeps a collective home free of comment
+  clutter); once the page loads, defaults are indistinguishable from
   user filters. This requires distinguishing *no query param* (apply
   defaults) from *empty query param* (user cleared everything): `?q=`
   present-but-empty means "browse everything in scope", absent means

--- a/test/controllers/pulse_controller_test.rb
+++ b/test/controllers/pulse_controller_test.rb
@@ -106,7 +106,8 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
   end
 
   # Collective feed page (docs/NAVIGATION_DESIGN.md "Feeds are queries"):
-  # fixed scope collective:handle, default query cycle:this-week.
+  # fixed scope collective:handle, default query -subtype:comment
+  # (spans all cycles; only comments are hidden).
 
   test "collective feed shows indexed content with the fixed token and default query" do
     sign_in_as(@user, tenant: @tenant)
@@ -121,7 +122,7 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     assert_select ".pulse-feed-bar-scope code", text: "collective:#{@collective.handle}"
     # The comment exclusion is part of the visible default query — the
     # viewer can see it and remove it, not a hidden structural filter.
-    assert_select "textarea[name='q']", text: "cycle:this-week -subtype:comment"
+    assert_select "textarea[name='q']", text: "-subtype:comment"
     assert_includes response.body, "collective feed probe"
   end
 
@@ -148,7 +149,7 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "A default-hidden comment"
   end
 
-  test "collective feed defaults to this week; cleared query shows all time" do
+  test "collective feed default spans all cycles; a cycle: filter narrows it" do
     sign_in_as(@user, tenant: @tenant)
     Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
     Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
@@ -160,12 +161,15 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     Collective.clear_thread_scope
     Tenant.clear_thread_scope
 
+    # Default query no longer pins to the current cycle — past content shows.
     get "#{@collective.path}"
     assert_response :success
-    assert_not_includes response.body, "ancient collective post"
-
-    get "#{@collective.path}", params: { q: "" }
     assert_includes response.body, "ancient collective post"
+
+    # A cycle: filter narrows back to the current window.
+    get "#{@collective.path}", params: { q: "cycle:this-week" }
+    assert_response :success
+    assert_not_includes response.body, "ancient collective post"
   end
 
   test "collective feed cannot be pointed at another collective" do
@@ -228,7 +232,7 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     get "#{@collective.path}", headers: { "Accept" => "text/markdown" }
     assert_response :success
     assert_includes response.body, "scope: collective:#{@collective.handle}"
-    assert_includes response.body, "query: cycle:this-week -subtype:comment"
+    assert_includes response.body, "query: -subtype:comment"
   end
 
   test "workspace feed is scoped to the private zone" do

--- a/test/controllers/pulse_controller_test.rb
+++ b/test/controllers/pulse_controller_test.rb
@@ -232,7 +232,8 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     get "#{@collective.path}", headers: { "Accept" => "text/markdown" }
     assert_response :success
     assert_includes response.body, "scope: collective:#{@collective.handle}"
-    assert_includes response.body, "query: -subtype:comment"
+    # yaml_escape quotes a value starting with "-" so it doesn't parse as a YAML list item.
+    assert_includes response.body, "query: \"-subtype:comment\""
   end
 
   test "workspace feed is scoped to the private zone" do


### PR DESCRIPTION
Closes #430.

The collective home feed's default query was `cycle:this-week -subtype:comment`, which pinned it to the current cycle. Per the issue, only `-subtype:comment` should remain — the feed now spans all cycles by default and merely hides comments.

## Changes
- `PulseController#feed` — default query is now `-subtype:comment` (workspaces still get no default). The `cycle: "all"` base was already in place, so a bare feed now shows all-time content.
- Updated the visible default in the feed bar (the query is real, editable text — a viewer can still type `cycle:this-week` to narrow it).
- Docs: `help/collectives`, `help/cycles`, `help/markdown_ui`, and `docs/NAVIGATION_DESIGN.md` no longer describe the current-cycle default.
- Tests: `pulse_controller_test` — updated the default-query assertions and inverted the "defaults to this week" test into "default spans all cycles; a `cycle:` filter narrows it".

🤖 Generated with [Claude Code](https://claude.com/claude-code)