### PR TITLE
Move collective Explore nav links into a kebab menu (#431)

### DIFF
--- a/app/assets/stylesheets/pulse/_sidebar.css
+++ b/app/assets/stylesheets/pulse/_sidebar.css
@@ -113,6 +113,79 @@
   min-width: 0;
 }
 
+/* Kebab menu on the collective-info block (Explore/navigation links). A
+   <details> element anchors the dropdown; visibility follows the open/closed
+   state, so do NOT set `display` on the list. */
+.pulse-sidebar-menu {
+  position: relative;
+  display: inline-block;
+  flex-shrink: 0;
+  align-self: flex-start;
+}
+
+.pulse-sidebar-menu-toggle {
+  cursor: pointer;
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-fg-muted);
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.pulse-sidebar-menu-toggle:hover {
+  color: var(--color-fg-default);
+  background: var(--color-canvas-subtle);
+}
+
+/* Hide the native disclosure triangle the <summary> renders by default. */
+.pulse-sidebar-menu-toggle::-webkit-details-marker {
+  display: none;
+}
+.pulse-sidebar-menu-toggle::marker {
+  content: "";
+}
+
+.pulse-sidebar-menu-list {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 100;
+  min-width: 160px;
+  margin-top: 4px;
+  padding: 6px;
+  background: var(--color-canvas-default);
+  border: 1px solid var(--color-border-default);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  white-space: nowrap;
+}
+
+.pulse-sidebar-menu-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pulse-sidebar-menu-list li {
+  margin: 0;
+}
+
+.pulse-sidebar-menu-list li a {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  color: var(--color-fg-default);
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+.pulse-sidebar-menu-list li a:hover {
+  background: var(--color-canvas-subtle);
+  text-decoration: none;
+}
+
 .pulse-member-link {
   color: var(--color-fg-muted);
   text-decoration: none;

--- a/app/views/pulse/_sidebar.html.erb
+++ b/app/views/pulse/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <aside class="pulse-sidebar">
-  <%= render 'pulse/sidebar_collective_info' %>
+  <%= render 'pulse/sidebar_collective_info', show_collective_menu: true %>
   <%= render 'pulse/sidebar_pinned' %>
   <%= render 'pulse/sidebar_cycle' unless @hide_cycle_sidebar %>
   <% if @recent_cycle_summaries.present? %>

--- a/app/views/pulse/_sidebar_collective_info.html.erb
+++ b/app/views/pulse/_sidebar_collective_info.html.erb
@@ -23,5 +23,48 @@
       </div>
       <% end -%>
     </div>
+    <%# Explore/navigation links live in a kebab menu here on the collective
+        home + dashboard (passed show_collective_menu: true). Uses the
+        <details>-based kebab-menu controller (CSP-safe, outside-click close). %>
+    <% if local_assigns[:show_collective_menu] %>
+      <details class="pulse-sidebar-menu" data-controller="kebab-menu">
+        <summary class="pulse-sidebar-menu-toggle" title="More">
+          <%= octicon 'kebab-horizontal', height: 16 %>
+        </summary>
+        <div class="pulse-sidebar-menu-list">
+          <ul>
+            <li>
+              <a href="<%= @current_collective.path %>/dashboard">
+                <%= octicon 'meter', height: 14 %> Dashboard
+              </a>
+            </li>
+            <li>
+              <a href="<%= @current_collective.path %>/cycles">
+                <%= octicon 'iterations', height: 14 %> Cycles
+              </a>
+            </li>
+            <li>
+              <a href="<%= @current_collective.path %>/backlinks">
+                <%= octicon 'link', height: 14 %> Backlinks
+              </a>
+            </li>
+            <% unless @current_collective.private_workspace? %>
+            <li>
+              <a href="<%= @current_collective.path %>/representation">
+                <%= octicon 'people', height: 14 %> Representation
+              </a>
+            </li>
+            <% end %>
+            <% if !@current_collective.private_workspace? && @current_user&.collective_member&.can_edit_settings? %>
+            <li>
+              <a href="<%= @current_collective.path %>/settings">
+                <%= octicon 'gear', height: 14 %> Settings
+              </a>
+            </li>
+            <% end %>
+          </ul>
+        </div>
+      </details>
+    <% end %>
   </div>
 </div>

--- a/app/views/pulse/_sidebar_links.html.erb
+++ b/app/views/pulse/_sidebar_links.html.erb
@@ -1,41 +1,12 @@
-<div class="pulse-links-section">
-  <div class="pulse-section-label">Explore</div>
-  <ul class="pulse-links-list">
-    <li>
-      <a href="<%= @current_collective.path %>/dashboard">
-        <%= octicon 'meter', height: 14 %> Dashboard
-      </a>
-    </li>
-    <li>
-      <a href="<%= @current_collective.path %>/cycles">
-        <%= octicon 'iterations', height: 14 %> Cycles
-      </a>
-    </li>
-    <li>
-      <a href="<%= @current_collective.path %>/backlinks">
-        <%= octicon 'link', height: 14 %> Backlinks
-      </a>
-    </li>
-    <% unless @current_collective.private_workspace? %>
-    <li>
-      <a href="<%= @current_collective.path %>/representation">
-        <%= octicon 'people', height: 14 %> Representation
-      </a>
-    </li>
-    <% end %>
-    <% if !@current_collective.private_workspace? && @current_user&.collective_member&.can_edit_settings? %>
-      <li>
-        <a href="<%= @current_collective.path %>/settings">
-          <%= octicon 'gear', height: 14 %> Settings
-        </a>
-      </li>
-    <% end %>
-  </ul>
-  <% if !@current_collective.private_workspace? && @current_user&.collective_member&.can_invite? %>
+<%# The Explore navigation links (Dashboard, Cycles, Backlinks, Representation,
+    Settings) now live in the kebab menu on the collective-info block above
+    (see _sidebar_collective_info). This section keeps only the Invite CTA. %>
+<% if !@current_collective.private_workspace? && @current_user&.collective_member&.can_invite? %>
+  <div class="pulse-links-section">
     <div class="pulse-invite-section">
       <a href="<%= @current_collective.path %>/invite" class="pulse-invite-btn">
         <%= octicon 'person-add', height: 14 %> Invite Member
       </a>
     </div>
-  <% end %>
-</div>
+  </div>
+<% end %>

--- a/test/controllers/pulse_controller_test.rb
+++ b/test/controllers/pulse_controller_test.rb
@@ -273,6 +273,21 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     assert_select ".pulse-heartbeat-box, .pulse-sidebar [class*='heartbeat']", minimum: 1
   end
 
+  test "explore nav links live in a kebab menu on the collective-info block" do
+    sign_in_as(@user, tenant: @tenant)
+
+    get @collective.path.to_s
+    assert_response :success
+    # The standalone "Explore" section label is gone — the links moved into
+    # the kebab menu on the collective-info block.
+    assert_select ".pulse-links-section .pulse-section-label", text: "Explore", count: 0
+    assert_select "details.pulse-sidebar-menu[data-controller='kebab-menu']" do
+      assert_select "a[href=?]", "#{@collective.path}/dashboard"
+      assert_select "a[href=?]", "#{@collective.path}/cycles"
+      assert_select "a[href=?]", "#{@collective.path}/backlinks"
+    end
+  end
+
   test "cycle navigation links target the dashboard" do
     sign_in_as(@user, tenant: @tenant)
     get "#{@collective.path}/dashboard"


### PR DESCRIPTION
Closes #431.

The collective home/dashboard sidebar carried a standalone **Explore** section (Dashboard, Cycles, Backlinks, Representation, Settings) below the collective-info block. This moves those links into a kebab (⋮) menu on the collective-info block itself — the "top sidebar section" — decluttering the sidebar.

## Changes
- `_sidebar_collective_info.html.erb` — adds a `<details>`-based kebab menu (rendered only when passed `show_collective_menu: true`) containing the Explore nav links, with the same visibility conditionals as before (Representation/Settings hidden on private workspaces / for non-editors).
- `_sidebar.html.erb` — passes `show_collective_menu: true` (so only the full pulse sidebar, i.e. feed + dashboard, gets the menu; resource/settings sidebars are untouched).
- `_sidebar_links.html.erb` — stripped to just the Invite Member CTA (kept visible; it isn't an Explore item).
- `pulse/_sidebar.css` — styles for `.pulse-sidebar-menu`.

Reuses the existing `kebab-menu` Stimulus controller (CSP-safe `<details>` + outside-click dismissal), the same pattern as the per-member menu on the members page. Links stay in the DOM (inside the menu), so anchors remain reachable.

## Tests
- `pulse_controller_test` — asserts the standalone Explore label is gone and the Dashboard/Cycles/Backlinks links render inside the kebab on the feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)