### PR TITLE
Special @-tags: @everyone / @admins + reserved-handle registry (#449)

### DIFF
--- a/app/models/collective.rb
+++ b/app/models/collective.rb
@@ -883,14 +883,23 @@ class Collective < ApplicationRecord
     !!(open_to_all || all_members_can_invite)
   end
 
+  # Members holding `role` (e.g. "admin", "representative", "summarizer").
+  # Backs the role group tags (@admins/@representatives/… — see
+  # MentionParser.resolve_collective_local), which are derived from the role
+  # list so this stays the single lookup for any current or future role.
+  sig { params(role: String).returns(T::Array[User]) }
+  def users_with_role(role)
+    T.unsafe(collective_members).where_has_role(role).map(&:user)
+  end
+
   sig { returns(T::Array[User]) }
   def representatives
-    T.unsafe(collective_members).where_has_role("representative").map(&:user)
+    users_with_role("representative")
   end
 
   sig { returns(T::Array[User]) }
   def admins
-    T.unsafe(collective_members).where_has_role("admin").map(&:user)
+    users_with_role("admin")
   end
 
   # True when `user` holds the admin role in this collective. Gates the

--- a/app/models/collective.rb
+++ b/app/models/collective.rb
@@ -124,7 +124,7 @@ class Collective < ApplicationRecord
 
   sig { params(handle: String).returns(T::Boolean) }
   def self.handle_available?(handle)
-    return false if RESERVED_HANDLES.include?(handle.to_s.downcase)
+    return false if ReservedHandles.forbidden_for_collective?(handle)
 
     # Collective and user handles share one per-tenant namespace (Goal 2 of
     # handle-model-unification): creating a collective also seeds an identity
@@ -652,8 +652,6 @@ class Collective < ApplicationRecord
     paid_tier?
   end
 
-  RESERVED_HANDLES = ["main"].freeze
-
   sig { void }
   def handle_is_valid
     if handle.present?
@@ -662,7 +660,7 @@ class Collective < ApplicationRecord
       # (tenant_id, handle) uniqueness index stay case-insensitive.
       only_alphanumeric_with_dash = T.must(handle).match?(/\A[a-zA-Z0-9-]+\z/)
       errors.add(:handle, "must be alphanumeric with dashes") unless only_alphanumeric_with_dash
-      errors.add(:handle, "is reserved") if RESERVED_HANDLES.include?(T.must(handle).downcase)
+      errors.add(:handle, "is reserved") if ReservedHandles.forbidden_for_collective?(handle)
     else
       errors.add(:handle, "can't be blank")
     end
@@ -893,6 +891,25 @@ class Collective < ApplicationRecord
   sig { returns(T::Array[User]) }
   def admins
     T.unsafe(collective_members).where_has_role("admin").map(&:user)
+  end
+
+  # True when `user` holds the admin role in this collective. Gates the
+  # @everyone mention (admin-only); see MentionParser.resolve_collective_local.
+  sig { params(user: T.nilable(User)).returns(T::Boolean) }
+  def admin?(user)
+    return false if user.nil?
+
+    T.unsafe(collective_members).where_has_role("admin").exists?(user_id: user.id)
+  end
+
+  # Every current (non-archived) member's user. Unlike #team this is uncapped —
+  # it backs the @everyone fan-out, which must reach the whole collective.
+  sig { returns(T::Array[User]) }
+  def member_users
+    collective_members
+      .where(archived_at: nil)
+      .includes(:user)
+      .map(&:user)
   end
 
   sig { returns(T::Boolean) }

--- a/app/models/reserved_handles.rb
+++ b/app/models/reserved_handles.rb
@@ -3,15 +3,21 @@
 # Single source of truth for handles that are not ordinary, user-claimable
 # handles. Two kinds live here:
 #
-#   * GROUP TAGS (@everyone, @admins) — collective-local aliases that a mention
-#     expands to a *set* of users, by membership or role. They never name a real
-#     user record, so no user (and no collective, whose identity user shares the
-#     same tenant namespace) may claim them.
+#   * GROUP TAGS (@everyone, @admins, @representatives, @summarizers, …) —
+#     collective-local aliases that a mention expands to a *set* of users, by
+#     membership or role. They never name a real user record, so no user (and
+#     no collective, whose identity user shares the same tenant namespace) may
+#     claim them.
 #   * AGENT HANDLES (@trio) — real user records that share one name across
 #     collectives while each resolves collective-locally to the local instance.
 #     Claimable only by a system agent whose system_role matches. This is also
 #     the mechanism for the cross-collective agent-identity angle (@claude/@trio
 #     → local instance).
+#
+# The role group tags are DERIVED from the collective role list
+# (CollectiveMember.valid_roles) rather than hardcoded, so adding a role — or,
+# later, a per-collective custom role — automatically reserves and resolves its
+# @<role>s tag with no change here. (#453 feedback)
 #
 # Before this registry the same facts were scattered across
 # Collective::RESERVED_HANDLES, TenantUser::RESERVED_HANDLES, and
@@ -24,11 +30,23 @@ module ReservedHandles
 
   # --- Group tags -----------------------------------------------------------
   EVERYONE = "everyone"
-  ADMINS   = "admins"
   # @here (currently-active members) is intentionally deferred to a later pass.
 
-  # Order is the fan-out order used when a mention names several tags.
-  GROUP_TAGS = T.let([EVERYONE, ADMINS].freeze, T::Array[String])
+  # Each collective role maps to its pluralized tag (admin → @admins,
+  # representative → @representatives, summarizer → @summarizers). Keyed by tag
+  # so resolution and reservation can look up the role a tag expands to. Derived
+  # from the role list, so it tracks new/custom roles automatically.
+  sig { returns(T::Hash[String, String]) }
+  def self.role_tags
+    T.unsafe(CollectiveMember).valid_roles.index_by { |role| role.pluralize }
+  end
+
+  # @everyone plus every role tag: the handles a mention expands to a *set* of
+  # users. No user or collective may claim any of them.
+  sig { returns(T::Array[String]) }
+  def self.group_tags
+    [EVERYONE] + role_tags.keys
+  end
 
   # --- Agent-identity handles ----------------------------------------------
   # handle => system_role required to claim it. Only the main collective's trio
@@ -42,21 +60,20 @@ module ReservedHandles
   # Handles with no group/agent semantics that a collective still may not take.
   COLLECTIVE_ONLY = T.let(["main"].freeze, T::Array[String])
 
-  # Handles a mention resolves *within the collective it was written in* rather
-  # than through the tenant-wide handle index: group tags plus agent handles.
-  # Resolving these locally is what stops a collective-local tag (or a shared
-  # agent name) from fanning out to whoever happens to hold the literal handle
-  # elsewhere in the tenant.
-  COLLECTIVE_LOCAL = T.let((GROUP_TAGS + AGENT_ROLES.keys).freeze, T::Array[String])
-
   sig { params(handle: T.nilable(String)).returns(T::Boolean) }
   def self.group_tag?(handle)
-    GROUP_TAGS.include?(handle.to_s.downcase)
+    group_tags.include?(handle.to_s.downcase)
   end
 
+  # True when a mention resolves `handle` *within the collective it was written
+  # in* rather than through the tenant-wide handle index: group tags plus agent
+  # handles. Resolving these locally is what stops a collective-local tag (or a
+  # shared agent name) from fanning out to whoever happens to hold the literal
+  # handle elsewhere in the tenant.
   sig { params(handle: T.nilable(String)).returns(T::Boolean) }
   def self.collective_local?(handle)
-    COLLECTIVE_LOCAL.include?(handle.to_s.downcase)
+    h = handle.to_s.downcase
+    group_tag?(h) || AGENT_ROLES.key?(h)
   end
 
   # The system_role required to claim `handle` as a user, or nil when the handle
@@ -85,6 +102,6 @@ module ReservedHandles
   sig { params(handle: T.nilable(String)).returns(T::Boolean) }
   def self.forbidden_for_collective?(handle)
     h = handle.to_s.downcase
-    COLLECTIVE_ONLY.include?(h) || GROUP_TAGS.include?(h)
+    COLLECTIVE_ONLY.include?(h) || group_tag?(h)
   end
 end

--- a/app/models/reserved_handles.rb
+++ b/app/models/reserved_handles.rb
@@ -1,0 +1,90 @@
+# typed: strict
+
+# Single source of truth for handles that are not ordinary, user-claimable
+# handles. Two kinds live here:
+#
+#   * GROUP TAGS (@everyone, @admins) — collective-local aliases that a mention
+#     expands to a *set* of users, by membership or role. They never name a real
+#     user record, so no user (and no collective, whose identity user shares the
+#     same tenant namespace) may claim them.
+#   * AGENT HANDLES (@trio) — real user records that share one name across
+#     collectives while each resolves collective-locally to the local instance.
+#     Claimable only by a system agent whose system_role matches. This is also
+#     the mechanism for the cross-collective agent-identity angle (@claude/@trio
+#     → local instance).
+#
+# Before this registry the same facts were scattered across
+# Collective::RESERVED_HANDLES, TenantUser::RESERVED_HANDLES, and
+# MentionParser::TRIO_HANDLE, which had already drifted (a collective could be
+# named "trio" even though the handle was reserved for users). Folding them into
+# one place keeps reservation and collective-local resolution from diverging.
+# (#449)
+module ReservedHandles
+  extend T::Sig
+
+  # --- Group tags -----------------------------------------------------------
+  EVERYONE = "everyone"
+  ADMINS   = "admins"
+  # @here (currently-active members) is intentionally deferred to a later pass.
+
+  # Order is the fan-out order used when a mention names several tags.
+  GROUP_TAGS = T.let([EVERYONE, ADMINS].freeze, T::Array[String])
+
+  # --- Agent-identity handles ----------------------------------------------
+  # handle => system_role required to claim it. Only the main collective's trio
+  # actually holds the literal handle; per-collective trios carry hex-suffixed
+  # handles and are reached through the collective-local resolution below.
+  AGENT_ROLES = T.let({ "trio" => "trio" }.freeze, T::Hash[String, String])
+
+  TRIO = "trio"
+
+  # --- Collective-only reservations ----------------------------------------
+  # Handles with no group/agent semantics that a collective still may not take.
+  COLLECTIVE_ONLY = T.let(["main"].freeze, T::Array[String])
+
+  # Handles a mention resolves *within the collective it was written in* rather
+  # than through the tenant-wide handle index: group tags plus agent handles.
+  # Resolving these locally is what stops a collective-local tag (or a shared
+  # agent name) from fanning out to whoever happens to hold the literal handle
+  # elsewhere in the tenant.
+  COLLECTIVE_LOCAL = T.let((GROUP_TAGS + AGENT_ROLES.keys).freeze, T::Array[String])
+
+  sig { params(handle: T.nilable(String)).returns(T::Boolean) }
+  def self.group_tag?(handle)
+    GROUP_TAGS.include?(handle.to_s.downcase)
+  end
+
+  sig { params(handle: T.nilable(String)).returns(T::Boolean) }
+  def self.collective_local?(handle)
+    COLLECTIVE_LOCAL.include?(handle.to_s.downcase)
+  end
+
+  # The system_role required to claim `handle` as a user, or nil when the handle
+  # carries no role gate.
+  sig { params(handle: T.nilable(String)).returns(T.nilable(String)) }
+  def self.required_system_role(handle)
+    AGENT_ROLES[handle.to_s.downcase]
+  end
+
+  # True when `handle` may not be claimed by a user with the given system_role.
+  # Group tags are never a real user; an agent handle is claimable only by the
+  # matching system_role (identity users, which carry no system_role, are thus
+  # excluded from agent handles too).
+  sig { params(handle: T.nilable(String), system_role: T.nilable(String)).returns(T::Boolean) }
+  def self.forbidden_for_user?(handle, system_role: nil)
+    return true if group_tag?(handle)
+
+    required = required_system_role(handle)
+    !required.nil? && system_role != required
+  end
+
+  # True when no collective may take `handle` as its handle. Group tags are
+  # reserved so a collective (via its identity user) can't shadow the tag; the
+  # "main" handle is reserved for the main collective. Agent handles are left
+  # claimable as collective handles for backwards compatibility.
+  sig { params(handle: T.nilable(String)).returns(T::Boolean) }
+  def self.forbidden_for_collective?(handle)
+    h = handle.to_s.downcase
+    COLLECTIVE_ONLY.include?(h) || GROUP_TAGS.include?(h)
+  end
+end

--- a/app/models/tenant_user.rb
+++ b/app/models/tenant_user.rb
@@ -11,11 +11,12 @@ class TenantUser < ApplicationRecord
   belongs_to :user
   before_create :set_defaults
 
-  # Handles claimable only by a system agent with the matching system_role.
-  # Currently: "trio" is reserved for the trio system agent (only the main
-  # collective's trio actually claims it; other per-collective trios use
-  # random hex handles to avoid the tenant-wide uniqueness collision).
-  RESERVED_HANDLES = T.let({ "trio" => "trio" }.freeze, T::Hash[String, String])
+  # Backwards-compatible alias for the agent-handle role map, now owned by the
+  # ReservedHandles registry. Kept because a historical migration references
+  # `TenantUser::RESERVED_HANDLES`. New code should call ReservedHandles
+  # directly, which also knows about the group tags (@everyone/@admins) that no
+  # user may claim regardless of system_role. (#449)
+  RESERVED_HANDLES = T.let(ReservedHandles::AGENT_ROLES, T::Hash[String, String])
 
   BIO_MAX_LENGTH      = 500
   LOCATION_MAX_LENGTH = 100
@@ -66,13 +67,11 @@ class TenantUser < ApplicationRecord
 
   sig { void }
   def reserved_handle_requires_matching_system_role
-    # Reserved keys are lowercase; fold the (now case-preserving) handle so
-    # "Trio"/"TRIO" can't slip past the system-role gate.
+    # ReservedHandles folds case internally, so "Trio"/"TRIO" and "Everyone"
+    # can't slip past. Group tags are forbidden outright; agent handles require
+    # the matching system_role.
     return if handle.blank?
-
-    required_role = RESERVED_HANDLES[handle.downcase]
-    return unless required_role
-    return if T.must(user).system_role == required_role
+    return unless ReservedHandles.forbidden_for_user?(handle, system_role: T.must(user).system_role)
 
     errors.add(:handle, "is reserved")
   end
@@ -93,9 +92,8 @@ class TenantUser < ApplicationRecord
     # Names with no parameterizable characters (e.g. CJK or emoji-only)
     # yield "" — fall back to a neutral base rather than an empty handle.
     base = "user" if base.blank?
-    required_role = RESERVED_HANDLES[base]
     candidate = base
-    candidate = "#{base}-#{SecureRandom.hex(2)}" unless required_role.nil? || user.system_role == required_role
+    candidate = "#{base}-#{SecureRandom.hex(2)}" if ReservedHandles.forbidden_for_user?(base, system_role: user.system_role)
     candidate = "#{base}-#{SecureRandom.hex(2)}" while tenant_scoped_only(tenant_id).exists?(handle: candidate)
     candidate
   end
@@ -121,8 +119,9 @@ class TenantUser < ApplicationRecord
     scope = tenant_scoped_only(tenant_id)
     scope = scope.where.not(user_id: except_user_id) if except_user_id.present?
     candidate = root
-    # Identity users never carry a system_role, so any reserved key is off-limits.
-    candidate = "#{root}-#{SecureRandom.hex(2)}" if RESERVED_HANDLES.key?(root.downcase)
+    # Identity users never carry a system_role, so any group tag or agent handle
+    # is off-limits (forbidden_for_user? with a nil role rejects both).
+    candidate = "#{root}-#{SecureRandom.hex(2)}" if ReservedHandles.forbidden_for_user?(root, system_role: nil)
     candidate = "#{root}-#{SecureRandom.hex(2)}" while scope.exists?(handle: candidate)
     candidate
   end

--- a/app/services/api_helper.rb
+++ b/app/services/api_helper.rb
@@ -412,7 +412,8 @@ class ApiHelper
     mentioned_users = MentionParser.parse_for_notification(
       note.text,
       tenant_id: current_tenant.id,
-      collective: current_collective
+      collective: current_collective,
+      author: current_user
     )
 
     begin

--- a/app/services/mention_parser.rb
+++ b/app/services/mention_parser.rb
@@ -109,12 +109,16 @@ class MentionParser
   end
 
   # Expand collective-local tags to the users they name, within `collective`:
-  #   @trio     → this collective's trio user
-  #   @admins   → this collective's admins (any member may use it)
-  #   @everyone → all members, but only when `author` is an admin. Without a
-  #               known admin author the tag expands to nobody, so it can never
-  #               fan out by accident (e.g. background/system parse paths that
-  #               don't carry an author).
+  #   @trio             → this collective's trio user
+  #   @admins /         → members holding that role (any member may use a role
+  #   @representatives /   tag). The tags come from ReservedHandles.role_tags,
+  #   @summarizers / …     which is derived from the collective role list, so a
+  #                        new/custom role's tag resolves here with no change.
+  #   @everyone         → all members, but only when `author` is an admin.
+  #                       Without a known admin author the tag expands to nobody,
+  #                       so it can never fan out by accident (e.g.
+  #                       background/system parse paths that don't carry an
+  #                       author).
   sig do
     params(
       handles: T::Array[String],
@@ -131,7 +135,9 @@ class MentionParser
       result << trio if trio
     end
 
-    result.concat(collective.admins) if wanted.include?(ReservedHandles::ADMINS)
+    ReservedHandles.role_tags.each do |tag, role|
+      result.concat(collective.users_with_role(role)) if wanted.include?(tag)
+    end
 
     if wanted.include?(ReservedHandles::EVERYONE) && author && collective.admin?(author)
       result.concat(collective.member_users)

--- a/app/services/mention_parser.rb
+++ b/app/services/mention_parser.rb
@@ -6,7 +6,9 @@ class MentionParser
   extend T::Sig
 
   MENTION_PATTERN = /@([a-zA-Z0-9_-]+)/
-  TRIO_HANDLE = "trio"
+  # Kept as an alias so existing references (User, autocomplete, dispatcher)
+  # keep working; the canonical value now lives in the reserved-handle registry.
+  TRIO_HANDLE = ReservedHandles::TRIO
 
   # A Redcarpet plain-text renderer that drops code while keeping every other
   # kind of text. It subclasses StripDown — which already extracts the text
@@ -49,21 +51,22 @@ class MentionParser
       text: T.nilable(String),
       tenant_id: T.nilable(String),
       collective: T.nilable(Collective),
+      author: T.nilable(User),
     ).returns(T::Array[User])
   end
-  def self.parse(text, tenant_id:, collective: nil)
+  def self.parse(text, tenant_id:, collective: nil, author: nil)
     return [] if text.blank? || tenant_id.blank?
 
     handles = extract_handles(text)
     return [] if handles.empty?
 
-    # When a collective is provided, "@trio" ALWAYS means this collective's
-    # trio. The handle index would otherwise also resolve "@trio" to the
-    # main collective's trio (which claims the literal handle "trio") even
-    # when mentioned in some other collective, fanning out the mention to a
-    # trio that isn't local to the conversation.
+    # Collective-local handles (@trio, @everyone, @admins) ALWAYS mean this
+    # collective's trio/members/admins. The tenant-wide handle index would
+    # otherwise resolve, say, "@trio" to the main collective's trio (which
+    # claims the literal handle) even when written in some other collective,
+    # fanning out the mention to a set that isn't local to the conversation.
     index_handles = if collective
-      handles - [TRIO_HANDLE]
+      handles.reject { |h| ReservedHandles.collective_local?(h) }
     else
       handles
     end
@@ -76,31 +79,67 @@ class MentionParser
       []
     end
 
-    if collective && handles.include?(TRIO_HANDLE)
-      trio = collective.trio_user
-      users << trio if trio
-    end
+    users.concat(resolve_collective_local(handles, collective: collective, author: author)) if collective
 
-    users
+    # A user can be named by more than one tag (mentioned directly and via
+    # @everyone, or in both @everyone and @admins); collapse so callers don't
+    # double-notify.
+    users.uniq(&:id)
   end
 
   # Parse mentions and filter to valid notification recipients:
   # - Must be a member of the collective
   # - Must not be the excluded user (typically the actor)
+  #
+  # `author` is the user whose text this is; it gates @everyone (admin-only).
   sig do
     params(
       text: T.nilable(String),
       tenant_id: T.nilable(String),
       collective: Collective,
       exclude_user: T.nilable(User),
+      author: T.nilable(User),
     ).returns(T::Array[User])
   end
-  def self.parse_for_notification(text, tenant_id:, collective:, exclude_user: nil)
-    users = parse(text, tenant_id: tenant_id, collective: collective)
+  def self.parse_for_notification(text, tenant_id:, collective:, exclude_user: nil, author: nil)
+    users = parse(text, tenant_id: tenant_id, collective: collective, author: author)
     users
       .reject { |u| exclude_user && u.id == exclude_user.id }
       .select { |u| collective.user_is_member?(u) }
   end
+
+  # Expand collective-local tags to the users they name, within `collective`:
+  #   @trio     → this collective's trio user
+  #   @admins   → this collective's admins (any member may use it)
+  #   @everyone → all members, but only when `author` is an admin. Without a
+  #               known admin author the tag expands to nobody, so it can never
+  #               fan out by accident (e.g. background/system parse paths that
+  #               don't carry an author).
+  sig do
+    params(
+      handles: T::Array[String],
+      collective: Collective,
+      author: T.nilable(User),
+    ).returns(T::Array[User])
+  end
+  def self.resolve_collective_local(handles, collective:, author:)
+    wanted = handles.map(&:downcase)
+    result = T.let([], T::Array[User])
+
+    if wanted.include?(TRIO_HANDLE)
+      trio = collective.trio_user
+      result << trio if trio
+    end
+
+    result.concat(collective.admins) if wanted.include?(ReservedHandles::ADMINS)
+
+    if wanted.include?(ReservedHandles::EVERYONE) && author && collective.admin?(author)
+      result.concat(collective.member_users)
+    end
+
+    result
+  end
+  private_class_method :resolve_collective_local
 
   # Resolve mentioned handles to profile paths so @mentions can be rendered
   # as links. Returns a hash of { handle => profile_path } containing only
@@ -121,11 +160,10 @@ class MentionParser
     handles = extract_handles(text, strip: false)
     return {} if handles.empty?
 
-    # Same @trio handling as .parse: when a collective is provided, "@trio"
-    # always means this collective's trio, resolved below rather than through
-    # the tenant-wide handle index.
+    # Same collective-local handling as .parse: within a collective, @trio and
+    # the group tags resolve locally, not through the tenant-wide handle index.
     index_handles = if collective
-      handles - [TRIO_HANDLE]
+      handles.reject { |h| ReservedHandles.collective_local?(h) }
     else
       handles
     end
@@ -141,9 +179,22 @@ class MentionParser
         end
     end
 
-    if collective && handles.include?(TRIO_HANDLE)
-      trio_path = collective.trio_user&.path
-      paths[TRIO_HANDLE] = trio_path if trio_path
+    if collective
+      # Keys are the handles as written (case preserved) so the renderer, which
+      # looks up each matched substring verbatim, links them regardless of case.
+      collective_path = collective.path
+      handles.each do |handle|
+        down = handle.downcase
+        if down == TRIO_HANDLE
+          trio_path = collective.trio_user&.path
+          paths[handle] = trio_path if trio_path
+        elsif ReservedHandles.group_tag?(down)
+          # @everyone / @admins render as a link to the collective. Rendering is
+          # display only — the admin-only gate on @everyone lives on the
+          # notification path, so the tag is shown regardless of who wrote it.
+          paths[handle] = collective_path
+        end
+      end
     end
 
     paths

--- a/app/services/notification_dispatcher.rb
+++ b/app/services/notification_dispatcher.rb
@@ -140,7 +140,7 @@ class NotificationDispatcher
     handle_reply_notification(event, note) if note.is_comment?
 
     # Find mentioned users from the note text
-    mentioned_users = MentionParser.parse(note.text, tenant_id: event.tenant_id, collective: note.collective)
+    mentioned_users = MentionParser.parse(note.text, tenant_id: event.tenant_id, collective: note.collective, author: event.actor)
 
     # Don't notify the actor (they mentioned themselves)
     mentioned_users = mentioned_users.reject { |u| u.id == event.actor_id }
@@ -313,7 +313,7 @@ class NotificationDispatcher
 
     # Parse mentions from question and description fields
     text_to_parse = [decision.question, decision.description].compact.join(" ")
-    mentioned_users = MentionParser.parse(text_to_parse, tenant_id: event.tenant_id, collective: decision.collective)
+    mentioned_users = MentionParser.parse(text_to_parse, tenant_id: event.tenant_id, collective: decision.collective, author: event.actor)
 
     # Don't notify the actor (they mentioned themselves)
     mentioned_users = mentioned_users.reject { |u| u.id == event.actor_id }
@@ -346,7 +346,7 @@ class NotificationDispatcher
 
     # Parse mentions from title and description fields
     text_to_parse = [commitment.title, commitment.description].compact.join(" ")
-    mentioned_users = MentionParser.parse(text_to_parse, tenant_id: event.tenant_id, collective: commitment.collective)
+    mentioned_users = MentionParser.parse(text_to_parse, tenant_id: event.tenant_id, collective: commitment.collective, author: event.actor)
 
     # Don't notify the actor (they mentioned themselves)
     mentioned_users = mentioned_users.reject { |u| u.id == event.actor_id }
@@ -380,7 +380,7 @@ class NotificationDispatcher
 
     # Parse mentions from title and description fields
     text_to_parse = [option.title, option.description].compact.join(" ")
-    mentioned_users = MentionParser.parse(text_to_parse, tenant_id: event.tenant_id, collective: option.collective)
+    mentioned_users = MentionParser.parse(text_to_parse, tenant_id: event.tenant_id, collective: option.collective, author: event.actor)
 
     # Don't notify the actor (they mentioned themselves)
     mentioned_users = mentioned_users.reject { |u| u.id == event.actor_id }

--- a/app/views/help/collectives.md.erb
+++ b/app/views/help/collectives.md.erb
@@ -23,6 +23,7 @@ Admins can configure:
 
 - **Admin** — Can change settings, manage members, and perform all actions
 - **Representative** — Can start representation sessions to act on behalf of the collective in other collectives
+- **Summarizer** — Can write and maintain the summaries of the collective's content
 - **Member** — Can create content, vote, comment, and participate in the collective
 
 ## Representation and Collective Agency

--- a/app/views/help/notifications.md.erb
+++ b/app/views/help/notifications.md.erb
@@ -16,6 +16,15 @@ Notifications keep you aware of activity that involves you across all collective
 
 Each notification links back to the content or event that triggered it.
 
+## Group Mentions
+
+Alongside mentioning an individual by their `@handle`, two special tags notify a group within the collective they're written in:
+
+- **`@admins`** — notifies the collective's admins. Any member may use it.
+- **`@everyone`** — notifies every member of the collective. Only admins can trigger an `@everyone` fan-out; written by a non-admin it's shown but notifies no one.
+
+Both resolve **collective-locally**: an `@everyone` in one collective never reaches another. These handles are reserved, so no one can register a user or collective named `everyone` or `admins`.
+
 ## Unread, Read, and Dismissed
 
 Notifications move through three states:

--- a/app/views/help/notifications.md.erb
+++ b/app/views/help/notifications.md.erb
@@ -18,12 +18,19 @@ Each notification links back to the content or event that triggered it.
 
 ## Group Mentions
 
-Alongside mentioning an individual by their `@handle`, two special tags notify a group within the collective they're written in:
+Alongside mentioning an individual by their `@handle`, a few special tags notify a group within the collective they're written in.
 
-- **`@admins`** — notifies the collective's admins. Any member may use it.
-- **`@everyone`** — notifies every member of the collective. Only admins can trigger an `@everyone` fan-out; written by a non-admin it's shown but notifies no one.
+**Role tags** notify every member holding a [collective role](/help/collectives#roles):
 
-Both resolve **collective-locally**: an `@everyone` in one collective never reaches another. These handles are reserved, so no one can register a user or collective named `everyone` or `admins`.
+- **`@admins`** — notifies the collective's admins.
+- **`@representatives`** — notifies its representatives.
+- **`@summarizers`** — notifies its summarizers.
+
+Any member may use a role tag. The set of role tags follows the collective's role list, so every role has a matching `@<role>s` tag — if a role is added later, its tag works automatically.
+
+**`@everyone`** notifies every member of the collective. Only admins can trigger an `@everyone` fan-out; written by a non-admin it's shown but notifies no one.
+
+All of these resolve **collective-locally**: an `@everyone` in one collective never reaches another. The tags are reserved, so no one can register a user or collective that would shadow one.
 
 ## Unread, Read, and Dismissed
 

--- a/test/models/collective_test.rb
+++ b/test/models/collective_test.rb
@@ -64,6 +64,24 @@ class CollectiveTest < ActiveSupport::TestCase
     assert_match(/handle is reserved/i, error.message)
   end
 
+  test "Collective rejects group-tag handles so they can't shadow the tag" do
+    tenant = create_tenant
+    user = create_user
+    ReservedHandles::GROUP_TAGS.each do |tag|
+      error = assert_raises(ActiveRecord::RecordInvalid, "#{tag} should be reserved") do
+        Collective.create!(tenant: tenant, created_by: user, name: tag.capitalize, handle: tag)
+      end
+      assert_match(/handle is reserved/i, error.message)
+    end
+  end
+
+  test "Collective.handle_available? returns false for group-tag handles" do
+    ReservedHandles::GROUP_TAGS.each do |tag|
+      assert_not Collective.handle_available?(tag), "#{tag} must be unavailable"
+      assert_not Collective.handle_available?(tag.upcase), "#{tag} check must be case-insensitive"
+    end
+  end
+
   test "Collective handle keeps the case the creator chose" do
     tenant = create_tenant
     user = create_user

--- a/test/models/collective_test.rb
+++ b/test/models/collective_test.rb
@@ -67,7 +67,7 @@ class CollectiveTest < ActiveSupport::TestCase
   test "Collective rejects group-tag handles so they can't shadow the tag" do
     tenant = create_tenant
     user = create_user
-    ReservedHandles::GROUP_TAGS.each do |tag|
+    ReservedHandles.group_tags.each do |tag|
       error = assert_raises(ActiveRecord::RecordInvalid, "#{tag} should be reserved") do
         Collective.create!(tenant: tenant, created_by: user, name: tag.capitalize, handle: tag)
       end
@@ -76,7 +76,7 @@ class CollectiveTest < ActiveSupport::TestCase
   end
 
   test "Collective.handle_available? returns false for group-tag handles" do
-    ReservedHandles::GROUP_TAGS.each do |tag|
+    ReservedHandles.group_tags.each do |tag|
       assert_not Collective.handle_available?(tag), "#{tag} must be unavailable"
       assert_not Collective.handle_available?(tag.upcase), "#{tag} check must be case-insensitive"
     end

--- a/test/models/reserved_handles_test.rb
+++ b/test/models/reserved_handles_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class ReservedHandlesTest < ActiveSupport::TestCase
+  test "group_tag? recognizes group tags case-insensitively" do
+    assert ReservedHandles.group_tag?("everyone")
+    assert ReservedHandles.group_tag?("Admins")
+    assert_not ReservedHandles.group_tag?("trio")
+    assert_not ReservedHandles.group_tag?("alice")
+    assert_not ReservedHandles.group_tag?(nil)
+  end
+
+  test "collective_local? covers group tags and agent handles" do
+    assert ReservedHandles.collective_local?("everyone")
+    assert ReservedHandles.collective_local?("admins")
+    assert ReservedHandles.collective_local?("trio")
+    assert_not ReservedHandles.collective_local?("alice")
+  end
+
+  test "required_system_role returns the agent role or nil" do
+    assert_equal "trio", ReservedHandles.required_system_role("trio")
+    assert_equal "trio", ReservedHandles.required_system_role("TRIO")
+    assert_nil ReservedHandles.required_system_role("everyone")
+    assert_nil ReservedHandles.required_system_role("alice")
+  end
+
+  test "forbidden_for_user? blocks group tags for everyone" do
+    assert ReservedHandles.forbidden_for_user?("everyone", system_role: nil)
+    assert ReservedHandles.forbidden_for_user?("everyone", system_role: "trio")
+    assert ReservedHandles.forbidden_for_user?("admins", system_role: "trio")
+  end
+
+  test "forbidden_for_user? gates agent handles on matching system_role" do
+    assert ReservedHandles.forbidden_for_user?("trio", system_role: nil)
+    assert ReservedHandles.forbidden_for_user?("trio", system_role: "something-else")
+    assert_not ReservedHandles.forbidden_for_user?("trio", system_role: "trio")
+  end
+
+  test "forbidden_for_user? allows ordinary handles" do
+    assert_not ReservedHandles.forbidden_for_user?("alice", system_role: nil)
+  end
+
+  test "forbidden_for_collective? blocks main and group tags but not agent handles" do
+    assert ReservedHandles.forbidden_for_collective?("main")
+    assert ReservedHandles.forbidden_for_collective?("everyone")
+    assert ReservedHandles.forbidden_for_collective?("ADMINS")
+    # Agent handles stay claimable as collective handles (backwards compatible).
+    assert_not ReservedHandles.forbidden_for_collective?("trio")
+    assert_not ReservedHandles.forbidden_for_collective?("alice")
+  end
+end

--- a/test/models/reserved_handles_test.rb
+++ b/test/models/reserved_handles_test.rb
@@ -9,7 +9,18 @@ class ReservedHandlesTest < ActiveSupport::TestCase
     assert_not ReservedHandles.group_tag?(nil)
   end
 
+  test "role_tags and group_tags are derived from the collective role list" do
+    # One pluralized tag per role, so new/custom roles reserve automatically.
+    expected = CollectiveMember.valid_roles.index_by(&:pluralize)
+    assert_equal expected, ReservedHandles.role_tags
+    # Every role's tag is a group tag, plus @everyone.
+    assert ReservedHandles.group_tag?("representatives")
+    assert ReservedHandles.group_tag?("summarizers")
+    assert_equal(["everyone"] + expected.keys, ReservedHandles.group_tags)
+  end
+
   test "collective_local? covers group tags and agent handles" do
+    assert ReservedHandles.collective_local?("representatives")
     assert ReservedHandles.collective_local?("everyone")
     assert ReservedHandles.collective_local?("admins")
     assert ReservedHandles.collective_local?("trio")

--- a/test/models/tenant_user_test.rb
+++ b/test/models/tenant_user_test.rb
@@ -350,6 +350,29 @@ class TenantUserTest < ActiveSupport::TestCase
     assert_includes tu.errors[:handle].to_s.downcase, "reserved"
   end
 
+  test "group tag handles are rejected for a human user" do
+    tenant = create_tenant
+    ReservedHandles::GROUP_TAGS.each do |tag|
+      user = create_user(email: "gt-#{tag}-#{SecureRandom.hex(4)}@example.com")
+      tu = TenantUser.new(tenant: tenant, user: user, handle: tag, display_name: user.name)
+      assert_not tu.valid?, "#{tag} should be reserved"
+      assert_includes tu.errors[:handle].to_s.downcase, "reserved"
+    end
+  end
+
+  test "a group tag handle is rejected even for a system agent" do
+    # Unlike @trio, group tags never name a real user, so no system_role
+    # entitles a record to claim them.
+    tenant = create_tenant
+    agent = User.create!(
+      email: "sys_#{SecureRandom.hex(4)}@system.harmonic.local",
+      name: "Everyone", user_type: "ai_agent", system_role: "trio", parent_id: nil,
+    )
+    tu = TenantUser.new(tenant: tenant, user: agent, handle: "everyone", display_name: "Everyone")
+    assert_not tu.valid?
+    assert_includes tu.errors[:handle].to_s.downcase, "reserved"
+  end
+
   test "handle 'trio' is rejected when set via update! on an existing TenantUser" do
     # Defense in depth: even if a caller bypasses the controller layer and
     # calls update! directly, the reserved-handle validation rejects "trio"

--- a/test/models/tenant_user_test.rb
+++ b/test/models/tenant_user_test.rb
@@ -352,7 +352,7 @@ class TenantUserTest < ActiveSupport::TestCase
 
   test "group tag handles are rejected for a human user" do
     tenant = create_tenant
-    ReservedHandles::GROUP_TAGS.each do |tag|
+    ReservedHandles.group_tags.each do |tag|
       user = create_user(email: "gt-#{tag}-#{SecureRandom.hex(4)}@example.com")
       tu = TenantUser.new(tenant: tenant, user: user, handle: tag, display_name: user.name)
       assert_not tu.valid?, "#{tag} should be reserved"

--- a/test/services/mention_parser_test.rb
+++ b/test/services/mention_parser_test.rb
@@ -196,6 +196,30 @@ class MentionParserTest < ActiveSupport::TestCase
     assert_not_includes result.map(&:id), member.id
   end
 
+  test "parse resolves every role tag to its role holders for any author" do
+    # The role tags are derived from CollectiveMember.valid_roles, so this
+    # covers @representatives / @summarizers as well as @admins, and any role
+    # added later. Each expands to the members holding that role.
+    tenant, collective, admin = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    collective.add_user!(admin, roles: ["admin"])
+
+    rep = create_user(email: "rep@example.com", name: "Rep")
+    tenant.add_user!(rep)
+    collective.add_user!(rep, roles: ["representative"])
+
+    summarizer = create_user(email: "sum@example.com", name: "Summarizer")
+    tenant.add_user!(summarizer)
+    collective.add_user!(summarizer, roles: ["summarizer"])
+
+    # A plain member (author) with no role can still use the role tags.
+    reps = MentionParser.parse("ping @representatives", tenant_id: tenant.id, collective: collective, author: rep)
+    assert_equal [rep.id], reps.map(&:id)
+
+    sums = MentionParser.parse("ping @summarizers", tenant_id: tenant.id, collective: collective, author: rep)
+    assert_equal [summarizer.id], sums.map(&:id)
+  end
+
   test "parse resolves @everyone to all members when the author is an admin" do
     tenant, collective, admin = create_tenant_collective_user
     Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)

--- a/test/services/mention_parser_test.rb
+++ b/test/services/mention_parser_test.rb
@@ -178,6 +178,104 @@ class MentionParserTest < ActiveSupport::TestCase
     assert_includes result.map(&:id), trio.id
   end
 
+  # === group tags: @everyone / @admins ===
+
+  test "parse resolves @admins to the collective's admins for any author" do
+    tenant, collective, admin = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    collective.add_user!(admin, roles: ["admin"])
+
+    member = create_user(email: "m@example.com", name: "Member")
+    tenant.add_user!(member)
+    collective.add_user!(member)
+
+    # A non-admin author still expands @admins.
+    result = MentionParser.parse("heads up @admins", tenant_id: tenant.id, collective: collective, author: member)
+
+    assert_includes result.map(&:id), admin.id
+    assert_not_includes result.map(&:id), member.id
+  end
+
+  test "parse resolves @everyone to all members when the author is an admin" do
+    tenant, collective, admin = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    collective.add_user!(admin, roles: ["admin"])
+
+    member = create_user(email: "m@example.com", name: "Member")
+    tenant.add_user!(member)
+    collective.add_user!(member)
+
+    result = MentionParser.parse("@everyone please read", tenant_id: tenant.id, collective: collective, author: admin)
+
+    assert_includes result.map(&:id), admin.id
+    assert_includes result.map(&:id), member.id
+  end
+
+  test "parse does not expand @everyone when the author is not an admin" do
+    tenant, collective, admin = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    collective.add_user!(admin, roles: ["admin"])
+
+    member = create_user(email: "m@example.com", name: "Member")
+    tenant.add_user!(member)
+    collective.add_user!(member)
+
+    result = MentionParser.parse("@everyone please read", tenant_id: tenant.id, collective: collective, author: member)
+
+    assert_equal [], result
+  end
+
+  test "parse does not expand @everyone without a known author" do
+    tenant, collective, admin = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    collective.add_user!(admin, roles: ["admin"])
+
+    # No author kwarg → the admin-only gate can't be satisfied, so no fan-out.
+    result = MentionParser.parse("@everyone please read", tenant_id: tenant.id, collective: collective)
+
+    assert_equal [], result
+  end
+
+  test "parse ignores group tags when no collective is provided" do
+    tenant, collective, admin = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    collective.add_user!(admin, roles: ["admin"])
+
+    result = MentionParser.parse("@everyone @admins", tenant_id: tenant.id, author: admin)
+
+    assert_equal [], result
+  end
+
+  test "parse dedupes a user named both directly and via a group tag" do
+    tenant, collective, admin = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    collective.add_user!(admin, roles: ["admin"])
+    admin.tenant_user.update!(handle: "alice")
+
+    result = MentionParser.parse("@everyone and especially @alice", tenant_id: tenant.id, collective: collective, author: admin)
+
+    assert_equal 1, result.count { |u| u.id == admin.id }
+  end
+
+  test "resolve_paths links group tags to the collective for any reader" do
+    tenant, collective, _admin = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+
+    result = MentionParser.resolve_paths("@everyone and @admins", tenant_id: tenant.id, collective: collective)
+
+    assert_equal collective.path, result["everyone"]
+    assert_equal collective.path, result["admins"]
+  end
+
+  test "resolve_paths leaves group tags unresolved without a collective" do
+    tenant, collective, _admin = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+
+    result = MentionParser.resolve_paths("@everyone", tenant_id: tenant.id)
+
+    assert_equal({}, result)
+  end
+
   test "parse ignores mentions that don't match users" do
     tenant, collective, user = create_tenant_collective_user
     Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)


### PR DESCRIPTION
Closes #449. Implements **Option B** from the design decision (harmonic-devs [ddeb6975](https://www.harmonic.social/collectives/harmonic-devs/d/ddeb6975), both voters starred it).

## What this does

Adds two collective-local group mention tags and folds handle-reservation into one registry.

### `ReservedHandles` registry (`app/models/reserved_handles.rb`)
Single source of truth for handles that aren't ordinary, user-claimable handles. Folds in the three places this fact used to live — `Collective::RESERVED_HANDLES`, `TenantUser::RESERVED_HANDLES`, `MentionParser::TRIO_HANDLE` — which had already drifted (a collective could be named `trio` even though the handle was reserved for users). It distinguishes:
- **Group tags** (`@everyone`, `@admins`) — expand to a *set* of users; never a real record, so no user or collective may claim them.
- **Agent handles** (`@trio`) — real records sharing one name across collectives, each resolving collective-locally. Role-gated. This is also the mechanism for the cross-collective agent-identity angle Dan flagged (`@claude`/`@trio` → local instance).

### Group-mention resolution (`MentionParser`)
- `@admins` → the collective's admins. Any member may use it.
- `@everyone` → all members, **but only when the author is an admin**. Without a known admin author (background/system parse paths) it expands to nobody, so it can never fan out by accident. The author is now threaded through the notification dispatcher and the reminder path.
- Results are deduped, so a user named directly *and* via a tag is notified once.
- Both resolve **collective-locally** — an `@everyone` in one collective never reaches another.
- Render path links `@everyone`/`@admins` to the collective page (display only; the admin gate lives on the notification path).

### Reservation
`everyone`/`admins` are now reserved across the unified user+collective namespace, so neither a user nor a collective identity can shadow the tag. Agent handles stay claimable as *collective* handles (backwards compatible; only the group tags are newly reserved).

## Deferred (follow-ups, not in this PR)
- **`@here`** (active/present members) — explicitly out of scope for v1 per Option B.
- **Interactive confirm dialog** for large `@everyone` fan-outs — the admin-only gate is the guardrail in this pass; a compose-time "notify N members?" confirm is a UI-layer follow-up.
- **Autocomplete** — surfacing `@everyone`/`@admins` in the mention autocomplete dropdown (the tags work when typed; they're just not suggested yet).

## Testing
All local, via `docker-compose.dev.yml`:
- `reserved_handles_test.rb` (new), `mention_parser_test.rb` (+group-tag section), `tenant_user_test.rb`, `collective_test.rb`, `notification_dispatcher_test.rb`, `automation_mention_filter_test.rb`, `markdown_renderer_test.rb`, `autocomplete_controller_test.rb` — all green.
- `srb tc` — no errors.

No migration (all resolution logic + a Ruby registry), so no `structure.sql` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)