### PR TITLE
Fix #471: collective is the auto-confirmed reader under collective representation

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -65,11 +65,21 @@ class Note < ApplicationRecord
       event_type: "create",
       happened_at: created_at
     )
-    # Under representation, the represented user did not actually read the
-    # note — the representative did. Attribute the auto-read-confirmation
-    # to whoever performed the creation. Self-acting falls through to
-    # `created_by` as before.
-    reader = RepresentationContext.current_representative_user || T.must(created_by)
+    # Auto-confirm a read for whoever actually engaged with the note.
+    #
+    # Under *user* representation the represented user (created_by) did not
+    # read the note — the representative did — so attribute the read to the
+    # representative. Under *collective* representation the note is authored
+    # by the collective's identity user, and the representative read it *as*
+    # a member of that collective, so the collective itself is both author
+    # and reader — her individual identity is not a separate party (#471).
+    # Self-acting falls through to `created_by`.
+    author = T.must(created_by)
+    reader = if author.collective_identity?
+               author
+             else
+               RepresentationContext.current_representative_user || author
+             end
     confirm_read!(reader)
     commentable.confirm_read!(reader) if commentable.is_a?(Note)
   end

--- a/test/integration/api_representation_test.rb
+++ b/test/integration/api_representation_test.rb
@@ -836,6 +836,79 @@ class ApiRepresentationTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "acting on behalf of"
   end
 
+  test "creating a note under collective rep auto-confirms the collective, not the representative" do
+    # Inverse of user representation (#471): under *collective* representation
+    # `created_by` is the collective's identity user, and the representative
+    # read the note *as* a member of that collective — so the collective is
+    # both author and reader. The representative's individual identity is not a
+    # separate party and must NOT get its own auto-read-confirmation.
+    @collective.collective_members.find_by(user: @bob).add_role!("representative")
+    identity_user = @collective.identity_user
+    assert identity_user, "collective should have an identity user"
+
+    session = RepresentationSession.create!(
+      tenant: @tenant,
+      collective: @collective,
+      representative_user: @bob,
+      confirmed_understanding: true,
+      began_at: Time.current,
+    )
+
+    post "/collectives/#{@collective.handle}/note/actions/create_note",
+         params: { title: "Collective note", text: "Posted as the collective" },
+         headers: @headers.merge(
+           "X-Representation-Session-ID" => session.id,
+           "X-Representing-Collective" => @collective.handle,
+         )
+    assert_response :success
+    note = Note.where(title: "Collective note").last
+    assert note, "note should have been created"
+    assert_equal identity_user.id, note.created_by_id, "note should be authored by the collective identity"
+
+    confirmations = NoteHistoryEvent.where(note: note, event_type: "read_confirmation")
+    assert_equal [identity_user.id], confirmations.pluck(:user_id),
+                 "Only the collective (identity user) should be auto-confirmed as reader; the representative must not be separately marked"
+  end
+
+  test "creating a comment under collective rep auto-confirms the collective on parent and comment" do
+    # Same inversion for the comment path: the collective is the reader of both
+    # the comment and the parent it replies to, not the representative.
+    @collective.collective_members.find_by(user: @bob).add_role!("representative")
+    identity_user = @collective.identity_user
+
+    parent_author = create_user(email: "parent_author_#{SecureRandom.hex(4)}@example.com", name: "Parent Author")
+    @tenant.add_user!(parent_author)
+    mark_activated!(parent_author)
+    @collective.add_user!(parent_author)
+    parent_note = create_note(tenant: @tenant, collective: @collective, created_by: parent_author, title: "Parent")
+
+    session = RepresentationSession.create!(
+      tenant: @tenant,
+      collective: @collective,
+      representative_user: @bob,
+      confirmed_understanding: true,
+      began_at: Time.current,
+    )
+
+    post "#{parent_note.path}/actions/add_comment",
+         params: { text: "Reply as the collective" },
+         headers: @headers.merge(
+           "X-Representation-Session-ID" => session.id,
+           "X-Representing-Collective" => @collective.handle,
+         )
+    assert_response :success
+    comment = Note.where(text: "Reply as the collective").last
+    assert comment, "comment should have been created"
+
+    comment_confirmations = NoteHistoryEvent.where(note: comment, event_type: "read_confirmation").pluck(:user_id)
+    assert_includes comment_confirmations, identity_user.id, "Collective should be auto-confirmed on the comment"
+    refute_includes comment_confirmations, @bob.id, "Representative must not be auto-confirmed on the comment"
+
+    parent_confirmations = NoteHistoryEvent.where(note: parent_note, event_type: "read_confirmation").pluck(:user_id)
+    assert_includes parent_confirmations, identity_user.id, "Collective should be auto-confirmed on the parent"
+    refute_includes parent_confirmations, @bob.id, "Representative must not be auto-confirmed on the parent"
+  end
+
   test "collective representation requires X-Representing-Collective header" do
     # Set up Bob as a representative for the collective
     @collective.collective_members.find_by(user: @bob).add_role!("representative")


### PR DESCRIPTION
Fixes #471.

## The bug

When a collective representative posts a note (or comments), the note is correctly authored **by the collective** — but the auto-confirmed reader was the **representative**, not the collective.

## Why user and collective representation are opposite here

The `Note` `after_create` hook auto-confirms a read for the party that actually engaged with the note. Two cases, and they invert:

- **User representation** (Alice posts on behalf of Bob): Alice is *not* Bob. `created_by` is Bob, who never read the note — Alice did. So the read is attributed to the **representative** (Alice). ✅ already correct.
- **Collective representation** (Alice posts on behalf of a collective she's a member of): Alice *is* the collective in that capacity — acting as the collective is the only way collectives post at all. `created_by` is the collective's identity user, and Alice reading it as a member means **the collective** has read it. Her individual identity is not a separate party.

The old code unconditionally attributed the read to the representative, so it was wrong for the collective case.

## The fix

One branch in the hook: when `created_by` is a collective identity user, the collective is both author and reader; otherwise keep the existing representative/self attribution.

A collective identity user only ever authors via representation, so `created_by.collective_identity?` is *exactly* the collective-representation case — no representation-session plumbing needed. Covers both the note itself and the auto-confirm-on-comment of the parent.

## Tests

Two integration tests in `api_representation_test.rb`, mirroring the existing user-rep ones:
- a collective rep posting a note → the collective (not the representative) is the sole auto-confirmed reader
- a collective rep commenting → the collective is confirmed on both the comment and the parent, the representative on neither

Both fail without the fix (verified: representative's id appears instead of the collective's), pass with it. Full `api_representation_test.rb` green (35 runs, 0 failures); `srb tc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)