### PR TITLE
LLM gateway: internal relay for billed LLM calls (stage 1)

### DIFF
--- a/.claude/plans/harmonic-llm-gateway.md
+++ b/.claude/plans/harmonic-llm-gateway.md
@@ -104,8 +104,16 @@ external client ──HTTPS──► llm.harmonic.social (Caddy) ──► llm-g
 
 ## The resolve contract (shared by single customer and pool)
 
-Two internal endpoints, both over the existing HMAC + IP-allowlist channel. Designed so
-the gateway is written **once** and never changes as callers or payer types are added.
+Two internal endpoints, both over the existing HMAC + IP-allowlist channel. The **relay**
+(select payer → forward to Stripe → return verbatim) is written once and never changes as
+payer types are added. The **ingress** is the part that grows per caller type: today the
+caller identifies itself with `X-Harmonic-Task-Run-Id` / `X-Harmonic-Subdomain` routing
+headers (agent-runner-specific), and stage 4's external keys will add a different identity
+handshake plus real caller auth at the gateway. The seam holds below the handler.
+
+Note the accepted trade: `select-payer` runs per LLM call, so every call costs one extra
+internal Rails round-trip (milliseconds against an LLM call's seconds). That is the price
+of per-call payer selection, which stage 2's random pick requires.
 
 ### `POST /internal/llm-gateway/select-payer` — before relaying
 
@@ -227,26 +235,30 @@ is resolved via `select-payer` rather than passed in.
 
 Tasks:
 
-1. **`llm-gateway` container** — Node/TS, internal-only on the backend network, reusing the
-   agent-runner's `HmacSigner` / `RailsHttp` / `Logger` / `Retry` to call Rails. Holds
-   `STRIPE_GATEWAY_KEY`.
-2. **Rails `Internal::LlmGatewayController#select_payer`** (inherits `Internal::BaseController`
-   — HMAC + IP allowlist). Resolves the agent-context identity → `ai_agent` → principal →
-   `stripe_customer`, verifies funding (pricing-plan subscription + balance > 0 — the gate-(b)
-   logic already in [agent_runner_dispatch_service.rb:103](../../app/services/agent_runner_dispatch_service.rb#L103)),
-   returns `{ payer_customer_id, selection_id }` or an error. Extraction of existing dispatch
-   logic, not new logic.
-3. **Agent-runner rewire** — `stripe_gateway` mode calls the gateway (passing the
-   task-run / chat-session identity, **not** a customer id); litellm mode unchanged. Remove
-   `stripe_customer_stripe_id` from the dispatch stream and task plumbing
-   ([TaskQueue.ts:73-91](../../agent-runner/src/services/TaskQueue.ts#L73), PromptBuilder,
-   AgentLoop, crypto) — attribution now lives in the gateway, so the passed-through customer
-   id becomes dead data.
-4. **Wiring** — docker-compose `llm-gateway` service, env, Rails route for
-   `/internal/llm-gateway/*`.
-5. **Tests (TDD)** — `select_payer` request tests (resolution, funding gate, errors);
-   agent-runner mode-branch tests (stripe → gateway with identity, litellm untouched);
-   internal-agent parity check verified via the gateway's `llm_request` log + a balance drop.
+1. ✅ **`llm-gateway` service** — built as a second entrypoint in the agent-runner package
+   (`src/gateway/`: Relay + StripeUpstream Effect services, plain-node handler/server),
+   internal-only, reusing `HmacSigner` / `RailsHttp` / `Logger`. Holds `STRIPE_GATEWAY_KEY`
+   (fail-fast boot check). Relay + handler unit-tested.
+2. ✅ **Rails `Internal::LLMGatewayController#select_payer`** (inherits
+   `Internal::BaseController` — HMAC + IP allowlist) + `LLMGateway::PayerResolver`. Resolves
+   the task run → stamped billing customer, verifies the pricing-plan subscription (no live
+   balance fetch — see Open decisions), returns `{ payer_customer_id }` or a coded error.
+   Request-tested incl. cross-tenant isolation. (`selection_id` deferred to stage 2 with
+   `record-usage`, its only consumer.)
+3. ✅ **Agent-runner rewire** — `stripe_gateway` mode posts to the gateway with
+   `X-Harmonic-{Task-Run-Id,Subdomain,Model}` headers; litellm mode unchanged.
+   `stripe_customer_stripe_id` removed from the dispatch stream and task plumbing
+   (legacy payloads still parse); the runner holds no Stripe credentials.
+4. ✅ **Wiring** — `llm-gateway` compose service (same image, gateway entrypoint) in dev and
+   prod behind a `stripe` profile: prod enables via `COMPOSE_PROFILES=stripe` in the server
+   `.env` (deploy-managed — NOT started once by name like litellm), dev via `start.sh`
+   auto-adding the profile when `STRIPE_GATEWAY_KEY` is set. `billing:gateway_health` now
+   probes the gateway's `/health` instead of checking a Rails-side key. Deploy docs +
+   enablement runbook updated.
+5. **Tests (TDD, alongside each task)** — unit/request coverage done for 1–4. Remaining
+   before exit: the live parity smoke test — run the stack with the gateway enabled,
+   confirm an internal agent task bills via `llm_request` logs on both services + a
+   balance drop.
 
 Scope boundaries (deferred because Stage 1's only caller is the trusted agent-runner):
 **streaming (SSE)**, **model allowlist**, **rate limiting**, **request-size caps** → stage 4
@@ -304,6 +316,10 @@ rollout posture). Not publicly advertised.
 
 - **Per-collective feature flag**, app-admin controlled (mirrors `stripe_billing` gating).
   External keys for a collective work only while its flag is on.
+- **Gateway ingress auth.** Today the gateway trusts the backend network (any peer can
+  relay a money-spending call — acceptable while the network holds only trusted services).
+  External access requires authenticating callers at the gateway itself, and an external
+  identity handshake (key-based) alongside the internal task-run headers.
 - Public `llm.harmonic.social` edge (Caddy) + an external gateway-key credential type,
   scoped and revocable, with per-key spend caps and rate limits.
 - The untrusted-caller protections deferred from stage 1: **streaming (SSE) passthrough**
@@ -326,10 +342,14 @@ its own project. This initial project builds only the minimal UI in stage 3.
 
 ## Open decisions
 
-- **Balance freshness at selection.** Checking each member's live Stripe balance per call
-  is slow. Cache balances (short TTL) for the eligibility filter, and treat a 402 from the
-  relay as authoritative "dry now" → advance and retry once. Composes with Stripe's
-  zero-balance rejection.
+- **Balance freshness at selection — decided for single customer, one sub-decision left
+  for pools.** `select-payer` performs no live balance fetch (slow, stale, and it conflates
+  a Stripe API error with an empty balance). The balance gate is dispatch preflight (once
+  per task) plus the relay passing through Stripe's 402 — and the Stripe gateway team has
+  **confirmed zero-balance rejection is enabled** on the account, so the 402 is
+  authoritative, not assumed. Remaining for stage 2: how the pool eligibility filter
+  learns who is dry — short-TTL balance cache vs. treat a relay 402 as "dry now", mark the
+  member, re-pick once. Lean 402-retry (no cache invalidation problem).
 - **Model allowlist scope.** Per-gateway-key, per-pool, or global? Reuse
   `StripeGatewayModelMapper`'s mapping/validation.
 - **Internal/external traffic isolation (external phase).** After external access exists,

--- a/.claude/plans/harmonic-llm-gateway.md
+++ b/.claude/plans/harmonic-llm-gateway.md
@@ -1,0 +1,352 @@
+# Harmonic LLM Gateway
+
+A gateway service that makes LLM calls billed to a Harmonic prepaid credit balance,
+attributing each call to a payer — a single customer, or a collective's common pool where
+cost is spread across consenting members. It exists so a collective's members can pool
+their balances to fund their own agents.
+
+Related: [#464 common-pool LLM credits](https://github.com/ibis-coordination/Harmonic/issues/464).
+Depends on the Stripe AI Gateway billing already in production (see [docs/BILLING.md](../../docs/BILLING.md)).
+
+## Motivation
+
+Today, only Harmonic's own agent-runner spends prepaid credits, and it does so over an
+internal-only channel, with each call billed to a single customer. The goal is to let a
+**collective's members pool their prepaid balances** to fund the collective's agents, so
+LLM cost is shared fairly without any inter-user payment. A gateway service becomes the
+single place that decides, per call, which member's balance pays — and handles that
+attribution transparently so the caller never holds a Stripe key or knows how cost is
+distributed.
+
+## Scope & rollout posture
+
+**This is a collective feature, not a public LLM reseller.** The value is shared-balance
+access to fund a collective's own agents — something you cannot get by going direct to a
+provider. It is deliberately *not* a general-purpose "call any model with a Harmonic key"
+product; that framing carries resale-rights, money-transmission, acceptable-use, and SLA
+risk we are choosing not to take on. Minimizing legal and counterparty risk is a primary
+design constraint.
+
+Rollout follows that posture:
+
+- **Initial rollout is internal only.** The sole client is the agent-runner. The gateway
+  runs on the internal backend network with **no public endpoint** — no `llm.harmonic.social`
+  route, no external keys, no public money-spending surface. This erases most legal/abuse
+  concerns from the initial scope.
+- **External access is a controlled beta, gated per-collective by an admin-only feature
+  flag.** Opening the gateway to non-agent-runner clients happens for *select* collectives,
+  not the public. A per-collective feature flag (controlled by app admin, mirroring how
+  `stripe_billing` is gated) enables external access for a specific collective; it is not
+  publicly advertised. The flag is itself the risk boundary: every external participant is a
+  deliberate admin decision, so participation can be vetted and paired with explicit
+  commitment enrollment (the consent/contract instrument — see stage 2) before any external
+  key works. The architecture supports this as a pure additive (public route + an external
+  key type gated by the flag); it lands as stage 4, after the internal loop is proven.
+
+The commitment record is therefore load-bearing in two ways at once: it is the *fairness*
+mechanism (who may be drawn) and the *consent/contract* mechanism (explicit agreement to
+have one's balance spent). Never auto-enroll anyone into it.
+
+## The seam: one variable, two implementations
+
+The existing relay code ([agent-runner/src/services/LLMClient.ts](../../agent-runner/src/services/LLMClient.ts))
+already forwards to `llm.stripe.com` and parameterizes the *only* thing that matters for
+billing — a single header:
+
+```
+Authorization: Bearer {STRIPE_GATEWAY_KEY}
+X-Stripe-Customer-ID: {customer_id}
+```
+
+Everything else about the relay is invariant. So the entire difference between "one
+customer pays" and "a pool pays" lives in **how you answer "whose customer id goes in
+that header for this call?"** — not in the gateway. This is the seam the plan is built
+around:
+
+- **Single customer** — `api_key → one stripe_customer_id`. Set header, relay.
+- **Common pool** — `api_key → collective pool → pick a consenting member's
+  stripe_customer_id`. Set header, relay.
+
+Same gateway, same wire contract. The single-customer case is the N=1 degenerate case of
+the pool.
+
+## Architecture
+
+Initial (internal-only) topology — the agent-runner is the only client and there is no
+public edge:
+
+```
+agent-runner ──internal──► llm-gateway container ──Bearer key + customer header──► llm.stripe.com
+                                  │  ▲
+                        select-payer│  │record-usage   (HMAC + IP-allowlist internal API)
+                                  ▼  │
+                             Rails (web:3000)
+```
+
+Later (gated) external phase adds a public edge in front of the same gateway, unchanged
+below the edge:
+
+```
+external client ──HTTPS──► llm.harmonic.social (Caddy) ──► llm-gateway ──► (same as above)
+```
+
+- **Gateway is stateless and dumb.** It authenticates the caller, asks Rails who pays,
+  relays to Stripe, and reports token usage back. It holds `STRIPE_GATEWAY_KEY` but no
+  billing logic.
+- **Rails owns all policy** — key→payer resolution, pool membership/consent, eligibility,
+  selection, and pricing. Single source of truth.
+- **Reuses the agent-runner deployment template**: separate Docker container on the
+  backend network, talking to Rails over the existing HMAC-signed `/internal/*` channel
+  ([internal/base_controller.rb](../../app/controllers/internal/base_controller.rb)). The
+  public subdomain (via the Caddyfile generator,
+  [caddyfile_generator.rb](../../app/services/caddyfile_generator.rb)) is added only in the
+  external phase.
+
+## The resolve contract (shared by single customer and pool)
+
+Two internal endpoints, both over the existing HMAC + IP-allowlist channel. Designed so
+the gateway is written **once** and never changes as callers or payer types are added.
+
+### `POST /internal/llm-gateway/select-payer` — before relaying
+
+Request. The gateway passes a caller identity; initially that is the agent whose task is
+running (agent-runner), later it may be an external gateway key. Either resolves to a
+payer:
+
+```json
+{ "caller": { "type": "agent" | "gateway_key", "id": "..." }, "model": "anthropic/claude-sonnet-4.6" }
+```
+
+Response:
+
+```json
+{ "payer_customer_id": "cus_...", "selection_id": "sel_..." }
+```
+
+or `{ "error": "pool_exhausted" | "not_authorized" | "model_not_allowed" }`.
+
+Rails: resolve `caller → payer`. If the caller maps to a single customer (an agent's
+principal, or a single-customer key), return it directly. If it maps to a common pool,
+filter to members who consent (are in the common-pool commitment) and have positive
+balance, then **select one uniformly at random** (see below). Validate the model against
+the allowlist.
+
+### `POST /internal/llm-gateway/record-usage` — after relaying (async, fire-and-forget)
+
+```json
+{ "selection_id": "sel_...", "input_tokens": 812, "output_tokens": 344, "status": "ok" }
+```
+
+Rails computes cost from token counts × the per-model rate (pricing stays in Rails, never
+in the gateway) and logs it for observability. Under uniform-random selection this does
+**not** feed back into future selection — it is purely for accounting and monitoring.
+Runs after the client already has its response; retries on failure.
+
+## Selection strategy: uniform random
+
+For a pool of N eligible members, `select-payer` picks one **uniformly at random**. Each
+member pays 1/N of every call's cost in expectation, so cumulative shares converge to
+equal.
+
+Why uniform random over the alternatives:
+
+- **vs. round-robin** — round-robin equalizes call *counts*, not *dollars*, and can
+  phase-lock (if expensive calls recur on a period aligned with N, one member
+  systematically eats them). Random has no phase to lock onto.
+- **vs. greedy least-paid** — greedy is tighter (bounds the max spread to one call's cost)
+  but requires a durable per-(pool, member) cumulative-paid ledger, optimistic
+  reservation, concurrency control (`FOR UPDATE SKIP LOCKED`), and a new-member
+  initialization policy. Uniform random needs **none** of that — it is memoryless.
+- **Join-time problem dissolves.** Because there is no per-member history, a member who
+  joins later is simply eligible from that point on; there is nothing to catch up on and
+  no initialization decision.
+- **No concurrency contention.** Stateless selection means concurrent calls pick
+  independently — no locking, no reservation.
+
+**The one tradeoff — short-run variance.** Cumulative fairness is asymptotic. The absolute
+dollar spread between the luckiest and unluckiest member grows like √(number of calls)
+even as the relative spread shrinks. High-volume pools wash this out and nobody notices;
+a low-volume pool making a handful of expensive calls could see one member reproducibly
+pay 2–3× their share for a while.
+
+**Not a one-way door.** The selection policy is fully encapsulated in `select-payer`. If a
+low-volume pool ever needs tighter fairness, add the `cumulative_paid` ledger and switch
+that endpoint to greedy least-paid — no change to the gateway or the wire contract.
+`record-usage` already carries the per-call cost the ledger would need.
+
+## Deployment
+
+- **New container** `llm-gateway` on the backend network (mirrors agent-runner), holding
+  `STRIPE_GATEWAY_KEY` and the internal HMAC secret. **Initially internal-only** — reachable
+  by the agent-runner at `http://llm-gateway:PORT`, with no frontend exposure at all.
+- **Caddy (external phase only).** The public edge is not built in the initial project.
+  When external access is opened, add `llm.harmonic.social → llm-gateway:PORT` via the
+  Caddyfile generator (or a static block for testing). Unlike tenant blocks, this subdomain
+  routes to the gateway container, not `web:3000`.
+
+  **Decided: a dedicated subdomain (`llm.harmonic.social`), not a per-tenant path
+  (`<tenant>.harmonic.social/llm`).** The API key already carries all identity the gateway
+  needs — it resolves to a customer or a pool (in a collective, in a tenant), so a tenant
+  in the URL is redundant and introduces a second identity source that can disagree with
+  the key (validation friction for no benefit). The gateway is a *platform* service (one
+  gateway serves every pool), so a dedicated host matches its altitude; a per-tenant path
+  implies a per-tenant feature. Routing is one static block decoupled from tenant lifecycle,
+  vs. fanning a `handle /llm/*` reverse-proxy into every generated tenant block and
+  permanently reserving `/llm` in Rails' per-tenant URL namespace. `https://llm.harmonic.social`
+  also reads as a conventional LLM provider base URL — drop-in for OpenAI-compatible clients.
+  The `*.harmonic.social` wildcard cert already covers `llm.`, so no new cert. A per-tenant
+  path would only win for tenant-branded/white-label endpoints, which don't fit keys that
+  map to pools rather than tenant brands — and that stays additive later (point a custom
+  domain at the same gateway; keys carry identity regardless of host).
+- **Internal auth**: gateway → Rails uses the same HMAC-SHA256 + timestamp + nonce + IP
+  allowlist as the agent-runner. Add one direction: Rails must accept gateway-originated
+  internal calls (`select-payer`, `record-usage`).
+
+## Implementation stages
+
+Stages 1–3 are **internal-only**: the gateway exists, the agent-runner uses it, pools work,
+and a minimal UI proves the loop — all behind the backend network, no public endpoint.
+Stage 4 opens a **flag-gated external beta** to select collectives once the internal loop is
+proven. Each stage is independently landable and leaves the system working.
+
+### Stage 1 — Internal gateway, agent-runner as the only client (single customer)
+
+Stand up the `llm-gateway` container (internal-only, no public edge) and route the
+agent-runner's `stripe_gateway`-mode calls through it instead of calling `llm.stripe.com`
+directly. LiteLLM-mode calls stay unchanged. This move is the point of the whole design: it
+takes payer-selection authority out of dispatch and makes the gateway the **single** place
+that does Stripe attribution — which is what lets pools apply to internal agents for free in
+stage 2 (their calls resolve to a pool instead of a single customer with no agent-runner
+change).
+
+**The core is a lift-and-shift.** The existing stripe_gateway relay in
+[LLMClient.ts:81-170](../../agent-runner/src/services/LLMClient.ts#L81) (attach
+`Bearer STRIPE_GATEWAY_KEY` + `X-Stripe-Customer-ID`, POST `llm.stripe.com`, map 402/429,
+log `llm_request`) moves verbatim into the gateway; the only change is that the customer id
+is resolved via `select-payer` rather than passed in.
+
+Tasks:
+
+1. **`llm-gateway` container** — Node/TS, internal-only on the backend network, reusing the
+   agent-runner's `HmacSigner` / `RailsHttp` / `Logger` / `Retry` to call Rails. Holds
+   `STRIPE_GATEWAY_KEY`.
+2. **Rails `Internal::LlmGatewayController#select_payer`** (inherits `Internal::BaseController`
+   — HMAC + IP allowlist). Resolves the agent-context identity → `ai_agent` → principal →
+   `stripe_customer`, verifies funding (pricing-plan subscription + balance > 0 — the gate-(b)
+   logic already in [agent_runner_dispatch_service.rb:103](../../app/services/agent_runner_dispatch_service.rb#L103)),
+   returns `{ payer_customer_id, selection_id }` or an error. Extraction of existing dispatch
+   logic, not new logic.
+3. **Agent-runner rewire** — `stripe_gateway` mode calls the gateway (passing the
+   task-run / chat-session identity, **not** a customer id); litellm mode unchanged. Remove
+   `stripe_customer_stripe_id` from the dispatch stream and task plumbing
+   ([TaskQueue.ts:73-91](../../agent-runner/src/services/TaskQueue.ts#L73), PromptBuilder,
+   AgentLoop, crypto) — attribution now lives in the gateway, so the passed-through customer
+   id becomes dead data.
+4. **Wiring** — docker-compose `llm-gateway` service, env, Rails route for
+   `/internal/llm-gateway/*`.
+5. **Tests (TDD)** — `select_payer` request tests (resolution, funding gate, errors);
+   agent-runner mode-branch tests (stripe → gateway with identity, litellm untouched);
+   internal-agent parity check verified via the gateway's `llm_request` log + a balance drop.
+
+Scope boundaries (deferred because Stage 1's only caller is the trusted agent-runner):
+**streaming (SSE)**, **model allowlist**, **rate limiting**, **request-size caps** → stage 4
+(untrusted external callers; the agent-runner doesn't stream and models are already validated
+at dispatch). **`record-usage` persistence + usage table** → stage 2 (first consumer is the
+pool breakdown; Stage 1 verifies via logs + balance, as the current smoke test does).
+
+Small decisions: `selection_id` = stateless signed token carrying
+`(collective_id, payer_user_id, model)` (uniform-random needs no reservation, so no per-call
+write); agent-runner→gateway auth uses a **separate** HMAC secret from `AGENT_RUNNER_SECRET`
+(independent rotation/revocation, sets up stage-4 isolation); keep dispatch preflight as an
+early-abort with `select-payer` authoritative per-call; share the HMAC/http modules between
+agent-runner and gateway rather than copy (avoids crypto drift).
+
+Exit criteria: internal agents bill identically to today, now via the gateway; parity
+confirmed before proceeding.
+
+### Stage 2 — Common-pool logic (backend, testable)
+
+- `#464`'s common-pool commitment subtype: the consent/contract record for which collective
+  members may be drawn.
+- `select-payer` resolves a pool → eligible members (consenting + positive balance) →
+  **uniform-random** pick; skips dry members; returns `pool_exhausted` when none are
+  eligible.
+- `record-usage` persistence lands here (deferred from stage 1, first consumed by the
+  breakdown): a usage table + endpoint whose rows carry
+  `(collective_id, payer_user_id, model, tokens, cost)` so per collective/per user cost is
+  queryable.
+
+Internal agents whose collective has a pool now draw from members' balances. Testable
+without UI: unit-test selection (uniform distribution, dry-skip, exhaustion) and
+integration-test the `select-payer` / `record-usage` contract via console, fixtures, and
+the API.
+
+Exit criteria: a pooled collective's agent calls draw down members' balances correctly and
+the distribution is verified in tests.
+
+### Stage 3 — Minimal UI to prove end-to-end
+
+Only enough UI to exercise the backend by hand:
+
+- Create / join a common-pool commitment for a collective (explicit participation).
+- View the per-collective usage breakdown (realized cost vs. fair share).
+
+Explicitly *not* the real management experience.
+
+Exit criteria: a human can set up a pool in the UI, run a collective's agents through it,
+and watch the cost distribute — proving the full backend loop.
+
+### Stage 4 — External beta access (per-collective, admin-gated flag)
+
+Open the gateway beyond the agent-runner, to *select* collectives only. Additive to the
+architecture; the per-collective admin-only feature flag is the boundary (see Scope &
+rollout posture). Not publicly advertised.
+
+- **Per-collective feature flag**, app-admin controlled (mirrors `stripe_billing` gating).
+  External keys for a collective work only while its flag is on.
+- Public `llm.harmonic.social` edge (Caddy) + an external gateway-key credential type,
+  scoped and revocable, with per-key spend caps and rate limits.
+- The untrusted-caller protections deferred from stage 1: **streaming (SSE) passthrough**
+  (external clients stream), **model allowlist** enforced at the gateway, **rate limiting**,
+  and **request-size caps**.
+- **Internal/external traffic isolation** so a beta collective's runaway usage or a stolen
+  key can't take down internal agents (see Open decisions).
+- Explicit commitment enrollment as the consent/contract gate for every external
+  participant; acceptable-use framing sized to a vetted beta (the admin gate is the primary
+  abuse control, so full public-scale AUP enforcement is not a prerequisite).
+
+Exit criteria: a flagged beta collective can drive external LLM calls billed to its pool,
+isolated from internal traffic, with the flag as a one-switch off ramp.
+
+### Deferred — full pool management UX (separate project)
+
+The design-heavy surface: setup and consent flows, monitoring dashboards, spend controls,
+per-member distribution transparency, leaving a pool, etc. Out of scope here; tracked as
+its own project. This initial project builds only the minimal UI in stage 3.
+
+## Open decisions
+
+- **Balance freshness at selection.** Checking each member's live Stripe balance per call
+  is slow. Cache balances (short TTL) for the eligibility filter, and treat a 402 from the
+  relay as authoritative "dry now" → advance and retry once. Composes with Stripe's
+  zero-balance rejection.
+- **Model allowlist scope.** Per-gateway-key, per-pool, or global? Reuse
+  `StripeGatewayModelMapper`'s mapping/validation.
+- **Internal/external traffic isolation (external phase).** After external access exists,
+  external abuse, rate-limit saturation, or an upstream abuse flag on the shared Stripe
+  account would otherwise take down internal agents too (they route through the same
+  gateway). Likely resolution: one gateway *service*, two credential/quota lanes (separate
+  gateway keys and/or rate-limit buckets). Decide when scoping the external phase.
+- **Abuse & spend caps (external phase).** A public money-spending endpoint needs per-key
+  rate limits and per-key/per-pool spend ceilings independent of Stripe's balance gate,
+  plus a top-up chargeback posture (prepaid + consumable + card dispute = losing both the
+  money and the usage). Not needed while internal-only.
+- **Stored-value / pool legal structure.** Before external money flows, get a legal read
+  that the pool's direct-pay-per-call design (no inter-user transfer) stays clear of
+  money-transmission/stored-value regulation. Product framing itself is **decided** —
+  collective feature, not public reseller (see Scope & rollout posture).
+- **Deferred — usage reconciliation with Stripe.** Whether/how to true up Harmonic's
+  estimated `record-usage` costs against Stripe's actual metered charges (Stripe as source
+  of truth), and whether per-call metadata can make the per-collective split
+  Stripe-authoritative. Out of scope for the initial project; revisit once the backend loop
+  is proven.

--- a/.env.example
+++ b/.env.example
@@ -118,7 +118,8 @@ METRICS_AUTH_TOKEN=
 # Credit balance summary (read), Customer portal (write)
 STRIPE_API_KEY=
 # AI Gateway restricted key, used only as the Bearer token for llm.stripe.com.
-# Permissions: Billing -> Meter events (write). Needed by Rails AND agent-runner.
+# Permissions: Billing -> Meter events (write). Held by the llm-gateway
+# service only (compose profile "stripe") — not by Rails or the agent-runner.
 STRIPE_GATEWAY_KEY=
 # Webhook endpoint signature verification secret
 STRIPE_WEBHOOK_SECRET=
@@ -146,7 +147,8 @@ LLM_GATEWAY_MODE=litellm
 # Must be byte-identical on both sides. Generate with: openssl rand -hex 32
 AGENT_RUNNER_SECRET=
 # IP allowlist for /internal/* endpoints (comma-separated IPs or CIDRs).
-# In production this is the agent-runner container IP or the Docker network CIDR.
+# In production this must cover every internal service container (agent-runner
+# AND llm-gateway) — use the Docker network CIDR rather than a single IP.
 # Empty in dev/test lets any source through (reverse proxy already blocks /internal/*).
 INTERNAL_ALLOWED_IPS=
 #

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
+    "start:gateway": "node dist/gateway/server.js",
     "dev": "tsx watch src/index.ts",
+    "dev:gateway": "tsx watch src/gateway/server.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",

--- a/agent-runner/src/config/Config.ts
+++ b/agent-runner/src/config/Config.ts
@@ -7,6 +7,9 @@ export interface AppConfig {
   readonly agentRunnerSecret: string;
   readonly redisUrl: string;
   readonly litellmBaseUrl: string;
+  /** The Harmonic LLM gateway — where the runner sends billed (stripe_gateway) calls. */
+  readonly llmGatewayUrl: string;
+  /** The Stripe AI Gateway upstream — used by the gateway entrypoint, not the runner. */
   readonly stripeGatewayBaseUrl: string;
   /** Fallback route for tasks whose payload carries no llm_gateway_mode. */
   readonly llmGatewayMode: "litellm" | "stripe_gateway";
@@ -52,6 +55,7 @@ export const ConfigLive = Layer.effect(
       "STRIPE_GATEWAY_BASE_URL",
       (llmGatewayMode === "stripe_gateway" ? llmBaseUrl : undefined) ?? "https://llm.stripe.com",
     );
+    const llmGatewayUrl = yield* optionalEnv("LLM_GATEWAY_URL", "http://llm-gateway:4500");
     const stripeGatewayKey = process.env["STRIPE_GATEWAY_KEY"];
     const streamName = yield* optionalEnv("AGENT_TASKS_STREAM", "agent_tasks");
     const consumerGroup = yield* optionalEnv("AGENT_TASKS_CONSUMER_GROUP", "agent_runner");
@@ -71,6 +75,7 @@ export const ConfigLive = Layer.effect(
       agentRunnerSecret,
       redisUrl,
       litellmBaseUrl,
+      llmGatewayUrl,
       stripeGatewayBaseUrl,
       llmGatewayMode: llmGatewayMode as "litellm" | "stripe_gateway",
       stripeGatewayKey,

--- a/agent-runner/src/config/Config.ts
+++ b/agent-runner/src/config/Config.ts
@@ -43,18 +43,15 @@ export const ConfigLive = Layer.effect(
     const redisUrl = yield* optionalEnv("REDIS_URL", "redis://redis:6379");
     const llmGatewayMode = yield* optionalEnv("LLM_GATEWAY_MODE", "litellm");
     const harmonicInternalUrl = yield* optionalEnv("HARMONIC_INTERNAL_URL", "http://web:3000");
-    // LLM_BASE_URL historically overrode the single boot-mode endpoint; keep
-    // honoring it for whichever mode the env declares, with per-route
-    // overrides available via the explicit vars.
+    // LLM_BASE_URL is a legacy override for the LiteLLM route only. Billed
+    // calls go to LLM_GATEWAY_URL, and the gateway entrypoint's Stripe
+    // upstream is configured solely via STRIPE_GATEWAY_BASE_URL.
     const llmBaseUrl = process.env["LLM_BASE_URL"];
     const litellmBaseUrl = yield* optionalEnv(
       "LITELLM_BASE_URL",
       (llmGatewayMode === "litellm" ? llmBaseUrl : undefined) ?? "http://litellm:4000",
     );
-    const stripeGatewayBaseUrl = yield* optionalEnv(
-      "STRIPE_GATEWAY_BASE_URL",
-      (llmGatewayMode === "stripe_gateway" ? llmBaseUrl : undefined) ?? "https://llm.stripe.com",
-    );
+    const stripeGatewayBaseUrl = yield* optionalEnv("STRIPE_GATEWAY_BASE_URL", "https://llm.stripe.com");
     const llmGatewayUrl = yield* optionalEnv("LLM_GATEWAY_URL", "http://llm-gateway:4500");
     const stripeGatewayKey = process.env["STRIPE_GATEWAY_KEY"];
     const streamName = yield* optionalEnv("AGENT_TASKS_STREAM", "agent_tasks");

--- a/agent-runner/src/core/PromptBuilder.ts
+++ b/agent-runner/src/core/PromptBuilder.ts
@@ -29,7 +29,6 @@ export interface TaskPayload {
   readonly model: string | undefined;
   readonly agentId: string;
   readonly tenantSubdomain: string;
-  readonly stripeCustomerStripeId: string | undefined;
   /** Set by Rails at dispatch; undefined for payloads published before the field existed. */
   readonly llmGatewayMode: "litellm" | "stripe_gateway" | undefined;
   readonly mode: "task" | "chat_turn";

--- a/agent-runner/src/errors/Errors.ts
+++ b/agent-runner/src/errors/Errors.ts
@@ -40,5 +40,4 @@ export class TokenDecryptError extends Data.TaggedError("TokenDecryptError")<{
 
 export class GatewayError extends Data.TaggedError("GatewayError")<{
   readonly message: string;
-  readonly statusCode?: number | undefined;
 }> {}

--- a/agent-runner/src/errors/Errors.ts
+++ b/agent-runner/src/errors/Errors.ts
@@ -37,3 +37,8 @@ export class TokenDecryptError extends Data.TaggedError("TokenDecryptError")<{
   readonly taskRunId: string;
   readonly message: string;
 }> {}
+
+export class GatewayError extends Data.TaggedError("GatewayError")<{
+  readonly message: string;
+  readonly statusCode?: number | undefined;
+}> {}

--- a/agent-runner/src/gateway/Relay.ts
+++ b/agent-runner/src/gateway/Relay.ts
@@ -52,6 +52,11 @@ export const relay = (
           path: SELECT_PAYER_PATH,
           headers: buildHeaders(selectBody, config.agentRunnerSecret),
           body: selectBody,
+          // Keep this hop short: it's a local DB lookup, and its budget adds
+          // to the Stripe upstream's 120s. The caller's own timeout must
+          // exceed the sum (see LLMClient), or a slow-but-successful billed
+          // call gets aborted client-side after Stripe has already metered it.
+          timeoutMs: 10_000,
         }),
       catch: (error) =>
         new GatewayError({ message: `select-payer request failed: ${error instanceof Error ? error.message : String(error)}` }),

--- a/agent-runner/src/gateway/Relay.ts
+++ b/agent-runner/src/gateway/Relay.ts
@@ -1,0 +1,99 @@
+/**
+ * Gateway relay — the core of the LLM gateway.
+ *
+ * For one billed LLM call: resolve the payer via Rails `select-payer`, then
+ * forward the request body to the Stripe AI Gateway with that customer's
+ * billing header. The upstream response is returned verbatim so the caller
+ * (today the agent-runner's LLMClient) parses it exactly as it would a direct
+ * Stripe response. The gateway itself stays a dumb, stateless relay.
+ */
+
+import { Effect } from "effect";
+import { Config } from "../config/Config.js";
+import { RailsHttp } from "../services/RailsHttp.js";
+import { StripeUpstream } from "./StripeUpstream.js";
+import { buildHeaders } from "../services/HmacSigner.js";
+import { GatewayError } from "../errors/Errors.js";
+import { log } from "../services/Logger.js";
+
+const SELECT_PAYER_PATH = "/internal/llm-gateway/select-payer";
+
+export interface GatewayRelayRequest {
+  /** Task run behind this LLM call — the payer is resolved from it. */
+  readonly taskRunId: string;
+  /** Tenant subdomain, used as the Host for the internal Rails call. */
+  readonly subdomain: string;
+  /** Model name, for logging only (the body carries the authoritative model). */
+  readonly model: string;
+  /** Raw OpenAI chat-completions JSON to forward to Stripe verbatim. */
+  readonly body: string;
+}
+
+export interface GatewayRelayResult {
+  readonly status: number;
+  readonly body: string;
+}
+
+export const relay = (
+  req: GatewayRelayRequest,
+): Effect.Effect<GatewayRelayResult, GatewayError, Config | RailsHttp | StripeUpstream> =>
+  Effect.gen(function* () {
+    const config = yield* Config;
+    const rails = yield* RailsHttp;
+    const stripe = yield* StripeUpstream;
+
+    // 1. Resolve the payer (and funding) from Rails.
+    const selectBody = JSON.stringify({ task_run_id: req.taskRunId });
+    const selectResponse = yield* Effect.tryPromise({
+      try: () =>
+        rails.request({
+          method: "POST",
+          subdomain: req.subdomain,
+          path: SELECT_PAYER_PATH,
+          headers: buildHeaders(selectBody, config.agentRunnerSecret),
+          body: selectBody,
+        }),
+      catch: (error) =>
+        new GatewayError({ message: `select-payer request failed: ${error instanceof Error ? error.message : String(error)}` }),
+    });
+    const selectText = yield* Effect.promise(() => selectResponse.text());
+
+    // Propagate a payer-resolution failure (not_funded, not_a_billed_task,
+    // not found, …) verbatim without spending an LLM call.
+    if (selectResponse.statusCode !== 200) {
+      log.warn({
+        event: "select_payer_rejected",
+        task_run_id: req.taskRunId,
+        status_code: selectResponse.statusCode,
+      });
+      return { status: selectResponse.statusCode, body: selectText };
+    }
+
+    const parsed = yield* Effect.try({
+      try: () => JSON.parse(selectText) as { payer_customer_id?: string },
+      catch: () => new GatewayError({ message: "select-payer returned a non-JSON 200 body" }),
+    });
+    const payerCustomerId = parsed.payer_customer_id;
+    if (payerCustomerId === undefined || payerCustomerId === "") {
+      return yield* Effect.fail(new GatewayError({ message: "select-payer returned no payer_customer_id" }));
+    }
+
+    // 2. Forward to the Stripe AI Gateway with the billing header.
+    const startedAt = Date.now();
+    const upstream = yield* Effect.tryPromise({
+      try: () => stripe.chatCompletions({ customerId: payerCustomerId, body: req.body }),
+      catch: (error) =>
+        new GatewayError({ message: `stripe upstream failed: ${error instanceof Error ? error.message : String(error)}` }),
+    });
+
+    // Routing/observability only — never the customer id or prompt content.
+    log.info({
+      event: "llm_request",
+      gateway_mode: "stripe_gateway",
+      model: req.model,
+      status_code: upstream.status,
+      duration_ms: Date.now() - startedAt,
+    });
+
+    return { status: upstream.status, body: upstream.body };
+  });

--- a/agent-runner/src/gateway/StripeUpstream.ts
+++ b/agent-runner/src/gateway/StripeUpstream.ts
@@ -1,0 +1,54 @@
+/**
+ * Stripe AI Gateway upstream — Effect service.
+ *
+ * The single outbound hop to `llm.stripe.com`. It attaches the gateway bearer
+ * key and the per-call `X-Stripe-Customer-ID` (billing attribution), then
+ * returns the upstream response verbatim. Isolated behind a service tag so the
+ * relay can be tested without a live Stripe call.
+ */
+
+import { Context, Effect, Layer } from "effect";
+import { Config } from "../config/Config.js";
+
+export interface StripeUpstreamResult {
+  readonly status: number;
+  readonly body: string;
+}
+
+export interface StripeUpstreamService {
+  readonly chatCompletions: (opts: {
+    readonly customerId: string;
+    readonly body: string;
+  }) => Promise<StripeUpstreamResult>;
+}
+
+export class StripeUpstream extends Context.Tag("StripeUpstream")<StripeUpstream, StripeUpstreamService>() {}
+
+export const StripeUpstreamLive = Layer.effect(
+  StripeUpstream,
+  Effect.gen(function* () {
+    const config = yield* Config;
+
+    const chatCompletions: StripeUpstreamService["chatCompletions"] = async ({ customerId, body }) => {
+      if (config.stripeGatewayKey === undefined) {
+        throw new Error("STRIPE_GATEWAY_KEY is required to relay to the Stripe AI Gateway");
+      }
+
+      const response = await fetch(`${config.stripeGatewayBaseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${config.stripeGatewayKey}`,
+          "X-Stripe-Customer-ID": customerId,
+        },
+        body,
+        signal: AbortSignal.timeout(120_000),
+      });
+
+      const text = await response.text();
+      return { status: response.status, body: text };
+    };
+
+    return { chatCompletions };
+  }),
+);

--- a/agent-runner/src/gateway/handler.ts
+++ b/agent-runner/src/gateway/handler.ts
@@ -1,0 +1,65 @@
+/**
+ * HTTP request handling for the gateway, decoupled from the Effect runtime so
+ * the routing-header contract can be tested without a live Stripe/Rails stack.
+ *
+ * The relay itself is injected as a plain async function — {@link server.ts}
+ * wires in the real Effect runtime; tests wire in a fake.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { GatewayRelayRequest, GatewayRelayResult } from "./Relay.js";
+import { log } from "../services/Logger.js";
+
+export type RelayRunner = (req: GatewayRelayRequest) => Promise<GatewayRelayResult>;
+
+const readBody = (req: IncomingMessage): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+
+const header = (req: IncomingMessage, name: string): string | undefined => {
+  const value = req.headers[name];
+  return Array.isArray(value) ? value[0] : value;
+};
+
+const sendJson = (res: ServerResponse, status: number, body: string): void => {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(body);
+};
+
+export const createHandler =
+  (runRelay: RelayRunner) =>
+  async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    if (req.method === "GET" && req.url === "/health") {
+      sendJson(res, 200, JSON.stringify({ status: "ok" }));
+      return;
+    }
+    if (req.method !== "POST") {
+      sendJson(res, 405, JSON.stringify({ error: "method_not_allowed" }));
+      return;
+    }
+
+    const taskRunId = header(req, "x-harmonic-task-run-id");
+    const subdomain = header(req, "x-harmonic-subdomain");
+    const model = header(req, "x-harmonic-model") ?? "";
+    if (taskRunId === undefined || taskRunId === "" || subdomain === undefined || subdomain === "") {
+      sendJson(res, 400, JSON.stringify({ error: "missing_routing_headers" }));
+      return;
+    }
+
+    try {
+      const body = await readBody(req);
+      const result = await runRelay({ taskRunId, subdomain, model, body });
+      sendJson(res, result.status, result.body);
+    } catch (error) {
+      log.error({
+        event: "gateway_relay_error",
+        task_run_id: taskRunId,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      sendJson(res, 502, JSON.stringify({ error: "gateway_error" }));
+    }
+  };

--- a/agent-runner/src/gateway/server.ts
+++ b/agent-runner/src/gateway/server.ts
@@ -10,8 +10,8 @@
  *
  * The request body is forwarded to the Stripe AI Gateway verbatim; the upstream
  * response is returned unchanged so the caller parses it exactly as it would a
- * direct Stripe response. The service is internal-only (backend network, no
- * public edge) in this phase.
+ * direct Stripe response. The service is internal-only: backend network, no
+ * public route, no published port.
  */
 
 import { createServer } from "node:http";

--- a/agent-runner/src/gateway/server.ts
+++ b/agent-runner/src/gateway/server.ts
@@ -1,0 +1,57 @@
+/**
+ * LLM Gateway — HTTP entry point.
+ *
+ * A small HTTP server that fronts the {@link relay}. Callers (today the
+ * agent-runner) POST an OpenAI chat-completions body plus routing headers:
+ *
+ *   X-Harmonic-Task-Run-Id  — the task run behind the call (payer resolution)
+ *   X-Harmonic-Subdomain    — tenant subdomain (Host for the internal Rails call)
+ *   X-Harmonic-Model        — model name, for logging only
+ *
+ * The request body is forwarded to the Stripe AI Gateway verbatim; the upstream
+ * response is returned unchanged so the caller parses it exactly as it would a
+ * direct Stripe response. The service is internal-only (backend network, no
+ * public edge) in this phase.
+ */
+
+import { createServer } from "node:http";
+import { Layer, ManagedRuntime } from "effect";
+import { ConfigLive } from "../config/Config.js";
+import { RailsHttpLive } from "../services/RailsHttp.js";
+import { StripeUpstreamLive } from "./StripeUpstream.js";
+import { relay } from "./Relay.js";
+import { createHandler } from "./handler.js";
+import { log } from "../services/Logger.js";
+
+// Fail fast on the misconfiguration that would otherwise 502 every relay: the
+// gateway's entire job is to reach the Stripe AI Gateway with this key.
+if (process.env["STRIPE_GATEWAY_KEY"] === undefined || process.env["STRIPE_GATEWAY_KEY"] === "") {
+  log.error({ event: "gateway_misconfigured", message: "STRIPE_GATEWAY_KEY is required" });
+  process.exit(1);
+}
+
+const AppLayer = Layer.provideMerge(
+  Layer.mergeAll(RailsHttpLive, StripeUpstreamLive),
+  ConfigLive,
+);
+const runtime = ManagedRuntime.make(AppLayer);
+
+const handler = createHandler((req) => runtime.runPromise(relay(req)));
+
+const port = parseInt(process.env["GATEWAY_PORT"] ?? "4500", 10) || 4500;
+const server = createServer((req, res) => {
+  void handler(req, res);
+});
+
+server.listen(port, () => {
+  log.info({ event: "gateway_listening", port });
+});
+
+const shutdown = (signal: string): void => {
+  log.info({ event: "gateway_shutdown", signal });
+  server.close(() => {
+    void runtime.dispose().finally(() => process.exit(0));
+  });
+};
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/agent-runner/src/services/AgentLoop.ts
+++ b/agent-runner/src/services/AgentLoop.ts
@@ -328,7 +328,7 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
           messages,
           task.model,
           tools,
-          task.stripeCustomerStripeId,
+          { taskRunId: task.taskRunId, subdomain: task.tenantSubdomain },
           task.llmGatewayMode,
         ).pipe(
           Effect.map((r) => ({ ok: true as const, response: r })),
@@ -593,7 +593,7 @@ const updateScratchpad = (
       [{ role: "user", content: prompt }],
       task.model,
       [], // no tools for scratchpad
-      task.stripeCustomerStripeId,
+      { taskRunId: task.taskRunId, subdomain: task.tenantSubdomain },
       task.llmGatewayMode,
     );
 

--- a/agent-runner/src/services/LLMClient.ts
+++ b/agent-runner/src/services/LLMClient.ts
@@ -28,12 +28,22 @@ export interface LLMResponse {
   readonly reasoning: string | undefined;
 }
 
+/**
+ * Identity of the task behind a billed LLM call. The Harmonic LLM gateway
+ * resolves the paying Stripe customer from it — the runner never sees
+ * customer ids or Stripe credentials.
+ */
+export interface GatewayRouting {
+  readonly taskRunId: string;
+  readonly subdomain: string;
+}
+
 export interface LLMClientService {
   readonly chat: (
     messages: readonly Message[],
     model: string | undefined,
     tools: readonly ToolDefinition[],
-    stripeCustomerId: string | undefined,
+    routing: GatewayRouting | undefined,
     gatewayMode?: "litellm" | "stripe_gateway",
   ) => Effect.Effect<LLMResponse, LLMError>;
 }
@@ -78,11 +88,14 @@ export const LLMClientLive = Layer.effect(
   Effect.gen(function* () {
     const config = yield* Config;
 
-    const chat: LLMClientService["chat"] = (messages, model, tools, stripeCustomerId, gatewayMode) =>
+    const chat: LLMClientService["chat"] = (messages, model, tools, routing, gatewayMode) =>
       Effect.tryPromise({
         try: async () => {
           const mode = gatewayMode ?? config.llmGatewayMode;
-          const baseUrl = mode === "stripe_gateway" ? config.stripeGatewayBaseUrl : config.litellmBaseUrl;
+          // Billed calls go to the Harmonic LLM gateway, which resolves the
+          // payer and relays to the Stripe AI Gateway. Everything else goes
+          // straight to LiteLLM.
+          const baseUrl = mode === "stripe_gateway" ? config.llmGatewayUrl : config.litellmBaseUrl;
           const endpoint = mode === "stripe_gateway"
             ? "/chat/completions"
             : "/v1/chat/completions";
@@ -92,16 +105,14 @@ export const LLMClientLive = Layer.effect(
           };
 
           if (mode === "stripe_gateway") {
-            if (config.stripeGatewayKey === undefined) {
-              throw new Error("STRIPE_GATEWAY_KEY is required in stripe_gateway mode");
+            if (routing === undefined) {
+              // Without the task identity the gateway cannot resolve who pays —
+              // refuse rather than send an unattributable billed call.
+              throw new Error("stripe_gateway mode requires the task run identity for billing attribution");
             }
-            if (stripeCustomerId === undefined) {
-              // Without the customer header the gateway would bill the platform
-              // account instead of the tenant — refuse rather than eat the cost.
-              throw new Error("stripe_gateway mode requires a stripe customer id for billing attribution");
-            }
-            headers["Authorization"] = `Bearer ${config.stripeGatewayKey}`;
-            headers["X-Stripe-Customer-ID"] = stripeCustomerId;
+            headers["X-Harmonic-Task-Run-Id"] = routing.taskRunId;
+            headers["X-Harmonic-Subdomain"] = routing.subdomain;
+            headers["X-Harmonic-Model"] = model ?? "default";
           }
 
           const body = JSON.stringify({
@@ -127,13 +138,13 @@ export const LLMClientLive = Layer.effect(
           });
           const durationMs = Date.now() - startedAt;
 
-          // Routing fields only — never the customer id itself.
+          // Routing fields only — customer ids never flow through the runner.
           const requestLogFields = {
             gateway_mode: mode,
             model: model ?? "default",
             status_code: response.status,
             duration_ms: durationMs,
-            stripe_customer_present: stripeCustomerId !== undefined,
+            task_run_id: routing?.taskRunId,
           };
 
           if (!response.ok) {

--- a/agent-runner/src/services/LLMClient.ts
+++ b/agent-runner/src/services/LLMClient.ts
@@ -130,11 +130,16 @@ export const LLMClientLive = Layer.effect(
 
           const url = `${baseUrl}${endpoint}`;
           const startedAt = Date.now();
+          // The gateway hop nests two budgets (select-payer 10s + Stripe 120s),
+          // so its client-side timeout must exceed their sum — aborting here
+          // while the gateway's Stripe call runs on would bill the customer
+          // for a response we discard. Direct LiteLLM calls keep the flat 120s.
+          const timeoutMs = mode === "stripe_gateway" ? 160_000 : 120_000;
           const response = await fetch(url, {
             method: "POST",
             headers,
             body,
-            signal: AbortSignal.timeout(120_000),
+            signal: AbortSignal.timeout(timeoutMs),
           });
           const durationMs = Date.now() - startedAt;
 

--- a/agent-runner/src/services/TaskQueue.ts
+++ b/agent-runner/src/services/TaskQueue.ts
@@ -70,7 +70,6 @@ export function parseStreamEntry(fields: string[]): TaskPayload | null {
   const maxSteps = maxStepsStr !== undefined ? parseInt(maxStepsStr, 10) : 30;
 
   const model = map.get("model");
-  const stripeCustomerStripeId = map.get("stripe_customer_stripe_id");
   const llmGatewayModeStr = map.get("llm_gateway_mode");
   const llmGatewayMode =
     llmGatewayModeStr === "stripe_gateway" || llmGatewayModeStr === "litellm"
@@ -87,7 +86,6 @@ export function parseStreamEntry(fields: string[]): TaskPayload | null {
     model: model !== undefined && model !== "" ? model : undefined,
     agentId,
     tenantSubdomain,
-    stripeCustomerStripeId: stripeCustomerStripeId !== undefined && stripeCustomerStripeId !== "" ? stripeCustomerStripeId : undefined,
     llmGatewayMode,
     mode: mode === "chat_turn" ? "chat_turn" : "task",
     chatSessionId: chatSessionId !== undefined && chatSessionId !== "" ? chatSessionId : undefined,

--- a/agent-runner/test/config/Config.test.ts
+++ b/agent-runner/test/config/Config.test.ts
@@ -33,11 +33,23 @@ describe("Config LLM base URLs", () => {
     expect(config.stripeGatewayBaseUrl).toBe("https://llm.stripe.com");
   });
 
-  it("honors LLM_BASE_URL for the gateway route when boot mode is stripe_gateway", async () => {
+  it("LLM_BASE_URL never affects the Stripe upstream — that is STRIPE_GATEWAY_BASE_URL's job", async () => {
     vi.stubEnv("LLM_GATEWAY_MODE", "stripe_gateway");
     vi.stubEnv("LLM_BASE_URL", "https://gateway-proxy.test");
     const config = await loadConfig();
-    expect(config.stripeGatewayBaseUrl).toBe("https://gateway-proxy.test");
+    expect(config.stripeGatewayBaseUrl).toBe("https://llm.stripe.com");
     expect(config.litellmBaseUrl).toBe("http://litellm:4000");
+  });
+
+  it("honors STRIPE_GATEWAY_BASE_URL for the Stripe upstream", async () => {
+    vi.stubEnv("STRIPE_GATEWAY_BASE_URL", "https://stripe-proxy.test");
+    const config = await loadConfig();
+    expect(config.stripeGatewayBaseUrl).toBe("https://stripe-proxy.test");
+  });
+
+  it("defaults the Harmonic LLM gateway URL and honors LLM_GATEWAY_URL", async () => {
+    expect((await loadConfig()).llmGatewayUrl).toBe("http://llm-gateway:4500");
+    vi.stubEnv("LLM_GATEWAY_URL", "http://gateway.test:9000");
+    expect((await loadConfig()).llmGatewayUrl).toBe("http://gateway.test:9000");
   });
 });

--- a/agent-runner/test/core/PromptBuilder.test.ts
+++ b/agent-runner/test/core/PromptBuilder.test.ts
@@ -17,7 +17,6 @@ describe("buildInitialMessages", () => {
     model: undefined,
     agentId: "agent-1",
     tenantSubdomain: "test",
-    stripeCustomerStripeId: undefined,
   };
 
   it("builds system + user messages", () => {

--- a/agent-runner/test/gateway/Relay.test.ts
+++ b/agent-runner/test/gateway/Relay.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { Effect, Layer } from "effect";
+import { relay } from "../../src/gateway/Relay.js";
+import { StripeUpstream } from "../../src/gateway/StripeUpstream.js";
+import type { StripeUpstreamService } from "../../src/gateway/StripeUpstream.js";
+import { RailsHttp } from "../../src/services/RailsHttp.js";
+import type { RailsHttpService, RailsResponse, RailsRequestOptions } from "../../src/services/RailsHttp.js";
+import { Config } from "../../src/config/Config.js";
+import type { AppConfig } from "../../src/config/Config.js";
+
+const testConfig: AppConfig = {
+  harmonicInternalUrl: "http://web:3000",
+  harmonicHostname: "harmonic.local",
+  agentRunnerSecret: "test-secret",
+  redisUrl: "redis://redis:6379",
+  litellmBaseUrl: "http://litellm:4000",
+  stripeGatewayBaseUrl: "https://llm.stripe.com",
+  llmGatewayMode: "stripe_gateway",
+  stripeGatewayKey: "sk_test",
+  streamName: "agent_tasks",
+  consumerGroup: "agent_runner",
+  consumerName: "runner-test",
+  maxConcurrentTasks: 100,
+  streamMaxLen: 10000,
+};
+const ConfigTest = Layer.succeed(Config, testConfig);
+
+// Mock RailsHttp: canned select-payer response; optionally capture the request.
+const railsLayer = (
+  resp: { statusCode: number; body: string },
+  capture?: (opts: RailsRequestOptions) => void,
+): Layer.Layer<RailsHttp> => {
+  const service: RailsHttpService = {
+    request: async (opts): Promise<RailsResponse> => {
+      capture?.(opts);
+      return { statusCode: resp.statusCode, headers: {}, text: async () => resp.body };
+    },
+  };
+  return Layer.succeed(RailsHttp, service);
+};
+
+// Mock StripeUpstream with a supplied implementation.
+const stripeLayer = (impl: StripeUpstreamService["chatCompletions"]): Layer.Layer<StripeUpstream> =>
+  Layer.succeed(StripeUpstream, { chatCompletions: impl });
+
+const req = {
+  taskRunId: "task-run-1",
+  subdomain: "acme",
+  model: "anthropic/claude-sonnet-4.6",
+  body: JSON.stringify({ model: "anthropic/claude-sonnet-4.6", messages: [] }),
+};
+
+describe("gateway relay", () => {
+  it("resolves the payer and forwards to Stripe with the customer header", async () => {
+    let capturedCustomerId: string | undefined;
+    let capturedSelectPath: string | undefined;
+    let capturedSubdomain: string | undefined;
+
+    const layers = Layer.mergeAll(
+      ConfigTest,
+      railsLayer(
+        { statusCode: 200, body: JSON.stringify({ payer_customer_id: "cus_abc" }) },
+        (opts) => {
+          capturedSelectPath = opts.path;
+          capturedSubdomain = opts.subdomain;
+        },
+      ),
+      stripeLayer(async ({ customerId, body }) => {
+        capturedCustomerId = customerId;
+        return { status: 200, body: `{"echoed":${JSON.stringify(body)}}` };
+      }),
+    );
+
+    const result = await Effect.runPromise(Effect.provide(relay(req), layers));
+
+    expect(result.status).toBe(200);
+    expect(capturedCustomerId).toBe("cus_abc");
+    expect(capturedSelectPath).toBe("/internal/llm-gateway/select-payer");
+    expect(capturedSubdomain).toBe("acme");
+  });
+
+  it("propagates a select-payer failure without calling Stripe", async () => {
+    let stripeCalled = false;
+
+    const layers = Layer.mergeAll(
+      ConfigTest,
+      railsLayer({ statusCode: 402, body: JSON.stringify({ error: "not_funded" }) }),
+      stripeLayer(async () => {
+        stripeCalled = true;
+        return { status: 200, body: "{}" };
+      }),
+    );
+
+    const result = await Effect.runPromise(Effect.provide(relay(req), layers));
+
+    expect(result.status).toBe(402);
+    expect(JSON.parse(result.body)).toEqual({ error: "not_funded" });
+    expect(stripeCalled).toBe(false);
+  });
+
+  it("propagates a Stripe error status back to the caller", async () => {
+    const layers = Layer.mergeAll(
+      ConfigTest,
+      railsLayer({ statusCode: 200, body: JSON.stringify({ payer_customer_id: "cus_abc" }) }),
+      stripeLayer(async () => ({ status: 402, body: JSON.stringify({ error: "payment required" }) })),
+    );
+
+    const result = await Effect.runPromise(Effect.provide(relay(req), layers));
+
+    expect(result.status).toBe(402);
+  });
+});

--- a/agent-runner/test/gateway/Relay.test.ts
+++ b/agent-runner/test/gateway/Relay.test.ts
@@ -14,6 +14,7 @@ const testConfig: AppConfig = {
   agentRunnerSecret: "test-secret",
   redisUrl: "redis://redis:6379",
   litellmBaseUrl: "http://litellm:4000",
+  llmGatewayUrl: "http://llm-gateway:4500",
   stripeGatewayBaseUrl: "https://llm.stripe.com",
   llmGatewayMode: "stripe_gateway",
   stripeGatewayKey: "sk_test",
@@ -77,6 +78,25 @@ describe("gateway relay", () => {
     expect(capturedCustomerId).toBe("cus_abc");
     expect(capturedSelectPath).toBe("/internal/llm-gateway/select-payer");
     expect(capturedSubdomain).toBe("acme");
+  });
+
+  it("bounds the select-payer hop with a short timeout so the relay budget stays under the caller's", async () => {
+    let capturedTimeout: number | undefined;
+
+    const layers = Layer.mergeAll(
+      ConfigTest,
+      railsLayer(
+        { statusCode: 200, body: JSON.stringify({ payer_customer_id: "cus_abc" }) },
+        (opts) => {
+          capturedTimeout = opts.timeoutMs;
+        },
+      ),
+      stripeLayer(async () => ({ status: 200, body: "{}" })),
+    );
+
+    await Effect.runPromise(Effect.provide(relay(req), layers));
+
+    expect(capturedTimeout).toBe(10_000);
   });
 
   it("propagates a select-payer failure without calling Stripe", async () => {

--- a/agent-runner/test/gateway/StripeUpstream.test.ts
+++ b/agent-runner/test/gateway/StripeUpstream.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { Effect, Layer } from "effect";
+import { StripeUpstream, StripeUpstreamLive } from "../../src/gateway/StripeUpstream.js";
+import { Config } from "../../src/config/Config.js";
+import type { AppConfig } from "../../src/config/Config.js";
+
+const testConfig: AppConfig = {
+  harmonicInternalUrl: "http://web:3000",
+  harmonicHostname: "harmonic.local",
+  agentRunnerSecret: "test-secret",
+  redisUrl: "redis://redis:6379",
+  litellmBaseUrl: "http://litellm:4000",
+  llmGatewayUrl: "http://llm-gateway:4500",
+  stripeGatewayBaseUrl: "https://stripe.test",
+  llmGatewayMode: "litellm",
+  stripeGatewayKey: "rk_test_gw",
+  streamName: "agent_tasks",
+  consumerGroup: "agent_runner",
+  consumerName: "runner-test",
+  maxConcurrentTasks: 100,
+  streamMaxLen: 10000,
+};
+
+const run = (config: AppConfig, opts: { customerId: string; body: string }) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const stripe = yield* StripeUpstream;
+      return yield* Effect.promise(() => stripe.chatCompletions(opts));
+    }).pipe(Effect.provide(StripeUpstreamLive.pipe(Layer.provide(Layer.succeed(Config, config))))),
+  );
+
+describe("StripeUpstream", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts the body verbatim with the gateway key and customer billing header", async () => {
+    const fetchSpy = vi.fn(async () => new Response('{"ok":true}', { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const body = JSON.stringify({ model: "anthropic/claude-sonnet-4.6", messages: [] });
+    const result = await run(testConfig, { customerId: "cus_abc", body });
+
+    const [url, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://stripe.test/chat/completions");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer rk_test_gw");
+    expect(headers["X-Stripe-Customer-ID"]).toBe("cus_abc");
+    expect(init.body).toBe(body);
+    expect(result).toEqual({ status: 200, body: '{"ok":true}' });
+  });
+
+  it("returns the upstream status and body verbatim on error responses", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("insufficient credit", { status: 402 })));
+
+    const result = await run(testConfig, { customerId: "cus_abc", body: "{}" });
+
+    expect(result).toEqual({ status: 402, body: "insufficient credit" });
+  });
+
+  it("refuses to call Stripe without the gateway key", async () => {
+    const fetchSpy = vi.fn(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(
+      run({ ...testConfig, stripeGatewayKey: undefined }, { customerId: "cus_abc", body: "{}" }),
+    ).rejects.toThrow(/STRIPE_GATEWAY_KEY/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/agent-runner/test/gateway/handler.test.ts
+++ b/agent-runner/test/gateway/handler.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { createServer, type Server } from "node:http";
+import { createHandler, type RelayRunner } from "../../src/gateway/handler.js";
+import type { GatewayRelayRequest } from "../../src/gateway/Relay.js";
+
+let running: Server | undefined;
+
+afterEach(async () => {
+  if (running) {
+    await new Promise<void>((resolve) => running!.close(() => resolve()));
+    running = undefined;
+  }
+});
+
+const start = (runRelay: RelayRunner): Promise<string> =>
+  new Promise((resolve) => {
+    const handler = createHandler(runRelay);
+    running = createServer((req, res) => void handler(req, res));
+    running.listen(0, () => {
+      const addr = running!.address();
+      const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+
+const okRelay: RelayRunner = async () => ({ status: 200, body: JSON.stringify({ ok: true }) });
+
+describe("gateway handler", () => {
+  it("serves health without invoking the relay", async () => {
+    let called = false;
+    const url = await start(async (r) => {
+      called = true;
+      return okRelay(r);
+    });
+
+    const res = await fetch(`${url}/health`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+    expect(called).toBe(false);
+  });
+
+  it("passes routing headers and body through to the relay and returns its result", async () => {
+    let captured: GatewayRelayRequest | undefined;
+    const url = await start(async (r) => {
+      captured = r;
+      return { status: 200, body: JSON.stringify({ echoed: true }) };
+    });
+
+    const res = await fetch(`${url}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "X-Harmonic-Task-Run-Id": "task-run-9",
+        "X-Harmonic-Subdomain": "acme",
+        "X-Harmonic-Model": "anthropic/claude-sonnet-4.6",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ messages: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ echoed: true });
+    expect(captured).toEqual({
+      taskRunId: "task-run-9",
+      subdomain: "acme",
+      model: "anthropic/claude-sonnet-4.6",
+      body: JSON.stringify({ messages: [] }),
+    });
+  });
+
+  it("rejects a POST missing routing headers without invoking the relay", async () => {
+    let called = false;
+    const url = await start(async (r) => {
+      called = true;
+      return okRelay(r);
+    });
+
+    const res = await fetch(`${url}/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "missing_routing_headers" });
+    expect(called).toBe(false);
+  });
+
+  it("returns 405 for a non-POST, non-health request", async () => {
+    const url = await start(okRelay);
+    const res = await fetch(`${url}/chat/completions`, { method: "GET" });
+    expect(res.status).toBe(405);
+  });
+
+  it("maps a relay exception to 502", async () => {
+    const url = await start(async () => {
+      throw new Error("boom");
+    });
+
+    const res = await fetch(`${url}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "X-Harmonic-Task-Run-Id": "task-run-9",
+        "X-Harmonic-Subdomain": "acme",
+      },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "gateway_error" });
+  });
+});

--- a/agent-runner/test/services/AgentLoop.test.ts
+++ b/agent-runner/test/services/AgentLoop.test.ts
@@ -37,7 +37,6 @@ function makeTask(overrides?: Partial<TaskPayload>): TaskPayload {
     model: undefined,
     agentId: "agent-1",
     tenantSubdomain: "test",
-    stripeCustomerStripeId: undefined,
     mode: "task",
     chatSessionId: undefined,
     ...overrides,

--- a/agent-runner/test/services/LLMClient.test.ts
+++ b/agent-runner/test/services/LLMClient.test.ts
@@ -10,6 +10,7 @@ const baseConfig = {
   agentRunnerSecret: "test-secret",
   redisUrl: "redis://test:6379",
   litellmBaseUrl: "http://litellm:4000",
+  llmGatewayUrl: "http://llm-gateway:4500",
   stripeGatewayBaseUrl: "https://stripe.test",
   llmGatewayMode: "litellm" as const,
   stripeGatewayKey: undefined,
@@ -120,73 +121,71 @@ const okBody = {
 
 function runChatWith(
   config: Partial<typeof baseConfig>,
-  opts: { customerId?: string; gatewayMode?: "litellm" | "stripe_gateway"; response?: Response },
+  opts: {
+    routing?: { taskRunId: string; subdomain: string };
+    gatewayMode?: "litellm" | "stripe_gateway";
+    response?: Response;
+  },
 ) {
   const fetchSpy = vi.fn(async () => opts.response ?? jsonResponse(okBody));
   vi.stubGlobal("fetch", fetchSpy);
   const layer = Layer.succeed(Config, { ...baseConfig, ...config });
   const program = Effect.gen(function* () {
     const client = yield* LLMClient;
-    return yield* client.chat([], undefined, [], opts.customerId, opts.gatewayMode);
+    return yield* client.chat([], undefined, [], opts.routing, opts.gatewayMode);
   });
   return Effect.runPromise(
     program.pipe(Effect.provide(LLMClientLive.pipe(Layer.provide(layer)))),
   ).then(() => fetchSpy);
 }
 
+const routing = { taskRunId: "task-run-1", subdomain: "acme" };
+
 describe("LLMClient per-task gateway routing", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("routes to the Stripe gateway when the task says stripe_gateway", async () => {
-    const fetchSpy = await runChatWith(
-      { stripeGatewayKey: "rk_test_123" },
-      { customerId: "cus_abc", gatewayMode: "stripe_gateway" },
-    );
+  it("routes stripe_gateway calls to the Harmonic LLM gateway with routing headers", async () => {
+    const fetchSpy = await runChatWith({}, { routing, gatewayMode: "stripe_gateway" });
 
     const [url, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
-    expect(url).toBe("https://stripe.test/chat/completions");
+    expect(url).toBe("http://llm-gateway:4500/chat/completions");
     const headers = init.headers as Record<string, string>;
-    expect(headers["Authorization"]).toBe("Bearer rk_test_123");
-    expect(headers["X-Stripe-Customer-ID"]).toBe("cus_abc");
+    expect(headers["X-Harmonic-Task-Run-Id"]).toBe("task-run-1");
+    expect(headers["X-Harmonic-Subdomain"]).toBe("acme");
+    expect(headers["X-Harmonic-Model"]).toBe("default");
+    // The runner no longer holds Stripe credentials or customer ids.
+    expect(headers["Authorization"]).toBeUndefined();
+    expect(headers["X-Stripe-Customer-ID"]).toBeUndefined();
   });
 
   it("routes to LiteLLM when the task says litellm even if the config default is stripe_gateway", async () => {
     const fetchSpy = await runChatWith(
-      { llmGatewayMode: "stripe_gateway", stripeGatewayKey: "rk_test_123" },
-      { gatewayMode: "litellm" },
+      { llmGatewayMode: "stripe_gateway" },
+      { routing, gatewayMode: "litellm" },
     );
 
     const [url, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe("http://litellm:4000/v1/chat/completions");
     const headers = init.headers as Record<string, string>;
-    expect(headers["Authorization"]).toBeUndefined();
+    expect(headers["X-Harmonic-Task-Run-Id"]).toBeUndefined();
   });
 
   it("falls back to the config mode when the task carries no mode", async () => {
     const fetchSpy = await runChatWith(
-      { llmGatewayMode: "stripe_gateway", stripeGatewayKey: "rk_test_123" },
-      { customerId: "cus_abc" },
+      { llmGatewayMode: "stripe_gateway" },
+      { routing },
     );
 
     const [url] = fetchSpy.mock.calls[0] as unknown as [string];
-    expect(url).toBe("https://stripe.test/chat/completions");
+    expect(url).toBe("http://llm-gateway:4500/chat/completions");
   });
 
-  it("fails in stripe_gateway mode without a stripe customer id", async () => {
+  it("fails in stripe_gateway mode without routing identity", async () => {
     await expect(
-      runChatWith(
-        { stripeGatewayKey: "rk_test_123" },
-        { gatewayMode: "stripe_gateway" },
-      ),
-    ).rejects.toThrow(/customer/i);
-  });
-
-  it("fails in stripe_gateway mode without STRIPE_GATEWAY_KEY", async () => {
-    await expect(
-      runChatWith({}, { customerId: "cus_abc", gatewayMode: "stripe_gateway" }),
-    ).rejects.toThrow(/STRIPE_GATEWAY_KEY/);
+      runChatWith({}, { gatewayMode: "stripe_gateway" }),
+    ).rejects.toThrow(/task run/i);
   });
 });
 
@@ -196,13 +195,10 @@ describe("LLMClient request logging", () => {
     vi.restoreAllMocks();
   });
 
-  it("logs a structured llm_request line without leaking the customer id", async () => {
+  it("logs a structured llm_request line", async () => {
     const infoSpy = vi.spyOn(log, "info").mockImplementation(() => {});
 
-    await runChatWith(
-      { stripeGatewayKey: "rk_test_123" },
-      { customerId: "cus_abc", gatewayMode: "stripe_gateway" },
-    );
+    await runChatWith({}, { routing, gatewayMode: "stripe_gateway" });
 
     const entry = infoSpy.mock.calls
       .map((c) => c[0] as Record<string, unknown>)
@@ -211,13 +207,12 @@ describe("LLMClient request logging", () => {
       event: "llm_request",
       gateway_mode: "stripe_gateway",
       status_code: 200,
-      stripe_customer_present: true,
+      task_run_id: "task-run-1",
       model: "default",
       input_tokens: 1,
       output_tokens: 1,
     });
     expect(entry?.["duration_ms"]).toBeGreaterThanOrEqual(0);
-    expect(JSON.stringify(entry)).not.toContain("cus_abc");
   });
 
   it("logs the failure status when the gateway rejects the request", async () => {
@@ -225,9 +220,9 @@ describe("LLMClient request logging", () => {
 
     await expect(
       runChatWith(
-        { stripeGatewayKey: "rk_test_123" },
+        {},
         {
-          customerId: "cus_abc",
+          routing,
           gatewayMode: "stripe_gateway",
           response: new Response("insufficient credit", { status: 402 }),
         },
@@ -241,8 +236,7 @@ describe("LLMClient request logging", () => {
       event: "llm_request_failed",
       gateway_mode: "stripe_gateway",
       status_code: 402,
-      stripe_customer_present: true,
+      task_run_id: "task-run-1",
     });
-    expect(JSON.stringify(entry)).not.toContain("cus_abc");
   });
 });

--- a/agent-runner/test/services/TaskQueue.test.ts
+++ b/agent-runner/test/services/TaskQueue.test.ts
@@ -10,6 +10,7 @@ function fields(overrides: Record<string, string> = {}): string[] {
     model: "anthropic/claude-sonnet-4-6",
     agent_id: "agent-1",
     tenant_subdomain: "test",
+    // Legacy field from pre-gateway dispatches; the parser must ignore it.
     stripe_customer_stripe_id: "cus_abc",
     mode: "task",
     chat_session_id: "",

--- a/app/controllers/internal/llm_gateway_controller.rb
+++ b/app/controllers/internal/llm_gateway_controller.rb
@@ -12,7 +12,9 @@ module Internal
     # that should pay for it (and verify that payer is funded).
     sig { void }
     def select_payer
-      task_run = AiAgentTaskRun.find_by(id: params[:task_run_id])
+      # Eager-load the payer: this runs once per LLM call, so the lazy
+      # belongs_to would double the query count on a hot path.
+      task_run = AiAgentTaskRun.includes(:billing_customer).find_by(id: params[:task_run_id])
       if task_run.nil?
         render json: { error: "Task run not found" }, status: :not_found
         return

--- a/app/controllers/internal/llm_gateway_controller.rb
+++ b/app/controllers/internal/llm_gateway_controller.rb
@@ -1,0 +1,27 @@
+# typed: true
+# frozen_string_literal: true
+
+# Internal API for the LLM gateway service.
+# Inherits IP restriction, HMAC verification, and tenant resolution from BaseController.
+module Internal
+  class LLMGatewayController < BaseController
+    extend T::Sig
+
+    # POST /internal/llm-gateway/select-payer
+    # Given the task run behind a billed LLM call, resolve the Stripe customer
+    # that should pay for it (and verify that payer is funded).
+    sig { void }
+    def select_payer
+      task_run = AiAgentTaskRun.find_by(id: params[:task_run_id])
+      if task_run.nil?
+        render json: { error: "Task run not found" }, status: :not_found
+        return
+      end
+
+      result = LLMGateway::PayerResolver.resolve(task_run)
+      render json: { payer_customer_id: result.payer_customer_id }
+    rescue LLMGateway::PayerResolver::ResolutionError => e
+      render json: { error: e.code }, status: e.http_status
+    end
+  end
+end

--- a/app/services/agent_runner_dispatch_service.rb
+++ b/app/services/agent_runner_dispatch_service.rb
@@ -55,9 +55,8 @@ class AgentRunnerDispatchService
     end
 
     # Billing checks. System agents (e.g., Trio) are exempt: they have no
-    # billing_customer, are never charged, and the agent-runner already
-    # tolerates a missing stripe_customer_stripe_id by skipping the
-    # X-Stripe-Customer-ID header.
+    # billing_customer, are never charged, and route through LiteLLM rather
+    # than the LLM gateway.
     billing_customer = ai_agent.billing_customer
     if tenant.feature_enabled?("stripe_billing") && !ai_agent.system?
       # (a) The agent's identity must be paid for before we run a task — the
@@ -137,7 +136,7 @@ class AgentRunnerDispatchService
 
     # Publish to Redis Stream with encrypted token
     begin
-      publish_to_stream(token, billing_customer, model: model, gateway_mode: gateway_mode)
+      publish_to_stream(token, model: model, gateway_mode: gateway_mode)
     rescue StandardError => e
       # Redis failure after token creation — clean up the token and fail the task
       # so it shows up on the admin page instead of lurking as "queued" forever.
@@ -181,11 +180,13 @@ class AgentRunnerDispatchService
     Rails.logger.error("[AgentRunnerDispatchService] Failed to broadcast chat error: #{e.message}")
   end
 
-  sig { params(token: ApiToken, billing_customer: T.nilable(StripeCustomer), model: String, gateway_mode: String).void }
-  def publish_to_stream(token, billing_customer, model:, gateway_mode:)
+  sig { params(token: ApiToken, model: String, gateway_mode: String).void }
+  def publish_to_stream(token, model:, gateway_mode:)
     encrypted_token = AgentRunnerCrypto.encrypt(token.plaintext_token)
 
     redis = Redis.new(url: ENV["REDIS_URL"])
+    # No customer id in the payload: billing attribution is stamped on the task
+    # run (stripe_customer_id) and resolved by the LLM gateway per call.
     payload = {
       task_run_id: @task_run.id,
       encrypted_token: encrypted_token,
@@ -195,7 +196,6 @@ class AgentRunnerDispatchService
       llm_gateway_mode: gateway_mode,
       agent_id: T.must(@task_run.ai_agent).id,
       tenant_subdomain: T.must(@task_run.tenant).subdomain,
-      stripe_customer_stripe_id: billing_customer&.stripe_id || "",
       mode: @task_run.mode,
       chat_session_id: @task_run.chat_session_id || "",
     }

--- a/app/services/llm_gateway/payer_resolver.rb
+++ b/app/services/llm_gateway/payer_resolver.rb
@@ -1,0 +1,76 @@
+# typed: true
+# frozen_string_literal: true
+
+module LLMGateway
+  # Resolves which Stripe customer pays for a billed LLM call, and verifies the
+  # payer is funded. This is the single home for payer-selection policy: today
+  # it resolves a task run to its stamped billing customer (one payer); the
+  # common-pool selection will extend this same seam.
+  class PayerResolver
+    extend T::Sig
+
+    Result = Struct.new(:payer_customer_id, keyword_init: true)
+
+    # A resolution failure that carries the wire error code and HTTP status the
+    # gateway (and its callers) should surface.
+    class ResolutionError < StandardError
+      extend T::Sig
+
+      sig { returns(String) }
+      attr_reader :code
+
+      sig { returns(Symbol) }
+      attr_reader :http_status
+
+      sig { params(code: String, http_status: Symbol, message: String).void }
+      def initialize(code, http_status, message)
+        @code = code
+        @http_status = http_status
+        super(message)
+      end
+    end
+
+    sig { params(task_run: AiAgentTaskRun).returns(Result) }
+    def self.resolve(task_run)
+      new(task_run).resolve
+    end
+
+    sig { params(task_run: AiAgentTaskRun).void }
+    def initialize(task_run)
+      @task_run = task_run
+    end
+
+    sig { returns(Result) }
+    def resolve
+      billing_customer = @task_run.billing_customer
+      if billing_customer.nil?
+        raise ResolutionError.new(
+          "not_a_billed_task",
+          :unprocessable_entity,
+          "Task run has no billing customer; it is not a gateway-billed task."
+        )
+      end
+
+      # LLM usage must be funded: a prepaid-credit (pricing-plan) subscription
+      # must exist, or metered usage would never bill. This is a cheap, local
+      # check.
+      #
+      # The credit *balance* is deliberately NOT fetched here. `select_payer`
+      # runs on the per-LLM-call path, and a live Stripe balance call there is
+      # both slow and stale (Stripe aggregates deductions rather than deducting
+      # in real time), and it conflates a Stripe API error with an empty
+      # balance. The balance gate is enforced once at dispatch preflight and,
+      # authoritatively, by the gateway relaying a Stripe 402 when the balance
+      # is empty.
+      if billing_customer.pricing_plan_subscription_id.blank?
+        raise ResolutionError.new(
+          "not_funded",
+          :payment_required,
+          "AI usage billing is not set up. Add credits at /billing."
+        )
+      end
+
+      Result.new(payer_customer_id: billing_customer.stripe_id)
+    end
+  end
+end

--- a/app/services/stripe_service.rb
+++ b/app/services/stripe_service.rb
@@ -447,7 +447,7 @@ class StripeService
   sig { returns(T::Hash[Symbol, T.untyped]) }
   def self.gateway_health
     {
-      gateway_key_present: ENV["STRIPE_GATEWAY_KEY"].present?,
+      llm_gateway_reachable: llm_gateway_reachable?,
       credit_product_configured: ENV["STRIPE_CREDIT_PRODUCT_ID"].present?,
       pricing_plan_configured: ENV["STRIPE_PRICING_PLAN_ID"].present?,
       active_customers: StripeCustomer.where(active: true).map do |customer|
@@ -459,6 +459,20 @@ class StripeService
       end,
     }
   end
+
+  # STRIPE_GATEWAY_KEY lives on the llm-gateway service, not Rails, so health
+  # probes the service instead of checking local env.
+  sig { returns(T::Boolean) }
+  def self.llm_gateway_reachable?
+    url = URI.parse("#{ENV.fetch("LLM_GATEWAY_URL", "http://llm-gateway:4500")}/health")
+    response = Net::HTTP.start(url.host, url.port, open_timeout: 2, read_timeout: 2) do |http|
+      http.get(url.path)
+    end
+    response.is_a?(Net::HTTPSuccess)
+  rescue StandardError
+    false
+  end
+  private_class_method :llm_gateway_reachable?
 
   # Create a Stripe Billing Portal session.
   # Returns the portal URL for redirect.

--- a/app/services/stripe_service.rb
+++ b/app/services/stripe_service.rb
@@ -464,8 +464,9 @@ class StripeService
   # probes the service instead of checking local env.
   sig { returns(T::Boolean) }
   def self.llm_gateway_reachable?
-    url = URI.parse("#{ENV.fetch("LLM_GATEWAY_URL", "http://llm-gateway:4500")}/health")
-    response = Net::HTTP.start(url.host, url.port, open_timeout: 2, read_timeout: 2) do |http|
+    base = ENV.fetch("LLM_GATEWAY_URL", "http://llm-gateway:4500").delete_suffix("/")
+    url = URI.parse("#{base}/health")
+    response = Net::HTTP.start(url.host, url.port, use_ssl: url.scheme == "https", open_timeout: 2, read_timeout: 2) do |http|
       http.get(url.path)
     end
     response.is_a?(Net::HTTPSuccess)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,12 @@ Rails.application.routes.draw do
     get  'chat/:chat_session_id/history' => 'agent_runner#chat_history'
   end
 
+  # Internal API for the LLM gateway service (IP-restricted + HMAC-signed).
+  # The gateway resolves the payer for a billed LLM call and reports usage.
+  scope "internal/llm-gateway", module: "internal", as: "internal_llm_gateway" do
+    post 'select-payer' => 'llm_gateway#select_payer'
+  end
+
   # Incoming webhooks - public endpoint for external automation triggers
   post 'hooks/:webhook_path' => 'incoming_webhooks#receive', as: 'incoming_webhook'
 

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -90,7 +90,10 @@ services:
       # LLM_BASE_URL intentionally passed through only if set — empty string
       # would override agent-runner's per-mode default.
       - LLM_BASE_URL
-      - STRIPE_GATEWAY_KEY
+      # Where stripe_gateway-mode calls go (defaults to http://llm-gateway:4500).
+      # The runner holds no Stripe credentials — the llm-gateway service
+      # resolves the payer and relays to the Stripe AI Gateway.
+      - LLM_GATEWAY_URL
       - MAX_CONCURRENT_TASKS=${MAX_CONCURRENT_TASKS:-100}
       - STREAM_MAX_LEN=${STREAM_MAX_LEN:-10000}
     depends_on:
@@ -107,6 +110,45 @@ services:
     networks:
       - frontend  # needs external access for LLM API calls
       - backend
+
+  # LLM gateway — relays billed LLM calls to the Stripe AI Gateway, resolving
+  # the payer per call via the Rails internal API. The only service that holds
+  # STRIPE_GATEWAY_KEY. Internal-only: no Caddy route, no published port.
+  # Same image as agent-runner, different entrypoint.
+  #
+  # Own profile ("stripe"): it fail-fast exits without STRIPE_GATEWAY_KEY.
+  # Enable via COMPOSE_PROFILES=stripe in the server .env — NOT by starting it
+  # once by name (litellm-style): the gateway shares the agent-runner image and
+  # must be recreated by every deploy's `up -d`. See docs/DEPLOYMENT.md.
+  llm-gateway:
+    image: ghcr.io/ibis-coordination/harmonic-agent-runner:latest
+    command: ["node", "dist/gateway/server.js"]
+    restart: unless-stopped
+    profiles: ["stripe"]
+    environment:
+      - NODE_ENV=production
+      - AGENT_RUNNER_SECRET=${AGENT_RUNNER_SECRET:?AGENT_RUNNER_SECRET must be set}
+      - HARMONIC_INTERNAL_URL=http://web:3000
+      - HARMONIC_HOSTNAME=${HOSTNAME:?HOSTNAME must be set}
+      - STRIPE_GATEWAY_KEY
+      - STRIPE_GATEWAY_BASE_URL
+    depends_on:
+      web:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:4500/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+        reservations:
+          memory: 128M
+    networks:
+      - frontend  # outbound to llm.stripe.com
+      - backend   # Rails internal API; reachable by agent-runner
 
   redis:
     image: redis:7-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,6 +183,37 @@ services:
       - frontend  # needs external access for LLM API calls
       - backend
 
+  # LLM gateway — relays billed LLM calls to the Stripe AI Gateway, resolving
+  # the payer per call via the Rails internal API. The only service that holds
+  # STRIPE_GATEWAY_KEY; the agent-runner sends stripe_gateway-mode calls here
+  # instead of holding Stripe credentials itself. Internal-only: no Caddy
+  # route, no published port.
+  #
+  # Own profile ("stripe"): it fail-fast exits without STRIPE_GATEWAY_KEY, so
+  # it only makes sense when the Stripe AI Gateway is configured. start.sh
+  # enables the profile automatically when STRIPE_GATEWAY_KEY is set in .env
+  # (note: start.sh's --profile flags override any COMPOSE_PROFILES env var).
+  llm-gateway:
+    build: ./agent-runner
+    command: ["node", "dist/gateway/server.js"]
+    profiles: ["stripe"]
+    depends_on:
+      web:
+        condition: service_healthy
+    environment:
+      AGENT_RUNNER_SECRET: "${AGENT_RUNNER_SECRET}"
+      HARMONIC_INTERNAL_URL: http://web:3000
+      HARMONIC_HOSTNAME: "${HOSTNAME:-harmonic.local}"
+      STRIPE_GATEWAY_KEY: "${STRIPE_GATEWAY_KEY}"
+      STRIPE_GATEWAY_BASE_URL: "${STRIPE_GATEWAY_BASE_URL:-https://llm.stripe.com}"
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    networks:
+      - frontend  # outbound to llm.stripe.com
+      - backend   # Rails internal API; reachable by agent-runner
+
   # # LLM services for in-app AI chat (optional - use profiles to enable)
   # ollama:
   #   image: ollama/ollama:latest

--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -146,7 +146,7 @@ Local development note: the `agent-runner` compose service sits behind a `profil
 
 The secret has two distinct responsibilities:
 
-1. **HMAC signing** of internal API requests between Rails and agent-runner.
+1. **HMAC signing** of internal API requests to Rails — from the agent-runner (task lifecycle) AND from the llm-gateway (`select-payer`).
 2. **AES-256-GCM key material** (via HKDF) for the ephemeral task tokens published on the Redis stream.
 
 Because the secret is used for encryption, a rotation has a short grace window: any task already dispatched (encrypted token sitting in the stream) is un-decryptable by a runner that has only the new key. Plan accordingly.
@@ -154,7 +154,7 @@ Because the secret is used for encryption, a rotation has a short grace window: 
 Recommended procedure:
 
 1. **Drain in-flight work.** Ensure no new tasks will be dispatched: either pause the humans that trigger them, or temporarily stop creating task runs. Watch the Redis stream length (`XLEN agent_tasks`) drop to zero after the runner has processed the pending entries.
-2. **Roll the secret in env for both services simultaneously.** Rails and agent-runner must share the same value; a mismatch produces decrypt failures and HMAC rejections. If deploying rolling (not all-at-once), expect a brief window of 401s and decrypt errors — the runner now surfaces these as typed `TokenDecryptError` failures via `reporter.fail` rather than silently orphaning the task, so affected tasks will be marked failed rather than stuck in `queued`.
+2. **Roll the secret in env for all three consumers simultaneously.** Rails, agent-runner, and llm-gateway must share the same value; a mismatch produces decrypt failures and HMAC rejections — a stale llm-gateway fails every billed LLM call with select-payer 401s. If deploying rolling (not all-at-once), expect a brief window of 401s and decrypt errors — the runner now surfaces these as typed `TokenDecryptError` failures via `reporter.fail` rather than silently orphaning the task, so affected tasks will be marked failed rather than stuck in `queued`.
 3. **Use `rake agent_runner:redispatch_queued`** after the rotation to reissue any tasks that got stuck in `queued` state during the window. The rake guards against dispatching tasks that have already moved to `running` or a terminal state.
 4. **Expect nonce cache carryover.** Replay protection stores nonces in Redis with a 5-minute TTL; the rotated secret is unrelated, so the cache stays valid across the rotation.
 

--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -116,23 +116,31 @@ Visible at `/system-admin/agent-runner` (requires sys_admin role). Shows runner 
 | `HARMONIC_INTERNAL_URL` | No | `http://web:3000` | Direct TCP URL to Rails container |
 | `REDIS_URL` | No | `redis://redis:6379` | Redis connection |
 | `LITELLM_BASE_URL` | No | `http://litellm:4000` | LiteLLM endpoint |
-| `STRIPE_GATEWAY_BASE_URL` | No | `https://llm.stripe.com` | Stripe AI Gateway endpoint |
-| `LLM_BASE_URL` | No | — | Legacy override; applies to whichever route `LLM_GATEWAY_MODE` names |
+| `LLM_GATEWAY_URL` | No | `http://llm-gateway:4500` | Harmonic LLM gateway — where the runner sends billed (`stripe_gateway`-mode) calls. The runner holds no Stripe credentials; the gateway resolves the payer and relays to the Stripe AI Gateway. |
+| `LLM_BASE_URL` | No | — | Legacy override for the LiteLLM route only (billed calls always go to `LLM_GATEWAY_URL`) |
 | `LLM_GATEWAY_MODE` | No | `litellm` | Fallback route for tasks whose payload predates the per-task `llm_gateway_mode` stream field. Rails decides routing per task; this only covers old queued payloads. |
-| `STRIPE_GATEWAY_KEY` | No | — | Required for any task routed through the Stripe gateway |
 | `MAX_CONCURRENT_TASKS` | No | `100` | Maximum concurrent task fibers |
 | `STREAM_MAX_LEN` | No | `10000` | Redis stream approximate max length |
 | `AGENT_TASKS_STREAM` | No | `agent_tasks` | Redis stream name |
 | `AGENT_TASKS_CONSUMER_GROUP` | No | `agent_runner` | Consumer group name |
 | `AGENT_TASKS_CONSUMER_NAME` | No | `runner-{pid}` | Consumer name (unique per process) |
 
+The `llm-gateway` entrypoint (same image, `node dist/gateway/server.js`, compose profile
+`stripe`) additionally reads:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `STRIPE_GATEWAY_KEY` | Yes | — | Bearer token for `llm.stripe.com`; the gateway fail-fast exits without it |
+| `STRIPE_GATEWAY_BASE_URL` | No | `https://llm.stripe.com` | Stripe AI Gateway upstream |
+| `GATEWAY_PORT` | No | `4500` | Listen port |
+
 Rails also needs:
 | Variable | Description |
 |----------|-------------|
 | `AGENT_RUNNER_SECRET` | Same value as agent-runner (for encryption + HMAC verification) |
-| `INTERNAL_ALLOWED_IPS` | Comma-separated IPs/CIDRs for internal API access. In Docker, set this to the agent-runner container's bridge-network IP or the container network CIDR; the check uses the TCP peer address (`REMOTE_ADDR`), not the spoofable `X-Forwarded-For` header. |
+| `INTERNAL_ALLOWED_IPS` | Comma-separated IPs/CIDRs for internal API access. In Docker, set this to the container network CIDR (it must cover every internal caller: agent-runner and llm-gateway); the check uses the TCP peer address (`REMOTE_ADDR`), not the spoofable `X-Forwarded-For` header. |
 
-Local development note: the `agent-runner` compose service sits behind a `profiles: ["llm"]` gate. Start it with `docker compose --profile llm up agent-runner` (or `docker compose --profile llm up -d`) when you want to exercise the full dispatch path locally.
+Local development note: the `agent-runner` compose service sits behind a `profiles: ["llm"]` gate. Start it with `docker compose --profile llm up agent-runner` (or `docker compose --profile llm up -d`) when you want to exercise the full dispatch path locally. The `llm-gateway` service sits behind a separate `stripe` profile (it fail-fast exits without `STRIPE_GATEWAY_KEY`); `./scripts/start.sh` enables it automatically when `STRIPE_GATEWAY_KEY` is set in `.env`, or add `--profile stripe` manually.
 
 ## Rotating `AGENT_RUNNER_SECRET`
 

--- a/docs/BILLING.md
+++ b/docs/BILLING.md
@@ -99,7 +99,7 @@ How LLM usage billing turns on for a production tenant. Prerequisite: the Stripe
 
 **Restricted key permissions.** Two keys, minimal scopes. Every permission maps to a specific code path — when adding a new Stripe API call, extend the matching key's permissions and this table.
 
-`STRIPE_GATEWAY_KEY` — used exclusively as the Bearer token for `llm.stripe.com` requests (agent-runner):
+`STRIPE_GATEWAY_KEY` — used exclusively as the Bearer token for `llm.stripe.com` requests. Held only by the `llm-gateway` service (the agent-runner sends billed calls there and holds no Stripe credentials):
 
 | Permission | Access | Used by |
 |------------|--------|---------|
@@ -133,13 +133,18 @@ Webhook verification (`/stripe/webhooks`) uses `STRIPE_WEBHOOK_SECRET` for signa
 
    `STRIPE_SECRET_KEY` is the account secret key, used only for this run — it is not an app env var and never goes on the server. The webhook URL derives from `HOSTNAME`/`PRIMARY_SUBDOMAIN` exactly as the app's own non-tenant URLs do (or pass an explicit URL as the first argument). The script idempotently creates or verifies the credit product, the $3/month identity price, and the webhook endpoint (printing `STRIPE_WEBHOOK_SECRET` on creation), verifies the pricing plan and gateway key when their env vars are provided, and prints the env-var block plus any remaining dashboard-only steps. Re-run it after each manual step until the manual-steps list is empty.
 2. **Dashboard-only steps** (the script prints these with exact instructions):
-   - Create the two restricted keys per the permission tables above (`STRIPE_GATEWAY_KEY` → Rails and agent-runner; `STRIPE_API_KEY` → Rails only).
+   - Create the two restricted keys per the permission tables above (`STRIPE_GATEWAY_KEY` → llm-gateway service only; `STRIPE_API_KEY` → Rails only).
    - Create the pricing plan (Dashboard → Pricing plans → Create → "Billing for LLM tokens" template): select the models to offer and set the **markup percentage** — this is the pricing decision. Set its `bpp_...` id as `STRIPE_PRICING_PLAN_ID`.
 3. **Ask Stripe to enable zero-balance rejection** (token-billing-team@stripe.com) so the gateway itself refuses requests once a customer's balance is empty — our dispatch preflight checks at task start, not per LLM call, and balance deduction is aggregated periodically rather than real-time.
-4. **Deploy** with the vars set. No behavior changes yet — routing stays on LiteLLM until a tenant qualifies.
-5. **Verify health:** `rails billing:gateway_health` should show all three vars present and list active customers with balances and subscription status.
+4. **Deploy** with the vars set, and enable the `llm-gateway` service by setting
+   `COMPOSE_PROFILES=stripe` in the server's `.env` (see the LLM Gateway section of
+   docs/DEPLOYMENT.md — do not start it by name like litellm; it must be deploy-managed).
+   Ensure `INTERNAL_ALLOWED_IPS` covers the gateway container (use the Docker network CIDR,
+   not a single container IP). No behavior changes yet — routing stays on LiteLLM until a
+   tenant qualifies.
+5. **Verify health:** `rails billing:gateway_health` should show the llm-gateway reachable, both config vars present, and list active customers with balances and subscription status.
 6. **Enable the flag:** `tenant.enable_feature_flag!("stripe_billing")` for the target tenant. From the next dispatch, that tenant's billed agents route through the gateway. Before flipping it on a tenant, confirm no *other* tenant already has the flag plus active billing customers — their agents would start requiring credits too.
-7. **Smoke test:** top up a small amount at `/billing/topup` (this also creates the pricing-plan subscription), run an agent task, confirm the balance dropped (`billing:gateway_health`) and the agent-runner logged `llm_request` lines with `"gateway_mode":"stripe_gateway"`. Full checklist: `test/manual/billing/gateway_enablement.manual_test.md`.
+7. **Smoke test:** top up a small amount at `/billing/topup` (this also creates the pricing-plan subscription), run an agent task, confirm the balance dropped (`billing:gateway_health`) and both the agent-runner and the llm-gateway logged `llm_request` lines with `"gateway_mode":"stripe_gateway"` (the runner's line shows the call reached the gateway; the gateway's line shows it reached Stripe). Full checklist: `test/manual/billing/gateway_enablement.manual_test.md`.
 
 **Model names.** Model names match the Stripe gateway's `provider/model` scheme 1-to-1, and `config/litellm_config.yaml` uses the same names, so an agent's configured model (e.g. `anthropic/claude-sonnet-4.6`) works unchanged whether it routes through the gateway or LiteLLM. `StripeGatewayModelMapper` resolves blank/`default` to its default model and passes `provider/model` names through; names the gateway cannot proxy (local Ollama, Arcee Trinity) fail the task at dispatch with an explanatory error — update the agent's model or route the tenant back to LiteLLM.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -111,6 +111,48 @@ tasks are automatically detected and marked failed:
 
 Users see orphaned task failures and can retry.
 
+### LLM Gateway
+
+The `llm-gateway` service relays billed LLM calls to the Stripe AI Gateway,
+resolving the payer per call via the Rails internal API. It runs the **same
+image** as the agent-runner with a different entrypoint, so CI image builds,
+`deploy.sh`, and `rollback.sh` all cover it with no changes — the rollback
+retag of `harmonic-agent-runner` applies to both services.
+
+It sits behind the `stripe` compose profile (it fail-fast exits without
+`STRIPE_GATEWAY_KEY`). To enable it, set in the server's `.env`:
+
+```bash
+COMPOSE_PROFILES=stripe
+```
+
+Compose reads `COMPOSE_PROFILES` from `.env` automatically, so every existing
+compose invocation (deploy, rollback, maintenance) manages the gateway once
+the profile is listed — required here because the gateway must update in
+lockstep with web/agent-runner (same image, shared internal contract).
+
+This differs from how litellm runs: litellm's `llm` profile is *not* listed,
+so it is started once by name (`docker compose up -d litellm` auto-activates
+a named service's profiles) and kept alive by its restart policy; plain
+`up -d` ignores it. That start-once pattern is fine for a third-party image
+with no deploy coupling, but do not use it for the gateway. (Listing `llm` in
+`COMPOSE_PROFILES` would also work, but changes litellm behavior: it would
+re-pull `main-latest` and restart on every deploy.)
+
+Two more requirements:
+
+- `INTERNAL_ALLOWED_IPS` must cover the gateway container — use the Docker
+  network CIDR, not a single container IP, since both agent-runner and
+  llm-gateway call `/internal/*`.
+- **Deploy web and agent-runner together across the gateway cutover**: the
+  runner no longer sends Stripe customer ids, and Rails no longer publishes
+  them to the stream. An old runner consuming a new payload in
+  `stripe_gateway` mode fails the task with a clear, re-runnable error. A
+  normal `deploy.sh` restarts everything together, so the window is seconds.
+
+Health: the service exposes `GET /health` on port 4500 (compose healthcheck
+uses it). It is internal-only — no Caddy route, no published port.
+
 ### Deployments with Downtime
 
 For schema-changing migrations:

--- a/lib/tasks/billing.rake
+++ b/lib/tasks/billing.rake
@@ -6,7 +6,7 @@ namespace :billing do
   task gateway_health: :environment do
     report = StripeService.gateway_health
 
-    puts "STRIPE_GATEWAY_KEY:       #{report[:gateway_key_present] ? "present" : "MISSING"}"
+    puts "llm-gateway /health:      #{report[:llm_gateway_reachable] ? "reachable" : "UNREACHABLE (is the stripe compose profile enabled?)"}"
     puts "STRIPE_CREDIT_PRODUCT_ID: #{report[:credit_product_configured] ? "present" : "MISSING"}"
     puts "STRIPE_PRICING_PLAN_ID:   #{report[:pricing_plan_configured] ? "present" : "MISSING"}"
     puts "Active billing customers: #{report[:active_customers].size}"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -25,6 +25,14 @@ HOST_MODE=$(grep -E "^HOST_MODE=" .env | cut -d'=' -f2 | cut -d'#' -f1 | tr -d '
 # Always enable the llm profile (agent-runner + sidecars).
 # Add profile for reverse proxy based on HOST_MODE.
 PROFILES="--profile llm"
+
+# Enable the llm-gateway when a Stripe gateway key is configured
+# (the gateway fail-fast exits without STRIPE_GATEWAY_KEY).
+STRIPE_GATEWAY_KEY_FROM_ENV=$(grep -E "^STRIPE_GATEWAY_KEY=" .env 2>/dev/null | cut -d'=' -f2- | cut -d'#' -f1 | tr -d ' ' || true)
+if [ -n "$STRIPE_GATEWAY_KEY_FROM_ENV" ]; then
+    PROFILES="$PROFILES --profile stripe"
+fi
+
 if [ "$HOST_MODE" = "caddy" ]; then
     PROFILES="$PROFILES --profile caddy"
 elif [ "$HOST_MODE" = "ngrok" ]; then

--- a/test/controllers/internal/llm_gateway_controller_test.rb
+++ b/test/controllers/internal/llm_gateway_controller_test.rb
@@ -1,0 +1,145 @@
+# typed: false
+
+require "test_helper"
+
+class Internal::LLMGatewayControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @tenant, @collective, @user = create_tenant_collective_user
+    @tenant.enable_feature_flag!("internal_ai_agents")
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+
+    @ai_agent = create_ai_agent(parent: @user)
+    @billing_customer = StripeCustomer.create!(
+      billable: @ai_agent,
+      stripe_id: "cus_test123",
+      active: true,
+      pricing_plan_subscription_id: "bpps_test123"
+    )
+    # A funded, billed task run (stamped with the customer, as dispatch does).
+    @task_run = AiAgentTaskRun.create!(
+      tenant: @tenant,
+      ai_agent: @ai_agent,
+      initiated_by: @user,
+      task: "Test task",
+      max_steps: 10,
+      status: "running",
+      stripe_customer_id: @billing_customer.id
+    )
+    # A task run that was never stamped with a billing customer.
+    @unbilled_task_run = AiAgentTaskRun.create!(
+      tenant: @tenant,
+      ai_agent: @ai_agent,
+      initiated_by: @user,
+      task: "Unbilled task",
+      max_steps: 10,
+      status: "running"
+    )
+
+    @previous_secret = ENV.fetch("AGENT_RUNNER_SECRET", nil)
+    @secret = "test-secret-for-hmac"
+    ENV["AGENT_RUNNER_SECRET"] = @secret
+
+    Tenant.clear_thread_scope
+    Collective.clear_thread_scope
+    host! "#{@tenant.subdomain}.#{ENV.fetch("HOSTNAME", "harmonic.local")}"
+  end
+
+  teardown do
+    if @previous_secret.nil?
+      ENV.delete("AGENT_RUNNER_SECRET")
+    else
+      ENV["AGENT_RUNNER_SECRET"] = @previous_secret
+    end
+  end
+
+  test "returns the payer customer id for a funded billed task" do
+    # The credit balance is not consulted here (enforced at dispatch + the
+    # relay's 402), so a live balance call must never happen on this path.
+    StripeService.stub :get_credit_balance, ->(_) { raise "must not fetch balance on the select-payer path" } do
+      select_payer(task_run_id: @task_run.id, model: "anthropic/claude-sonnet-4.6")
+    end
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal "cus_test123", body["payer_customer_id"]
+  end
+
+  test "returns 402 not_funded when there is no pricing plan subscription" do
+    @billing_customer.update!(pricing_plan_subscription_id: nil)
+
+    select_payer(task_run_id: @task_run.id)
+
+    assert_response :payment_required
+    assert_equal "not_funded", JSON.parse(response.body)["error"]
+  end
+
+  test "does not resolve a task run belonging to another tenant" do
+    other_tenant = create_tenant(subdomain: "other", name: "Other Tenant")
+    other_user = create_user
+    other_tenant.add_user!(other_user)
+    other_collective = create_collective(tenant: other_tenant, created_by: other_user, handle: "other-collective")
+    other_collective.add_user!(other_user)
+    Collective.scope_thread_to_collective(subdomain: other_tenant.subdomain, handle: other_collective.handle)
+    other_agent = create_ai_agent(parent: other_user)
+    other_customer = StripeCustomer.create!(
+      billable: other_agent,
+      stripe_id: "cus_other",
+      active: true,
+      pricing_plan_subscription_id: "bpps_other"
+    )
+    other_task_run = AiAgentTaskRun.create!(
+      tenant: other_tenant,
+      ai_agent: other_agent,
+      initiated_by: other_user,
+      task: "Other tenant task",
+      max_steps: 10,
+      status: "running",
+      stripe_customer_id: other_customer.id
+    )
+    Tenant.clear_thread_scope
+    Collective.clear_thread_scope
+
+    # The request arrives on @tenant's subdomain (set in setup) but references
+    # the other tenant's task run — it must not be resolvable.
+    select_payer(task_run_id: other_task_run.id)
+    assert_response :not_found
+  end
+
+  test "returns 422 not_a_billed_task when the task run has no billing customer" do
+    select_payer(task_run_id: @unbilled_task_run.id)
+
+    assert_response :unprocessable_entity
+    assert_equal "not_a_billed_task", JSON.parse(response.body)["error"]
+  end
+
+  test "returns 404 when the task run does not exist" do
+    select_payer(task_run_id: "does-not-exist")
+    assert_response :not_found
+  end
+
+  test "rejects an unsigned request" do
+    post "/internal/llm-gateway/select-payer",
+         params: { task_run_id: @task_run.id }.to_json,
+         headers: { "Content-Type" => "application/json" }
+    assert_response :unauthorized
+  end
+
+  private
+
+  def select_payer(body_hash)
+    body = body_hash.to_json
+    post "/internal/llm-gateway/select-payer", params: body, headers: signed_headers(body)
+  end
+
+  def signed_headers(body)
+    timestamp = Time.current.to_i.to_s
+    nonce = SecureRandom.uuid
+    signature = "sha256=" + OpenSSL::HMAC.hexdigest("sha256", @secret, "#{nonce}.#{timestamp}.#{body}")
+    {
+      "Content-Type" => "application/json",
+      "X-Internal-Signature" => signature,
+      "X-Internal-Timestamp" => timestamp,
+      "X-Internal-Nonce" => nonce,
+    }
+  end
+end

--- a/test/manual/billing/gateway_enablement.manual_test.md
+++ b/test/manual/billing/gateway_enablement.manual_test.md
@@ -11,8 +11,9 @@ End-to-end verification that prepaid LLM credits flow correctly: top-up → agen
 ## Prerequisites
 
 - Stripe account enrolled in the AI Gateway preview (`llm.stripe.com`)
-- `STRIPE_GATEWAY_KEY`, `STRIPE_CREDIT_PRODUCT_ID`, and `STRIPE_PRICING_PLAN_ID` set (see docs/BILLING.md runbook)
-- `rails billing:gateway_health` shows all three vars present
+- `STRIPE_GATEWAY_KEY` set on the llm-gateway service; `STRIPE_CREDIT_PRODUCT_ID` and `STRIPE_PRICING_PLAN_ID` set on Rails (see docs/BILLING.md runbook)
+- `llm-gateway` service running (`stripe` compose profile) and healthy (`GET /health`)
+- `rails billing:gateway_health` shows the llm-gateway reachable and both config vars present
 - Tenant A: `stripe_billing` enabled, a user with an active subscription and one internal AI agent
 - Tenant B: `stripe_billing` NOT enabled, with one internal AI agent (regression control)
 
@@ -36,13 +37,14 @@ End-to-end verification that prepaid LLM credits flow correctly: top-up → agen
 ### Steps
 
 1. Run a short task with Tenant A's agent
-2. Watch agent-runner logs for `llm_request` lines
+2. Watch agent-runner AND llm-gateway logs for `llm_request` lines
 3. Run `rails billing:gateway_health` after completion
 
 ### Checklist
 
 - [ ] Task completes successfully
-- [ ] Log lines show `"gateway_mode":"stripe_gateway"`, `"stripe_customer_present":true`, and a `provider/model`-format model name
+- [ ] Runner log lines show `"gateway_mode":"stripe_gateway"`, a `task_run_id`, and a `provider/model`-format model name
+- [ ] Gateway log lines show `"gateway_mode":"stripe_gateway"` with a 200 status (the relay reached Stripe)
 - [ ] Meter events for the run appear in the Stripe dashboard (Usage-based billing → Meters) within seconds
 - [ ] Balance drops by roughly the expected token cost (deduction is aggregated periodically — allow up to an hour, not instant)
 

--- a/test/services/agent_runner_dispatch_service_test.rb
+++ b/test/services/agent_runner_dispatch_service_test.rb
@@ -229,7 +229,8 @@ class AgentRunnerDispatchServiceTest < ActiveSupport::TestCase
     fields = entry[1]
     assert_equal "stripe_gateway", fields["llm_gateway_mode"]
     assert_equal "anthropic/claude-sonnet-4.6", fields["model"]
-    assert_equal "cus_test123", fields["stripe_customer_stripe_id"]
+    # Customer ids no longer ride the stream; the gateway resolves the payer from the task run.
+    assert_nil fields["stripe_customer_stripe_id"]
     redis.close
   end
 
@@ -442,7 +443,7 @@ class AgentRunnerDispatchServiceTest < ActiveSupport::TestCase
     assert_equal "queued", task_run.status, "system agent dispatch should not fail: #{task_run.error}"
     entry = redis.xrange("agent_tasks").find { |_id, fields| fields["task_run_id"] == task_run.id }
     assert_not_nil entry, "system agent task should be dispatched to the stream"
-    assert_equal "", entry[1]["stripe_customer_stripe_id"]
+    assert_nil entry[1]["stripe_customer_stripe_id"]
     redis.close
   end
 

--- a/test/services/stripe_service_test.rb
+++ b/test/services/stripe_service_test.rb
@@ -1851,6 +1851,36 @@ class StripeServiceTest < ActiveSupport::TestCase
     assert health1[:pricing_plan_subscribed]
   end
 
+  test "gateway_health probes over TLS when LLM_GATEWAY_URL is https" do
+    stub_request(:get, "https://gateway.example/health")
+      .to_return(status: 200, body: { status: "ok" }.to_json)
+
+    original_url = ENV["LLM_GATEWAY_URL"]
+    ENV["LLM_GATEWAY_URL"] = "https://gateway.example"
+    begin
+      report = StripeService.gateway_health
+    ensure
+      original_url.nil? ? ENV.delete("LLM_GATEWAY_URL") : ENV["LLM_GATEWAY_URL"] = original_url
+    end
+
+    assert report[:llm_gateway_reachable]
+  end
+
+  test "gateway_health tolerates a trailing slash in LLM_GATEWAY_URL" do
+    stub_request(:get, "http://llm-gateway:4500/health")
+      .to_return(status: 200, body: { status: "ok" }.to_json)
+
+    original_url = ENV["LLM_GATEWAY_URL"]
+    ENV["LLM_GATEWAY_URL"] = "http://llm-gateway:4500/"
+    begin
+      report = StripeService.gateway_health
+    ensure
+      original_url.nil? ? ENV.delete("LLM_GATEWAY_URL") : ENV["LLM_GATEWAY_URL"] = original_url
+    end
+
+    assert report[:llm_gateway_reachable]
+  end
+
   test "gateway_health reports missing config and unreachable gateway" do
     # An unreachable llm-gateway (connection refused) must report false, not raise.
     stub_request(:get, "http://llm-gateway:4500/health").to_raise(Errno::ECONNREFUSED)

--- a/test/services/stripe_service_test.rb
+++ b/test/services/stripe_service_test.rb
@@ -1693,6 +1693,17 @@ class StripeServiceTest < ActiveSupport::TestCase
     original.nil? ? ENV.delete("STRIPE_PRICING_PLAN_ID") : ENV["STRIPE_PRICING_PLAN_ID"] = original
   end
 
+  # For tests that exercise a path where the pricing plan must NOT be
+  # configured (e.g. the credit-grant-only topup flow). The dev container env
+  # may carry a real STRIPE_PRICING_PLAN_ID, so tests can't assume absence.
+  def without_pricing_plan_env
+    original = ENV["STRIPE_PRICING_PLAN_ID"]
+    ENV.delete("STRIPE_PRICING_PLAN_ID")
+    yield
+  ensure
+    ENV["STRIPE_PRICING_PLAN_ID"] = original unless original.nil?
+  end
+
   def stub_pricing_plan_subscription_flow(reserve_total: "0")
     stub_request(:get, "https://api.stripe.com/v2/billing/pricing_plans/#{PLAN_ID}")
       .to_return(status: 200, body: { id: PLAN_ID, live_version: PLAN_VERSION }.to_json, headers: { "Content-Type" => "application/json" })
@@ -1816,18 +1827,20 @@ class StripeServiceTest < ActiveSupport::TestCase
         headers: { "Content-Type" => "application/json" },
       )
 
-    original_key = ENV["STRIPE_GATEWAY_KEY"]
+    # STRIPE_GATEWAY_KEY lives on the llm-gateway service, not Rails — health
+    # reports the gateway's reachability instead of a local env check.
+    stub_request(:get, "http://llm-gateway:4500/health")
+      .to_return(status: 200, body: { status: "ok" }.to_json)
+
     original_product = ENV["STRIPE_CREDIT_PRODUCT_ID"]
-    ENV["STRIPE_GATEWAY_KEY"] = "rk_test_gateway"
     ENV["STRIPE_CREDIT_PRODUCT_ID"] = "prod_test_credit"
     begin
       report = with_pricing_plan_env { StripeService.gateway_health }
     ensure
-      original_key.nil? ? ENV.delete("STRIPE_GATEWAY_KEY") : ENV["STRIPE_GATEWAY_KEY"] = original_key
       original_product.nil? ? ENV.delete("STRIPE_CREDIT_PRODUCT_ID") : ENV["STRIPE_CREDIT_PRODUCT_ID"] = original_product
     end
 
-    assert report[:gateway_key_present]
+    assert report[:llm_gateway_reachable]
     assert report[:credit_product_configured]
     assert report[:pricing_plan_configured]
     customer_ids = report[:active_customers].map { |c| c[:stripe_id] }
@@ -1838,19 +1851,22 @@ class StripeServiceTest < ActiveSupport::TestCase
     assert health1[:pricing_plan_subscribed]
   end
 
-  test "gateway_health reports missing config" do
-    original_key = ENV["STRIPE_GATEWAY_KEY"]
+  test "gateway_health reports missing config and unreachable gateway" do
+    # An unreachable llm-gateway (connection refused) must report false, not raise.
+    stub_request(:get, "http://llm-gateway:4500/health").to_raise(Errno::ECONNREFUSED)
+
     original_product = ENV["STRIPE_CREDIT_PRODUCT_ID"]
-    ENV.delete("STRIPE_GATEWAY_KEY")
+    original_plan = ENV["STRIPE_PRICING_PLAN_ID"]
     ENV.delete("STRIPE_CREDIT_PRODUCT_ID")
+    ENV.delete("STRIPE_PRICING_PLAN_ID")
     begin
       report = StripeService.gateway_health
     ensure
-      ENV["STRIPE_GATEWAY_KEY"] = original_key unless original_key.nil?
       ENV["STRIPE_CREDIT_PRODUCT_ID"] = original_product unless original_product.nil?
+      ENV["STRIPE_PRICING_PLAN_ID"] = original_plan unless original_plan.nil?
     end
 
-    assert_not report[:gateway_key_present]
+    assert_not report[:llm_gateway_reachable]
     assert_not report[:credit_product_configured]
     assert_not report[:pricing_plan_configured]
     assert_equal [], report[:active_customers]
@@ -1900,7 +1916,7 @@ class StripeServiceTest < ActiveSupport::TestCase
       },
     )
 
-    StripeService.handle_webhook_event(event)
+    without_pricing_plan_env { StripeService.handle_webhook_event(event) }
 
     # Should NOT have changed subscription state
     sc.reload
@@ -1933,7 +1949,7 @@ class StripeServiceTest < ActiveSupport::TestCase
       },
     )
 
-    StripeService.handle_webhook_event(event)
+    without_pricing_plan_env { StripeService.handle_webhook_event(event) }
 
     assert_requested(
       :post,


### PR DESCRIPTION
## Summary

Stage 1 of the [LLM gateway plan](.claude/plans/harmonic-llm-gateway.md) (toward #464 common-pool LLM credits): a new internal `llm-gateway` service becomes the single place that does Stripe billing attribution for LLM calls, and the agent-runner routes its billed calls through it.

- **`Internal::LLMGatewayController#select_payer`** (HMAC + IP-restricted): resolves a task run → its stamped billing customer, verifies the pricing-plan subscription, returns `payer_customer_id`. Deliberately no per-call balance fetch — the balance gate is dispatch preflight + Stripe's zero-balance rejection (confirmed enabled), surfaced as a relayed 402.
- **`llm-gateway` service** — second entrypoint in the agent-runner package (same image, `node dist/gateway/server.js`): resolves the payer via select-payer, relays the OpenAI-compatible body to `llm.stripe.com` with the customer billing header, returns the upstream response verbatim. Internal-only: no Caddy route, no published port.
- **Agent-runner rewire**: `stripe_gateway`-mode calls post to the gateway with `X-Harmonic-{Task-Run-Id,Subdomain,Model}` routing headers. The runner no longer holds `STRIPE_GATEWAY_KEY` or sees customer ids (smaller blast radius); `stripe_customer_stripe_id` is removed from the dispatch stream (legacy payloads still parse). LiteLLM mode unchanged; system agents unaffected.
- **Deploy**: compose service behind a `stripe` profile — prod enables via `COMPOSE_PROFILES=stripe` in the server `.env` (deploy-managed, unlike started-by-name litellm); dev via `start.sh` auto-detecting `STRIPE_GATEWAY_KEY`. `billing:gateway_health` now probes the gateway's `/health` instead of checking a Rails-side key. No changes needed to `deploy.sh`/`rollback.sh`/image workflow (same image).

## Deploy notes (operator)

- Set `COMPOSE_PROFILES=stripe` in the server `.env`; move `STRIPE_GATEWAY_KEY` off the agent-runner env (compose change does this).
- Ensure `INTERNAL_ALLOWED_IPS` covers the gateway container — network CIDR, not a single IP.
- Deploy web + agent-runner together across this cutover (old runner + new payload fails stripe-mode tasks with a clear, re-runnable error; normal deploy restarts both).

## Test plan

- [x] Rails: select-payer request tests (funding gate, unbilled task, cross-tenant isolation, HMAC), dispatch tests (27), stripe service tests (75, incl. new gateway-health probe + env-drift fixes)
- [x] Agent-runner: 234 tests incl. gateway relay/handler contract and LLMClient routing-header tests; typecheck clean
- [ ] Live parity smoke test (gateway enabled, internal agent task bills, `llm_request` on both services + balance drop) — next step after CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)