### PR TITLE
Fix #469: let a collective identity post at the public root via MCP

### DIFF
--- a/app/services/action_authorization.rb
+++ b/app/services/action_authorization.rb
@@ -78,6 +78,16 @@ module ActionAuthorization
       return true unless collective
       # The collective's own identity user acts as a member of its own collective.
       return true if collective.identity_user?(user)
+      # A collective identity acting via representation (or a collective automation)
+      # is a member of the public main collective without a CollectiveMember record.
+      # This mirrors ApplicationController#validate_authenticated_access, whose main-
+      # collective branch does nothing for a collective_identity user rather than
+      # calling add_user!. Without this, a collective could author on its own pages
+      # and any collective it belongs to, but never at the public root (/note) over
+      # markdown/MCP — even though the browser HTML flow authorizes exactly that,
+      # which is why a human representative can post publicly as the collective but an
+      # agent representative gets "not authorized to perform 'create_note'". (#469)
+      return true if user.collective_identity? && collective.is_main_collective?
 
       collective.user_is_member?(user)
     },

--- a/test/integration/api_collective_representation_test.rb
+++ b/test/integration/api_collective_representation_test.rb
@@ -269,4 +269,52 @@ class ApiCollectiveRepresentationTest < ActionDispatch::IntegrationTest
                  "should explain the missing end capability")
     assert_equal 0, RepresentationSession.where(collective: @collective).count
   end
+
+  # ---------------------------------------------------------------------------
+  # Posting publicly at the root as the collective (#469)
+  #
+  # A human representative can post a public note at the main-collective root
+  # (/note) as the collective, but an AI-agent representative got
+  # "not authorized to perform 'create_note'". The acting identity is the
+  # represented collective's identity_user, which holds no CollectiveMember row
+  # on the main collective — so the :collective_member gate denied it over
+  # markdown/MCP even though the browser HTML flow authorizes exactly this.
+  # ---------------------------------------------------------------------------
+  test "agent representative can create a public note at the root as the collective" do
+    @tenant.main_collective.enable_api!
+
+    # The agent has public writes enabled (the #467 guardrail its owner toggled
+    # on) — so this exercises the *later* #469 gate, not that one.
+    agent = create_ai_agent(parent: @alice, name: "Pub Agent #{SecureRandom.hex(4)}",
+                            agent_configuration: { "mode" => "internal", "allow_public_writes" => true })
+    @tenant.add_user!(agent)
+    @collective.add_user!(agent)
+    @collective.collective_members.find_by(user: agent).add_role!("representative")
+    token = ApiToken.create!(tenant: @tenant, user: agent, scopes: ApiToken.valid_scopes)
+    headers = {
+      "Authorization" => "Bearer #{token.plaintext_token}",
+      "Accept" => "text/markdown",
+    }
+
+    post "#{represent_path}/actions/start_representation", headers: headers
+    assert_response :success, "start failed: #{response.body}"
+    session_id = response.body.match(/Session ID: `([a-f0-9-]+)`/)[1]
+
+    rep_headers = headers.merge(
+      "X-Representation-Session-ID" => session_id,
+      "X-Representing-Collective" => @collective.handle,
+    )
+
+    assert_difference -> { Note.count }, 1 do
+      post "/note/actions/create_note",
+           params: { text: "Public announcement from the collective." },
+           headers: rep_headers
+    end
+
+    assert_response :success, "root create_note under collective representation must succeed: #{response.body}"
+    note = Note.order(:created_at).last
+    assert_equal @collective.identity_user_id, note.created_by_id,
+                 "the note must be attributed to the collective identity, not the agent"
+    assert note.collective.is_main_collective?, "the note must land on the public main collective"
+  end
 end

--- a/test/services/action_authorization_test.rb
+++ b/test/services/action_authorization_test.rb
@@ -93,6 +93,36 @@ class ActionAuthorizationTest < ActiveSupport::TestCase
     refute ActionAuthorization.check_authorization(:collective_member, non_member, context)
   end
 
+  # Regression for #469: a collective identity acting via representation could not
+  # author at the public root (/note) over markdown/MCP because it holds no
+  # CollectiveMember record on the main collective — even though the browser flow
+  # authorizes it there. The check must treat a collective_identity user as a
+  # member of the main collective specifically.
+  test "collective_member authorization treats a collective identity as a member of the main collective" do
+    identity = @collective.identity_user
+    assert identity.collective_identity?, "sanity: identity_user is a collective_identity user"
+
+    main = @tenant.main_collective
+    # The identity is NOT a member of the main collective and is not ITS identity user...
+    refute main.identity_user?(identity)
+    refute main.user_is_member?(identity)
+    # ...yet it is authorized as a member of the public root.
+    assert ActionAuthorization.check_authorization(:collective_member, identity, { collective: main })
+
+    # But the relaxation is scoped to the MAIN collective only: the same identity
+    # is still denied on an unrelated collective it doesn't belong to.
+    other = create_collective(tenant: @tenant, created_by: @user, handle: "aa-other-#{SecureRandom.hex(4)}")
+    refute other.identity_user?(identity)
+    refute other.user_is_member?(identity)
+    refute ActionAuthorization.check_authorization(:collective_member, identity, { collective: other })
+
+    # And it does not open the root to non-identity non-members (e.g. a plain human).
+    human_non_member = create_user
+    @tenant.add_user!(human_non_member)
+    refute human_non_member.collective_identity?
+    refute ActionAuthorization.check_authorization(:collective_member, human_non_member, { collective: main })
+  end
+
   # Test: Resource owner authorization
   test "resource_owner authorization checks created_by_id" do
     note = Note.create!(


### PR DESCRIPTION
Fixes #469.

## Root cause

A collective acting through a representation session (or a collective automation) posts as its **`identity_user`**. That user holds no `CollectiveMember` record on the tenant's **main collective**, so the `:collective_member` authorization rule (`ActionAuthorization`) returned `false` at the public root (`/note`). Over markdown/MCP the agent representative got `"not authorized to perform 'create_note'"`, and reading `/note` as the collective listed **zero actions** in the frontmatter.

A **human** representative doesn't hit this, which is why the same post worked for a human but not for an agent:

- The browser HTML create path posts to a plain controller route, **not** `/actions/<name>`, so the execute-time `ActionAuthorizationCheck` gate is skipped (`app/controllers/concerns/action_authorization_check.rb:48`).
- `ApplicationController#validate_authenticated_access` explicitly **does nothing** (rather than requiring/creating membership) for a `collective_identity` user on the main collective (`application_controller.rb:606-611`).

So the browser path authorizes a collective posting at the root, but the markdown/MCP action path — which *does* run `ActionAuthorization.authorized?` — had no equivalent carve-out. The two surfaces disagreed. (This is distinct from the #467 public-writes toggle, which is an earlier gate that had already been passed.)

## Fix

Mirror the browser's rule in the authorization layer: in the `:collective_member` check, treat a `collective_identity` user as a member of the **main** collective specifically.

```ruby
return true if user.collective_identity? && collective.is_main_collective?
```

Scoped to the main (public) collective, so a collective identity still can't act on unrelated collectives it doesn't belong to. Because both the execute-time gate and the frontmatter action listing consult `ActionAuthorization.authorized?`, this fixes both — `/note` now lists **and** accepts `create_note` under a collective representation session.

To even *become* the collective identity user over MCP you must hold a valid representation session as the collective's representative (or be a collective automation), so representation itself remains the gate.

## Tests

- **Unit** (`action_authorization_test.rb`): a `collective_identity` user is authorized as a member of the main collective, but still denied on an unrelated collective, and the root is **not** opened to non-identity non-members.
- **Integration** (`api_collective_representation_test.rb`): an agent representative (with public-writes enabled) starts a collective session and successfully `create_note`s at `/note`; the note is attributed to the collective identity and lands on the main collective.

Both new tests fail without the one-line fix and pass with it. Full authorization suite (`action_authorization`, `capability_check`, `action_authorization_gate`, `markdown_action_authorization`, `ai_agent_capability`, `api_collective_representation`) green — 109 runs, 0 failures. `srb tc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)