### PR TITLE
Add pull-to-refresh for the installed PWA (#401)

### DIFF
--- a/app/assets/stylesheets/pulse.css
+++ b/app/assets/stylesheets/pulse.css
@@ -8,6 +8,7 @@
  *= require pulse/_layout
  *= require pulse/_places_sheet
  *= require pulse/_tab_bar
+ *= require pulse/_pull_to_refresh
  *= require pulse/_components
  *= require pulse/_markdown_editor
  *= require pulse/_sidebar

--- a/app/assets/stylesheets/pulse/_pull_to_refresh.css
+++ b/app/assets/stylesheets/pulse/_pull_to_refresh.css
@@ -1,0 +1,63 @@
+/* Pull-to-refresh indicator (#401)
+ *
+ * A spinner the pull-to-refresh controller injects into <body> and drives only
+ * in the installed PWA (standalone / fullscreen), where the browser's own
+ * overscroll refresh is unavailable. The controller sets transform/opacity
+ * inline as the user pulls; these rules cover the resting look, the spring-back
+ * transition, and the refreshing spin. Reuses the shared `spin` keyframe from
+ * _components.css.
+ */
+.pull-to-refresh-indicator {
+  position: fixed;
+  top: 0;
+  left: 50%;
+  z-index: 300; /* above the sticky top header (z-index: 200) */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  margin-left: -18px;
+  border-radius: var(--border-radius-full);
+  background: var(--color-canvas-default);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  /* Parked just above the top edge until a pull translates it down. */
+  transform: translateY(-48px);
+  opacity: 0;
+  pointer-events: none;
+  /* Keep clear of the notch when the PWA draws under it (viewport-fit=cover). */
+  margin-top: env(safe-area-inset-top);
+}
+
+/* Applied for the spring-back and the settle-into-refresh, but removed while
+   the finger is driving the pull so tracking stays 1:1. */
+.pull-to-refresh-indicator--animating {
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.pull-to-refresh-spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--color-border-default);
+  border-top-color: var(--color-accent-fg);
+  border-radius: var(--border-radius-full);
+}
+
+/* Past the trigger threshold: signal that releasing now will refresh. */
+.pull-to-refresh-indicator--armed .pull-to-refresh-spinner {
+  border-top-color: var(--color-success-fg);
+}
+
+/* Released past the threshold: spin until the page reloads. */
+.pull-to-refresh-indicator--refreshing .pull-to-refresh-spinner {
+  animation: spin 0.8s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pull-to-refresh-indicator--animating {
+    transition: none;
+  }
+  .pull-to-refresh-indicator--refreshing .pull-to-refresh-spinner {
+    animation: none;
+  }
+}

--- a/app/javascript/controllers/index.ts
+++ b/app/javascript/controllers/index.ts
@@ -51,6 +51,7 @@ import NotificationActionsController from "./notification_actions_controller"
 import NotificationBadgeController from "./notification_badge_controller"
 import PlacesSheetController from "./places_sheet_controller"
 import PlacesBadgesController from "./places_badges_controller"
+import PullToRefreshController from "./pull_to_refresh_controller"
 import CsvImportController from "./csv_import_controller"
 import NoteController from "./note_controller"
 import NoteMediaUploaderController from "./note_media_uploader_controller"
@@ -133,6 +134,7 @@ application.register("notification-actions", NotificationActionsController)
 application.register("notification-badge", NotificationBadgeController)
 application.register("places-sheet", PlacesSheetController)
 application.register("places-badges", PlacesBadgesController)
+application.register("pull-to-refresh", PullToRefreshController)
 application.register("note", NoteController)
 application.register("note-media-uploader", NoteMediaUploaderController)
 application.register("note-subtype", NoteSubtypeController)

--- a/app/javascript/controllers/pull_to_refresh_controller.test.ts
+++ b/app/javascript/controllers/pull_to_refresh_controller.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import PullToRefreshController from "./pull_to_refresh_controller"
+
+// A pull is finger travel; the controller applies RESISTANCE=0.5 and triggers at
+// a 64px *pulled* distance, so ~128px+ of finger travel arms the refresh.
+function touch(type: string, clientX: number, clientY: number): Event {
+  const e = new Event(type, { bubbles: true, cancelable: true })
+  const point = { clientX, clientY }
+  Object.assign(e, { touches: [point], changedTouches: [point] })
+  return e
+}
+
+describe("PullToRefreshController", () => {
+  let application: Application
+  let element: HTMLElement
+  let visit: ReturnType<typeof vi.fn>
+
+  function setStandalone(standalone: boolean): void {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: standalone }) as unknown as typeof window.matchMedia
+  }
+
+  // Mount on a child element (not <body>) so removing it in teardown reliably
+  // fires disconnect() and unhooks the window listeners between tests.
+  async function mount(): Promise<void> {
+    element = document.createElement("div")
+    element.setAttribute("data-controller", "pull-to-refresh")
+    document.body.appendChild(element)
+    await new Promise((r) => setTimeout(r, 0))
+  }
+
+  function pull(fromY: number, toY: number): void {
+    window.dispatchEvent(touch("touchstart", 100, fromY))
+    window.dispatchEvent(touch("touchmove", 100, toY))
+    window.dispatchEvent(touch("touchend", 100, toY))
+  }
+
+  beforeAll(() => {
+    application = Application.start()
+    application.register("pull-to-refresh", PullToRefreshController)
+  })
+
+  afterAll(() => {
+    application.stop()
+  })
+
+  beforeEach(() => {
+    visit = vi.fn()
+    window.Turbo = { visit } as unknown as typeof window.Turbo
+    vi.stubGlobal("requestAnimationFrame", () => 1)
+    vi.stubGlobal("cancelAnimationFrame", () => {})
+  })
+
+  afterEach(async () => {
+    element?.remove()
+    // Let Stimulus observe the removal and run disconnect().
+    await new Promise((r) => setTimeout(r, 0))
+    document.body.innerHTML = ""
+    delete window.Turbo
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it("does nothing outside a standalone PWA", async () => {
+    setStandalone(false)
+    await mount()
+    expect(document.querySelector(".pull-to-refresh-indicator")).toBeNull()
+    pull(10, 300)
+    expect(visit).not.toHaveBeenCalled()
+  })
+
+  it("injects the indicator when running as a standalone PWA", async () => {
+    setStandalone(true)
+    await mount()
+    expect(document.querySelector(".pull-to-refresh-indicator")).not.toBeNull()
+  })
+
+  it("refreshes via Turbo when pulled past the threshold and released", async () => {
+    setStandalone(true)
+    await mount()
+    pull(10, 300) // 290px travel → ~96px pull, well past the 64px trigger
+    expect(visit).toHaveBeenCalledTimes(1)
+    expect(visit).toHaveBeenCalledWith(window.location.href, { action: "replace" })
+  })
+
+  it("does not refresh when the pull is too short", async () => {
+    setStandalone(true)
+    await mount()
+    pull(10, 90) // 80px travel → 40px pull, below the 64px trigger
+    expect(visit).not.toHaveBeenCalled()
+  })
+
+  it("ignores a mostly-horizontal swipe", async () => {
+    setStandalone(true)
+    await mount()
+    window.dispatchEvent(touch("touchstart", 100, 10))
+    window.dispatchEvent(touch("touchmove", 400, 60)) // dx 300 > dy 50
+    window.dispatchEvent(touch("touchend", 400, 60))
+    expect(visit).not.toHaveBeenCalled()
+  })
+
+  it("falls back to a full reload when Turbo is absent", async () => {
+    delete window.Turbo
+    const reload = vi.fn()
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, href: "https://example.test/", reload },
+      configurable: true,
+      writable: true,
+    })
+    setStandalone(true)
+    await mount()
+    pull(10, 300)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it("removes the indicator on disconnect", async () => {
+    setStandalone(true)
+    await mount()
+    expect(document.querySelector(".pull-to-refresh-indicator")).not.toBeNull()
+    element.remove()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(document.querySelector(".pull-to-refresh-indicator")).toBeNull()
+  })
+})

--- a/app/javascript/controllers/pull_to_refresh_controller.ts
+++ b/app/javascript/controllers/pull_to_refresh_controller.ts
@@ -1,0 +1,195 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Pull-to-refresh for the installed PWA (#401, pairs with the mobile back
+// button #322).
+//
+// A browser gives you pull-to-refresh for free, but a PWA in standalone /
+// fullscreen display has no browser chrome and no native overscroll refresh —
+// so the same gesture that reloads any web page does nothing once Harmonic is
+// installed to the home screen. This wires it up ourselves, but ONLY in that
+// standalone case: in a normal mobile browser the platform still owns the
+// gesture and we must not double up on it.
+//
+// Wired on <body> (alongside places-sheet). When active, a drag downward from
+// the very top of the page pulls a spinner into view; releasing past the
+// threshold refreshes the current page (Turbo Drive when present, a full
+// reload otherwise). Below the threshold it springs back and nothing happens.
+//
+//   <body data-controller="places-sheet pull-to-refresh">
+//
+// The whole page (window) is the scroll container here — see _base.css — so we
+// read window.scrollY to know when we're at the top, and translate a spinner
+// element the controller injects into <body>.
+declare global {
+  interface Window {
+    Turbo?: { visit: (location: string, options?: { action?: string }) => void }
+  }
+}
+
+// Multiplier applied to finger travel so the pull feels weighted (rubber-band).
+const RESISTANCE = 0.5
+// Visual pull (px, after resistance) at which release triggers a refresh.
+const TRIGGER_THRESHOLD = 64
+// Cap on how far the indicator travels, so an aggressive drag doesn't fling it.
+const MAX_PULL = 96
+
+export default class PullToRefreshController extends Controller<HTMLElement> {
+  private indicator: HTMLElement | null = null
+  private spinner: HTMLElement | null = null
+
+  private tracking = false
+  private refreshing = false
+  private startX = 0
+  private startY = 0
+  private pull = 0
+  private frame = 0
+
+  private readonly onTouchStart = (e: TouchEvent): void => this.handleStart(e)
+  private readonly onTouchMove = (e: TouchEvent): void => this.handleMove(e)
+  private readonly onTouchEnd = (): void => this.handleEnd()
+
+  connect(): void {
+    // Only take over the gesture where the platform doesn't provide it.
+    if (!this.isStandalone()) return
+
+    this.buildIndicator()
+    window.addEventListener("touchstart", this.onTouchStart, { passive: true })
+    // Non-passive: we preventDefault while actively pulling so the page's own
+    // overscroll doesn't fight the indicator.
+    window.addEventListener("touchmove", this.onTouchMove, { passive: false })
+    window.addEventListener("touchend", this.onTouchEnd, { passive: true })
+    window.addEventListener("touchcancel", this.onTouchEnd, { passive: true })
+  }
+
+  disconnect(): void {
+    window.removeEventListener("touchstart", this.onTouchStart)
+    window.removeEventListener("touchmove", this.onTouchMove)
+    window.removeEventListener("touchend", this.onTouchEnd)
+    window.removeEventListener("touchcancel", this.onTouchEnd)
+    if (this.frame) cancelAnimationFrame(this.frame)
+    this.indicator?.remove()
+    this.indicator = null
+    this.spinner = null
+  }
+
+  private handleStart(e: TouchEvent): void {
+    // Start a pull only from the top of the page, with a single finger, and
+    // not while a refresh is already in flight.
+    if (this.refreshing || e.touches.length !== 1 || this.currentScrollY() > 0) return
+    const touch = e.touches[0]
+    this.tracking = true
+    this.startX = touch.clientX
+    this.startY = touch.clientY
+    this.pull = 0
+  }
+
+  private handleMove(e: TouchEvent): void {
+    if (!this.tracking) return
+    const touch = e.touches[0]
+    const dy = touch.clientY - this.startY
+    const dx = touch.clientX - this.startX
+
+    // Bail on upward scroll, a scroll that left the top, or a mostly-horizontal
+    // gesture (e.g. a swipe) — let the page handle those normally.
+    if (dy <= 0 || this.currentScrollY() > 0 || Math.abs(dx) > Math.abs(dy)) {
+      this.reset()
+      return
+    }
+
+    // We're committing to a pull: stop the page from scrolling/bouncing.
+    e.preventDefault()
+    this.pull = Math.min(dy * RESISTANCE, MAX_PULL)
+    this.render()
+  }
+
+  private handleEnd(): void {
+    if (!this.tracking) return
+    if (this.pull >= TRIGGER_THRESHOLD) {
+      this.refresh()
+    } else {
+      this.reset()
+    }
+  }
+
+  private refresh(): void {
+    this.refreshing = true
+    this.tracking = false
+    if (this.indicator) {
+      this.indicator.classList.add("pull-to-refresh-indicator--animating")
+      this.indicator.classList.remove("pull-to-refresh-indicator--armed")
+      this.indicator.classList.add("pull-to-refresh-indicator--refreshing")
+      this.indicator.style.transform = `translateY(${TRIGGER_THRESHOLD}px)`
+      this.indicator.style.opacity = "1"
+    }
+    if (this.spinner) this.spinner.style.transform = ""
+
+    const href = window.location.href
+    if (window.Turbo) {
+      window.Turbo.visit(href, { action: "replace" })
+    } else {
+      window.location.reload()
+    }
+  }
+
+  private render(): void {
+    if (this.frame) return
+    this.frame = requestAnimationFrame(() => {
+      this.frame = 0
+      const indicator = this.indicator
+      const spinner = this.spinner
+      if (!indicator || !spinner) return
+      const progress = Math.min(this.pull / TRIGGER_THRESHOLD, 1)
+      indicator.classList.remove("pull-to-refresh-indicator--animating")
+      indicator.style.transform = `translateY(${this.pull}px)`
+      indicator.style.opacity = String(progress)
+      indicator.classList.toggle("pull-to-refresh-indicator--armed", this.pull >= TRIGGER_THRESHOLD)
+      // Wind the spinner up as the pull deepens for tactile feedback.
+      spinner.style.transform = `rotate(${progress * 270}deg)`
+    })
+  }
+
+  // Spring the indicator back out of view and drop the gesture.
+  private reset(): void {
+    this.tracking = false
+    this.pull = 0
+    if (this.frame) {
+      cancelAnimationFrame(this.frame)
+      this.frame = 0
+    }
+    const indicator = this.indicator
+    if (indicator) {
+      indicator.classList.add("pull-to-refresh-indicator--animating")
+      indicator.classList.remove("pull-to-refresh-indicator--armed")
+      indicator.style.transform = ""
+      indicator.style.opacity = "0"
+    }
+    if (this.spinner) this.spinner.style.transform = ""
+  }
+
+  private buildIndicator(): void {
+    if (this.indicator) return
+    const indicator = document.createElement("div")
+    indicator.className = "pull-to-refresh-indicator"
+    indicator.setAttribute("aria-hidden", "true")
+    const spinner = document.createElement("span")
+    spinner.className = "pull-to-refresh-spinner"
+    indicator.appendChild(spinner)
+    document.body.appendChild(indicator)
+    this.indicator = indicator
+    this.spinner = spinner
+  }
+
+  private currentScrollY(): number {
+    // Clamp iOS rubber-band overscroll, matching auto-hide-header.
+    return Math.max(0, window.scrollY)
+  }
+
+  private isStandalone(): boolean {
+    const media =
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(display-mode: standalone), (display-mode: fullscreen), (display-mode: minimal-ui)").matches
+    // iOS Safari predates display-mode and exposes navigator.standalone instead.
+    const iosStandalone = (window.navigator as Navigator & { standalone?: boolean }).standalone === true
+    return media || iosStandalone
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
     <%= stylesheet_link_tag "pulse", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
-  <body data-controller="places-sheet">
+  <body data-controller="places-sheet pull-to-refresh">
     <div id="expanding-heart">
       <%= octicon 'heart' %>
     </div>


### PR DESCRIPTION
Closes #401. Pairs with the mobile back button (#322).

## Why
A browser gives you pull-to-refresh for free, but a PWA in **standalone / fullscreen** display has no browser chrome and no native overscroll refresh — so the gesture that reloads any web page does nothing once Harmonic is installed to the home screen. Same gap #322 filled for the missing back control.

## What
A `pull-to-refresh` Stimulus controller on `<body>` that activates **only in standalone mode** (`matchMedia('(display-mode: standalone/fullscreen/minimal-ui)')`, or `navigator.standalone` on iOS Safari). In a normal mobile browser it stays inert so we never double up on the platform's own gesture.

When active, a downward drag from the very top of the page (the window is the scroll container — see `_base.css`):
- pulls a spinner into view with weighted resistance, arming at 64px of pull;
- on release past the threshold, refreshes the current page — Turbo Drive (`Turbo.visit(href, { action: "replace" })`) when present, a full `location.reload()` otherwise;
- below the threshold, springs back and does nothing.

It bails on upward scroll, a scroll that left the top, or a mostly-horizontal gesture, so normal scrolling and swipes are untouched. The indicator element is injected by the controller, so there's **no dead affordance** without JS or outside the PWA — mirroring #322's philosophy.

## Files
- `controllers/pull_to_refresh_controller.ts` + test (7 cases: standalone gating, threshold arm/refuse, Turbo vs reload, horizontal-swipe guard, disconnect cleanup)
- `pulse/_pull_to_refresh.css` (new partial; app design tokens + shared `spin` keyframe) wired into `pulse.css`
- registered in `controllers/index.ts`, wired onto `<body>` in `application.html.erb`

## Testing
`npx tsc --noEmit` clean; `npx vitest run` — **422 passed** (incl. the 7 new); `npm run build` succeeds.

Note: standalone-only behavior can't be exercised in a normal desktop browser tab; the gesture logic is covered by unit tests. Happy to walk through it on a home-screen install if you want a live check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)