### PR TITLE
Let free accounts buy LLM credits without a subscription (#433)

### DIFF
--- a/app/controllers/billing_controller.rb
+++ b/app/controllers/billing_controller.rb
@@ -77,8 +77,12 @@ class BillingController < ApplicationController
 
   # POST /billing/topup
   def topup
-    unless current_user.stripe_customer&.active?
-      flash[:error] = "You need an active subscription before adding credits."
+    # Credits are a one-time payment, independent of the $3/mo subscription.
+    # Free accounts (all resources billing-exempt, no subscription) still need
+    # to buy LLM credits to power internal agents — so gate on billing being
+    # enabled, not on an active subscription.
+    unless current_tenant&.feature_enabled?("stripe_billing")
+      flash[:error] = "Billing is not enabled."
       return redirect_to billing_show_path
     end
 
@@ -95,7 +99,9 @@ class BillingController < ApplicationController
       return redirect_to billing_show_path
     end
 
-    stripe_customer = current_user.stripe_customer
+    # find_or_create so a free account with no prior subscription can still
+    # attach a one-time credit payment to a Stripe customer.
+    stripe_customer = StripeService.find_or_create_customer(current_user)
     billing_url = billing_show_url
     success_url = "#{billing_url}?checkout_session_id={CHECKOUT_SESSION_ID}"
 
@@ -297,9 +303,16 @@ class BillingController < ApplicationController
   end
 
   def load_credit_balance
-    return unless @stripe_customer&.active?
+    # Credits are decoupled from the subscription, so surface the balance
+    # whenever billing is enabled. A free account that has never set up billing
+    # has no Stripe customer yet — show $0 until their first top-up creates one.
+    return unless current_tenant&.feature_enabled?("stripe_billing")
 
-    @credit_balance_cents = StripeService.get_credit_balance(@stripe_customer)
+    @credit_balance_cents = if @stripe_customer
+      StripeService.get_credit_balance(@stripe_customer)
+    else
+      0
+    end
   end
 
   def load_billing_inventory

--- a/app/controllers/billing_controller.rb
+++ b/app/controllers/billing_controller.rb
@@ -81,9 +81,15 @@ class BillingController < ApplicationController
     # Free accounts (all resources billing-exempt, no subscription) still need
     # to buy LLM credits to power internal agents — so gate on billing being
     # enabled, not on an active subscription.
+    #
+    # Every real caller reaches this action from a tenant with billing enabled
+    # (the top-up form is only rendered when the flag is on), so this is a
+    # defensive guard against a hand-crafted POST. When billing is off the
+    # billing page has nothing to show either, so send the user home rather
+    # than bounce them to an empty /billing.
     unless current_tenant&.feature_enabled?("stripe_billing")
       flash[:error] = "Billing is not enabled."
-      return redirect_to billing_show_path
+      return redirect_to root_path
     end
 
     amount_cents = params[:amount_cents].to_i

--- a/app/views/billing/_credits_section.html.erb
+++ b/app/views/billing/_credits_section.html.erb
@@ -1,0 +1,38 @@
+<%# AI Agent LLM credits. Credits are a one-time top-up, independent of the
+    $3/mo subscription — so this section shows for both active subscribers and
+    free accounts (all resources billing-exempt), which still need credits to
+    power internal agents. See BillingController#topup / #load_credit_balance. %>
+<section class="pulse-section" style="margin-bottom: 24px;">
+  <h2 class="pulse-section-title">AI Agent Credits</h2>
+  <p class="pulse-muted" style="margin-bottom: 12px;">Prepaid credits for AI agent LLM usage. Agents draw down from this balance as they run.</p>
+
+  <div style="margin-bottom: 16px;">
+    <% if @credit_balance_cents.nil? %>
+      <p class="pulse-muted">Balance unavailable — try refreshing.</p>
+    <% else %>
+      <p style="font-size: 1.5em; font-weight: 600;">
+        $<%= format("%.2f", @credit_balance_cents / 100.0) %>
+      </p>
+      <% if @credit_balance_cents == 0 %>
+        <p class="pulse-muted" style="margin-top: 4px;">Add funds to run AI agents.</p>
+      <% end %>
+    <% end %>
+  </div>
+
+  <%# Opt out of Turbo: server redirects to Stripe Checkout (cross-origin),
+      which Turbo cannot follow under our CSP connect-src. Full-page nav. %>
+  <%= form_tag billing_topup_path, method: :post, style: "display: flex; align-items: center; gap: 8px;", data: { turbo: false } do %>
+    <label for="topup_amount" class="pulse-muted" style="white-space: nowrap;">Add funds:</label>
+    <select name="amount_cents" id="topup_amount" class="pulse-input" style="width: auto;">
+      <option value="500">$5.00</option>
+      <option value="1000">$10.00</option>
+      <option value="2500" selected>$25.00</option>
+      <option value="5000">$50.00</option>
+      <option value="10000">$100.00</option>
+    </select>
+    <button type="submit" class="pulse-action-btn pulse-action-btn-primary">
+      <%= octicon 'plus', height: 14 %>
+      Add Funds
+    </button>
+  <% end %>
+</section>

--- a/app/views/billing/show.html.erb
+++ b/app/views/billing/show.html.erb
@@ -124,40 +124,7 @@
         </section>
       <% end %>
 
-      <section class="pulse-section" style="margin-bottom: 24px;">
-        <h2 class="pulse-section-title">AI Agent Credits</h2>
-        <p class="pulse-muted" style="margin-bottom: 12px;">Prepaid credits for AI agent LLM usage. Agents draw down from this balance as they run.</p>
-
-        <div style="margin-bottom: 16px;">
-          <% if @credit_balance_cents.nil? %>
-            <p class="pulse-muted">Balance unavailable — try refreshing.</p>
-          <% else %>
-            <p style="font-size: 1.5em; font-weight: 600;">
-              $<%= format("%.2f", @credit_balance_cents / 100.0) %>
-            </p>
-            <% if @credit_balance_cents == 0 %>
-              <p class="pulse-muted" style="margin-top: 4px;">Add funds to run AI agents.</p>
-            <% end %>
-          <% end %>
-        </div>
-
-        <%# Opt out of Turbo: server redirects to Stripe Checkout (cross-origin),
-            which Turbo cannot follow under our CSP connect-src. Full-page nav. %>
-        <%= form_tag billing_topup_path, method: :post, style: "display: flex; align-items: center; gap: 8px;", data: { turbo: false } do %>
-          <label for="topup_amount" class="pulse-muted" style="white-space: nowrap;">Add funds:</label>
-          <select name="amount_cents" id="topup_amount" class="pulse-input" style="width: auto;">
-            <option value="500">$5.00</option>
-            <option value="1000">$10.00</option>
-            <option value="2500" selected>$25.00</option>
-            <option value="5000">$50.00</option>
-            <option value="10000">$100.00</option>
-          </select>
-          <button type="submit" class="pulse-action-btn pulse-action-btn-primary">
-            <%= octicon 'plus', height: 14 %>
-            Add Funds
-          </button>
-        <% end %>
-      </section>
+      <%= render "billing/credits_section" %>
 
     <% elsif @billable_quantity && @billable_quantity == 0 %>
       <%# === No subscription needed — nothing billable yet (or fully exempt) === %>
@@ -169,6 +136,12 @@
           Billable items will show up here when created. AI agents cost <strong>$3/month</strong> each.
         </p>
       </section>
+
+      <%# Free accounts still buy LLM credits — the $3/mo fee is waived, but
+          credits are a separate one-time top-up that powers internal agents. %>
+      <% if current_tenant&.feature_enabled?("stripe_billing") %>
+        <%= render "billing/credits_section" %>
+      <% end %>
 
       <section class="pulse-section" style="margin-bottom: 24px;">
         <h2 class="pulse-section-title">Your Resources</h2>

--- a/app/views/billing/show.html.erb
+++ b/app/views/billing/show.html.erb
@@ -139,7 +139,7 @@
 
       <%# Free accounts still buy LLM credits — the $3/mo fee is waived, but
           credits are a separate one-time top-up that powers internal agents. %>
-      <% if current_tenant&.feature_enabled?("stripe_billing") %>
+      <% if @current_tenant&.feature_enabled?("stripe_billing") %>
         <%= render "billing/credits_section" %>
       <% end %>
 

--- a/test/controllers/billing_controller_test.rb
+++ b/test/controllers/billing_controller_test.rb
@@ -298,7 +298,9 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
 
     post "/billing/topup", params: { amount_cents: "2500" }
 
-    assert_redirected_to "/billing"
+    # Billing is off for this tenant, so /billing itself has nothing to offer —
+    # the user is sent home, not bounced to an empty billing page.
+    assert_redirected_to root_path
     assert_not_requested checkout_stub
   end
 

--- a/test/controllers/billing_controller_test.rb
+++ b/test/controllers/billing_controller_test.rb
@@ -24,6 +24,9 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
     @original_price_id = ENV["STRIPE_PRICE_ID"]
     ENV["STRIPE_PRICE_ID"] = "price_test_123"
 
+    @original_credit_product_id = ENV["STRIPE_CREDIT_PRODUCT_ID"]
+    ENV["STRIPE_CREDIT_PRODUCT_ID"] = "prod_credit_test"
+
     # Stub credit balance API for all tests (load_credit_balance runs on every show)
     stub_request(:get, %r{https://api.stripe.com/v1/billing/credit_balance_summary.*})
       .to_return(
@@ -36,6 +39,7 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
   teardown do
     Stripe.api_key = @original_stripe_key
     ENV["STRIPE_PRICE_ID"] = @original_price_id
+    ENV["STRIPE_CREDIT_PRODUCT_ID"] = @original_credit_product_id
   end
 
   # === Show ===
@@ -231,6 +235,71 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     sc.reload
     assert_not sc.active, "Should not activate billing for mismatched customer"
+  end
+
+  # === Topup (LLM credits) ===
+
+  # Regression for #433: free accounts (all resources billing-exempt, no
+  # subscription) still need to buy LLM credits to power internal agents.
+  def build_free_account
+    free_tenant = create_tenant(subdomain: "billing-credits-#{SecureRandom.hex(4)}")
+    enable_stripe_billing_flag!(free_tenant)
+    free_user = create_user(email: "billing-credits-#{SecureRandom.hex(4)}@example.com", name: "Free Admin")
+    free_tenant.add_user!(free_user)
+    free_tenant.create_main_collective!(created_by: free_user)
+    host! "#{free_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    [free_tenant, free_user]
+  end
+
+  test "billing page offers the credit top-up form to a free account" do
+    _free_tenant, free_user = build_free_account
+    sign_in_as(free_user, tenant: _free_tenant)
+
+    get "/billing"
+    assert_response :success
+    # Free account: nothing to pay, but the credits section is still offered.
+    assert_match(/nothing to pay/i, response.body)
+    assert_match(/AI Agent Credits/, response.body)
+    assert_select "form[action=?]", "/billing/topup"
+  end
+
+  test "free account can add credits without an active subscription" do
+    _free_tenant, free_user = build_free_account
+    sign_in_as(free_user, tenant: _free_tenant)
+
+    stub_request(:post, "https://api.stripe.com/v1/customers")
+      .to_return(status: 200, body: { id: "cus_credits123", object: "customer" }.to_json,
+                 headers: { "Content-Type" => "application/json" })
+    stub_request(:post, "https://api.stripe.com/v1/prices")
+      .to_return(status: 200, body: { id: "price_credits123", object: "price" }.to_json,
+                 headers: { "Content-Type" => "application/json" })
+    checkout_stub = stub_request(:post, "https://api.stripe.com/v1/checkout/sessions")
+      .to_return(status: 200,
+                 body: { id: "cs_credits123", object: "checkout.session",
+                         url: "https://checkout.stripe.com/session/cs_credits123" }.to_json,
+                 headers: { "Content-Type" => "application/json" })
+
+    post "/billing/topup", params: { amount_cents: "2500" }
+
+    assert_response :redirect
+    assert_match %r{checkout\.stripe\.com}, response.location
+    assert_requested checkout_stub
+  end
+
+  test "topup is rejected when billing is not enabled" do
+    plain_tenant = create_tenant(subdomain: "billing-off-#{SecureRandom.hex(4)}")
+    plain_user = create_user(email: "billing-off-#{SecureRandom.hex(4)}@example.com", name: "No Billing")
+    plain_tenant.add_user!(plain_user)
+    plain_tenant.create_main_collective!(created_by: plain_user)
+    host! "#{plain_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as(plain_user, tenant: plain_tenant)
+
+    checkout_stub = stub_request(:post, "https://api.stripe.com/v1/checkout/sessions")
+
+    post "/billing/topup", params: { amount_cents: "2500" }
+
+    assert_redirected_to "/billing"
+    assert_not_requested checkout_stub
   end
 
   # === Setup ===


### PR DESCRIPTION
Closes #433.

Free accounts (app admins whose AI-agent/collective resources are billing-exempt) don't pay the $3/mo fee, so they never open a Stripe subscription. But LLM credits are a **separate one-time purchase** that powers internal agents — and both the billing page and the `topup` action required an *active subscription*, so free accounts had no way to add credits.

## Fix
- **`BillingController#topup`** — gate on `stripe_billing` being enabled instead of an active subscription, and `find_or_create_customer` so a free account with no prior subscription can attach a one-time credit payment. (Errors when billing is disabled.)
- **`BillingController#load_credit_balance`** — surface the balance whenever billing is enabled; a free account with no Stripe customer yet shows `$0` until its first top-up creates one.
- **View** — extracted the "AI Agent Credits" section into `billing/_credits_section` and rendered it in the free/exempt branch (`billable_quantity == 0`), not only the active-subscription branch.

Credit grants already call `ensure_pricing_plan_subscription!`, so a free account's purchased credits meter and drain correctly once bought — no separate subscription needed.

## Tests
`billing_controller_test`:
- the billing page offers the top-up form to a free account
- a free account can start a credit top-up (reaches Stripe Checkout) with no active subscription
- topup is rejected when `stripe_billing` is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)