### PR TITLE
Single source of truth for the search filter reference (#429)

### DIFF
--- a/app/helpers/search_filter_reference_helper.rb
+++ b/app/helpers/search_filter_reference_helper.rb
@@ -1,0 +1,130 @@
+# typed: false
+# frozen_string_literal: true
+
+# Single source of truth for the search-operator reference table.
+#
+# The same operators are documented in two places: the /help/search page
+# (rendered as markdown) and the /search page's syntax panel (rendered as
+# HTML). Both derive from SECTIONS below so the two can never drift. When
+# SearchQueryParser learns a new operator, add it here and both surfaces
+# update together.
+module SearchFilterReferenceHelper
+  # Each section has a title, an ordered list of column keys, the rows
+  # (one hash per row, keyed by the column symbols), and an optional
+  # description shown above the table. Cell text is markdown — backticks
+  # and links render on the help page directly and on the /search page via
+  # `markdown_inline`.
+  SECTIONS = [
+    {
+      id: :filtering,
+      title: "Filtering",
+      columns: %i[operator values example],
+      rows: [
+        { operator: "`visibility:`", values: "public, shared, private", example: "`visibility:shared`" },
+        { operator: "`collective:`", values: "collective handle", example: "`collective:my-team`" },
+        { operator: "`list:`", values: "list id, or `mutuals` / `tuned_in` (see [Lists](/help/lists))", example: "`list:mutuals`, `list:tuned_in`, `list:abc12345`" },
+        { operator: "`type:`", values: "note, decision, commitment", example: "`type:note`" },
+        { operator: "`subtype:`", values: "post, reminder, table, comment, statement, summary, vote, lottery, executive, action, calendar_event, policy", example: "`subtype:reminder`" },
+        { operator: "`status:`", values: "open, closed", example: "`status:open`" },
+        { operator: "`media:`", values: "image, text-only", example: "`media:image`" },
+        { operator: "`creator:`", values: "@handle", example: "`creator:@alice`" },
+        { operator: "`read-by:`", values: "@handle", example: "`read-by:@alice`" },
+        { operator: "`voter:`", values: "@handle", example: "`voter:@alice`" },
+        { operator: "`participant:`", values: "@handle", example: "`participant:@alice`" },
+        { operator: "`mentions:`", values: "@handle", example: "`mentions:@bob`" },
+        { operator: "`replying-to:`", values: "@handle", example: "`replying-to:@alice`" },
+        { operator: "`critical-mass-achieved:`", values: "true, false", example: "`critical-mass-achieved:true`" },
+      ],
+    },
+    {
+      id: :numeric,
+      title: "Numeric Filters",
+      description: "Use `min-` and `max-` prefixes with these fields:",
+      columns: %i[field example],
+      rows: [
+        { field: "`links`", example: "`min-links:3`" },
+        { field: "`backlinks`", example: "`min-backlinks:1`" },
+        { field: "`comments`", example: "`max-comments:10`" },
+        { field: "`readers`", example: "`min-readers:5`" },
+        { field: "`voters`", example: "`min-voters:3`" },
+        { field: "`participants`", example: "`min-participants:2`" },
+      ],
+    },
+    {
+      id: :date,
+      title: "Date Filters",
+      columns: %i[operator values example],
+      rows: [
+        { operator: "`cycle:`", values: "today, this-week, last-month, etc.", example: "`cycle:this-week`" },
+        { operator: "`after:`", values: "YYYY-MM-DD or relative (-Nd/-Nw/-Nm/-Ny)", example: "`after:-7d`" },
+        { operator: "`before:`", values: "YYYY-MM-DD or relative (+Nd/+Nw/+Nm/+Ny)", example: "`before:2026-01-01`" },
+      ],
+    },
+    {
+      id: :sorting,
+      title: "Sorting and Grouping",
+      columns: %i[operator values],
+      rows: [
+        { operator: "`sort:`", values: "newest, oldest, updated, deadline, relevance" },
+        { operator: "`group:`", values: "collective, creator, type, status, date, week, month, none" },
+        { operator: "`limit:`", values: "1-100" },
+      ],
+    },
+  ].freeze
+
+  COLUMN_HEADERS = {
+    operator: "Operator",
+    values: "Values",
+    example: "Example",
+    field: "Field",
+  }.freeze
+
+  def search_filter_reference_section(id)
+    section = SECTIONS.find { |s| s[:id] == id.to_sym }
+    return "" unless section
+
+    render_search_filter_section_markdown(section)
+  end
+
+  # The full reference as HTML, for the /search syntax panel. Each section
+  # becomes a small heading + table; cell markdown is rendered inline.
+  def search_filter_reference_html
+    safe_join(SECTIONS.map { |section| render_search_filter_section_html(section) })
+  end
+
+  private
+
+  def render_search_filter_section_markdown(section)
+    cols = section[:columns]
+    lines = ["### #{section[:title]}", ""]
+    if section[:description]
+      lines << section[:description]
+      lines << ""
+    end
+    lines << "| #{cols.map { |c| COLUMN_HEADERS[c] }.join(' | ')} |"
+    lines << "|#{cols.map { '---' }.join('|')}|"
+    section[:rows].each do |row|
+      lines << "| #{cols.map { |c| row[c] }.join(' | ')} |"
+    end
+    lines << ""
+    lines.join("\n")
+  end
+
+  def render_search_filter_section_html(section)
+    cols = section[:columns]
+    header = content_tag(:tr, safe_join(cols.map { |c| content_tag(:th, COLUMN_HEADERS[c]) }))
+    body = section[:rows].map do |row|
+      content_tag(:tr, safe_join(cols.map { |c| content_tag(:td, markdown_inline(row[c].to_s)) }))
+    end
+
+    parts = [content_tag(:h4, section[:title], style: "font-size: 0.9rem; margin: 1rem 0 0.25rem;")]
+    if section[:description]
+      parts << content_tag(:p, markdown_inline(section[:description]),
+                           style: "font-size: 0.85rem; color: var(--color-fg-muted); margin-bottom: 0.5rem;")
+    end
+    parts << content_tag(:table,
+                         safe_join([content_tag(:thead, header), content_tag(:tbody, safe_join(body))]),
+                         class: "pulse-table", style: "font-size: 0.85rem;")
+    safe_join(parts)
+  end
+end

--- a/app/views/help/search.md.erb
+++ b/app/views/help/search.md.erb
@@ -18,24 +18,7 @@ Navigate to `/search?q={query}` to search. Plain text searches content. Use `"qu
 
 Use operators in your query to filter, sort, and group results.
 
-### Filtering
-
-| Operator | Values | Example |
-|----------|--------|---------|
-| `visibility:` | public, shared, private | `visibility:shared` |
-| `collective:` | collective handle | `collective:my-team` |
-| `list:` | list id, or `mutuals` / `tuned_in` (see [Lists](/help/lists)) | `list:mutuals`, `list:tuned_in`, `list:abc12345` |
-| `type:` | note, decision, commitment | `type:note` |
-| `subtype:` | post, reminder, table, comment, statement, summary, vote, lottery, executive, action, calendar_event, policy | `subtype:reminder` |
-| `status:` | open, closed | `status:open` |
-| `media:` | image, text-only | `media:image` |
-| `creator:` | @handle | `creator:@alice` |
-| `read-by:` | @handle | `read-by:@alice` |
-| `voter:` | @handle | `voter:@alice` |
-| `participant:` | @handle | `participant:@alice` |
-| `mentions:` | @handle | `mentions:@bob` |
-| `replying-to:` | @handle | `replying-to:@alice` |
-| `critical-mass-achieved:` | true, false | `critical-mass-achieved:true` |
+<%= search_filter_reference_section(:filtering) %>
 
 ### Your State (`my:`)
 
@@ -75,34 +58,9 @@ operators (which combine with AND): `my:voted my:committed` matches items
 that are *both*, not either. Aliases can't be negated — write the
 underlying operator (e.g. `-creator:@you`) instead.
 
-### Numeric Filters
-
-Use `min-` and `max-` prefixes with these fields:
-
-| Field | Example |
-|-------|---------|
-| `links` | `min-links:3` |
-| `backlinks` | `min-backlinks:1` |
-| `comments` | `max-comments:10` |
-| `readers` | `min-readers:5` |
-| `voters` | `min-voters:3` |
-| `participants` | `min-participants:2` |
-
-### Date Filters
-
-| Operator | Values | Example |
-|----------|--------|---------|
-| `cycle:` | today, this-week, last-month, etc. | `cycle:this-week` |
-| `after:` | YYYY-MM-DD or relative (-Nd/-Nw/-Nm/-Ny) | `after:-7d` |
-| `before:` | YYYY-MM-DD or relative (+Nd/+Nw/+Nm/+Ny) | `before:2026-01-01` |
-
-### Sorting and Grouping
-
-| Operator | Values |
-|----------|--------|
-| `sort:` | newest, oldest, updated, deadline, relevance |
-| `group:` | collective, creator, type, status, date, week, month, none |
-| `limit:` | 1-100 |
+<%= search_filter_reference_section(:numeric) %>
+<%= search_filter_reference_section(:date) %>
+<%= search_filter_reference_section(:sorting) %>
 
 ## Examples
 

--- a/app/views/search/show.html.erb
+++ b/app/views/search/show.html.erb
@@ -108,33 +108,9 @@
         Use operators to filter, sort, and group results. Plain text searches content.
         Use <code>"quotes"</code> for exact phrase matching. Prefix with <code>-</code> to negate.
       </p>
-      <table class="pulse-table" style="font-size: 0.85rem;">
-        <thead>
-          <tr><th>Operator</th><th>Values</th></tr>
-        </thead>
-        <tbody>
-          <tr><td><code>visibility:</code></td><td>public, shared, private</td></tr>
-          <tr><td><code>collective:</code></td><td>collective handle</td></tr>
-          <tr><td><code>list:</code></td><td>list id, or <code>mutuals</code> / <code>tuned_in</code> (your own)</td></tr>
-          <tr><td><code>type:</code></td><td>note, decision, commitment</td></tr>
-          <tr><td><code>subtype:</code></td><td>post, reminder, table, comment, statement, summary, vote, lottery, executive, action, calendar_event, policy</td></tr>
-          <tr><td><code>status:</code></td><td>open, closed</td></tr>
-          <tr><td><code>creator:</code></td><td>@handle</td></tr>
-          <tr><td><code>read-by:</code></td><td>@handle</td></tr>
-          <tr><td><code>voter:</code></td><td>@handle</td></tr>
-          <tr><td><code>participant:</code></td><td>@handle</td></tr>
-          <tr><td><code>mentions:</code></td><td>@handle</td></tr>
-          <tr><td><code>replying-to:</code></td><td>@handle</td></tr>
-          <tr><td><code>min-*/max-*:</code></td><td>links, backlinks, comments, readers, voters, participants</td></tr>
-          <tr><td><code>critical-mass-achieved:</code></td><td>true, false</td></tr>
-          <tr><td><code>sort:</code></td><td>newest, oldest, updated, deadline, relevance</td></tr>
-          <tr><td><code>group:</code></td><td>collective, creator, type, status, date, week, month, none</td></tr>
-          <tr><td><code>cycle:</code></td><td>today, this-week, last-month, etc.</td></tr>
-          <tr><td><code>after:</code></td><td>YYYY-MM-DD or -Nd/-Nw/-Nm/-Ny</td></tr>
-          <tr><td><code>before:</code></td><td>YYYY-MM-DD or +Nd/+Nw/+Nm/+Ny</td></tr>
-          <tr><td><code>limit:</code></td><td>1-100</td></tr>
-        </tbody>
-      </table>
+      <%# Reference tables are rendered from SearchFilterReferenceHelper::SECTIONS, %>
+      <%# the single source of truth shared with the /help/search page. %>
+      <%= search_filter_reference_html %>
     </section>
   </div>
 </article>

--- a/app/views/search/show.md.erb
+++ b/app/views/search/show.md.erb
@@ -58,26 +58,10 @@ Enter a search query to find items.
 
 Use operators to filter, sort, and group results. Plain text searches content. Use `"quotes"` for exact phrase matching. Prefix with `-` to negate.
 
-| Operator | Values |
-|----------|--------|
-| `visibility:` | public, shared, private |
-| `collective:` | collective handle |
-| `list:` | list id, or `mutuals` / `tuned_in` (your own) |
-| `type:` | note, decision, commitment |
-| `subtype:` | post, reminder, table, comment, statement, summary, vote, lottery, executive, action, calendar_event, policy |
-| `status:` | open, closed |
-| `creator:` | @handle |
-| `read-by:` | @handle |
-| `voter:` | @handle |
-| `participant:` | @handle |
-| `mentions:` | @handle |
-| `replying-to:` | @handle |
-| `min-*/max-*:` | links, backlinks, comments, readers, voters, participants |
-| `critical-mass-achieved:` | true, false |
-| `sort:` | newest, oldest, updated, deadline, relevance |
-| `group:` | collective, creator, type, status, date, week, month, none |
-| `cycle:` | today, this-week, last-month, etc. |
-| `after:` | YYYY-MM-DD or -Nd/-Nw/-Nm/-Ny |
-| `before:` | YYYY-MM-DD or +Nd/+Nw/+Nm/+Ny |
-| `limit:` | 1-100 |
+<%# Rendered from SearchFilterReferenceHelper::SECTIONS — the single source %>
+<%# of truth shared with /help/search and the /search HTML syntax panel. %>
+<%= search_filter_reference_section(:filtering) -%>
+<%= search_filter_reference_section(:numeric) -%>
+<%= search_filter_reference_section(:date) -%>
+<%= search_filter_reference_section(:sorting) -%>
 

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -83,6 +83,31 @@ class SearchTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, "`scope:`"
   end
 
+  test "the /search panel and /help/search render operators from the shared source of truth" do
+    sign_in_as(@user, tenant: @tenant)
+
+    # media: previously lived only on the help page — the /search panel had
+    # drifted and omitted it. Both now derive from
+    # SearchFilterReferenceHelper::SECTIONS, so every operator in the source
+    # must appear on both surfaces.
+    operators = SearchFilterReferenceHelper::SECTIONS
+                .select { |s| s[:columns].include?(:operator) }
+                .flat_map { |s| s[:rows].map { |r| r[:operator].delete("`") } }
+    assert_includes operators, "media:"
+
+    get search_path
+    assert_response :success
+    operators.each do |op|
+      assert_includes response.body, "<code>#{op}</code>", "/search panel missing #{op}"
+    end
+
+    get "/help/search"
+    assert_response :success
+    operators.each do |op|
+      assert_includes response.body, "<code>#{op}</code>", "/help/search missing #{op}"
+    end
+  end
+
   # Markdown tests
 
   test "GET search with Accept text/markdown returns markdown" do


### PR DESCRIPTION
Closes #429.

The search-operator reference table was hand-maintained in **three** places:
- `/help/search` (markdown, with an Example column)
- the `/search` HTML syntax panel (`search/show.html.erb`)
- the `/search` markdown view (`search/show.md.erb`)

They had already drifted — the `media:` operator (added in #427) existed only on the help page; the `/search` panels never got it.

## Change
Introduces `SearchFilterReferenceHelper::SECTIONS` — one structured data source for the operator reference (sections → columns → rows, cell text in markdown). All three surfaces now render from it:
- `search_filter_reference_section(id)` emits a markdown table for one section — used by the help page and the `/search` markdown view.
- `search_filter_reference_html` emits the full HTML reference (cell markdown rendered inline via `markdown_inline`) — used by the `/search` panel.

Adding an operator now means editing `SECTIONS` once; every surface updates together. As a side effect the `/search` panels gain `media:` and the example column, matching the help page.

## Tests
- `search_test.rb` — new test iterates `SECTIONS` and asserts every operator renders on both `/search` and `/help/search`. The existing `visibility:`/`scope:` assertions still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)