### PR TITLE
Fix #477: make collective identities first-class main-collective members

### DIFF
--- a/app/models/collective.rb
+++ b/app/models/collective.rb
@@ -689,6 +689,15 @@ class Collective < ApplicationRecord
     )
     self.identity_user = identity
     save!
+
+    # Make the identity a first-class member of the tenant's main collective, so
+    # it's counted in the directory and admissible to the tenant-wide "everyone"
+    # list on the general membership path — no special-case exception needed
+    # (issue #477). The main collective has no parent to join, and during its own
+    # creation `tenant.main_collective` isn't wired up yet, so skip both cases:
+    # only join when a main collective exists and it isn't this collective.
+    main = T.must(tenant).main_collective
+    main.add_user!(identity) if main && main.id != id
   end
 
   # Keep the identity user's handle in lockstep when the collective is renamed,

--- a/app/models/collective_member.rb
+++ b/app/models/collective_member.rb
@@ -10,15 +10,6 @@ class CollectiveMember < ApplicationRecord
   belongs_to :collective
   belongs_to :user
 
-  validate :identity_users_not_member_of_main_collective
-
-  sig { void }
-  def identity_users_not_member_of_main_collective
-    if user.collective_identity? && collective == T.must(tenant).main_collective
-      errors.add(:user, "Collective identity users cannot be members of the main collective")
-    end
-  end
-
   sig { returns(User) }
   def user
     @user ||= super

--- a/app/models/user_list_member.rb
+++ b/app/models/user_list_member.rb
@@ -63,26 +63,7 @@ class UserListMember < ApplicationRecord
   sig { void }
   def member_is_collective_member
     return if CollectiveMember.exists?(collective_id: collective_id, user_id: user_id)
-    return if addable_collective_identity?
 
     errors.add(:user_id, "must be a member of the collective")
-  end
-
-  # Collective-identity users are structurally barred from *membership* in the
-  # main collective — a collective can't be a member of the tenant-wide
-  # "everyone" — but they're still tenant citizens you can tune in to. The
-  # primary "tuned in" list is main-collective-scoped, so admit an identity
-  # user there as long as its collective lives in this list's tenant. Without
-  # this, tuning in to a collective identity fails validation even once the
-  # request reaches the right route (issue #468).
-  sig { returns(T::Boolean) }
-  def addable_collective_identity?
-    member = user
-    list = user_list
-    return false if member.nil? || list.nil?
-    return false unless member.collective_identity?
-    return false unless list.collective&.is_main_collective?
-
-    Collective.where(identity_user_id: member.id, tenant_id: list.tenant_id).exists?
   end
 end

--- a/app/services/action_authorization.rb
+++ b/app/services/action_authorization.rb
@@ -78,17 +78,11 @@ module ActionAuthorization
       return true unless collective
       # The collective's own identity user acts as a member of its own collective.
       return true if collective.identity_user?(user)
-      # A collective identity acting via representation (or a collective automation)
-      # is a member of the public main collective without a CollectiveMember record.
-      # This mirrors ApplicationController#validate_authenticated_access, whose main-
-      # collective branch does nothing for a collective_identity user rather than
-      # calling add_user!. Without this, a collective could author on its own pages
-      # and any collective it belongs to, but never at the public root (/note) over
-      # markdown/MCP — even though the browser HTML flow authorizes exactly that,
-      # which is why a human representative can post publicly as the collective but an
-      # agent representative gets "not authorized to perform 'create_note'". (#469)
-      return true if user.collective_identity? && collective.is_main_collective?
-
+      # A collective identity is a real CollectiveMember of the tenant's main
+      # collective (created by Collective#create_identity_user! and backfilled for
+      # existing identities in #477), so authoring at the public root (/note) over
+      # markdown/MCP now passes on the general membership path below — no special
+      # case needed. This was previously a carve-out (#469) that #477 made vestigial.
       collective.user_is_member?(user)
     },
     resource_owner: lambda { |user, context|

--- a/db/migrate/20260709190000_backfill_collective_identity_main_memberships.rb
+++ b/db/migrate/20260709190000_backfill_collective_identity_main_memberships.rb
@@ -1,0 +1,45 @@
+# typed: false
+
+# Issue #477: collective-identity users are now first-class *members* of their
+# tenant's main collective, minted alongside the identity in
+# `Collective#create_identity_user!`. Existing identities predate that hook, so
+# backfill the missing main-collective `CollectiveMember` rows.
+#
+# Scope mirrors the creation hook exactly:
+#   - only non-workspace/non-chat collectives have an identity user at all
+#     (those two types return early with no identity),
+#   - the main collective itself is skipped — an identity has no parent-of-the-
+#     parent to join, and counting it as its own member is meaningless,
+#   - tenants without a main collective yet (mid-bootstrap fixtures) are skipped.
+#
+# Idempotent: the NOT EXISTS guard means re-running inserts nothing, and it
+# respects the (tenant_id, collective_id, user_id) unique index. Raw SQL keeps
+# the backfill independent of model validations/callbacks and tenant scoping
+# (Tenant.current_id is nil inside migrations); `id` and `settings` fall to their
+# column defaults (gen_random_uuid / '{}'), and identities hold no roles so the
+# empty settings is exactly what a fresh membership would carry.
+class BackfillCollectiveIdentityMainMemberships < ActiveRecord::Migration[7.2]
+  def up
+    execute(<<~SQL)
+      INSERT INTO collective_members (tenant_id, collective_id, user_id, created_at, updated_at)
+      SELECT c.tenant_id, t.main_collective_id, c.identity_user_id, now(), now()
+      FROM collectives c
+      JOIN tenants t ON t.id = c.tenant_id
+      WHERE c.identity_user_id IS NOT NULL
+        AND c.collective_type NOT IN ('private_workspace', 'chat')
+        AND t.main_collective_id IS NOT NULL
+        AND c.id <> t.main_collective_id
+        AND NOT EXISTS (
+          SELECT 1 FROM collective_members cm
+          WHERE cm.collective_id = t.main_collective_id
+            AND cm.user_id = c.identity_user_id
+        )
+    SQL
+  end
+
+  def down
+    # No-op: we can't distinguish backfilled rows from memberships an admin may
+    # have since curated, and dropping identities from the main collective would
+    # reintroduce the very special-casing this issue removed.
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10312,6 +10312,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260709190000'),
 ('20260705220000'),
 ('20260705182920'),
 ('20260703120000'),

--- a/test/controllers/user_lists_html_test.rb
+++ b/test/controllers/user_lists_html_test.rb
@@ -208,9 +208,9 @@ class UserListsHtmlTest < ActionDispatch::IntegrationTest
     identity_user = identity_collective.identity_user
     assert identity_user, "expected the standard collective to have an identity user"
 
-    # The list is main-collective-scoped (see setup). A collective-identity user
-    # can be tuned in to (added to a main-collective list) even though it isn't a
-    # main-collective member — see UserListMember#addable_collective_identity?.
+    # The list is main-collective-scoped (see setup). Since #477 a collective
+    # identity is a first-class main-collective member, so it can be tuned in to
+    # (added to a main-collective list) via the general membership path.
     list = UserList.create!(creator: @user, owner: @user, name: "Has an identity member")
     list.user_list_members.create!(added_by: @user, user: identity_user)
 

--- a/test/controllers/users_tune_in_actions_test.rb
+++ b/test/controllers/users_tune_in_actions_test.rb
@@ -137,8 +137,9 @@ class UsersTuneInActionsTest < ActionDispatch::IntegrationTest
 
   test "execute_tune_in succeeds for a collective-identity user (issue #468)" do
     # A standard collective owns an identity User sharing its handle, reachable
-    # at /u/<handle>. Tuning in adds it to the actor's main-collective primary
-    # list even though identity users aren't main-collective members.
+    # at /u/<handle>. Since #477 the identity is a first-class main-collective
+    # member, so tuning in adds it to the actor's main-collective primary list
+    # via the general membership path (no special-case exception).
     ic = Collective.create!(
       tenant: @tenant, name: "Ident Co", handle: "ident-#{SecureRandom.hex(4)}",
       collective_type: "standard", created_by: @user, updated_by: @user

--- a/test/models/collective_member_test.rb
+++ b/test/models/collective_member_test.rb
@@ -140,7 +140,10 @@ class CollectiveMemberTest < ActiveSupport::TestCase
 
   # === Identity User Validation Tests ===
 
-  test "identity user cannot be member of main collective" do
+  # Issue #477: collective identities are now first-class members of the main
+  # collective — the old bar (identity_users_not_member_of_main_collective) was
+  # vestigial and blocked tuning in to an identity on the general path.
+  test "identity user can be member of main collective (issue #477)" do
     @tenant.create_main_collective!(created_by: @user)
     main_collective = @tenant.main_collective
     identity = @collective.identity_user
@@ -150,8 +153,8 @@ class CollectiveMemberTest < ActiveSupport::TestCase
       collective: main_collective,
       user: identity,
     )
-    assert_not collective_member.valid?
-    assert_includes collective_member.errors[:user], "Collective identity users cannot be members of the main collective"
+    assert collective_member.valid?
+    assert collective_member.save
   end
 
   test "identity user can be member of non-main collective" do

--- a/test/models/collective_test.rb
+++ b/test/models/collective_test.rb
@@ -189,6 +189,32 @@ class CollectiveTest < ActiveSupport::TestCase
     assert_equal "collective_identity", collective.identity_user.user_type
   end
 
+  # Issue #477: a new collective's identity is born a first-class member of the
+  # tenant's main collective, so it's counted in the directory and admissible to
+  # the tenant-wide "everyone" list without any special-case exception.
+  test "create_identity_user! joins the identity to the main collective (issue #477)" do
+    tenant = create_tenant
+    user = create_user
+    tenant.create_main_collective!(created_by: user)
+    main = tenant.main_collective
+
+    collective = Collective.create!(tenant: tenant, created_by: user, name: "Foo Team", handle: "foo-team")
+
+    assert_includes main.member_users, collective.identity_user
+  end
+
+  # The main collective has no parent-of-the-parent to join, and counting its own
+  # identity as its own member is meaningless — so it must not self-join.
+  test "the main collective's own identity is not a member of the main collective (issue #477)" do
+    tenant = create_tenant
+    user = create_user
+    tenant.create_main_collective!(created_by: user)
+    main = tenant.main_collective
+
+    assert main.identity_user.present?
+    assert_not_includes main.member_users, main.identity_user
+  end
+
   # Goal 2 of handle-model-unification: the identity user shares the collective's
   # own handle so @foo-team and /collectives/foo-team resolve to one identity.
   test "identity user shares the collective's handle" do

--- a/test/models/user_list_member_test.rb
+++ b/test/models/user_list_member_test.rb
@@ -106,9 +106,10 @@ class UserListMemberTest < ActiveSupport::TestCase
     assert_includes m.errors[:user_id].join(" "), "collective"
   end
 
-  # The main-collective exception for identity users (issue #468) must NOT leak
-  # to non-main lists: @list is scoped to a non-main collective, and the identity
-  # user isn't a member of it, so it's still rejected.
+  # Since #477 an identity is a member of the *main* collective only. Membership
+  # doesn't extend to arbitrary collectives, so a non-main list still requires
+  # real membership: @list is scoped to a non-main collective the identity hasn't
+  # joined, so it's rejected on the general path.
   test "collective-identity non-member is still rejected from a non-main-collective list" do
     ic = create_collective(tenant: @tenant, created_by: @user, name: "Ident", handle: "ident-#{SecureRandom.hex(4)}")
     identity_user = ic.identity_user

--- a/test/services/action_authorization_test.rb
+++ b/test/services/action_authorization_test.rb
@@ -93,24 +93,24 @@ class ActionAuthorizationTest < ActiveSupport::TestCase
     refute ActionAuthorization.check_authorization(:collective_member, non_member, context)
   end
 
-  # Regression for #469: a collective identity acting via representation could not
-  # author at the public root (/note) over markdown/MCP because it holds no
-  # CollectiveMember record on the main collective — even though the browser flow
-  # authorizes it there. The check must treat a collective_identity user as a
-  # member of the main collective specifically.
+  # Regression for #469 (via #477): a collective identity acting via representation
+  # must be able to author at the public root (/note) over markdown/MCP. As of #477
+  # a collective identity is a real CollectiveMember of the tenant's main collective,
+  # so this authorizes on the general membership path rather than a special carve-out.
   test "collective_member authorization treats a collective identity as a member of the main collective" do
     identity = @collective.identity_user
     assert identity.collective_identity?, "sanity: identity_user is a collective_identity user"
 
     main = @tenant.main_collective
-    # The identity is NOT a member of the main collective and is not ITS identity user...
+    # The identity is a real member of the main collective (#477), though not ITS
+    # own identity user...
     refute main.identity_user?(identity)
-    refute main.user_is_member?(identity)
-    # ...yet it is authorized as a member of the public root.
+    assert main.user_is_member?(identity)
+    # ...so it is authorized as a member of the public root.
     assert ActionAuthorization.check_authorization(:collective_member, identity, { collective: main })
 
-    # But the relaxation is scoped to the MAIN collective only: the same identity
-    # is still denied on an unrelated collective it doesn't belong to.
+    # But membership is scoped to the MAIN collective: the same identity is still
+    # denied on an unrelated collective it doesn't belong to.
     other = create_collective(tenant: @tenant, created_by: @user, handle: "aa-other-#{SecureRandom.hex(4)}")
     refute other.identity_user?(identity)
     refute other.user_is_member?(identity)


### PR DESCRIPTION
Closes #477. The principled fix spun out of #475 (fixes #468): make collective-identity users real **members** of their tenant's main collective, and delete the special-case logic in two places rather than adding a third.

## What changed

1. **Creation hook** — `Collective#create_identity_user!` now joins the freshly-minted identity to the tenant's main collective in the same flow. Skips two cases: the main collective itself (an identity has no parent-of-the-parent to join, and self-membership is meaningless), and the mid-bootstrap moment when `tenant.main_collective` isn't wired up yet.
2. **Backfill migration** — one-shot, idempotent, no-downtime raw-SQL insert of the missing main-collective `CollectiveMember` rows for existing identities. Scope mirrors the hook exactly (non-workspace/chat, non-main, `NOT EXISTS` guard against the unique index).
3. **Deleted `identity_users_not_member_of_main_collective`** (the vestigial bar).
4. **Deleted the #475 `addable_collective_identity?` exception** — tuning in to an identity now passes on the general `member_is_collective_member` path.

## Gating status (from the issue)

- **Notification delivery — #345.** Verified the concrete delivery path is already safe: identities are non-human, and `TenantUser#notification_channels_for` only returns the `email` channel when `user.human?` (tenant_user.rb:245). So once identities are members, `@everyone`/member fan-outs **never email** an identity's `@not-a-real-email.com` address — they create in-app rows only, which surface to the identity's representatives. No external spam. #345's routing/visibility polish stays worth doing but is **not a blocker** for this.
- **`@everyone`/role on the main collective — #476.** `@everyone` fan-out is admin-authored-only (`MentionParser.resolve_collective_local`); #476 would bar it on the main collective entirely, which bounds the fan-out further. These land coherently either way; nothing here conflicts with #476.
- **Directory cosmetics — product call for @danallison.** `member_count`/`.team` now list collectives as citizens alongside their members (they become @mentionable/assignable in the main collective). This is the one intentionally-visible behavior change and the issue flagged it as needing your call on whether the member list should show collectives. Easy to hide in the directory view later without touching membership if you'd rather.
- **Future census/quorum math** — no member-count-based quorum exists in `decision.rb` today, so counting a collective alongside its members is only cosmetic. Noted in the issue as the one spot a real exception would be needed if such math is ever added.

## Tests

- Flipped `collective_member_test` "cannot be member of main" → "can be member of main (#477)".
- Added `collective_test` coverage: identity auto-joins main on creation; the main collective's own identity does **not** self-join.
- Updated the #468 tune-in tests to assert the general path (no exception).
- Ran the affected model/controller suites (248 runs) and the fan-out-adjacent services (mention_parser, audience_resolver, notification_dispatcher — 102 runs): all green. `srb tc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)