### PR TITLE
LLM gateway stage 4: external ingress via llm_gateway API keys

### DIFF
--- a/.claude/plans/harmonic-llm-gateway.md
+++ b/.claude/plans/harmonic-llm-gateway.md
@@ -352,18 +352,33 @@ surface accepts exactly its own type. A leaked token is exactly one kind of inci
 data access (rest), audited agent action (mcp), or spend with zero data access
 (llm_gateway).
 
-Remaining stage-4 scope:
+**Ingress BUILT (2026-07-10, branch llm-gateway-ingress; implementation plan in
+llm-gateway-stage4-ingress.md):**
 
-- **Per-collective feature flag**, app-admin controlled (mirrors `stripe_billing` gating).
-  External gateway calls for a collective's agents work only while its flag is on.
-- Public `llm.harmonic.social` edge (Caddy static block) exposing an OpenAI-compatible
-  `POST /v1/chat/completions`; the gateway forwards the bearer token to Rails for
-  validation (gateway stays stateless — revocation takes effect on the next call).
-- The untrusted-caller protections deferred from stage 1: **streaming (SSE) passthrough**
-  (external clients stream), **model allowlist** enforced at the gateway, **rate limiting**,
-  **request-size caps**, and **per-key spend ceilings** independent of Stripe's balance
-  gate (a leaked key spends other people's money until the pool is dry; the balance gate
-  alone doesn't bound that).
+- **Tenant-level `llm_gateway` feature flag** (decided over per-collective: mirrors
+  `stripe_billing` exactly; per-collective gating arrives with the real pool feature).
+  Toggle appears automatically in tenant admin settings.
+- `llm.<hostname>` Caddy block forwarding ONLY `/v1/*` to the gateway; the gateway's
+  unauthenticated internal relay path stays unreachable from outside.
+- OpenAI-compatible `POST /v1/chat/completions` with the agent's llm_gateway key as
+  Bearer. Rails authenticates per call via `select-payer-for-token`
+  (`ApiToken.authenticate_llm_gateway` — cross-tenant hash lookup, thread re-scoped from
+  the token's tenant) and returns payer + mapped model; gateway stays stateless, so
+  revocation takes effect on the next call. Model validation via
+  `StripeGatewayModelMapper`; OpenAI-shaped error bodies pass through verbatim.
+- **Streaming (SSE) passthrough** — upstream bytes pipe straight through; one code path
+  serves stream and non-stream.
+- **Per-key rate limits** (in-memory sliding window, `GATEWAY_EXTERNAL_RPM`=20 /
+  `GATEWAY_EXTERNAL_RPD`=500) + **request-size cap** (`GATEWAY_MAX_BODY_BYTES`=1 MB) as
+  the spend-rate stopgap; **dollar spend ceilings deferred** until record-usage
+  persistence exists.
+- Dev E2E verified through the real edge: 401/403/429 (with Retry-After) negative paths,
+  and the valid-key path relaying Stripe's balance-rejection 400 verbatim (full-chain
+  proof while the Stripe blocker stands).
+
+Still remaining for the beta:
+
+- Prod DNS for `llm.harmonic.social` (deploy step, not code).
 - **Internal/external traffic isolation** so a beta collective's runaway usage or a stolen
   key can't take down internal agents (see Open decisions).
 - Explicit commitment enrollment as the consent/contract gate for every external

--- a/.claude/plans/llm-gateway-stage4-ingress.md
+++ b/.claude/plans/llm-gateway-stage4-ingress.md
@@ -1,0 +1,190 @@
+# LLM Gateway — Stage 4 ingress (external access via `llm_gateway` API keys)
+
+## Context
+
+Stages 1–2 of the LLM gateway are live: internal agents' billed LLM calls relay through
+the `llm-gateway` service (agent-runner image, `src/gateway/`), which resolves the payer
+per call via `POST /internal/llm-gateway/select-payer` (`Internal::LLMGatewayController` →
+`LLMGateway::PayerResolver`, pool-first via `LLM_POOL_CONFIG`, else the task run's stamped
+billing customer). PR #483 shipped the 3-type ApiToken system: the `llm_gateway` token
+type exists and is fully fenced — external agents can hold one, but **no endpoint accepts
+it yet**.
+
+This stage builds the ingress: an external agent presents its `llm_gateway` token as a
+Bearer key against an OpenAI-compatible `POST /v1/chat/completions` on a public
+`llm.<hostname>` edge, billed through the agent's existing funding mapping (pool config,
+else its billing customer). Identity-keyed, not funding-keyed (decided 2026-07-09): the
+token says who calls; the agent's own mapping says who pays.
+
+Design source: `.claude/plans/harmonic-llm-gateway.md` Stage 4. Decisions confirmed
+2026-07-10: **tenant-level flag** (mirrors `stripe_billing`), **RPM + daily request cap**
+as the spend-ceiling stopgap (dollar ceilings wait for record-usage), **one PR**.
+
+## Request path
+
+```
+OpenAI client (base_url=https://llm.harmonic.social/v1, api_key=<llm_gateway token>)
+  → Caddy `llm.<hostname>` block: forwards ONLY /v1/* to llm-gateway:4500
+    → gateway POST /v1/chat/completions
+        1. body-size cap → 413; per-key rate limit (RPM + RPD, in-memory) → 429
+        2. POST Rails /internal/llm-gateway/select-payer-for-token (HMAC, IP-restricted)
+           body: { agent_token, model }
+             - authenticate token cross-tenant by hash; must be llm_gateway type + active
+             - re-scope thread to the token's tenant; check tenant `llm_gateway` flag
+             - resolve payer: pool_customer_ids(agent) sample → else agent.billing_customer
+             - map/validate model via StripeGatewayModelMapper
+             - 200 { payer_customer_id, model } | 401 | 403 | 402 | 400
+        3. non-200 → pass through verbatim (no LLM spend)
+        4. rewrite body.model to mapped model; forward to Stripe AI Gateway with
+           X-Stripe-Customer-ID
+        5. stream upstream response bytes back verbatim (SSE and non-streaming, one path)
+```
+
+The internal relay (`POST /chat/completions` + `X-Harmonic-*` headers, no auth — network
+isolation is its auth) is unchanged and unreachable from the edge: Caddy forwards only
+`/v1/*`, and the handler routes the two paths separately.
+
+## Rails changes
+
+**`app/models/api_token.rb` — `ApiToken.authenticate_llm_gateway(token_string)`**
+Cross-tenant lookup by token hash. The unguessable 256-bit hash IS the credential
+(lookup = authentication), which is why this is safe pre-tenant — same character as User
+auth. None of the four ApplicationRecord wrappers fit (no tenant id, no user, non-nil
+thread tenant), so this is the one deliberate `unscoped` outside ApplicationRecord,
+carrying the `# unscoped-allowed` marker + justification comment. Query:
+`unscoped.where(token_hash:, deleted_at: nil, internal: false, token_type: "llm_gateway").first`
+(`unscoped` drops BOTH the tenant default scope and ApiToken's own
+`default_scope { where(internal: false) }`, hence re-adding `internal: false` — only
+user-issued keys authenticate here). Caller checks `expired?` (matches existing
+`.authenticate` convention where expiry is a call-site check).
+
+**`app/controllers/internal/llm_gateway_controller.rb` — `select_payer_for_token`**
+New action; `skip_before_action :resolve_tenant_from_subdomain` for it (routes have no
+subdomain constraint — the before_action is the only coupling). IP restriction + HMAC
+still apply. Flow:
+- `ApiToken.authenticate_llm_gateway(params[:agent_token])` → 401 `invalid_token` if nil
+  or `expired?` (body shaped like OpenAI errors: `{error: {message:, type:, code:}}` —
+  the gateway passes these bodies through to the client verbatim).
+- `Tenant.scope_thread_to_tenant` for the token's tenant (same helper
+  `resolve_tenant_from_subdomain` uses), then load the agent user.
+- 403 `feature_disabled` unless `tenant.feature_enabled?("llm_gateway")`.
+- `LLMGateway::PayerResolver.resolve_for_agent(agent)` → 402 `not_funded` on
+  ResolutionError.
+- `StripeGatewayModelMapper.map(params[:model])` → 400 `unsupported_model` on
+  UnmappedModelError.
+- `token.token_used!`; 200 `{ payer_customer_id:, model: <mapped> }`.
+
+**`app/services/llm_gateway/payer_resolver.rb` — `resolve_for_agent(agent)`**
+Pool branch reuses `pool_customer_ids(agent.id)` (uniform-random sample, same log line);
+else `agent.billing_customer` with the same funded checks as the task-run path (customer
+present + `pricing_plan_subscription_id` present, else `ResolutionError` 402
+`not_funded`). Extract the shared billing-customer check so the two resolve paths don't
+diverge.
+
+**`config/routes.rb`** — add `post 'select-payer-for-token'` to the existing
+`internal/llm-gateway` scope.
+
+**`config/feature_flags.yml`** — add `llm_gateway` entry (`app_enabled: true`,
+`default_tenant: false`, `collective_level: false`). The tenant_admin settings UI is
+generic over the yml (`tenant_admin_controller.rb:69`, `settings.html.erb:56`), so the
+toggle appears with no UI code.
+
+## Gateway changes (`agent-runner/src/gateway/`)
+
+**`handler.ts`** — route on path:
+- `GET /health` — unchanged.
+- `POST /chat/completions` (and legacy `POST /` if currently accepted) — existing
+  internal header flow, unchanged.
+- `POST /v1/chat/completions` — new external flow (below). Anything else 404/405.
+
+**New `ExternalRelay.ts`** (mirrors `Relay.ts` structure, Effect service deps:
+Config, RailsHttp, StripeUpstream):
+- Extract Bearer from `Authorization` → 401 OpenAI-style error if missing. Never log it.
+- Body read with size cap (`GATEWAY_MAX_BODY_BYTES`, default 1 MB) → 413.
+- Rate limit before any Rails/Stripe work: in-memory sliding-window per key
+  (bucket key = SHA-256 of the bearer), `GATEWAY_EXTERNAL_RPM` (default 20) +
+  `GATEWAY_EXTERNAL_RPD` (default 500) → 429 with `Retry-After`. Small standalone
+  `RateLimiter` module (injectable clock for tests). Single-instance in-memory is
+  fine — one gateway container; document that on the module.
+- Parse body JSON minimally (`model`, detect `stream`) → 400 on unparseable JSON.
+- Call `select-payer-for-token` via RailsHttp (10s timeout like the internal hop), Host =
+  `HARMONIC_PRIMARY_SUBDOMAIN` (new env, default `app`; the action ignores the subdomain
+  but Rails host authorization needs a real one). Non-200 → pass through verbatim.
+- Rewrite `body.model` to the returned mapped model; forward to Stripe.
+- **Streaming passthrough**: `StripeUpstream` gains `chatCompletionsStream` returning
+  `{status, headers (content-type), body: ReadableStream}`; the handler pipes bytes to
+  the response as they arrive. One code path serves `stream: true` (SSE) and
+  non-streaming responses alike. Existing buffered `chatCompletions` stays for the
+  internal relay.
+
+**Observability** — log line per external call mirroring the internal one
+(`event: "llm_request_external"`, token prefix only, model, status, duration); the
+select-payer rejection warn mirrors `select_payer_rejected`.
+
+**Compose (`docker-compose.yml`, `docker-compose.production.yml`)** — add
+`HARMONIC_PRIMARY_SUBDOMAIN`, `GATEWAY_EXTERNAL_RPM/RPD`, `GATEWAY_MAX_BODY_BYTES` to
+llm-gateway env; update the "no Caddy route" comment (now: edge-routed for `/v1/*` only).
+`.env.example` documents the new vars.
+
+## Edge
+
+**`app/services/caddyfile_generator.rb`** — emit an `llm.<hostname>` block:
+
+```
+llm.<hostname> {
+    handle /v1/* {
+        reverse_proxy llm-gateway:4500
+    }
+    respond 403
+}
+```
+
+Caddy and llm-gateway already share the `frontend` network in dev and prod. When the
+`stripe` profile is off, the block 502s — acceptable (service intentionally absent).
+Regenerate the committed `Caddyfile` (rake `caddyfile:generate`). Prod also needs DNS for
+`llm.harmonic.social` — deploy note, not code.
+
+## Rollout posture
+
+Three independent off-switches: `stripe` compose profile (service exists at all),
+tenant `llm_gateway` flag (default off — the ingress is inert everywhere until an admin
+enables it), token revocation (gateway stateless — next call re-authenticates).
+Deliberately deferred: dollar spend ceilings (needs record-usage persistence),
+internal/external traffic isolation beyond path routing (flag is the off-ramp),
+commitment-based consent enrollment (arrives with the real pool feature).
+
+## Tests (red-green, in this order)
+
+Rails (minitest):
+- `test/models/api_token_test.rb` — `authenticate_llm_gateway`: finds across tenants;
+  nil for wrong type / revoked / internal / unknown; expired token returned but
+  `expired?` true.
+- `test/services/llm_gateway/payer_resolver_test.rb` — `resolve_for_agent`: pool branch,
+  billing-customer branch, `not_funded` when customer missing or unsubscribed.
+- `test/controllers/internal/llm_gateway_controller_test.rb` (or existing integration
+  file) — full matrix: 401 (missing/invalid/expired/wrong-type token), 403 flag off,
+  402 not funded, 400 unsupported model, 200 pool payer, 200 billing-customer payer,
+  thread re-scoped to the token's tenant, `last_used_at` bumped.
+
+Gateway (vitest, existing patterns — fake `RelayRunner` for handler tests, Effect
+`Layer.succeed` mocks for relay tests):
+- `test/gateway/handler.test.ts` — path routing (internal untouched, `/v1/…` external,
+  unknown 404), missing bearer 401.
+- `test/gateway/ExternalRelay.test.ts` — size cap 413, rate limit 429 (+ RPD), malformed
+  JSON 400, select-payer rejection passthrough, model rewrite, header forwarding,
+  streaming passthrough with a fake `ReadableStream` upstream.
+- `test/gateway/RateLimiter.test.ts` — window mechanics with injected clock.
+
+## Verification
+
+1. `docker compose exec web bundle exec rails test <the three Rails files>`; `cd
+   agent-runner && npm test && npm run typecheck && npm run build`.
+2. `srb tc`, rubocop, `./scripts/check-tenant-safety.sh` (the marker must pass).
+3. Dev E2E: enable `llm_gateway` flag on the test tenant, mint an `llm_gateway` token for
+   an external agent covered by `LLM_POOL_CONFIG`, regenerate Caddyfile, then from the
+   host: `curl https://llm.harmonic.local/v1/chat/completions -H "Authorization: Bearer
+   <token>" -d '{"model":"anthropic/claude-sonnet-4.6","messages":[…]}'` — expect
+   Stripe's 400 balance error passed through verbatim (that error IS the relay-works
+   proof while the Stripe blocker stands), and the same call with `"stream": true`
+   streaming the error/SSE bytes. Negative checks: flag off → 403, revoked token → 401,
+   rest-type token → 401, `POST /chat/completions` from outside → 403 (Caddy).

--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,14 @@ STRIPE_MAX_TOPUP_CENTS=50000
 # skip the individual billing checks at dispatch. Unset = no pools.
 # LLM_POOL_CONFIG={"<agent-id>": ["cus_a", "cus_b"]}
 LLM_POOL_CONFIG=
+# LLM gateway external ingress (llm.<hostname>, /v1/chat/completions).
+# External agents authenticate with llm_gateway-type API keys; access is
+# gated per tenant by the llm_gateway feature flag. Per-key request limits
+# bound a leaked key's burn rate until dollar spend ceilings exist.
+# GATEWAY_EXTERNAL_RPM=20
+# GATEWAY_EXTERNAL_RPD=500
+# Request body size cap in bytes (default 1 MB)
+# GATEWAY_MAX_BODY_BYTES=1048576
 # DEPRECATED fallback for the agent-runner only: tasks now carry llm_gateway_mode
 # in the Redis stream payload (set by Rails per tenant), and this env var is used
 # solely for payloads published before that field existed.

--- a/agent-runner/src/config/Config.ts
+++ b/agent-runner/src/config/Config.ts
@@ -4,6 +4,12 @@ import { ConfigError } from "../errors/Errors.js";
 export interface AppConfig {
   readonly harmonicInternalUrl: string;
   readonly harmonicHostname: string;
+  /**
+   * Host subdomain for internal Rails calls that carry no tenant of their own
+   * (the gateway's select-payer-for-token resolves the tenant from the API
+   * key, but Rails host authorization still needs a real Host header).
+   */
+  readonly primarySubdomain: string;
   readonly agentRunnerSecret: string;
   readonly redisUrl: string;
   readonly litellmBaseUrl: string;
@@ -40,6 +46,7 @@ export const ConfigLive = Layer.effect(
   Effect.gen(function* () {
     const agentRunnerSecret = yield* requireEnv("AGENT_RUNNER_SECRET");
     const harmonicHostname = yield* requireEnv("HARMONIC_HOSTNAME");
+    const primarySubdomain = yield* optionalEnv("HARMONIC_PRIMARY_SUBDOMAIN", "app");
     const redisUrl = yield* optionalEnv("REDIS_URL", "redis://redis:6379");
     const llmGatewayMode = yield* optionalEnv("LLM_GATEWAY_MODE", "litellm");
     const harmonicInternalUrl = yield* optionalEnv("HARMONIC_INTERNAL_URL", "http://web:3000");
@@ -69,6 +76,7 @@ export const ConfigLive = Layer.effect(
     return {
       harmonicInternalUrl,
       harmonicHostname,
+      primarySubdomain,
       agentRunnerSecret,
       redisUrl,
       litellmBaseUrl,

--- a/agent-runner/src/gateway/ExternalRelay.ts
+++ b/agent-runner/src/gateway/ExternalRelay.ts
@@ -1,0 +1,131 @@
+/**
+ * External relay — the gateway's public ingress flow.
+ *
+ * An external agent calls the OpenAI-compatible /v1/chat/completions with its
+ * llm_gateway API key as the Bearer token. Rails authenticates the key and
+ * resolves the payer via `select-payer-for-token` (the key says WHO calls;
+ * the agent's own pool/billing mapping says WHO PAYS); the relay then forwards
+ * the body — model rewritten to the mapped name — to the Stripe AI Gateway and
+ * streams the response back verbatim. Rails error bodies are OpenAI-shaped and
+ * pass through to the client unchanged.
+ */
+
+import { Effect } from "effect";
+import { Config } from "../config/Config.js";
+import { RailsHttp } from "../services/RailsHttp.js";
+import { StripeUpstream } from "./StripeUpstream.js";
+import { buildHeaders } from "../services/HmacSigner.js";
+import { GatewayError } from "../errors/Errors.js";
+import { log } from "../services/Logger.js";
+
+const SELECT_PAYER_FOR_TOKEN_PATH = "/internal/llm-gateway/select-payer-for-token";
+
+export interface ExternalRelayRequest {
+  /** The caller's llm_gateway API key. Never logged. */
+  readonly bearerToken: string;
+  /** Raw OpenAI chat-completions JSON from the external client. */
+  readonly body: string;
+}
+
+export interface ExternalRelayResult {
+  readonly status: number;
+  readonly contentType: string;
+  /** A stream for upstream responses; a string for locally-produced errors and passthroughs. */
+  readonly body: string | ReadableStream<Uint8Array>;
+}
+
+const openAiError = (status: number, code: string, message: string): ExternalRelayResult => ({
+  status,
+  contentType: "application/json",
+  body: JSON.stringify({ error: { message, type: "invalid_request_error", code } }),
+});
+
+export const externalRelay = (
+  req: ExternalRelayRequest,
+): Effect.Effect<ExternalRelayResult, GatewayError, Config | RailsHttp | StripeUpstream> =>
+  Effect.gen(function* () {
+    const config = yield* Config;
+    const rails = yield* RailsHttp;
+    const stripe = yield* StripeUpstream;
+
+    let parsed: Record<string, unknown>;
+    try {
+      const value: unknown = JSON.parse(req.body);
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        return openAiError(400, "invalid_json", "Request body must be a JSON object.");
+      }
+      parsed = value as Record<string, unknown>;
+    } catch {
+      return openAiError(400, "invalid_json", "Request body is not valid JSON.");
+    }
+    const requestedModel = typeof parsed["model"] === "string" ? parsed["model"] : undefined;
+
+    // 1. Authenticate the key and resolve the payer + mapped model via Rails.
+    const selectBody = JSON.stringify(
+      requestedModel === undefined
+        ? { agent_token: req.bearerToken }
+        : { agent_token: req.bearerToken, model: requestedModel },
+    );
+    const selectResponse = yield* Effect.tryPromise({
+      try: () =>
+        rails.request({
+          method: "POST",
+          subdomain: config.primarySubdomain,
+          path: SELECT_PAYER_FOR_TOKEN_PATH,
+          headers: buildHeaders(selectBody, config.agentRunnerSecret),
+          body: selectBody,
+          // Short hop, same budget reasoning as the internal relay: this plus
+          // the Stripe upstream's 120s must stay under the client's timeout.
+          timeoutMs: 10_000,
+        }),
+      catch: (error) =>
+        new GatewayError({ message: `select-payer-for-token request failed: ${error instanceof Error ? error.message : String(error)}` }),
+    });
+    const selectText = yield* Effect.promise(() => selectResponse.text());
+
+    // Pass auth/flag/funding/model rejections through verbatim (the bodies
+    // are already OpenAI-shaped) without spending an LLM call.
+    if (selectResponse.statusCode !== 200) {
+      log.warn({
+        event: "select_payer_for_token_rejected",
+        status_code: selectResponse.statusCode,
+      });
+      return { status: selectResponse.statusCode, contentType: "application/json", body: selectText };
+    }
+
+    const selectParsed = yield* Effect.try({
+      try: () => JSON.parse(selectText) as { payer_customer_id?: string; model?: string },
+      catch: () => new GatewayError({ message: "select-payer-for-token returned a non-JSON 200 body" }),
+    });
+    const payerCustomerId = selectParsed.payer_customer_id;
+    if (payerCustomerId === undefined || payerCustomerId === "") {
+      return yield* Effect.fail(new GatewayError({ message: "select-payer-for-token returned no payer_customer_id" }));
+    }
+    const mappedModel = selectParsed.model;
+
+    // 2. Forward to the Stripe AI Gateway with the model Rails resolved
+    // (blank/"default" maps to the canonical default) and stream the
+    // response back.
+    if (mappedModel !== undefined) {
+      parsed["model"] = mappedModel;
+    }
+    const startedAt = Date.now();
+    const upstream = yield* Effect.tryPromise({
+      try: () => stripe.chatCompletionsStream({ customerId: payerCustomerId, body: JSON.stringify(parsed) }),
+      catch: (error) =>
+        new GatewayError({ message: `stripe upstream failed: ${error instanceof Error ? error.message : String(error)}` }),
+    });
+
+    // Routing/observability only — never the key, customer id, or prompt
+    // content. Status/duration are as-of response headers; streamed bodies
+    // finish later.
+    log.info({
+      event: "llm_request_external",
+      gateway_mode: "stripe_gateway",
+      model: mappedModel ?? requestedModel ?? "",
+      status_code: upstream.status,
+      duration_ms: Date.now() - startedAt,
+    });
+
+    return { status: upstream.status, contentType: upstream.contentType, body: upstream.body ?? "" };
+  });

--- a/agent-runner/src/gateway/RateLimiter.ts
+++ b/agent-runner/src/gateway/RateLimiter.ts
@@ -1,0 +1,72 @@
+/**
+ * Per-key sliding-window rate limiter for the gateway's external ingress.
+ *
+ * A leaked llm_gateway key spends other people's money until the pool is dry;
+ * Stripe's 402 bounds the total but not the burn rate. This bounds requests
+ * per minute and per day per key until real dollar spend ceilings exist
+ * (which need per-call usage persistence).
+ *
+ * In-memory on purpose: the gateway runs as a single container, so there is
+ * no shared state to coordinate. If the gateway is ever scaled out, the
+ * limits become per-instance and this needs a shared store.
+ */
+
+export interface RateLimiterOptions {
+  readonly perMinute: number;
+  readonly perDay: number;
+  /** Injectable clock (ms since epoch) for tests. */
+  readonly now?: () => number;
+}
+
+export interface RateLimitDecision {
+  readonly allowed: boolean;
+  /** Seconds until the next request could be allowed; 0 when allowed. */
+  readonly retryAfterSeconds: number;
+}
+
+const MINUTE_MS = 60_000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export class RateLimiter {
+  private readonly perMinute: number;
+  private readonly perDay: number;
+  private readonly now: () => number;
+  /** Per key: request timestamps within the last day, oldest first. */
+  private readonly requests = new Map<string, number[]>();
+
+  constructor(options: RateLimiterOptions) {
+    this.perMinute = options.perMinute;
+    this.perDay = options.perDay;
+    this.now = options.now ?? Date.now;
+  }
+
+  /** Record the request if allowed; blocked requests consume no quota. */
+  check(key: string): RateLimitDecision {
+    const now = this.now();
+    const dayCutoff = now - DAY_MS;
+
+    const kept = (this.requests.get(key) ?? []).filter((t) => t > dayCutoff);
+    if (kept.length === 0) {
+      this.requests.delete(key);
+    }
+
+    if (kept.length >= this.perDay) {
+      // kept[0] is the oldest in-window request; quota frees when it ages out.
+      return this.blocked(kept[0]! + DAY_MS - now);
+    }
+
+    const minuteCutoff = now - MINUTE_MS;
+    const inLastMinute = kept.filter((t) => t > minuteCutoff);
+    if (inLastMinute.length >= this.perMinute) {
+      return this.blocked(inLastMinute[0]! + MINUTE_MS - now);
+    }
+
+    kept.push(now);
+    this.requests.set(key, kept);
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+
+  private blocked(retryAfterMs: number): RateLimitDecision {
+    return { allowed: false, retryAfterSeconds: Math.max(1, Math.ceil(retryAfterMs / 1000)) };
+  }
+}

--- a/agent-runner/src/gateway/StripeUpstream.ts
+++ b/agent-runner/src/gateway/StripeUpstream.ts
@@ -15,11 +15,26 @@ export interface StripeUpstreamResult {
   readonly body: string;
 }
 
+export interface StripeUpstreamStreamResult {
+  readonly status: number;
+  readonly contentType: string;
+  readonly body: ReadableStream<Uint8Array> | null;
+}
+
 export interface StripeUpstreamService {
   readonly chatCompletions: (opts: {
     readonly customerId: string;
     readonly body: string;
   }) => Promise<StripeUpstreamResult>;
+  /**
+   * Same hop, but the response body is handed back as a stream instead of
+   * buffered text — the external ingress pipes it to the client byte for
+   * byte, which serves SSE (stream: true) and plain JSON responses alike.
+   */
+  readonly chatCompletionsStream: (opts: {
+    readonly customerId: string;
+    readonly body: string;
+  }) => Promise<StripeUpstreamStreamResult>;
 }
 
 export class StripeUpstream extends Context.Tag("StripeUpstream")<StripeUpstream, StripeUpstreamService>() {}
@@ -29,12 +44,12 @@ export const StripeUpstreamLive = Layer.effect(
   Effect.gen(function* () {
     const config = yield* Config;
 
-    const chatCompletions: StripeUpstreamService["chatCompletions"] = async ({ customerId, body }) => {
+    const rawRequest = async ({ customerId, body }: { customerId: string; body: string }): Promise<Response> => {
       if (config.stripeGatewayKey === undefined) {
         throw new Error("STRIPE_GATEWAY_KEY is required to relay to the Stripe AI Gateway");
       }
 
-      const response = await fetch(`${config.stripeGatewayBaseUrl}/chat/completions`, {
+      return fetch(`${config.stripeGatewayBaseUrl}/chat/completions`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -44,11 +59,23 @@ export const StripeUpstreamLive = Layer.effect(
         body,
         signal: AbortSignal.timeout(120_000),
       });
+    };
 
+    const chatCompletions: StripeUpstreamService["chatCompletions"] = async (opts) => {
+      const response = await rawRequest(opts);
       const text = await response.text();
       return { status: response.status, body: text };
     };
 
-    return { chatCompletions };
+    const chatCompletionsStream: StripeUpstreamService["chatCompletionsStream"] = async (opts) => {
+      const response = await rawRequest(opts);
+      return {
+        status: response.status,
+        contentType: response.headers.get("content-type") ?? "application/json",
+        body: response.body,
+      };
+    };
+
+    return { chatCompletions, chatCompletionsStream };
   }),
 );

--- a/agent-runner/src/gateway/handler.ts
+++ b/agent-runner/src/gateway/handler.ts
@@ -1,21 +1,60 @@
 /**
  * HTTP request handling for the gateway, decoupled from the Effect runtime so
- * the routing-header contract can be tested without a live Stripe/Rails stack.
+ * the routing contract can be tested without a live Stripe/Rails stack.
  *
- * The relay itself is injected as a plain async function — {@link server.ts}
- * wires in the real Effect runtime; tests wire in a fake.
+ * Two ingress lanes, routed by path:
+ *
+ *   POST /chat/completions     — internal relay (agent-runner). No auth of its
+ *                                own: network isolation is the auth, and the
+ *                                edge proxy forwards only /v1/* so this path
+ *                                is unreachable from outside.
+ *   POST /v1/chat/completions  — external ingress (agents calling with their
+ *                                llm_gateway API keys via llm.<hostname>).
+ *                                Bearer-authenticated by Rails per call; size
+ *                                caps and per-key rate limits apply here.
+ *
+ * The relays are injected as plain async functions — {@link server.ts} wires
+ * in the real Effect runtime; tests wire in fakes.
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { createHash } from "node:crypto";
 import type { GatewayRelayRequest, GatewayRelayResult } from "./Relay.js";
+import type { ExternalRelayRequest, ExternalRelayResult } from "./ExternalRelay.js";
+import type { RateLimiter } from "./RateLimiter.js";
 import { log } from "../services/Logger.js";
 
 export type RelayRunner = (req: GatewayRelayRequest) => Promise<GatewayRelayResult>;
+export type ExternalRelayRunner = (req: ExternalRelayRequest) => Promise<ExternalRelayResult>;
 
-const readBody = (req: IncomingMessage): Promise<string> =>
+export interface GatewayHandlerDeps {
+  readonly runRelay: RelayRunner;
+  readonly runExternalRelay: ExternalRelayRunner;
+  readonly rateLimiter: RateLimiter;
+  readonly maxBodyBytes: number;
+}
+
+/** Sentinel for a body that exceeded maxBytes. */
+const OVERSIZED = Symbol("oversized");
+
+const readBody = (req: IncomingMessage, maxBytes: number): Promise<string | typeof OVERSIZED> =>
   new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    let total = 0;
+    req.on("data", (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > maxBytes) {
+        // Drain (not destroy) so the 413 response can still flush; the
+        // response carries Connection: close to stop a client that keeps
+        // uploading.
+        req.removeAllListeners("data");
+        req.resume();
+        resolve(OVERSIZED);
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
     req.on("error", reject);
   });
@@ -25,13 +64,102 @@ const header = (req: IncomingMessage, name: string): string | undefined => {
   return Array.isArray(value) ? value[0] : value;
 };
 
-const sendJson = (res: ServerResponse, status: number, body: string): void => {
-  res.writeHead(status, { "Content-Type": "application/json" });
+const sendJson = (res: ServerResponse, status: number, body: string, headers?: Record<string, string>): void => {
+  res.writeHead(status, { "Content-Type": "application/json", ...(headers ?? {}) });
   res.end(body);
 };
 
+const openAiError = (code: string, message: string): string =>
+  JSON.stringify({ error: { message, type: "invalid_request_error", code } });
+
+const sendExternalResult = (res: ServerResponse, result: ExternalRelayResult): void => {
+  res.writeHead(result.status, { "Content-Type": result.contentType });
+  if (typeof result.body === "string") {
+    res.end(result.body);
+    return;
+  }
+  // Pipe upstream bytes through as they arrive — this is what makes SSE
+  // streaming work end to end.
+  Readable.fromWeb(result.body as import("node:stream/web").ReadableStream<Uint8Array>).pipe(res);
+};
+
+const handleInternal = async (
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: GatewayHandlerDeps,
+): Promise<void> => {
+  const taskRunId = header(req, "x-harmonic-task-run-id");
+  const subdomain = header(req, "x-harmonic-subdomain");
+  const model = header(req, "x-harmonic-model") ?? "";
+  if (taskRunId === undefined || taskRunId === "" || subdomain === undefined || subdomain === "") {
+    sendJson(res, 400, JSON.stringify({ error: "missing_routing_headers" }));
+    return;
+  }
+
+  try {
+    const body = await readBody(req, deps.maxBodyBytes);
+    if (body === OVERSIZED) {
+      sendJson(res, 413, JSON.stringify({ error: "request_too_large" }), { "Connection": "close" });
+      return;
+    }
+    const result = await deps.runRelay({ taskRunId, subdomain, model, body });
+    sendJson(res, result.status, result.body);
+  } catch (error) {
+    log.error({
+      event: "gateway_relay_error",
+      task_run_id: taskRunId,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    sendJson(res, 502, JSON.stringify({ error: "gateway_error" }));
+  }
+};
+
+const handleExternal = async (
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: GatewayHandlerDeps,
+): Promise<void> => {
+  const authorization = header(req, "authorization") ?? "";
+  const bearerToken = authorization.startsWith("Bearer ") ? authorization.slice("Bearer ".length).trim() : "";
+  if (bearerToken === "") {
+    sendJson(res, 401, openAiError("missing_api_key", "Pass your llm_gateway API key as a Bearer token."));
+    return;
+  }
+
+  // Rate limit before any body read or Rails/Stripe work. The bucket is keyed
+  // by a hash so raw keys are never retained in limiter memory.
+  const limit = deps.rateLimiter.check(createHash("sha256").update(bearerToken).digest("hex"));
+  if (!limit.allowed) {
+    sendJson(
+      res,
+      429,
+      openAiError("rate_limit_exceeded", "Rate limit exceeded. Retry after the indicated delay."),
+      { "Retry-After": String(limit.retryAfterSeconds) },
+    );
+    return;
+  }
+
+  try {
+    const body = await readBody(req, deps.maxBodyBytes);
+    if (body === OVERSIZED) {
+      sendJson(res, 413, openAiError("request_too_large", "Request body exceeds the gateway's size limit."), {
+        "Connection": "close",
+      });
+      return;
+    }
+    const result = await deps.runExternalRelay({ bearerToken, body });
+    sendExternalResult(res, result);
+  } catch (error) {
+    log.error({
+      event: "gateway_external_relay_error",
+      message: error instanceof Error ? error.message : String(error),
+    });
+    sendJson(res, 502, openAiError("gateway_error", "The gateway could not complete the request."));
+  }
+};
+
 export const createHandler =
-  (runRelay: RelayRunner) =>
+  (deps: GatewayHandlerDeps) =>
   async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     if (req.method === "GET" && req.url === "/health") {
       sendJson(res, 200, JSON.stringify({ status: "ok" }));
@@ -42,24 +170,9 @@ export const createHandler =
       return;
     }
 
-    const taskRunId = header(req, "x-harmonic-task-run-id");
-    const subdomain = header(req, "x-harmonic-subdomain");
-    const model = header(req, "x-harmonic-model") ?? "";
-    if (taskRunId === undefined || taskRunId === "" || subdomain === undefined || subdomain === "") {
-      sendJson(res, 400, JSON.stringify({ error: "missing_routing_headers" }));
+    if (req.url === "/v1/chat/completions") {
+      await handleExternal(req, res, deps);
       return;
     }
-
-    try {
-      const body = await readBody(req);
-      const result = await runRelay({ taskRunId, subdomain, model, body });
-      sendJson(res, result.status, result.body);
-    } catch (error) {
-      log.error({
-        event: "gateway_relay_error",
-        task_run_id: taskRunId,
-        message: error instanceof Error ? error.message : String(error),
-      });
-      sendJson(res, 502, JSON.stringify({ error: "gateway_error" }));
-    }
+    await handleInternal(req, res, deps);
   };

--- a/agent-runner/src/gateway/server.ts
+++ b/agent-runner/src/gateway/server.ts
@@ -20,6 +20,8 @@ import { ConfigLive } from "../config/Config.js";
 import { RailsHttpLive } from "../services/RailsHttp.js";
 import { StripeUpstreamLive } from "./StripeUpstream.js";
 import { relay } from "./Relay.js";
+import { externalRelay } from "./ExternalRelay.js";
+import { RateLimiter } from "./RateLimiter.js";
 import { createHandler } from "./handler.js";
 import { log } from "../services/Logger.js";
 
@@ -36,7 +38,20 @@ const AppLayer = Layer.provideMerge(
 );
 const runtime = ManagedRuntime.make(AppLayer);
 
-const handler = createHandler((req) => runtime.runPromise(relay(req)));
+const intEnv = (name: string, defaultValue: number): number =>
+  parseInt(process.env[name] ?? "", 10) || defaultValue;
+
+const handler = createHandler({
+  runRelay: (req) => runtime.runPromise(relay(req)),
+  runExternalRelay: (req) => runtime.runPromise(externalRelay(req)),
+  // Spend-rate stopgap for external keys until dollar ceilings exist:
+  // requests per minute bound the burn rate, requests per day bound the total.
+  rateLimiter: new RateLimiter({
+    perMinute: intEnv("GATEWAY_EXTERNAL_RPM", 20),
+    perDay: intEnv("GATEWAY_EXTERNAL_RPD", 500),
+  }),
+  maxBodyBytes: intEnv("GATEWAY_MAX_BODY_BYTES", 1024 * 1024),
+});
 
 const port = parseInt(process.env["GATEWAY_PORT"] ?? "4500", 10) || 4500;
 const server = createServer((req, res) => {

--- a/agent-runner/test/gateway/ExternalRelay.test.ts
+++ b/agent-runner/test/gateway/ExternalRelay.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import { Effect, Layer } from "effect";
+import { externalRelay } from "../../src/gateway/ExternalRelay.js";
+import { StripeUpstream } from "../../src/gateway/StripeUpstream.js";
+import type { StripeUpstreamService } from "../../src/gateway/StripeUpstream.js";
+import { RailsHttp } from "../../src/services/RailsHttp.js";
+import type { RailsHttpService, RailsResponse, RailsRequestOptions } from "../../src/services/RailsHttp.js";
+import { Config } from "../../src/config/Config.js";
+import type { AppConfig } from "../../src/config/Config.js";
+
+const testConfig: AppConfig = {
+  harmonicInternalUrl: "http://web:3000",
+  harmonicHostname: "harmonic.local",
+  primarySubdomain: "app",
+  agentRunnerSecret: "test-secret",
+  redisUrl: "redis://redis:6379",
+  litellmBaseUrl: "http://litellm:4000",
+  llmGatewayUrl: "http://llm-gateway:4500",
+  stripeGatewayBaseUrl: "https://llm.stripe.com",
+  llmGatewayMode: "stripe_gateway",
+  stripeGatewayKey: "sk_test",
+  streamName: "agent_tasks",
+  consumerGroup: "agent_runner",
+  consumerName: "runner-test",
+  maxConcurrentTasks: 100,
+  streamMaxLen: 10000,
+};
+const ConfigTest = Layer.succeed(Config, testConfig);
+
+const railsLayer = (
+  resp: { statusCode: number; body: string },
+  capture?: (opts: RailsRequestOptions) => void,
+): Layer.Layer<RailsHttp> => {
+  const service: RailsHttpService = {
+    request: async (opts): Promise<RailsResponse> => {
+      capture?.(opts);
+      return { statusCode: resp.statusCode, headers: {}, text: async () => resp.body };
+    },
+  };
+  return Layer.succeed(RailsHttp, service);
+};
+
+const streamOf = (text: string): ReadableStream<Uint8Array> => new Response(text).body!;
+
+// Mock StripeUpstream: external relay uses only the streaming variant.
+const stripeLayer = (
+  impl: StripeUpstreamService["chatCompletionsStream"],
+): Layer.Layer<StripeUpstream> =>
+  Layer.succeed(StripeUpstream, {
+    chatCompletions: async () => {
+      throw new Error("external relay must use the streaming variant");
+    },
+    chatCompletionsStream: impl,
+  });
+
+const req = {
+  bearerToken: "hg_agent_key_123",
+  body: JSON.stringify({ model: "default", stream: true, messages: [{ role: "user", content: "hi" }] }),
+};
+
+describe("external relay", () => {
+  it("authenticates via select-payer-for-token and forwards with the mapped model", async () => {
+    let capturedOpts: RailsRequestOptions | undefined;
+    let capturedCustomerId: string | undefined;
+    let capturedBody: string | undefined;
+
+    const layers = Layer.mergeAll(
+      ConfigTest,
+      railsLayer(
+        {
+          statusCode: 200,
+          body: JSON.stringify({ payer_customer_id: "cus_abc", model: "anthropic/claude-sonnet-4.6" }),
+        },
+        (opts) => {
+          capturedOpts = opts;
+        },
+      ),
+      stripeLayer(async ({ customerId, body }) => {
+        capturedCustomerId = customerId;
+        capturedBody = body;
+        return { status: 200, contentType: "text/event-stream", body: streamOf("data: ok\n\n") };
+      }),
+    );
+
+    const result = await Effect.runPromise(Effect.provide(externalRelay(req), layers));
+
+    expect(capturedOpts?.path).toBe("/internal/llm-gateway/select-payer-for-token");
+    expect(capturedOpts?.subdomain).toBe("app");
+    expect(capturedOpts?.timeoutMs).toBe(10_000);
+    expect(JSON.parse(capturedOpts?.body ?? "{}")).toEqual({
+      agent_token: "hg_agent_key_123",
+      model: "default",
+    });
+
+    expect(capturedCustomerId).toBe("cus_abc");
+    // The forwarded body is the client's body with the model rewritten.
+    expect(JSON.parse(capturedBody ?? "{}")).toEqual({
+      model: "anthropic/claude-sonnet-4.6",
+      stream: true,
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.contentType).toBe("text/event-stream");
+    expect(await new Response(result.body as ReadableStream<Uint8Array>).text()).toBe("data: ok\n\n");
+  });
+
+  it("passes a select-payer rejection through verbatim without calling Stripe", async () => {
+    let stripeCalled = false;
+    const errorBody = JSON.stringify({
+      error: { message: "LLM gateway access is not enabled for this account.", type: "invalid_request_error", code: "feature_disabled" },
+    });
+
+    const layers = Layer.mergeAll(
+      ConfigTest,
+      railsLayer({ statusCode: 403, body: errorBody }),
+      stripeLayer(async () => {
+        stripeCalled = true;
+        return { status: 200, contentType: "application/json", body: streamOf("{}") };
+      }),
+    );
+
+    const result = await Effect.runPromise(Effect.provide(externalRelay(req), layers));
+
+    expect(result.status).toBe(403);
+    expect(result.contentType).toBe("application/json");
+    expect(result.body).toBe(errorBody);
+    expect(stripeCalled).toBe(false);
+  });
+
+  it("rejects an unparseable body without calling Rails or Stripe", async () => {
+    let railsCalled = false;
+    let stripeCalled = false;
+
+    const layers = Layer.mergeAll(
+      ConfigTest,
+      railsLayer({ statusCode: 200, body: "{}" }, () => {
+        railsCalled = true;
+      }),
+      stripeLayer(async () => {
+        stripeCalled = true;
+        return { status: 200, contentType: "application/json", body: streamOf("{}") };
+      }),
+    );
+
+    const result = await Effect.runPromise(
+      Effect.provide(externalRelay({ bearerToken: "hg_key", body: "not json{" }), layers),
+    );
+
+    expect(result.status).toBe(400);
+    const parsed = JSON.parse(result.body as string);
+    expect(parsed.error.code).toBe("invalid_json");
+    expect(parsed.error.type).toBe("invalid_request_error");
+    expect(railsCalled).toBe(false);
+    expect(stripeCalled).toBe(false);
+  });
+
+  it("fails when select-payer succeeds without a payer_customer_id", async () => {
+    const layers = Layer.mergeAll(
+      ConfigTest,
+      railsLayer({ statusCode: 200, body: JSON.stringify({ model: "anthropic/claude-sonnet-4.6" }) }),
+      stripeLayer(async () => ({ status: 200, contentType: "application/json", body: streamOf("{}") })),
+    );
+
+    await expect(Effect.runPromise(Effect.provide(externalRelay(req), layers))).rejects.toThrow(
+      /payer_customer_id/,
+    );
+  });
+
+  it("omits a missing model from the select-payer request rather than sending undefined", async () => {
+    let capturedBody: string | undefined;
+
+    const layers = Layer.mergeAll(
+      ConfigTest,
+      railsLayer(
+        { statusCode: 200, body: JSON.stringify({ payer_customer_id: "cus_abc", model: "anthropic/claude-sonnet-4.6" }) },
+        (opts) => {
+          capturedBody = opts.body;
+        },
+      ),
+      stripeLayer(async () => ({ status: 200, contentType: "application/json", body: streamOf("{}") })),
+    );
+
+    await Effect.runPromise(
+      Effect.provide(externalRelay({ bearerToken: "hg_key", body: JSON.stringify({ messages: [] }) }), layers),
+    );
+
+    expect(JSON.parse(capturedBody ?? "{}")).toEqual({ agent_token: "hg_key" });
+  });
+});

--- a/agent-runner/test/gateway/RateLimiter.test.ts
+++ b/agent-runner/test/gateway/RateLimiter.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { RateLimiter } from "../../src/gateway/RateLimiter.js";
+
+const makeClock = () => {
+  let t = 1_000_000;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+};
+
+describe("RateLimiter", () => {
+  it("allows requests under the per-minute limit", () => {
+    const clock = makeClock();
+    const limiter = new RateLimiter({ perMinute: 3, perDay: 100, now: clock.now });
+
+    for (let i = 0; i < 3; i++) {
+      expect(limiter.check("key-a").allowed).toBe(true);
+    }
+  });
+
+  it("blocks over the per-minute limit and reports when to retry", () => {
+    const clock = makeClock();
+    const limiter = new RateLimiter({ perMinute: 2, perDay: 100, now: clock.now });
+
+    limiter.check("key-a");
+    clock.advance(10_000);
+    limiter.check("key-a");
+
+    const decision = limiter.check("key-a");
+    expect(decision.allowed).toBe(false);
+    // The oldest request exits the 60s window 50s from now.
+    expect(decision.retryAfterSeconds).toBe(50);
+  });
+
+  it("allows again after the minute window slides past", () => {
+    const clock = makeClock();
+    const limiter = new RateLimiter({ perMinute: 1, perDay: 100, now: clock.now });
+
+    expect(limiter.check("key-a").allowed).toBe(true);
+    expect(limiter.check("key-a").allowed).toBe(false);
+
+    clock.advance(61_000);
+    expect(limiter.check("key-a").allowed).toBe(true);
+  });
+
+  it("enforces the per-day limit even when the per-minute rate is fine", () => {
+    const clock = makeClock();
+    const limiter = new RateLimiter({ perMinute: 10, perDay: 3, now: clock.now });
+
+    for (let i = 0; i < 3; i++) {
+      expect(limiter.check("key-a").allowed).toBe(true);
+      clock.advance(120_000);
+    }
+
+    const decision = limiter.check("key-a");
+    expect(decision.allowed).toBe(false);
+    expect(decision.retryAfterSeconds).toBeGreaterThan(0);
+
+    clock.advance(24 * 60 * 60 * 1000);
+    expect(limiter.check("key-a").allowed).toBe(true);
+  });
+
+  it("blocked requests do not consume quota", () => {
+    const clock = makeClock();
+    const limiter = new RateLimiter({ perMinute: 1, perDay: 100, now: clock.now });
+
+    limiter.check("key-a");
+    limiter.check("key-a");
+    limiter.check("key-a");
+
+    clock.advance(61_000);
+    expect(limiter.check("key-a").allowed).toBe(true);
+  });
+
+  it("tracks keys independently", () => {
+    const clock = makeClock();
+    const limiter = new RateLimiter({ perMinute: 1, perDay: 100, now: clock.now });
+
+    expect(limiter.check("key-a").allowed).toBe(true);
+    expect(limiter.check("key-a").allowed).toBe(false);
+    expect(limiter.check("key-b").allowed).toBe(true);
+  });
+});

--- a/agent-runner/test/gateway/StripeUpstream.test.ts
+++ b/agent-runner/test/gateway/StripeUpstream.test.ts
@@ -7,6 +7,7 @@ import type { AppConfig } from "../../src/config/Config.js";
 const testConfig: AppConfig = {
   harmonicInternalUrl: "http://web:3000",
   harmonicHostname: "harmonic.local",
+  primarySubdomain: "app",
   agentRunnerSecret: "test-secret",
   redisUrl: "redis://redis:6379",
   litellmBaseUrl: "http://litellm:4000",
@@ -66,5 +67,47 @@ describe("StripeUpstream", () => {
       run({ ...testConfig, stripeGatewayKey: undefined }, { customerId: "cus_abc", body: "{}" }),
     ).rejects.toThrow(/STRIPE_GATEWAY_KEY/);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  describe("chatCompletionsStream", () => {
+    const runStream = (config: AppConfig, opts: { customerId: string; body: string }) =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const stripe = yield* StripeUpstream;
+          return yield* Effect.promise(() => stripe.chatCompletionsStream(opts));
+        }).pipe(Effect.provide(StripeUpstreamLive.pipe(Layer.provide(Layer.succeed(Config, config))))),
+      );
+
+    it("returns the upstream body as a stream with its content type", async () => {
+      const fetchSpy = vi.fn(
+        async () =>
+          new Response("data: chunk\n\n", { status: 200, headers: { "Content-Type": "text/event-stream" } }),
+      );
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const body = JSON.stringify({ model: "anthropic/claude-sonnet-4.6", stream: true, messages: [] });
+      const result = await runStream(testConfig, { customerId: "cus_abc", body });
+
+      const [, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["X-Stripe-Customer-ID"]).toBe("cus_abc");
+      expect(result.status).toBe(200);
+      expect(result.contentType).toBe("text/event-stream");
+      expect(result.body).not.toBeNull();
+      expect(await new Response(result.body).text()).toBe("data: chunk\n\n");
+    });
+
+    it("streams error responses verbatim too", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => new Response('{"error":"nope"}', { status: 402, headers: { "Content-Type": "application/json" } })),
+      );
+
+      const result = await runStream(testConfig, { customerId: "cus_abc", body: "{}" });
+
+      expect(result.status).toBe(402);
+      expect(result.contentType).toBe("application/json");
+      expect(await new Response(result.body).text()).toBe('{"error":"nope"}');
+    });
   });
 });

--- a/agent-runner/test/gateway/handler.test.ts
+++ b/agent-runner/test/gateway/handler.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { createServer, type Server } from "node:http";
-import { createHandler, type RelayRunner } from "../../src/gateway/handler.js";
+import { createHandler, type RelayRunner, type ExternalRelayRunner, type GatewayHandlerDeps } from "../../src/gateway/handler.js";
 import type { GatewayRelayRequest } from "../../src/gateway/Relay.js";
+import type { ExternalRelayRequest } from "../../src/gateway/ExternalRelay.js";
+import { RateLimiter } from "../../src/gateway/RateLimiter.js";
 
 let running: Server | undefined;
 
@@ -12,9 +14,22 @@ afterEach(async () => {
   }
 });
 
-const start = (runRelay: RelayRunner): Promise<string> =>
+const okRelay: RelayRunner = async () => ({ status: 200, body: JSON.stringify({ ok: true }) });
+const okExternalRelay: ExternalRelayRunner = async () => ({
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ ok: true }),
+});
+
+const start = (deps: Partial<GatewayHandlerDeps>): Promise<string> =>
   new Promise((resolve) => {
-    const handler = createHandler(runRelay);
+    const handler = createHandler({
+      runRelay: okRelay,
+      runExternalRelay: okExternalRelay,
+      rateLimiter: new RateLimiter({ perMinute: 1000, perDay: 10000 }),
+      maxBodyBytes: 1024 * 1024,
+      ...deps,
+    });
     running = createServer((req, res) => void handler(req, res));
     running.listen(0, () => {
       const addr = running!.address();
@@ -23,14 +38,14 @@ const start = (runRelay: RelayRunner): Promise<string> =>
     });
   });
 
-const okRelay: RelayRunner = async () => ({ status: 200, body: JSON.stringify({ ok: true }) });
-
 describe("gateway handler", () => {
   it("serves health without invoking the relay", async () => {
     let called = false;
-    const url = await start(async (r) => {
-      called = true;
-      return okRelay(r);
+    const url = await start({
+      runRelay: async (r) => {
+        called = true;
+        return okRelay(r);
+      },
     });
 
     const res = await fetch(`${url}/health`);
@@ -41,9 +56,11 @@ describe("gateway handler", () => {
 
   it("passes routing headers and body through to the relay and returns its result", async () => {
     let captured: GatewayRelayRequest | undefined;
-    const url = await start(async (r) => {
-      captured = r;
-      return { status: 200, body: JSON.stringify({ echoed: true }) };
+    const url = await start({
+      runRelay: async (r) => {
+        captured = r;
+        return { status: 200, body: JSON.stringify({ echoed: true }) };
+      },
     });
 
     const res = await fetch(`${url}/chat/completions`, {
@@ -69,9 +86,11 @@ describe("gateway handler", () => {
 
   it("rejects a POST missing routing headers without invoking the relay", async () => {
     let called = false;
-    const url = await start(async (r) => {
-      called = true;
-      return okRelay(r);
+    const url = await start({
+      runRelay: async (r) => {
+        called = true;
+        return okRelay(r);
+      },
     });
 
     const res = await fetch(`${url}/chat/completions`, {
@@ -86,14 +105,16 @@ describe("gateway handler", () => {
   });
 
   it("returns 405 for a non-POST, non-health request", async () => {
-    const url = await start(okRelay);
+    const url = await start({});
     const res = await fetch(`${url}/chat/completions`, { method: "GET" });
     expect(res.status).toBe(405);
   });
 
   it("maps a relay exception to 502", async () => {
-    const url = await start(async () => {
-      throw new Error("boom");
+    const url = await start({
+      runRelay: async () => {
+        throw new Error("boom");
+      },
     });
 
     const res = await fetch(`${url}/chat/completions`, {
@@ -107,5 +128,141 @@ describe("gateway handler", () => {
 
     expect(res.status).toBe(502);
     expect(await res.json()).toEqual({ error: "gateway_error" });
+  });
+
+  describe("external ingress (/v1/chat/completions)", () => {
+    it("routes to the external relay with the bearer token and body", async () => {
+      let captured: ExternalRelayRequest | undefined;
+      const url = await start({
+        runExternalRelay: async (r) => {
+          captured = r;
+          return { status: 200, contentType: "application/json", body: JSON.stringify({ id: "cmpl-1" }) };
+        },
+      });
+
+      const res = await fetch(`${url}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Authorization": "Bearer hg_key_123", "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "default", messages: [] }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("application/json");
+      expect(await res.json()).toEqual({ id: "cmpl-1" });
+      expect(captured).toEqual({
+        bearerToken: "hg_key_123",
+        body: JSON.stringify({ model: "default", messages: [] }),
+      });
+    });
+
+    it("streams a ReadableStream result to the client", async () => {
+      const url = await start({
+        runExternalRelay: async () => ({
+          status: 200,
+          contentType: "text/event-stream",
+          body: new Response("data: one\n\ndata: two\n\n").body!,
+        }),
+      });
+
+      const res = await fetch(`${url}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Authorization": "Bearer hg_key_123" },
+        body: "{}",
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/event-stream");
+      expect(await res.text()).toBe("data: one\n\ndata: two\n\n");
+    });
+
+    it("rejects a missing bearer token with an OpenAI-shaped 401 without invoking the relay", async () => {
+      let called = false;
+      const url = await start({
+        runExternalRelay: async (r) => {
+          called = true;
+          return okExternalRelay(r);
+        },
+      });
+
+      const res = await fetch(`${url}/v1/chat/completions`, { method: "POST", body: "{}" });
+
+      expect(res.status).toBe(401);
+      const parsed = await res.json();
+      expect(parsed.error.code).toBe("missing_api_key");
+      expect(parsed.error.type).toBe("invalid_request_error");
+      expect(called).toBe(false);
+    });
+
+    it("rejects an oversized body with 413", async () => {
+      let called = false;
+      const url = await start({
+        maxBodyBytes: 64,
+        runExternalRelay: async (r) => {
+          called = true;
+          return okExternalRelay(r);
+        },
+      });
+
+      const res = await fetch(`${url}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Authorization": "Bearer hg_key_123" },
+        body: JSON.stringify({ padding: "x".repeat(200) }),
+      });
+
+      expect(res.status).toBe(413);
+      expect((await res.json()).error.code).toBe("request_too_large");
+      expect(called).toBe(false);
+    });
+
+    it("rate limits per key with a Retry-After header", async () => {
+      let calls = 0;
+      const url = await start({
+        rateLimiter: new RateLimiter({ perMinute: 1, perDay: 100 }),
+        runExternalRelay: async (r) => {
+          calls++;
+          return okExternalRelay(r);
+        },
+      });
+
+      const request = () =>
+        fetch(`${url}/v1/chat/completions`, {
+          method: "POST",
+          headers: { "Authorization": "Bearer hg_key_123" },
+          body: "{}",
+        });
+
+      expect((await request()).status).toBe(200);
+
+      const limited = await request();
+      expect(limited.status).toBe(429);
+      expect(Number(limited.headers.get("retry-after"))).toBeGreaterThan(0);
+      expect((await limited.json()).error.code).toBe("rate_limit_exceeded");
+      expect(calls).toBe(1);
+
+      // A different key is unaffected.
+      const other = await fetch(`${url}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Authorization": "Bearer hg_other_key" },
+        body: "{}",
+      });
+      expect(other.status).toBe(200);
+    });
+
+    it("maps an external relay exception to an OpenAI-shaped 502", async () => {
+      const url = await start({
+        runExternalRelay: async () => {
+          throw new Error("boom");
+        },
+      });
+
+      const res = await fetch(`${url}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Authorization": "Bearer hg_key_123" },
+        body: "{}",
+      });
+
+      expect(res.status).toBe(502);
+      expect((await res.json()).error.code).toBe("gateway_error");
+    });
   });
 });

--- a/app/controllers/internal/llm_gateway_controller.rb
+++ b/app/controllers/internal/llm_gateway_controller.rb
@@ -7,6 +7,11 @@ module Internal
   class LLMGatewayController < BaseController
     extend T::Sig
 
+    # The token caller arrives via the public llm.<hostname> edge, so there is
+    # no tenant subdomain to resolve — the token itself carries the tenant and
+    # the action scopes the thread to it after authentication.
+    skip_before_action :resolve_tenant_from_subdomain, only: :select_payer_for_token
+
     # POST /internal/llm-gateway/select-payer
     # Given the task run behind a billed LLM call, resolve the Stripe customer
     # that should pay for it (and verify that payer is funded).
@@ -24,6 +29,43 @@ module Internal
       render json: { payer_customer_id: result.payer_customer_id }
     rescue LLMGateway::PayerResolver::ResolutionError => e
       render json: { error: e.code }, status: e.http_status
+    end
+
+    # POST /internal/llm-gateway/select-payer-for-token
+    # Given an agent's llm_gateway API key (a gateway call made directly by an
+    # external agent, no task run), authenticate it and resolve the payer via
+    # the agent's own funding mapping. Error bodies are OpenAI-shaped because
+    # the gateway passes them through to the external client verbatim.
+    sig { void }
+    def select_payer_for_token
+      token = ApiToken.authenticate_llm_gateway(params[:agent_token].to_s)
+      if token.nil? || token.expired?
+        render_openai_error(:unauthorized, "invalid_token", "Invalid or expired API key.")
+        return
+      end
+
+      tenant = Tenant.scope_thread_to_tenant(subdomain: T.must(token.tenant).subdomain)
+      unless tenant.feature_enabled?("llm_gateway")
+        render_openai_error(:forbidden, "feature_disabled", "LLM gateway access is not enabled for this account.")
+        return
+      end
+
+      result = LLMGateway::PayerResolver.resolve_for_agent(T.must(token.user))
+      model = StripeGatewayModelMapper.map(params[:model])
+
+      token.token_used!
+      render json: { payer_customer_id: result.payer_customer_id, model: model }
+    rescue LLMGateway::PayerResolver::ResolutionError => e
+      render_openai_error(e.http_status, e.code, e.message)
+    rescue StripeGatewayModelMapper::UnmappedModelError => e
+      render_openai_error(:bad_request, "unsupported_model", e.message)
+    end
+
+    private
+
+    sig { params(status: Symbol, code: String, message: String).void }
+    def render_openai_error(status, code, message)
+      render json: { error: { message: message, type: "invalid_request_error", code: code } }, status: status
     end
   end
 end

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -297,6 +297,21 @@ class ApiToken < ApplicationRecord
     unscope(where: :internal).find_by(token_hash: token_hash, deleted_at: nil, tenant_id: tenant_id)
   end
 
+  # Authenticate a Bearer key presented to the LLM gateway. The gateway is a
+  # single cross-tenant edge (llm.<hostname>), so unlike `.authenticate` there
+  # is no tenant context yet — the token itself identifies the tenant, and the
+  # caller re-scopes the thread to it after this lookup. Bypassing the tenant
+  # scope is safe here because the unguessable 256-bit hash IS the credential:
+  # the lookup is the authentication, the same pre-tenant character as User
+  # auth. Only user-issued llm_gateway-type keys match; expiry is a call-site
+  # check (same convention as `.authenticate`).
+  sig { params(token_string: String).returns(T.nilable(ApiToken)) }
+  def self.authenticate_llm_gateway(token_string)
+    return nil if token_string.blank?
+
+    unscoped.find_by(token_hash: hash_token(token_string), deleted_at: nil, internal: false, token_type: "llm_gateway") # unscoped-allowed — cross-tenant auth by unguessable hash; tenant is derived FROM the token
+  end
+
   sig { params(token_string: String).returns(String) }
   def self.hash_token(token_string)
     Digest::SHA256.hexdigest(token_string)

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -309,7 +309,7 @@ class ApiToken < ApplicationRecord
   def self.authenticate_llm_gateway(token_string)
     return nil if token_string.blank?
 
-    unscoped.find_by(token_hash: hash_token(token_string), deleted_at: nil, internal: false, token_type: "llm_gateway") # unscoped-allowed — cross-tenant auth by unguessable hash; tenant is derived FROM the token
+    unscoped.find_by(token_hash: hash_token(token_string), deleted_at: nil, internal: false, token_type: "llm_gateway") # unscoped-allowed
   end
 
   sig { params(token_string: String).returns(String) }

--- a/app/services/caddyfile_generator.rb
+++ b/app/services/caddyfile_generator.rb
@@ -38,6 +38,12 @@ class CaddyfileGenerator
     lines << "\tredir https://#{primary_subdomain}.#{hostname}{uri} permanent"
     lines << "}"
 
+    # LLM gateway edge: external agents call the OpenAI-compatible ingress
+    # with their llm_gateway API keys. Only /v1/* is forwarded — the gateway's
+    # internal relay (/chat/completions) has no auth of its own and must stay
+    # unreachable from outside.
+    lines.concat(llm_gateway_block(hostname))
+
     # Primary subdomain
     lines.concat(subdomain_block("#{primary_subdomain}.#{hostname}"))
 
@@ -58,6 +64,18 @@ class CaddyfileGenerator
     end
 
     lines.join("\n") + "\n"
+  end
+
+  sig { params(hostname: String).returns(T::Array[String]) }
+  def llm_gateway_block(hostname)
+    [
+      "llm.#{hostname} {",
+      "\thandle /v1/* {",
+      "\t\treverse_proxy llm-gateway:4500",
+      "\t}",
+      "\trespond 403",
+      "}",
+    ]
   end
 
   sig { params(host: String).returns(T::Array[String]) }

--- a/app/services/llm_gateway/payer_resolver.rb
+++ b/app/services/llm_gateway/payer_resolver.rb
@@ -45,6 +45,49 @@ module LLMGateway
       new(task_run).resolve
     end
 
+    # Resolve the payer for a gateway call made directly by an agent (external
+    # ingress — authenticated by its llm_gateway API key, no task run). Same
+    # funding policy as the task-run path: pool first, else the agent's own
+    # billing customer.
+    sig { params(agent: User).returns(Result) }
+    def self.resolve_for_agent(agent)
+      pool_result(agent.id, context: "agent=#{agent.id}") || funded_result(agent.billing_customer)
+    end
+
+    sig { params(agent_id: String, context: String).returns(T.nilable(Result)) }
+    def self.pool_result(agent_id, context:)
+      pool = pool_customer_ids(agent_id)
+      return nil if pool.empty?
+
+      payer = T.must(pool.sample)
+      Rails.logger.info("[LLMGateway] Pool payer selected #{context} payer=#{payer} pool_size=#{pool.size}")
+      Result.new(payer_customer_id: payer)
+    end
+
+    # LLM usage must be funded: a prepaid-credit (pricing-plan) subscription
+    # must exist, or metered usage would never bill. This is a cheap, local
+    # check.
+    #
+    # The credit *balance* is deliberately NOT fetched here. Payer resolution
+    # runs on the per-LLM-call path, and a live Stripe balance call there is
+    # both slow and stale (Stripe aggregates deductions rather than deducting
+    # in real time), and it conflates a Stripe API error with an empty
+    # balance. The balance gate is enforced once at dispatch preflight and,
+    # authoritatively, by the gateway relaying a Stripe 402 when the balance
+    # is empty.
+    sig { params(billing_customer: T.nilable(StripeCustomer)).returns(Result) }
+    def self.funded_result(billing_customer)
+      if billing_customer.nil? || billing_customer.pricing_plan_subscription_id.blank?
+        raise ResolutionError.new(
+          "not_funded",
+          :payment_required,
+          "AI usage billing is not set up. Add credits at /billing."
+        )
+      end
+
+      Result.new(payer_customer_id: billing_customer.stripe_id)
+    end
+
     sig { params(agent_id: String).returns(T::Array[String]) }
     def self.pool_customer_ids(agent_id)
       raw = ENV.fetch(POOL_CONFIG_ENV, nil)
@@ -65,14 +108,8 @@ module LLMGateway
 
     sig { returns(Result) }
     def resolve
-      pool = self.class.pool_customer_ids(T.must(@task_run.ai_agent_id))
-      if pool.any?
-        payer = T.must(pool.sample)
-        Rails.logger.info(
-          "[LLMGateway] Pool payer selected task_run=#{@task_run.id} payer=#{payer} pool_size=#{pool.size}"
-        )
-        return Result.new(payer_customer_id: payer)
-      end
+      pool = self.class.pool_result(T.must(@task_run.ai_agent_id), context: "task_run=#{@task_run.id}")
+      return pool if pool
 
       billing_customer = @task_run.billing_customer
       if billing_customer.nil?
@@ -83,26 +120,7 @@ module LLMGateway
         )
       end
 
-      # LLM usage must be funded: a prepaid-credit (pricing-plan) subscription
-      # must exist, or metered usage would never bill. This is a cheap, local
-      # check.
-      #
-      # The credit *balance* is deliberately NOT fetched here. `select_payer`
-      # runs on the per-LLM-call path, and a live Stripe balance call there is
-      # both slow and stale (Stripe aggregates deductions rather than deducting
-      # in real time), and it conflates a Stripe API error with an empty
-      # balance. The balance gate is enforced once at dispatch preflight and,
-      # authoritatively, by the gateway relaying a Stripe 402 when the balance
-      # is empty.
-      if billing_customer.pricing_plan_subscription_id.blank?
-        raise ResolutionError.new(
-          "not_funded",
-          :payment_required,
-          "AI usage billing is not set up. Add credits at /billing."
-        )
-      end
-
-      Result.new(payer_customer_id: billing_customer.stripe_id)
+      self.class.funded_result(billing_customer)
     end
   end
 end

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -69,6 +69,14 @@ feature_flags:
     default_collective: false
     collective_level: false
 
+  llm_gateway:
+    name: "LLM Gateway External Access"
+    description: "Allows the tenant's external agents to call the LLM gateway directly with their llm_gateway API keys, billed to their pool or billing customer. Requires Stripe billing."
+    app_enabled: true
+    default_tenant: false
+    default_collective: false
+    collective_level: false
+
   vote_receipt_emails:
     name: "Vote Receipt Emails"
     description: "Allows voters to opt in to receiving email receipts when they vote"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   # The gateway resolves the payer for a billed LLM call and reports usage.
   scope "internal/llm-gateway", module: "internal", as: "internal_llm_gateway" do
     post 'select-payer' => 'llm_gateway#select_payer'
+    post 'select-payer-for-token' => 'llm_gateway#select_payer_for_token'
   end
 
   # Incoming webhooks - public endpoint for external automation triggers

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -113,7 +113,9 @@ services:
 
   # LLM gateway — relays billed LLM calls to the Stripe AI Gateway, resolving
   # the payer per call via the Rails internal API. The only service that holds
-  # STRIPE_GATEWAY_KEY. Internal-only: no Caddy route, no published port.
+  # STRIPE_GATEWAY_KEY. No published port; Caddy forwards ONLY /v1/* on
+  # llm.<hostname> (the external, bearer-authenticated ingress) — the internal
+  # relay path stays unreachable from outside.
   # Same image as agent-runner, different entrypoint.
   #
   # Own profile ("stripe"): it fail-fast exits without STRIPE_GATEWAY_KEY.
@@ -130,8 +132,13 @@ services:
       - AGENT_RUNNER_SECRET=${AGENT_RUNNER_SECRET:?AGENT_RUNNER_SECRET must be set}
       - HARMONIC_INTERNAL_URL=http://web:3000
       - HARMONIC_HOSTNAME=${HOSTNAME:?HOSTNAME must be set}
+      - HARMONIC_PRIMARY_SUBDOMAIN=${PRIMARY_SUBDOMAIN:-app}
       - STRIPE_GATEWAY_KEY
       - STRIPE_GATEWAY_BASE_URL
+      # External-ingress limits (per llm_gateway API key)
+      - GATEWAY_EXTERNAL_RPM
+      - GATEWAY_EXTERNAL_RPD
+      - GATEWAY_MAX_BODY_BYTES
     depends_on:
       web:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,8 +186,9 @@ services:
   # LLM gateway — relays billed LLM calls to the Stripe AI Gateway, resolving
   # the payer per call via the Rails internal API. The only service that holds
   # STRIPE_GATEWAY_KEY; the agent-runner sends stripe_gateway-mode calls here
-  # instead of holding Stripe credentials itself. Internal-only: no Caddy
-  # route, no published port.
+  # instead of holding Stripe credentials itself. No published port; Caddy
+  # forwards ONLY /v1/* on llm.<hostname> (the external, bearer-authenticated
+  # ingress) — the internal relay path stays unreachable from outside.
   #
   # Own profile ("stripe"): it fail-fast exits without STRIPE_GATEWAY_KEY, so
   # it only makes sense when the Stripe AI Gateway is configured. start.sh
@@ -204,8 +205,13 @@ services:
       AGENT_RUNNER_SECRET: "${AGENT_RUNNER_SECRET}"
       HARMONIC_INTERNAL_URL: http://web:3000
       HARMONIC_HOSTNAME: "${HOSTNAME:-harmonic.local}"
+      HARMONIC_PRIMARY_SUBDOMAIN: "${PRIMARY_SUBDOMAIN:-app}"
       STRIPE_GATEWAY_KEY: "${STRIPE_GATEWAY_KEY}"
       STRIPE_GATEWAY_BASE_URL: "${STRIPE_GATEWAY_BASE_URL:-https://llm.stripe.com}"
+      # External-ingress limits (per llm_gateway API key)
+      GATEWAY_EXTERNAL_RPM: "${GATEWAY_EXTERNAL_RPM:-20}"
+      GATEWAY_EXTERNAL_RPD: "${GATEWAY_EXTERNAL_RPD:-500}"
+      GATEWAY_MAX_BODY_BYTES: "${GATEWAY_MAX_BODY_BYTES:-1048576}"
     deploy:
       resources:
         limits:

--- a/test/controllers/internal/llm_gateway_controller_test.rb
+++ b/test/controllers/internal/llm_gateway_controller_test.rb
@@ -141,6 +141,175 @@ class Internal::LLMGatewayControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
+  # === select-payer-for-token (external gateway ingress) ===
+  # These requests arrive via the public llm.<hostname> edge, so the gateway
+  # cannot know a tenant subdomain — the token itself carries the tenant.
+  # All error bodies are OpenAI-shaped ({error: {message, type, code}})
+  # because the gateway passes them through to the external client verbatim.
+
+  def create_gateway_agent_and_token(token_type: "llm_gateway")
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    agent = create_ai_agent(parent: @user, agent_configuration: { "mode" => "external" })
+    token = ApiToken.create!(
+      tenant: @tenant, user: agent, name: "Gateway key", scopes: ["read:all"], token_type: token_type
+    )
+    [agent, token]
+  ensure
+    Tenant.clear_thread_scope
+    Collective.clear_thread_scope
+  end
+
+  def with_pool_config(pool_by_agent_id)
+    previous = ENV.fetch(LLMGateway::PayerResolver::POOL_CONFIG_ENV, nil)
+    ENV[LLMGateway::PayerResolver::POOL_CONFIG_ENV] = pool_by_agent_id.to_json
+    yield
+  ensure
+    if previous.nil?
+      ENV.delete(LLMGateway::PayerResolver::POOL_CONFIG_ENV)
+    else
+      ENV[LLMGateway::PayerResolver::POOL_CONFIG_ENV] = previous
+    end
+  end
+
+  def select_payer_for_token(body_hash)
+    # Host is deliberately NOT a tenant subdomain: the action must not depend
+    # on subdomain tenant resolution.
+    host! "app.#{ENV.fetch("HOSTNAME", "harmonic.local")}"
+    body = body_hash.to_json
+    post "/internal/llm-gateway/select-payer-for-token", params: body, headers: signed_headers(body)
+  end
+
+  def assert_openai_error(code)
+    error = JSON.parse(response.body)["error"]
+    assert error.is_a?(Hash), "expected an OpenAI-shaped error body, got #{response.body}"
+    assert_equal code, error["code"]
+    assert error["message"].present?
+    assert error["type"].present?
+  end
+
+  test "token caller: returns a pool payer and the mapped model" do
+    @tenant.enable_feature_flag!("llm_gateway")
+    agent, token = create_gateway_agent_and_token
+
+    with_pool_config(agent.id => ["cus_pool_a", "cus_pool_b"]) do
+      select_payer_for_token(agent_token: token.plaintext_token, model: "anthropic/claude-sonnet-4.6")
+    end
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_includes ["cus_pool_a", "cus_pool_b"], body["payer_customer_id"]
+    assert_equal "anthropic/claude-sonnet-4.6", body["model"]
+    assert_not_nil token.reload.last_used_at, "expected last_used_at to be bumped"
+  end
+
+  test "token caller: falls back to the agent's billing customer" do
+    @tenant.enable_feature_flag!("llm_gateway")
+    agent, token = create_gateway_agent_and_token
+    customer = StripeCustomer.create!(
+      billable: agent, stripe_id: "cus_external_agent", active: true, pricing_plan_subscription_id: "bpps_ext"
+    )
+    agent.update!(stripe_customer_id: customer.id)
+
+    select_payer_for_token(agent_token: token.plaintext_token, model: "anthropic/claude-sonnet-4.6")
+
+    assert_response :success
+    assert_equal "cus_external_agent", JSON.parse(response.body)["payer_customer_id"]
+  end
+
+  test "token caller: blank model maps to the default model" do
+    @tenant.enable_feature_flag!("llm_gateway")
+    agent, token = create_gateway_agent_and_token
+
+    with_pool_config(agent.id => ["cus_pool_a"]) do
+      select_payer_for_token(agent_token: token.plaintext_token)
+    end
+
+    assert_response :success
+    assert_equal StripeGatewayModelMapper::DEFAULT_MODEL, JSON.parse(response.body)["model"]
+  end
+
+  test "token caller: 401 for a missing token" do
+    select_payer_for_token(model: "anthropic/claude-sonnet-4.6")
+    assert_response :unauthorized
+    assert_openai_error("invalid_token")
+  end
+
+  test "token caller: 401 for an unknown token" do
+    select_payer_for_token(agent_token: "not-a-real-token")
+    assert_response :unauthorized
+    assert_openai_error("invalid_token")
+  end
+
+  test "token caller: 401 for a revoked token" do
+    @tenant.enable_feature_flag!("llm_gateway")
+    _agent, token = create_gateway_agent_and_token
+    plaintext = token.plaintext_token
+    token.delete!
+
+    select_payer_for_token(agent_token: plaintext)
+    assert_response :unauthorized
+    assert_openai_error("invalid_token")
+  end
+
+  test "token caller: 401 for an expired token" do
+    @tenant.enable_feature_flag!("llm_gateway")
+    _agent, token = create_gateway_agent_and_token
+    token.update_column(:expires_at, 1.hour.ago)
+
+    select_payer_for_token(agent_token: token.plaintext_token)
+    assert_response :unauthorized
+    assert_openai_error("invalid_token")
+  end
+
+  test "token caller: 401 for a rest-type token" do
+    @tenant.enable_feature_flag!("llm_gateway")
+    _agent, token = create_gateway_agent_and_token(token_type: "rest")
+
+    select_payer_for_token(agent_token: token.plaintext_token)
+    assert_response :unauthorized
+    assert_openai_error("invalid_token")
+  end
+
+  test "token caller: 403 when the tenant flag is off" do
+    agent, token = create_gateway_agent_and_token
+
+    with_pool_config(agent.id => ["cus_pool_a"]) do
+      select_payer_for_token(agent_token: token.plaintext_token)
+    end
+
+    assert_response :forbidden
+    assert_openai_error("feature_disabled")
+  end
+
+  test "token caller: 402 when the agent is not funded" do
+    @tenant.enable_feature_flag!("llm_gateway")
+    _agent, token = create_gateway_agent_and_token
+
+    select_payer_for_token(agent_token: token.plaintext_token)
+    assert_response :payment_required
+    assert_openai_error("not_funded")
+  end
+
+  test "token caller: 400 for a model the gateway cannot proxy" do
+    @tenant.enable_feature_flag!("llm_gateway")
+    agent, token = create_gateway_agent_and_token
+
+    with_pool_config(agent.id => ["cus_pool_a"]) do
+      select_payer_for_token(agent_token: token.plaintext_token, model: "local-ollama-model")
+    end
+
+    assert_response :bad_request
+    assert_openai_error("unsupported_model")
+  end
+
+  test "token caller: rejects an unsigned request" do
+    host! "app.#{ENV.fetch("HOSTNAME", "harmonic.local")}"
+    post "/internal/llm-gateway/select-payer-for-token",
+         params: { agent_token: "anything" }.to_json,
+         headers: { "Content-Type" => "application/json" }
+    assert_response :unauthorized
+  end
+
   private
 
   def select_payer(body_hash)

--- a/test/jobs/regenerate_caddyfile_job_test.rb
+++ b/test/jobs/regenerate_caddyfile_job_test.rb
@@ -68,6 +68,13 @@ class RegenerateCaddyfileJobTest < ActiveJob::TestCase
       if block.include?("redir")
         # Bare domain redirect block
         assert_includes block, "redir https://", "Bare domain should redirect"
+      elsif block.start_with?("llm.")
+        # LLM gateway edge: only /v1/* is forwarded, and to the gateway —
+        # never to the Rails app.
+        assert_includes block, "reverse_proxy llm-gateway:4500",
+          "LLM edge should proxy to the gateway: #{block}"
+        assert_not_includes block, "reverse_proxy web:3000",
+          "LLM edge must not proxy to the Rails app: #{block}"
       else
         assert_includes block, "reverse_proxy web:3000",
           "Block should proxy to web:3000: #{block}"

--- a/test/models/api_token_test.rb
+++ b/test/models/api_token_test.rb
@@ -796,4 +796,71 @@ class ApiTokenTest < ActiveSupport::TestCase
     assert_not token.valid?
     assert token.errors[:token_type].any?, "expected an immutability error"
   end
+
+  # === authenticate_llm_gateway tests ===
+
+  def create_llm_gateway_token(**overrides)
+    agent = create_external_agent
+    token = build_token(user: agent, token_type: "llm_gateway", name: "Gateway key", **overrides)
+    token.save!
+    token
+  end
+
+  test "authenticate_llm_gateway finds a token without tenant context" do
+    token = create_llm_gateway_token
+
+    other_tenant = create_tenant(subdomain: "other-tenant")
+    Tenant.scope_thread_to_tenant(subdomain: other_tenant.subdomain)
+
+    found = ApiToken.authenticate_llm_gateway(T.must(token.plaintext_token))
+    assert found, "expected the token to be found from another tenant's context"
+    assert_equal token.id, found.id
+  ensure
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+  end
+
+  test "authenticate_llm_gateway rejects rest and mcp tokens" do
+    agent = create_external_agent
+    ["rest", "mcp"].each do |type|
+      token = build_token(user: agent, token_type: type, name: "#{type} token")
+      token.save!
+      assert_nil ApiToken.authenticate_llm_gateway(T.must(token.plaintext_token)),
+                 "#{type} token must not authenticate for the LLM gateway"
+    end
+  end
+
+  test "authenticate_llm_gateway rejects revoked tokens" do
+    token = create_llm_gateway_token
+    plaintext = T.must(token.plaintext_token)
+    token.delete!
+
+    assert_nil ApiToken.authenticate_llm_gateway(plaintext)
+  end
+
+  test "authenticate_llm_gateway rejects internal tokens" do
+    agent = create_internal_agent
+    task_run = AiAgentTaskRun.create!(
+      tenant: @tenant, ai_agent: agent, initiated_by: @user,
+      task: "Test", max_steps: 5, status: "queued"
+    )
+    token = ApiToken.create_internal_token(
+      user: agent, tenant: @tenant, context: task_run, token_type: "llm_gateway"
+    )
+
+    assert_nil ApiToken.authenticate_llm_gateway(T.must(token.plaintext_token))
+  end
+
+  test "authenticate_llm_gateway returns nil for unknown or blank tokens" do
+    assert_nil ApiToken.authenticate_llm_gateway("not-a-real-token")
+    assert_nil ApiToken.authenticate_llm_gateway("")
+  end
+
+  test "authenticate_llm_gateway returns expired tokens for the caller to reject" do
+    token = create_llm_gateway_token
+    token.update_column(:expires_at, 1.hour.ago)
+
+    found = ApiToken.authenticate_llm_gateway(T.must(token.plaintext_token))
+    assert found, "expired tokens are returned; expiry is a call-site check"
+    assert found.expired?
+  end
 end

--- a/test/services/caddyfile_generator_test.rb
+++ b/test/services/caddyfile_generator_test.rb
@@ -1,0 +1,29 @@
+# typed: false
+
+require "test_helper"
+
+class CaddyfileGeneratorTest < ActiveSupport::TestCase
+  test "emits an llm edge block that forwards only /v1/* to the gateway" do
+    output = CaddyfileGenerator.new.generate
+    hostname = ENV.fetch("HOSTNAME")
+
+    block = output[/^llm\.#{Regexp.escape(hostname)} \{.*?^\}/m]
+    assert block, "expected an llm.#{hostname} block in the generated Caddyfile"
+    assert_includes block, "handle /v1/* {"
+    assert_includes block, "reverse_proxy llm-gateway:4500"
+    assert_includes block, "respond 403"
+    # The internal relay path must not be routed from the edge.
+    assert_not_includes block, "reverse_proxy web:3000"
+  end
+
+  test "tenant subdomain blocks still proxy to web and block /internal" do
+    output = CaddyfileGenerator.new.generate
+    hostname = ENV.fetch("HOSTNAME")
+    primary = ENV.fetch("PRIMARY_SUBDOMAIN")
+
+    block = output[/^#{Regexp.escape(primary)}\.#{Regexp.escape(hostname)} \{.*?^\}/m]
+    assert block
+    assert_includes block, "reverse_proxy web:3000"
+    assert_includes block, "handle /internal/* {"
+  end
+end

--- a/test/services/llm_gateway/payer_resolver_test.rb
+++ b/test/services/llm_gateway/payer_resolver_test.rb
@@ -100,5 +100,58 @@ module LLMGateway
       end
       assert_equal "not_a_billed_task", error.code
     end
+
+    # === resolve_for_agent (external gateway calls — no task run) ===
+
+    def create_agent_billing_customer!(**overrides)
+      customer = StripeCustomer.create!(
+        billable: @ai_agent,
+        stripe_id: "cus_agent_individual",
+        active: true,
+        pricing_plan_subscription_id: "bpps_test123",
+        **overrides,
+      )
+      @ai_agent.update!(stripe_customer_id: customer.id)
+      customer
+    end
+
+    test "resolve_for_agent picks from the pool when the agent is pool-configured" do
+      configure_pool!(["cus_pool_a", "cus_pool_b"])
+
+      result = PayerResolver.resolve_for_agent(@ai_agent)
+      assert_includes ["cus_pool_a", "cus_pool_b"], result.payer_customer_id
+    end
+
+    test "resolve_for_agent pool takes precedence over the agent's billing customer" do
+      create_agent_billing_customer!
+      configure_pool!(["cus_pool_a"])
+
+      result = PayerResolver.resolve_for_agent(@ai_agent)
+      assert_equal "cus_pool_a", result.payer_customer_id
+    end
+
+    test "resolve_for_agent falls back to the agent's billing customer" do
+      create_agent_billing_customer!
+
+      result = PayerResolver.resolve_for_agent(@ai_agent)
+      assert_equal "cus_agent_individual", result.payer_customer_id
+    end
+
+    test "resolve_for_agent raises not_funded when the agent has no billing customer" do
+      error = assert_raises(PayerResolver::ResolutionError) do
+        PayerResolver.resolve_for_agent(@ai_agent)
+      end
+      assert_equal "not_funded", error.code
+      assert_equal :payment_required, error.http_status
+    end
+
+    test "resolve_for_agent raises not_funded when the billing customer has no credit subscription" do
+      create_agent_billing_customer!(pricing_plan_subscription_id: nil)
+
+      error = assert_raises(PayerResolver::ResolutionError) do
+        PayerResolver.resolve_for_agent(@ai_agent)
+      end
+      assert_equal "not_funded", error.code
+    end
   end
 end


### PR DESCRIPTION
## Summary

Builds the stage-4 ingress for the LLM gateway (#464): an external agent points any OpenAI-compatible client at `https://llm.<hostname>/v1` with its `llm_gateway`-type API key (shipped in #483), and the call is billed through the agent's existing funding mapping — pool config, else its billing customer. Identity-keyed, not funding-keyed: the key says who calls; the agent's mapping says who pays.

```
OpenAI client (api_key = llm_gateway token)
  → Caddy llm.<hostname>: forwards ONLY /v1/* to llm-gateway:4500
    → gateway POST /v1/chat/completions
        rate limit + size cap → Rails select-payer-for-token (HMAC, IP-restricted)
        → forward to Stripe AI Gateway with X-Stripe-Customer-ID, model rewritten
        → stream response bytes back verbatim (SSE and plain JSON, one path)
```

## Rails

- `ApiToken.authenticate_llm_gateway` — cross-tenant lookup by token hash. The unguessable 256-bit hash IS the credential (lookup = authentication), so this is safe pre-tenant; the token carries the tenant, which the endpoint then scopes the thread to. This is the one deliberate `unscoped` outside ApplicationRecord, carrying the `# unscoped-allowed` marker. Only user-issued, llm_gateway-type keys match.
- `POST /internal/llm-gateway/select-payer-for-token` — skips subdomain tenant resolution (the public edge has no tenant subdomain), authenticates the key, gates on the new **tenant-level `llm_gateway` feature flag** (default off, mirrors `stripe_billing`; toggle appears automatically in tenant admin settings), resolves the payer, validates/maps the model. Error bodies are OpenAI-shaped and pass through to the external client verbatim: 401 invalid_token / 403 feature_disabled / 402 not_funded / 400 unsupported_model.
- `PayerResolver.resolve_for_agent` — pool-first (uniform-random, same as task runs), else the agent's funded billing customer. The task-run and agent paths now share `pool_result`/`funded_result` so the funding policy cannot diverge.

## Gateway (agent-runner)

- Path-routed lanes: `POST /v1/chat/completions` (bearer-authenticated external) vs `POST /chat/completions` (internal relay, unchanged — no auth of its own, network isolation is its auth, and the edge forwards only `/v1/*` so it stays unreachable from outside).
- **SSE streaming passthrough**: `StripeUpstream.chatCompletionsStream` hands the response body back as a stream; the handler pipes bytes as they arrive. One code path serves `stream: true` and plain responses.
- Untrusted-caller protections, applied before any Rails/Stripe work:
  - per-key rate limits (in-memory sliding window; `GATEWAY_EXTERNAL_RPM`=20, `GATEWAY_EXTERNAL_RPD`=500) — the spend-rate stopgap until dollar ceilings exist (needs record-usage persistence); Stripe's 402 remains the hard balance gate. Buckets are keyed by key hash; raw keys are never retained or logged.
  - request-size cap (`GATEWAY_MAX_BODY_BYTES`, default 1 MB) that drains and closes rather than severing the socket before the 413 flushes.

## Edge

- `CaddyfileGenerator` emits an `llm.<hostname>` block: `/v1/*` → `llm-gateway:4500`, everything else 403.
- Compose wires the new env (`HARMONIC_PRIMARY_SUBDOMAIN` for the Host on the internal hop, plus the limits); documented in `.env.example`.

## Rollout posture

Three independent off-switches: the `stripe` compose profile (service exists at all), the tenant `llm_gateway` flag (default off — the ingress is inert everywhere until enabled), and token revocation (gateway is stateless; next call re-authenticates). Prod additionally needs DNS for `llm.harmonic.social` before anything is reachable.

## Testing

- Red-green throughout: 27 new Rails tests (token auth, resolver, full endpoint matrix, Caddy block) and 20 new/updated vitest tests (rate limiter mechanics, handler routing/401/413/429, external relay incl. model rewrite and streaming, stream upstream). All 103 Rails runs and 259 agent-runner tests green; `srb tc`, `tsc`, tenant-safety check pass.
- Live dev E2E through the real Caddy edge: missing key → 401, rest-type key → 401, internal path → 403 at the edge, burst of 22 → exactly 20 allowed then 429 with `Retry-After`, and the valid key relaying Stripe's balance-rejection 400 verbatim — full-chain proof while the Stripe account blocker stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)