### PR TITLE
Fix #468: allow tuning in to a collective-identity user

### DIFF
--- a/app/models/user_list_member.rb
+++ b/app/models/user_list_member.rb
@@ -63,7 +63,26 @@ class UserListMember < ApplicationRecord
   sig { void }
   def member_is_collective_member
     return if CollectiveMember.exists?(collective_id: collective_id, user_id: user_id)
+    return if addable_collective_identity?
 
     errors.add(:user_id, "must be a member of the collective")
+  end
+
+  # Collective-identity users are structurally barred from *membership* in the
+  # main collective — a collective can't be a member of the tenant-wide
+  # "everyone" — but they're still tenant citizens you can tune in to. The
+  # primary "tuned in" list is main-collective-scoped, so admit an identity
+  # user there as long as its collective lives in this list's tenant. Without
+  # this, tuning in to a collective identity fails validation even once the
+  # request reaches the right route (issue #468).
+  sig { returns(T::Boolean) }
+  def addable_collective_identity?
+    member = user
+    list = user_list
+    return false if member.nil? || list.nil?
+    return false unless member.collective_identity?
+    return false unless list.collective&.is_main_collective?
+
+    Collective.where(identity_user_id: member.id, tenant_id: list.tenant_id).exists?
   end
 end

--- a/app/views/shared/_tune_in_button.html.erb
+++ b/app/views/shared/_tune_in_button.html.erb
@@ -8,12 +8,21 @@
   # `tune_in_on_list_user_ids` for the batch-loading pattern.
 %>
 <% if viewer && viewer.id != target.id && !blocked %>
+  <%
+    # Tune-in acts on the user resource at /u/<handle>, NOT target.path: for a
+    # collective-identity user `#path` points at the collective profile
+    # (/collectives/<handle>), which has no tune_in action — so appending it
+    # 404s (issue #468). Use the TenantUser handle (which the /u/:handle routes
+    # resolve via find_by), NOT User#handle — the latter returns the display
+    # form "collectives/<handle>" for identity users, not a resolvable handle.
+    user_action_base = "/u/#{target.tenant_user&.handle}"
+  %>
   <%= render AjaxToggleButtonComponent.new(
         on:        on_list,
-        on_url:    "#{target.path}/actions/tune_out",
+        on_url:    "#{user_action_base}/actions/tune_out",
         on_html:   pulse_icon('tuning_in', size: :sm) + " Tuned in",
         on_class:  "pulse-action-btn-secondary pulse-tune-in-btn",
-        off_url:   "#{target.path}/actions/tune_in",
+        off_url:   "#{user_action_base}/actions/tune_in",
         off_html:  octicon('plus', height: 14) + " Tune in",
         off_class: "pulse-action-btn pulse-tune-in-btn",
         title:     "Tuning in adds this user's activity to your timeline view",

--- a/test/controllers/user_lists_html_test.rb
+++ b/test/controllers/user_lists_html_test.rb
@@ -194,6 +194,43 @@ class UserListsHtmlTest < ActionDispatch::IntegrationTest
     assert_no_match(/pulse-tune-in-btn/, own_row.to_s)
   end
 
+  test "show HTML: tune-in button for a collective-identity member targets /u/<handle>, not the collective path (issue #468)" do
+    # A standard collective auto-creates an identity User that shares the
+    # collective's handle and owns a TenantUser — so it is a real, tune-in-able
+    # user reachable at /u/<handle>. Its #path, however, points at the
+    # collective profile (/collectives/<handle>), which has no tune_in action.
+    # The button must build its URL from the user resource, not from #path,
+    # else it POSTs to a 404.
+    identity_collective = Collective.create!(
+      tenant: @tenant, name: "Ident Co", handle: "ident-#{SecureRandom.hex(4)}",
+      collective_type: "standard", created_by: @user, updated_by: @user
+    )
+    identity_user = identity_collective.identity_user
+    assert identity_user, "expected the standard collective to have an identity user"
+
+    # The list is main-collective-scoped (see setup). A collective-identity user
+    # can be tuned in to (added to a main-collective list) even though it isn't a
+    # main-collective member — see UserListMember#addable_collective_identity?.
+    list = UserList.create!(creator: @user, owner: @user, name: "Has an identity member")
+    list.user_list_members.create!(added_by: @user, user: identity_user)
+
+    sign_in_as(@user, tenant: @tenant)
+    get "/lists/#{list.truncated_id}?tab=members"
+    assert_response :success
+
+    # The resolvable handle is the identity user's TenantUser handle (suffixed on
+    # collision with the collective's own handle), NOT the bare collective handle
+    # nor User#handle's "collectives/<handle>" display form.
+    handle = identity_user.tenant_users.find_by(tenant_id: @tenant.id).handle
+    # Off state (identity user not on the viewer's primary list): current URL is
+    # tune_in, alt is tune_out — both must live under the /u/ user resource.
+    assert_select ".pulse-list-members [data-ajax-toggle-url-value=?]", "/u/#{handle}/actions/tune_in"
+    assert_select ".pulse-list-members [data-ajax-toggle-alt-url-value=?]", "/u/#{handle}/actions/tune_out"
+    # And never the collective path (the bug) nor the "collectives/" display form.
+    assert_select ".pulse-list-members [data-ajax-toggle-url-value^='/collectives/']", count: 0
+    assert_select ".pulse-list-members [data-ajax-toggle-url-value*='/collectives/']", count: 0
+  end
+
   test "show HTML: members tab hides the tune-in button when the member is blocked either way" do
     list = UserList.create!(creator: @user, owner: @user, name: "Tabbed")
     list.user_list_members.create!(added_by: @user, user: @other)

--- a/test/controllers/users_tune_in_actions_test.rb
+++ b/test/controllers/users_tune_in_actions_test.rb
@@ -135,6 +135,27 @@ class UsersTuneInActionsTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "execute_tune_in succeeds for a collective-identity user (issue #468)" do
+    # A standard collective owns an identity User sharing its handle, reachable
+    # at /u/<handle>. Tuning in adds it to the actor's main-collective primary
+    # list even though identity users aren't main-collective members.
+    ic = Collective.create!(
+      tenant: @tenant, name: "Ident Co", handle: "ident-#{SecureRandom.hex(4)}",
+      collective_type: "standard", created_by: @user, updated_by: @user
+    )
+    identity_user = ic.identity_user
+    assert identity_user, "expected the standard collective to have an identity user"
+
+    assert_difference -> { UserListMember.where(user_id: identity_user.id).count }, +1 do
+      post "/u/#{handle_of(identity_user)}/actions/tune_in", params: {}.to_json, headers: @headers
+    end
+    assert_response :success
+    assert_includes response.body, "Tuned in."
+
+    primary = UserList.unscope(where: :collective_id).find_by(owner_id: @user.id, is_primary: true)
+    assert_includes primary.members, identity_user
+  end
+
   test "execute_tune_in rejects tuning in to yourself" do
     post "/u/#{handle_of(@user)}/actions/tune_in", params: {}.to_json, headers: @headers
     # The tune_in rule excludes your own profile, and that rule is enforced at

--- a/test/models/user_list_member_test.rb
+++ b/test/models/user_list_member_test.rb
@@ -106,6 +106,19 @@ class UserListMemberTest < ActiveSupport::TestCase
     assert_includes m.errors[:user_id].join(" "), "collective"
   end
 
+  # The main-collective exception for identity users (issue #468) must NOT leak
+  # to non-main lists: @list is scoped to a non-main collective, and the identity
+  # user isn't a member of it, so it's still rejected.
+  test "collective-identity non-member is still rejected from a non-main-collective list" do
+    ic = create_collective(tenant: @tenant, created_by: @user, name: "Ident", handle: "ident-#{SecureRandom.hex(4)}")
+    identity_user = ic.identity_user
+    assert identity_user&.collective_identity?, "expected an identity user for the standard collective"
+
+    m = UserListMember.new(user_list: @list, user: identity_user, added_by: @user)
+    assert_not m.valid?
+    assert_includes m.errors[:user_id].join(" "), "collective"
+  end
+
   # ---- Scope-mismatch guard ----
 
   test "scope_matches_list rejects mismatched collective_id" do


### PR DESCRIPTION
Fixes #468.

## Problem

Tuning in to a collective-identity user failed. Dan reported the visible symptom: the button POSTed to `/collectives/<handle>/actions/tune_in` and 404'd. Behind that 404 was a second wall — even on the correct route the action returned 422.

## Root causes & fixes

**1. Wrong route (the reported 404).** `app/views/shared/_tune_in_button.html.erb` built its URL from `target.path`. For a collective-identity user `User#path` points at the collective profile (`/collectives/<handle>`), which has no `tune_in` action. The button now targets the user resource (`/u/<handle>/actions/tune_in`) using the **TenantUser** handle — note `User#handle` returns the `"collectives/<handle>"` display form for identity users, not a routable handle, so we read `target.tenant_user&.handle` (the suffixed, resolvable handle that `/u/:handle` looks up).

**2. Membership validation (the hidden 422).** `execute_tune_in` adds the target to the actor's **main-collective-scoped** primary list, but `UserListMember#member_is_collective_member` rejected it: collective-identity users are structurally barred from main-collective *membership* (a collective can't be a member of the tenant-wide "everyone"). They're still tenant citizens you can tune in to, so the validation now admits an identity user onto a main-collective list when its collective lives in the list's tenant. Non-main lists stay strict — an identity user must be an actual member.

This partial is shared by the user-lists, mutuals, and notifications surfaces, so all three are fixed.

## Tests
- `user_lists_html_test` — the members-tab tune-in button for an identity member targets `/u/<handle>`, never the collective path or the `collectives/` display form.
- `users_tune_in_actions_test` — full tune-in flow to a collective identity succeeds (200) and the identity lands on the primary list.
- `user_list_member_test` — the main-collective exception does **not** leak: an identity non-member is still rejected from a non-main list.

Ran the three files + `notifications_controller_test` + `srb tc` locally: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)