### PR TITLE
Align email styling with the app style guide (#439)

### DIFF
--- a/app/views/alert_mailer/critical_alert.html.erb
+++ b/app/views/alert_mailer/critical_alert.html.erb
@@ -1,30 +1,15 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; }
-    .alert-box { border: 2px solid #dc3545; border-radius: 8px; padding: 20px; margin: 20px 0; background: #fff5f5; }
-    .alert-header { color: #dc3545; margin: 0 0 10px 0; font-size: 20px; }
-    .meta { color: #666; font-size: 14px; margin: 15px 0; }
-    .context { background: #f8f9fa; padding: 15px; border-radius: 4px; font-family: monospace; font-size: 13px; }
-    .context-title { font-weight: bold; margin-bottom: 10px; }
-  </style>
-</head>
-<body>
-  <div class="alert-box">
-    <h1 class="alert-header">Critical Alert</h1>
-    <p><%= @message %></p>
-    <div class="meta">
-      <strong>Environment:</strong> <%= @environment %><br>
-      <strong>Hostname:</strong> <%= @hostname %><br>
-      <strong>Time:</strong> <%= @timestamp %>
-    </div>
-    <% if @context.present? %>
-      <div class="context">
-        <div class="context-title">Additional Context:</div>
-        <pre><%= JSON.pretty_generate(@context) %></pre>
-      </div>
-    <% end %>
+<div class="alert-box">
+  <h1 class="alert-header">Critical Alert</h1>
+  <p><%= @message %></p>
+  <div class="meta">
+    <strong>Environment:</strong> <%= @environment %><br>
+    <strong>Hostname:</strong> <%= @hostname %><br>
+    <strong>Time:</strong> <%= @timestamp %>
   </div>
-</body>
-</html>
+  <% if @context.present? %>
+    <div class="context">
+      <div class="context-title">Additional Context:</div>
+      <pre><%= JSON.pretty_generate(@context) %></pre>
+    </div>
+  <% end %>
+</div>

--- a/app/views/data_export_mailer/export_ready.html.erb
+++ b/app/views/data_export_mailer/export_ready.html.erb
@@ -1,48 +1,29 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <style>
-    body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; background-color: #f5f5f5; }
-    .container { max-width: 600px; margin: 0 auto; padding: 20px; background-color: #ffffff; }
-    .header { border-bottom: 2px solid #007bff; padding-bottom: 20px; margin-bottom: 20px; }
-    .header h1 { margin: 0; font-size: 24px; color: #333; }
-    .content { margin: 20px 0; }
-    .content h2 { font-size: 18px; margin: 0 0 10px 0; color: #333; }
-    .button { display: inline-block; padding: 12px 24px; background-color: #007bff; color: white; text-decoration: none; border-radius: 4px; margin: 20px 0; }
-    .details { font-size: 14px; color: #666; margin: 16px 0; }
-    .footer { margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee; font-size: 12px; color: #999; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <div class="header">
-      <h1>Harmonic</h1>
-    </div>
+<div class="container">
+  <div class="header">
+    <h1>Harmonic</h1>
+  </div>
 
-    <div class="content">
-      <h2>Your data export is ready</h2>
-      <p>The export for <strong><%= @collective.name %></strong> has been completed and is ready for download.</p>
+  <div class="content">
+    <h2>Your data export is ready</h2>
+    <p>The export for <strong><%= @collective.name %></strong> has been completed and is ready for download.</p>
 
-      <% if @data_export.record_counts.present? %>
-        <div class="details">
-          Exported: <%= @data_export.record_counts.map { |k, v| "#{v} #{k}" }.join(", ") %>
-        </div>
-      <% end %>
-
-      <a href="<%= @download_url %>" class="button">Download Export</a>
-
+    <% if @data_export.record_counts.present? %>
       <div class="details">
-        You'll need to verify your identity (2FA) before downloading.
-        <% if @data_export.expires_at %>
-          <br>This download expires on <%= @data_export.expires_at.strftime("%B %d, %Y") %>.
-        <% end %>
+        Exported: <%= @data_export.record_counts.map { |k, v| "#{v} #{k}" }.join(", ") %>
       </div>
-    </div>
+    <% end %>
 
-    <div class="footer">
-      <p>You requested this export from Harmonic. If you didn't request it, please contact your collective administrator.</p>
+    <a href="<%= @download_url %>" class="button">Download Export</a>
+
+    <div class="details">
+      You'll need to verify your identity (2FA) before downloading.
+      <% if @data_export.expires_at %>
+        <br>This download expires on <%= @data_export.expires_at.strftime("%B %d, %Y") %>.
+      <% end %>
     </div>
   </div>
-</body>
-</html>
+
+  <div class="footer">
+    <p>You requested this export from Harmonic. If you didn't request it, please contact your collective administrator.</p>
+  </div>
+</div>

--- a/app/views/data_export_mailer/user_export_ready.html.erb
+++ b/app/views/data_export_mailer/user_export_ready.html.erb
@@ -1,48 +1,29 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <style>
-    body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; background-color: #f5f5f5; }
-    .container { max-width: 600px; margin: 0 auto; padding: 20px; background-color: #ffffff; }
-    .header { border-bottom: 2px solid #007bff; padding-bottom: 20px; margin-bottom: 20px; }
-    .header h1 { margin: 0; font-size: 24px; color: #333; }
-    .content { margin: 20px 0; }
-    .content h2 { font-size: 18px; margin: 0 0 10px 0; color: #333; }
-    .button { display: inline-block; padding: 12px 24px; background-color: #007bff; color: white; text-decoration: none; border-radius: 4px; margin: 20px 0; }
-    .details { font-size: 14px; color: #666; margin: 16px 0; }
-    .footer { margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee; font-size: 12px; color: #999; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <div class="header">
-      <h1>Harmonic</h1>
-    </div>
+<div class="container">
+  <div class="header">
+    <h1>Harmonic</h1>
+  </div>
 
-    <div class="content">
-      <h2>Your personal data export is ready</h2>
-      <p>Your copy of the data you've created and participated in has been packaged and is ready for download.</p>
+  <div class="content">
+    <h2>Your personal data export is ready</h2>
+    <p>Your copy of the data you've created and participated in has been packaged and is ready for download.</p>
 
-      <% if @data_export.record_counts.present? %>
-        <div class="details">
-          Exported: <%= @data_export.record_counts.map { |k, v| "#{v} #{k}" }.join(", ") %>
-        </div>
-      <% end %>
-
-      <a href="<%= @download_url %>" class="button">Download Export</a>
-
+    <% if @data_export.record_counts.present? %>
       <div class="details">
-        You'll need to verify your identity (2FA) before downloading.
-        <% if @data_export.expires_at %>
-          <br>This download expires on <%= @data_export.expires_at.strftime("%B %d, %Y") %>.
-        <% end %>
+        Exported: <%= @data_export.record_counts.map { |k, v| "#{v} #{k}" }.join(", ") %>
       </div>
-    </div>
+    <% end %>
 
-    <div class="footer">
-      <p>You requested a copy of your data from Harmonic. If you didn't request it, please contact support.</p>
+    <a href="<%= @download_url %>" class="button">Download Export</a>
+
+    <div class="details">
+      You'll need to verify your identity (2FA) before downloading.
+      <% if @data_export.expires_at %>
+        <br>This download expires on <%= @data_export.expires_at.strftime("%B %d, %Y") %>.
+      <% end %>
     </div>
   </div>
-</body>
-</html>
+
+  <div class="footer">
+    <p>You requested a copy of your data from Harmonic. If you didn't request it, please contact support.</p>
+  </div>
+</div>

--- a/app/views/email_change_mailer/confirmation.html.erb
+++ b/app/views/email_change_mailer/confirmation.html.erb
@@ -1,7 +1,18 @@
-<p>Hi <%= @user.name %>,</p>
+<div class="container">
+  <div class="header">
+    <h1>Harmonic</h1>
+  </div>
 
-<p>You requested to change your email address on <%= ENV['HOSTNAME'] %>. Please confirm your new email address by clicking the link below:</p>
+  <div class="content">
+    <h2>Confirm your new email address</h2>
+    <p>Hi <%= @user.name %>,</p>
 
-<p><a href="<%= @confirm_url %>">Confirm email address</a></p>
+    <p>You requested to change your email address on <%= ENV['HOSTNAME'] %>. Please confirm your new email address by clicking the button below:</p>
 
-<p>This link will expire in 24 hours. If you did not request this change, you can ignore this email.</p>
+    <a href="<%= @confirm_url %>" class="button">Confirm email address</a>
+
+    <div class="details">
+      This link will expire in 24 hours. If you did not request this change, you can ignore this email.
+    </div>
+  </div>
+</div>

--- a/app/views/email_change_mailer/security_notice.html.erb
+++ b/app/views/email_change_mailer/security_notice.html.erb
@@ -1,17 +1,26 @@
-<p>Hi <%= @user.name %>,</p>
+<div class="container">
+  <div class="header">
+    <h1>Harmonic</h1>
+  </div>
 
-<p>An email change was requested for your account on <%= ENV['HOSTNAME'] %>.</p>
+  <div class="content">
+    <h2>Email change requested</h2>
+    <p>Hi <%= @user.name %>,</p>
 
-<p>If you made this request, a confirmation email has been sent to your new address. No action is needed here.</p>
+    <p>An email change was requested for your account on <%= ENV['HOSTNAME'] %>.</p>
 
-<p>If you did <strong>not</strong> request this change:</p>
-<ol>
-  <li><a href="<%= @login_url %>">Log in to your account</a> immediately.</li>
-  <li>Go to Settings > Email and change your email back.</li>
-  <% if @has_password %>
-    <li>Change your password from the login page using "Forgot your password?"</li>
-  <% end %>
-  <% if @external_providers.any? %>
-    <li>Review your <%= @external_providers.to_sentence %> account<%= "s" if @external_providers.many? %> for unauthorized access.</li>
-  <% end %>
-</ol>
+    <p>If you made this request, a confirmation email has been sent to your new address. No action is needed here.</p>
+
+    <p>If you did <strong>not</strong> request this change:</p>
+    <ol>
+      <li><a href="<%= @login_url %>">Log in to your account</a> immediately.</li>
+      <li>Go to Settings > Email and change your email back.</li>
+      <% if @has_password %>
+        <li>Change your password from the login page using "Forgot your password?"</li>
+      <% end %>
+      <% if @external_providers.any? %>
+        <li>Review your <%= @external_providers.to_sentence %> account<%= "s" if @external_providers.many? %> for unauthorized access.</li>
+      <% end %>
+    </ol>
+  </div>
+</div>

--- a/app/views/email_confirmation_mailer/confirm.html.erb
+++ b/app/views/email_confirmation_mailer/confirm.html.erb
@@ -1,46 +1,26 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <style>
-    body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; background-color: #f5f5f5; }
-    .container { max-width: 600px; margin: 0 auto; padding: 20px; background-color: #ffffff; }
-    .header { border-bottom: 2px solid #007bff; padding-bottom: 20px; margin-bottom: 20px; }
-    .header h1 { margin: 0; font-size: 24px; color: #333; }
-    .content { margin: 20px 0; }
-    .content h2 { font-size: 18px; margin: 0 0 10px 0; color: #333; }
-    .content p { margin: 0 0 15px 0; color: #666; }
-    .button { display: inline-block; padding: 12px 24px; background-color: #007bff; color: white; text-decoration: none; border-radius: 4px; margin: 20px 0; }
-    .details { font-size: 14px; color: #666; margin: 16px 0; }
-    .footer { margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee; font-size: 12px; color: #999; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <div class="header">
-      <h1>Harmonic</h1>
-    </div>
+<div class="container">
+  <div class="header">
+    <h1>Harmonic</h1>
+  </div>
 
-    <div class="content">
-      <h2>Confirm your email address</h2>
-      <p>Hi <%= @identity.name %>,</p>
-      <p>Please confirm your email address to finish activating your account on <%= ENV['HOSTNAME'] %>.</p>
+  <div class="content">
+    <h2>Confirm your email address</h2>
+    <p>Hi <%= @identity.name %>,</p>
+    <p>Please confirm your email address to finish activating your account on <%= ENV['HOSTNAME'] %>.</p>
 
-      <a href="<%= @confirm_url %>" class="button">Confirm email address</a>
+    <a href="<%= @confirm_url %>" class="button">Confirm email address</a>
 
-      <p style="font-size: 12px; color: #999;">
-        Or copy and paste this link into your browser:<br>
-        <%= @confirm_url %>
-      </p>
+    <p class="link-fallback">
+      Or copy and paste this link into your browser:<br>
+      <%= @confirm_url %>
+    </p>
 
-      <div class="details">
-        This link will expire in 7 days.
-      </div>
-    </div>
-
-    <div class="footer">
-      <p>If you didn't create this account, you can safely ignore this email.</p>
+    <div class="details">
+      This link will expire in 7 days.
     </div>
   </div>
-</body>
-</html>
+
+  <div class="footer">
+    <p>If you didn't create this account, you can safely ignore this email.</p>
+  </div>
+</div>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -2,8 +2,131 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <style>
-      /* Email styles need to be inline */
+      /*
+        Email styles kept consistent with the app style guide.
+        Values mirror the light-mode design tokens in
+        app/assets/stylesheets/root_variables.css (GitHub-derived palette,
+        system font stack). Email clients don't support CSS variables or
+        external stylesheets reliably, so the token values are inlined here.
+      */
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #f6f8fa; /* --color-canvas-subtle */
+        color: #24292f;            /* --color-fg-default */
+        line-height: 1.5;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+      }
+
+      .container {
+        max-width: 600px;
+        margin: 0 auto;
+        padding: 24px;             /* --spacing-xl */
+        background-color: #ffffff; /* --color-canvas-default */
+      }
+
+      .header {
+        border-bottom: 1px solid #d0d7de; /* --color-border-default */
+        padding-bottom: 16px;             /* --spacing-lg */
+        margin-bottom: 16px;
+      }
+      .header h1 {
+        margin: 0;
+        font-size: 24px;
+        font-weight: 600;
+        color: #24292f;
+      }
+
+      .content { margin: 16px 0; }
+      .content h2 {
+        margin: 0 0 12px 0;        /* --spacing-md */
+        font-size: 20px;
+        font-weight: 600;
+        color: #24292f;
+      }
+      .content p { margin: 0 0 16px 0; color: #24292f; }
+
+      a { color: #0969da; text-decoration: none; } /* --color-accent-fg */
+      a:hover { text-decoration: underline; }
+
+      .button {
+        display: inline-block;
+        margin: 16px 0;
+        padding: 8px 16px;          /* --button-padding-default */
+        background-color: #0969da;  /* --color-accent-emphasis */
+        color: #ffffff !important;
+        font-weight: 600;
+        text-decoration: none;
+        border-radius: 6px;         /* --border-radius-lg */
+      }
+      .button:hover { background-color: #0860ca; text-decoration: none; }
+
+      .details, .meta {
+        font-size: 14px;
+        color: #57606a;            /* --color-fg-muted */
+        margin: 16px 0;
+      }
+
+      .body-text {
+        background-color: #f6f8fa;
+        padding: 16px;
+        border-radius: 6px;
+        border-left: 3px solid #0969da;
+      }
+
+      .receipt, .context {
+        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace; /* --fontStack-monospace */
+        font-size: 13px;
+        background-color: #f6f8fa;
+        padding: 12px;
+        border-radius: 6px;
+        word-break: break-all;
+        margin: 16px 0;
+      }
+      .context-title { font-weight: 600; margin-bottom: 12px; }
+
+      .link-fallback { font-size: 12px; color: #6e7781; } /* --color-fg-subtle */
+
+      .footer {
+        margin-top: 32px;          /* --spacing-2xl */
+        padding-top: 16px;
+        border-top: 1px solid #d8dee4; /* --color-border-muted */
+        font-size: 12px;
+        color: #6e7781;
+      }
+      .footer a { color: #0969da; }
+
+      /* Notification-type badges, mapped to app semantic colors */
+      .notification-type {
+        display: inline-block;
+        margin-bottom: 12px;
+        padding: 4px 8px;          /* --button-padding-sm */
+        border-radius: 2em;
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+      }
+      .notification-type.mention       { background-color: #ddf4ff; color: #0969da; } /* accent */
+      .notification-type.comment       { background-color: #fff8c5; color: #9a6700; } /* attention */
+      .notification-type.participation { background-color: #dafbe1; color: #1a7f37; } /* success */
+      .notification-type.system        { background-color: #fbefff; color: #8250df; } /* done */
+
+      /* Critical alert (ops email) */
+      .alert-box {
+        margin: 16px 0;
+        padding: 20px;
+        border: 1px solid #cf222e;                /* --color-danger-fg */
+        border-radius: 6px;
+        background-color: rgba(207, 34, 46, 0.1); /* --color-danger-subtle */
+      }
+      .alert-header {
+        margin: 0 0 12px 0;
+        color: #cf222e;
+        font-size: 20px;
+        font-weight: 600;
+      }
     </style>
   </head>
 

--- a/app/views/notification_mailer/notification_email.html.erb
+++ b/app/views/notification_mailer/notification_email.html.erb
@@ -1,62 +1,35 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <style>
-    body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; background-color: #f5f5f5; }
-    .container { max-width: 600px; margin: 0 auto; padding: 20px; background-color: #ffffff; }
-    .header { border-bottom: 2px solid #007bff; padding-bottom: 20px; margin-bottom: 20px; }
-    .header h1 { margin: 0; font-size: 24px; color: #333; }
-    .notification-type { display: inline-block; padding: 4px 8px; border-radius: 4px; font-size: 12px; font-weight: bold; text-transform: uppercase; margin-bottom: 10px; }
-    .notification-type.mention { background-color: #e3f2fd; color: #1565c0; }
-    .notification-type.comment { background-color: #fff3e0; color: #ef6c00; }
-    .notification-type.participation { background-color: #e8f5e9; color: #2e7d32; }
-    .notification-type.system { background-color: #fce4ec; color: #c2185b; }
-    .content { margin: 20px 0; }
-    .content h2 { font-size: 18px; margin: 0 0 10px 0; color: #333; }
-    .content p { margin: 0 0 15px 0; color: #666; }
-    .body-text { background-color: #f9f9f9; padding: 15px; border-radius: 4px; border-left: 3px solid #007bff; }
-    .button { display: inline-block; padding: 12px 24px; background-color: #007bff; color: white; text-decoration: none; border-radius: 4px; margin: 20px 0; }
-    .button:hover { background-color: #0056b3; }
-    .footer { margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee; font-size: 12px; color: #999; }
-    .footer a { color: #007bff; text-decoration: none; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <div class="header">
-      <h1>Harmonic</h1>
-    </div>
-
-    <div class="content">
-      <span class="notification-type <%= @notification.notification_type %>"><%= @notification.notification_type %></span>
-
-      <h2><%= @notification.title %></h2>
-
-      <% if @notification.body.present? %>
-        <div class="body-text">
-          <p><%= @notification.body %></p>
-        </div>
-      <% end %>
-
-      <% if @notification_url.present? %>
-        <a href="<%= @notification_url %>" class="button">View Details</a>
-
-        <p style="font-size: 12px; color: #999;">
-          Or copy and paste this link into your browser:<br>
-          <%= @notification_url %>
-        </p>
-      <% end %>
-    </div>
-
-    <div class="footer">
-      <p>
-        You received this email because you have email notifications enabled for <%= @notification.notification_type %> notifications.
-      </p>
-      <p>
-        <a href="<%= @notification_url&.gsub(@notification.url || '', '/notifications') %>">Manage notification preferences</a>
-      </p>
-    </div>
+<div class="container">
+  <div class="header">
+    <h1>Harmonic</h1>
   </div>
-</body>
-</html>
+
+  <div class="content">
+    <span class="notification-type <%= @notification.notification_type %>"><%= @notification.notification_type %></span>
+
+    <h2><%= @notification.title %></h2>
+
+    <% if @notification.body.present? %>
+      <div class="body-text">
+        <p><%= @notification.body %></p>
+      </div>
+    <% end %>
+
+    <% if @notification_url.present? %>
+      <a href="<%= @notification_url %>" class="button">View Details</a>
+
+      <p class="link-fallback">
+        Or copy and paste this link into your browser:<br>
+        <%= @notification_url %>
+      </p>
+    <% end %>
+  </div>
+
+  <div class="footer">
+    <p>
+      You received this email because you have email notifications enabled for <%= @notification.notification_type %> notifications.
+    </p>
+    <p>
+      <a href="<%= @notification_url&.gsub(@notification.url || '', '/notifications') %>">Manage notification preferences</a>
+    </p>
+  </div>
+</div>

--- a/app/views/password_reset_mailer/reset_password_instructions.html.erb
+++ b/app/views/password_reset_mailer/reset_password_instructions.html.erb
@@ -1,20 +1,10 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <style>
-    body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
-    .container { max-width: 600px; margin: 0 auto; padding: 20px; }
-    .header { border-bottom: 2px solid #007bff; padding-bottom: 20px; margin-bottom: 20px; }
-    .button { display: inline-block; padding: 12px 24px; background-color: #007bff; color: white; text-decoration: none; border-radius: 4px; margin: 20px 0; }
-    .footer { margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee; font-size: 14px; color: #666; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <div class="header">
-      <h1>Password Reset Request</h1>
-    </div>
+<div class="container">
+  <div class="header">
+    <h1>Harmonic</h1>
+  </div>
+
+  <div class="content">
+    <h2>Password Reset Request</h2>
 
     <p>Hello <%= @identity.name || @identity.email %>,</p>
 
@@ -24,12 +14,13 @@
 
     <a href="<%= @reset_url %>" class="button">Reset My Password</a>
 
-    <p>Or copy and paste this link into your browser:</p>
-    <p><%= @reset_url %></p>
+    <p class="link-fallback">
+      Or copy and paste this link into your browser:<br>
+      <%= @reset_url %>
+    </p>
 
     <p><strong>This link will expire in 2 hours.</strong></p>
 
     <p>If you didn't request this password reset, please ignore this email. Your password won't be changed until you access the link above and create a new one.</p>
   </div>
-</body>
-</html>
+</div>

--- a/app/views/vote_receipt_mailer/receipt_email.html.erb
+++ b/app/views/vote_receipt_mailer/receipt_email.html.erb
@@ -1,37 +1,18 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <style>
-    body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; background-color: #f5f5f5; }
-    .container { max-width: 600px; margin: 0 auto; padding: 20px; background-color: #ffffff; }
-    .header { border-bottom: 2px solid #007bff; padding-bottom: 20px; margin-bottom: 20px; }
-    .header h1 { margin: 0; font-size: 24px; color: #333; }
-    .content { margin: 20px 0; }
-    .content h2 { font-size: 18px; margin: 0 0 10px 0; color: #333; }
-    .receipt { font-family: monospace; font-size: 13px; background-color: #f9f9f9; padding: 12px; border-radius: 4px; word-break: break-all; margin: 16px 0; }
-    .button { display: inline-block; padding: 12px 24px; background-color: #007bff; color: white; text-decoration: none; border-radius: 4px; margin: 20px 0; }
-    .footer { margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee; font-size: 12px; color: #999; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <div class="header">
-      <h1>Harmonic</h1>
-    </div>
-
-    <div class="content">
-      <h2>Vote recorded</h2>
-      <p>Your vote on "<%= @decision.question %>" has been recorded.</p>
-
-      <div class="receipt">Audit receipt: <%= @receipt %></div>
-
-      <a href="<%= @verify_url %>" class="button">Verify on Harmonic</a>
-    </div>
-
-    <div class="footer">
-      <p>You can use this receipt to confirm your vote was recorded correctly.</p>
-    </div>
+<div class="container">
+  <div class="header">
+    <h1>Harmonic</h1>
   </div>
-</body>
-</html>
+
+  <div class="content">
+    <h2>Vote recorded</h2>
+    <p>Your vote on "<%= @decision.question %>" has been recorded.</p>
+
+    <div class="receipt">Audit receipt: <%= @receipt %></div>
+
+    <a href="<%= @verify_url %>" class="button">Verify on Harmonic</a>
+  </div>
+
+  <div class="footer">
+    <p>You can use this receipt to confirm your vote was recorded correctly.</p>
+  </div>
+</div>


### PR DESCRIPTION
Closes #439.

## Problem
The HTML mailers used ad-hoc Bootstrap-ish styling — `#007bff` accent, `#333`/`#666`/`#999` grays, `#f5f5f5` backgrounds, Arial font — none of which match the app's GitHub-derived design tokens in `app/assets/stylesheets/root_variables.css`.

## What changed
- **Single source of truth.** Moved the email CSS into `layouts/mailer.html.erb`, using the app's token values: accent `#0969da`, fg `#24292f`/`#57606a`/`#6e7781`, canvas `#ffffff`/`#f6f8fa`, border `#d0d7de`, the system font stack, and the spacing/radius scale. Values are inlined (not `var(--…)`) because email clients don't support CSS custom properties or external stylesheets reliably.
- **Fixed a latent double-wrap bug.** `layout "mailer"` wraps every template, but most templates rendered a full `<html>` document — so they were emitted as `<html><body><!DOCTYPE html><html>…`. Those templates are now fragments; the layout supplies the document shell and styles.
- **Consistency across all mailers.** The `email_change` templates (previously bare, unstyled paragraphs) now use the same container/header shell as the rest.
- **Notification badges** remapped from Material colors to the app's semantic palette (accent / attention / success / done).

## Scope note
Matched the app's **light-mode** palette. The style guide also defines dark-mode tokens; dark-mode email support is client-dependent and I kept it out of scope — happy to add a \`prefers-color-scheme\` block as a follow-up if you want it.

## Testing
\`bin/rails test test/mailers\` — 28 runs, 95 assertions, 0 failures. Assertions are content/link-based, unaffected by the restyle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)