### PR TITLE
Fix #485: end a rejected browser representation session (partial — needs repro confirmation)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -469,6 +469,15 @@ class ApplicationController < ActionController::Base
     # reasons additionally surface a flash.
     reason = representation_rejection_reason(rep_session, @current_human_user, credential_valid: credential_valid)
     if reason
+      # End the rejected session in the DB before dropping the cookie. On the
+      # rejection path @current_representation_session is never set (that only
+      # happens in apply_representation_session! on success), so
+      # clear_representation!'s own `&.end!` is a no-op — which left a rejected
+      # session's row perpetually `active?` while the browser was silently
+      # kicked back to acting as itself (issue #485). Only end a session this
+      # human actually owns, so a mismatched/foreign credential (:not_found,
+      # :not_representative) never ends someone else's session.
+      rep_session.end! if rep_session&.active? && rep_session.representative_user_id == @current_human_user.id
       clear_representation!
       flash[:alert] = RepresentationPolicy::BROWSER_REPRESENTATION_FLASH[reason] if RepresentationPolicy::BROWSER_REPRESENTATION_FLASH.key?(reason)
       return

--- a/test/integration/rejected_representation_ends_session_test.rb
+++ b/test/integration/rejected_representation_ends_session_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+# Regression for #485.
+#
+# When the browser representation resolver REJECTS a session (expired, bad
+# representing credential, etc.) it calls clear_representation!, which drops the
+# cookies ("kicks the representative out") and reverts current_user to the human.
+# But clear_representation!'s `@current_representation_session&.end!` is a no-op
+# on the rejection path: that ivar is only assigned on the SUCCESS path
+# (apply_representation_session!). So a rejected session's DB row was left
+# perpetually `active?` — "kicks the representative out ... but does not actually
+# end the representation session" — while the request silently proceeded as the
+# human (so anything they posted was attributed to them, not the collective).
+#
+# resolve_browser_representation now ends the rejected session (when this human
+# owns it) before clearing the cookie.
+class RejectedRepresentationEndsSessionTest < ActionDispatch::IntegrationTest
+  def setup
+    @tenant = create_tenant(subdomain: "rep485-#{SecureRandom.hex(4)}")
+    @alice = create_user(email: "alice_#{SecureRandom.hex(4)}@example.com", name: "Alice")
+    @tenant.add_user!(@alice)
+    mark_activated!(@alice)
+    @tenant.create_main_collective!(created_by: @alice)
+    @collective = create_collective(tenant: @tenant, created_by: @alice,
+                                     handle: "rep485-col-#{SecureRandom.hex(4)}")
+    @collective.add_user!(@alice)
+    @collective.collective_members.find_by(user: @alice).add_role!("representative")
+    host! "#{@tenant.subdomain}.#{ENV.fetch('HOSTNAME', nil)}"
+  end
+
+  def ensure_2fa!(user)
+    identity = user.find_or_create_omni_auth_identity!
+    unless identity.otp_enabled
+      identity.generate_otp_secret!
+      identity.enable_otp!
+    end
+    identity
+  end
+
+  def start_representing_collective
+    identity = ensure_2fa!(@alice)
+    post "/collectives/#{@collective.handle}/represent", params: { understand: "1" }
+    if response.status == 302 && URI.parse(response.location).path == "/reverify"
+      totp = ROTP::TOTP.new(identity.otp_secret)
+      post "/reverify", params: { code: totp.now }
+      post "/collectives/#{@collective.handle}/represent", params: { understand: "1" }
+    end
+    follow_redirect! if response.status == 302
+    RepresentationSession.unscoped.find_by(collective: @collective, representative_user: @alice)
+  end
+
+  test "a rejected browser representation session is ended in the DB, not left active" do
+    sign_in_as(@alice, tenant: @tenant)
+    rep_session = start_representing_collective
+    assert rep_session&.active?, "precondition: collective representation session is active"
+
+    # Force a rejection on the next request without ending the session ourselves:
+    # push began_at past SESSION_LIFETIME so the resolver's `expired?` check fires.
+    rep_session.update_columns(began_at: 2.hours.ago)
+
+    get "/"
+    assert_response :success
+
+    rep_session.reload
+    assert_nil session[:representation_session_id],
+      "representation cookie should be cleared on rejection"
+    assert rep_session.ended?,
+      "a rejected browser representation must be ended in the DB (issue #485), " \
+      "so it stops showing as an active session"
+  end
+end


### PR DESCRIPTION
Draft — addresses the reproducible half of #485 and asks @danallison to confirm the exact trigger before I finalize.

## What I confirmed (with a failing→passing test)

`resolve_browser_representation` rejects a session for six reasons (`:not_found`, `:ended`, `:expired`, `:grant_inactive`, `:not_representative`, `:invalid_credential`). On **every** rejection it calls `clear_representation!`, which:

- deletes the representation cookies (**"kicks the representative out"**), and
- reverts `current_user` to the human — so **anything posted in that same request is attributed to the human, not the represented collective**.

But `clear_representation!`'s `@current_representation_session&.end!` is a **no-op on the rejection path**: that ivar is only assigned on the *success* path (`apply_representation_session!`). So the rejected session's DB row is left perpetually `active?` — **"does not actually end the representation session."**

That is all three reported symptoms, from one place.

## The fix

End the rejected session explicitly (guarded on ownership so a foreign/mismatched credential never ends someone else's session) before dropping the cookie. All 90 tests across the five representation suites stay green; `srb tc` clean.

## The part I could NOT reproduce — need your input

I could not find a mechanism by which **#478 or #474** causes the rejection *specifically when posting in the public space*:

- **#474** only changed `Note`'s `after_create` read-confirmation hook (reader = collective when the author is a collective identity). It touches neither representation resolution nor session ending.
- **#478** only made collective identities real main-collective members. On current `main`, posting publicly as a collective works over **both** the browser (`POST /note`) and MCP/agent (`/note/actions/create_note`) for a member identity; a *non*-member identity gets a clean `403`, not the reported symptom.

The most likely real-world trigger for the rejection is **session expiry** (`SESSION_LIFETIME = 1.hour`): if the session had been open > 1h when you posted, the post request rejects → all three symptoms. That's a pre-existing latent bug this PR fixes, but it isn't strictly caused by #478/#474.

**To pin the exact trigger, can you confirm:**
1. Interface — browser, or an MCP/agent tool call?
2. Which collective, and had the session been open a while (≳ 1 hour)?
3. Any flash/banner shown, or was the drop-out silent?

Also flagging a **follow-up UX gap**: three rejection reasons (`:not_found`, `:invalid_credential`, `:not_representative`) clear representation **silently** (no flash). So a human whose session went invalid mid-work posts as themselves with no warning. Worth surfacing a "you're no longer representing X" flash for those too — happy to fold in once we confirm the trigger.

Closes #485 *if* expiry is the trigger; otherwise this is the correct base fix and I'll extend it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)