### PR TITLE
Fix stale 'this week' empty-feed copy and all-time link loop (#448)

### DIFF
--- a/app/views/pulse/feed.html.erb
+++ b/app/views/pulse/feed.html.erb
@@ -19,16 +19,11 @@
           <%= render 'pulse/feed_item', feed_item: feed_item %>
         <% end %>
       <% elsif default_feed_view? %>
+        <%# The default view spans all cycles (it only hides comments), so an
+            empty default feed is empty across all time — no "this week" window
+            to broaden past. %>
         <div class="pulse-feed-empty">
-          <% if @feed_default_query.present? %>
-            <p>Nothing here this week.</p>
-            <p class="pulse-body-text-muted">
-              <%= link_to "Show all time", "#{@current_collective.path}?q=" %>
-            </p>
-          <% else %>
-            <%# Workspaces: no default query, so the default view IS all time. %>
-            <p>Nothing here yet.</p>
-          <% end %>
+          <p>Nothing here yet.</p>
         </div>
       <% else %>
         <div class="pulse-feed-empty">

--- a/app/views/pulse/feed.md.erb
+++ b/app/views/pulse/feed.md.erb
@@ -15,7 +15,7 @@ You must send a heartbeat to access this collective for the current cycle.
 <% end -%>
 <% elsif default_feed_view? %>
 
-Nothing here this week. Pass `?q=` (empty) to browse all time, or refine with [filters](/help/search).
+Nothing here yet. Refine with [filters](/help/search) to narrow the view.
 <% else %>
 
 No results match the current query. The canonical URL (no `q` param) restores the default view.

--- a/test/controllers/pulse_controller_test.rb
+++ b/test/controllers/pulse_controller_test.rb
@@ -172,6 +172,26 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, "ancient collective post"
   end
 
+  test "an empty default feed says nothing yet, not this week, and offers no all-time loop" do
+    # The default query spans all cycles now (it only hides comments), so an
+    # empty default feed is empty across all time — the stale "this week" copy
+    # and its "Show all time" link (which looped back to the same view) are gone.
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    empty = Collective.create!(
+      tenant: @tenant, created_by: @user,
+      name: "Empty Feed Collective", handle: "empty-feed-#{SecureRandom.hex(4)}",
+    )
+    empty.add_user!(@user)
+    Tenant.clear_thread_scope
+
+    sign_in_as(@user, tenant: @tenant)
+    get empty.path.to_s
+    assert_response :success
+    assert_select ".pulse-feed-empty p", text: "Nothing here yet."
+    assert_not_includes response.body, "Nothing here this week."
+    assert_select "a", text: "Show all time", count: 0
+  end
+
   test "collective feed cannot be pointed at another collective" do
     sign_in_as(@user, tenant: @tenant)
     get "#{@collective.path}", params: { q: "collective:someplace-else" }


### PR DESCRIPTION
Fixes #448.

## Problem

#434 removed `cycle:this-week` from the default collective feed query — the default now only hides comments (`-subtype:comment`) and spans all cycles. But the empty-state copy was never updated:

- An empty default feed still said **"Nothing here this week."** with a **"Show all time"** link to `?q=`.
- `?q=` (empty) is a *refinement*, not the default view, so it rendered **"No results match your filters."** → **"Clear filters"** → back to the default → **"Nothing here this week."**

For a genuinely empty collective, clicking through looped between the two messages.

## Fix

The default view already spans all time, so there is no "this week" window to broaden past. Drop the stale copy and the looping link: an empty default feed now just says **"Nothing here yet."** for collectives and workspaces alike (HTML + markdown views).

## Test

Added a regression test asserting an empty collective's default feed shows "Nothing here yet.", never "Nothing here this week.", and offers no "Show all time" link. Full `pulse_controller_test` green (18 runs, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)