### PR TITLE
Common-pool funding v1: agent_funding collectives

### DIFF
--- a/.claude/plans/harmonic-llm-gateway.md
+++ b/.claude/plans/harmonic-llm-gateway.md
@@ -329,18 +329,48 @@ DB-backed — funding collective → consenting members → their Stripe custome
 uniform-random per call — replacing `LLM_POOL_CONFIG`. Camp B intact: each member's own
 balance pays Stripe directly per call; the collective never holds funds.
 
-Open questions to resolve at build time:
+**First implementation pass — decided 2026-07-10 (minimal prototype for the private
+beta; everything else iterates on real-user feedback):**
 
-- **Consent duration**: open-ended-until-exit (what membership naturally gives) vs the
-  time-bounded/renewable window argued for in the earlier commitment design ("time-bound
-  establishes clearer expectations and lowers risk"). Possibly membership admits you and
-  funding participation rides a renewable window (dues-like).
-- **Agent admission governance**: admitting an agent spends everyone's money; a Decision
-  is the natural gate. Who can propose, what threshold.
-- **Dry-member handling** (402-retry vs balance cache) — still hostage to Stripe's answer
-  on the zero-balance blocker.
-- How `agent_funders` interacts with `billable_types`, listability, and the join UX (all
-  keyed on `collective_type` today).
+- **Consent span: open-ended until exit.** Membership IS the consent; leaving ends it. No
+  windows, no renewal machinery. The time-boundedness argument stays banked below for
+  iteration if beta members want renewal periods.
+- **Agent admission: collective admins only.** Attaching an agent to a funding collective
+  is an admin action. The Decision-gate upgrade layers on later.
+- **Unfunded members: funded to join, skipped if lapsed.** Invite acceptance requires an
+  active funded billing customer (keeps "joining = consenting to fund" real). If funding
+  lapses after joining, the member is skipped in draws (logged), not pool-breaking.
+- **Type properties: unlisted, invite-only, not billable.** Like chat collectives —
+  excluded from public listing and `billable_types`. The invite/join flow carries the
+  funding-consent language for this type.
+
+Build shape for the v1 cut:
+
+- `agent_funders` added to `VALID_COLLECTIVE_TYPES` (immutable like the others); creation
+  through the existing collective-creation path with the new type.
+- Funding link = association from the agent to its funding collective; valid only when
+  the collective is `agent_funders` type and the agent's `parent` is an active member
+  (primary-must-be-a-funder, checked at attach time AND per call).
+- `PayerResolver.pool_customer_ids` becomes DB-backed: funding collective → active
+  members → each member's funded billing customer (active + pricing-plan subscription) →
+  uniform-random draw. Thread-scope-safe lookups (`tenant_scoped_only` + explicit ids —
+  select-payer runs after tenant re-scope but never through collective-scoped
+  associations).
+- **No primary, no service**, enforced statelessly per call at select-payer/dispatch: if
+  the agent's parent is no longer an active funding member, resolution fails with its own
+  error code (distinct from `not_funded`).
+- Agent profile shows "funded by ⟨collective⟩" publicly; roster keeps normal collective
+  visibility.
+- `LLM_POOL_CONFIG` PoC retired when the DB-backed lookup lands (delete the env branch —
+  it was built to be removable).
+- Usage transparency deferred: members see their own drain via Stripe's customer portal
+  receipts. The usage table / realized-vs-fair-share view is the first fast-follow
+  candidate (the Ostrom lens says monitoring is load-bearing — expect beta feedback here).
+
+Deferred to iteration (deliberately NOT in v1): renewable consent windows; Decision gate
+for agent admission; dry-member 402-retry vs balance cache (hostage to Stripe's
+zero-balance answer — today the 402 relays verbatim); public roster options beyond
+collective-default visibility; per-member spend ceilings within a pool.
 
 Notes carried from the abandoned commitment-subtype cut (still relevant where the
 commitment instrument returns, e.g. renewable funding windows): join-deadline vs

--- a/.claude/plans/harmonic-llm-gateway.md
+++ b/.claude/plans/harmonic-llm-gateway.md
@@ -298,12 +298,55 @@ yet — no schema, no models, no UI, no feature flags, no permanent decisions.
 Exit criteria: a pool-configured agent's calls draw down different members' balances
 across calls, observed on real Stripe customers, with the distribution verified in tests.
 
-Design notes banked for the real feature (from the abandoned first cut, never committed):
-commitment-subtype consent instrument; join-deadline vs funding-window semantics (the
-roster could freeze before the first draw); critical-mass-as-activation; window overlap
-rules; thread-scope-safe pool lookups (commitment participant counting via the
-collective-scoped association breaks outside request contexts). None of these are
-decisions yet.
+**Working sketch for the real feature (2026-07-10): primary principal + `agent_funders`
+collective.** This is the current design direction — a sketch to build the first cut
+from, not yet a shipped decision.
+
+The structure: every agent keeps exactly one **primary principal** — a human, publicly
+listed, accountable for the agent (and carrying its seat subscription), exactly today's
+`parent`. Token funding comes from an **`agent_funders` collective** (a fourth
+`collective_type`, immutable at creation like the others): joining it IS consenting to
+fund its agents' LLM usage from your own prepaid balance. Two crisp rules instead of one
+overloaded one: *the primary principal answers for the agent; the funding collective pays
+its tokens.* "Who pays?" and "who's responsible?" each have exactly one answer.
+
+Rules agreed in design discussion:
+
+1. **One name per role.** Funding members are "funders," never "secondary principals" —
+   "principal" stays singular and human. Funders carry no accountability slice.
+2. **The primary principal must be a funding member** — accountability with skin in the
+   game; their own customer is one of the pool draws.
+3. **Public listing splits by audience**: the agent shows "funded by ⟨collective⟩"
+   publicly; the member roster keeps the collective's normal visibility. No per-member
+   listed/unlisted flag.
+4. **No primary, no service**: if the primary leaves (the collective or the platform),
+   the agent suspends until another funding member steps up as primary. Enforced at
+   dispatch/select-payer.
+
+Implementation shape: `parent` association unchanged (human). New agent → funding
+collective association. `PayerResolver.resolve_for_agent` / `pool_customer_ids` becomes
+DB-backed — funding collective → consenting members → their Stripe customers,
+uniform-random per call — replacing `LLM_POOL_CONFIG`. Camp B intact: each member's own
+balance pays Stripe directly per call; the collective never holds funds.
+
+Open questions to resolve at build time:
+
+- **Consent duration**: open-ended-until-exit (what membership naturally gives) vs the
+  time-bounded/renewable window argued for in the earlier commitment design ("time-bound
+  establishes clearer expectations and lowers risk"). Possibly membership admits you and
+  funding participation rides a renewable window (dues-like).
+- **Agent admission governance**: admitting an agent spends everyone's money; a Decision
+  is the natural gate. Who can propose, what threshold.
+- **Dry-member handling** (402-retry vs balance cache) — still hostage to Stripe's answer
+  on the zero-balance blocker.
+- How `agent_funders` interacts with `billable_types`, listability, and the join UX (all
+  keyed on `collective_type` today).
+
+Notes carried from the abandoned commitment-subtype cut (still relevant where the
+commitment instrument returns, e.g. renewable funding windows): join-deadline vs
+funding-window semantics; critical-mass-as-activation; window overlap rules;
+thread-scope-safe pool lookups (collective-scoped associations misbehave outside request
+contexts — resolve membership via `tenant_scoped_only` + explicit ids).
 
 ### Stage 3 — Minimal UI to prove end-to-end
 

--- a/.claude/plans/harmonic-llm-gateway.md
+++ b/.claude/plans/harmonic-llm-gateway.md
@@ -298,13 +298,13 @@ yet — no schema, no models, no UI, no feature flags, no permanent decisions.
 Exit criteria: a pool-configured agent's calls draw down different members' balances
 across calls, observed on real Stripe customers, with the distribution verified in tests.
 
-**Working sketch for the real feature (2026-07-10): primary principal + `agent_funders`
+**Working sketch for the real feature (2026-07-10): primary principal + `agent_funding`
 collective.** This is the current design direction — a sketch to build the first cut
 from, not yet a shipped decision.
 
 The structure: every agent keeps exactly one **primary principal** — a human, publicly
 listed, accountable for the agent (and carrying its seat subscription), exactly today's
-`parent`. Token funding comes from an **`agent_funders` collective** (a fourth
+`parent`. Token funding comes from an **`agent_funding` collective** (a fourth
 `collective_type`, immutable at creation like the others): joining it IS consenting to
 fund its agents' LLM usage from your own prepaid balance. Two crisp rules instead of one
 overloaded one: *the primary principal answers for the agent; the funding collective pays
@@ -346,10 +346,10 @@ beta; everything else iterates on real-user feedback):**
 
 Build shape for the v1 cut:
 
-- `agent_funders` added to `VALID_COLLECTIVE_TYPES` (immutable like the others); creation
+- `agent_funding` added to `VALID_COLLECTIVE_TYPES` (immutable like the others); creation
   through the existing collective-creation path with the new type.
 - Funding link = association from the agent to its funding collective; valid only when
-  the collective is `agent_funders` type and the agent's `parent` is an active member
+  the collective is `agent_funding` type and the agent's `parent` is an active member
   (primary-must-be-a-funder, checked at attach time AND per call).
 - `PayerResolver.pool_customer_ids` becomes DB-backed: funding collective → active
   members → each member's funded billing customer (active + pricing-plan subscription) →

--- a/.env.example
+++ b/.env.example
@@ -135,12 +135,6 @@ STRIPE_CREDIT_PRODUCT_ID=
 STRIPE_PRICING_PLAN_ID=
 # Maximum single top-up amount in cents (default 50000 = $500)
 STRIPE_MAX_TOPUP_CENTS=50000
-# Common-pool LLM credits PROOF OF CONCEPT (#464). Maps agent ids to the
-# Stripe customers whose prepaid balances jointly fund that agent's calls;
-# the gateway picks one uniformly at random per call. Pool-configured agents
-# skip the individual billing checks at dispatch. Unset = no pools.
-# LLM_POOL_CONFIG={"<agent-id>": ["cus_a", "cus_b"]}
-LLM_POOL_CONFIG=
 # LLM gateway external ingress (llm.<hostname>, /v1/chat/completions).
 # External agents authenticate with llm_gateway-type API keys; access is
 # gated per tenant by the llm_gateway feature flag. Per-key request limits

--- a/app/controllers/collectives_controller.rb
+++ b/app/controllers/collectives_controller.rb
@@ -186,12 +186,13 @@ class CollectivesController < ApplicationController
       active_collective_ai_agent_ids = @collective_ai_agents.pluck(:id)
       addable_ids = user_ai_agent_ids - active_collective_ai_agent_ids
       @addable_ai_agents = User.where(id: addable_ids).includes(:tenant_users).where(tenant_users: { tenant_id: @current_tenant.id })
-      # Agents on this funding collective's payroll, and members' agents that
-      # could be attached (their principal is an active member).
+      # Agents on this funding collective's payroll, and this tenant's agents
+      # that could be attached (their principal is an active member).
       if @current_collective.agent_funding?
         @funded_agents = User.where(funding_collective_id: @current_collective.id).order(:name)
         active_member_ids = @current_collective.collective_members.where(archived_at: nil).pluck(:user_id)
         @attachable_agents = User.where(user_type: "ai_agent", parent_id: active_member_ids)
+          .includes(:tenant_users).where(tenant_users: { tenant_id: @current_tenant.id })
           .where.not(id: @funded_agents.pluck(:id))
           .order(:name)
       end
@@ -475,19 +476,24 @@ class CollectivesController < ApplicationController
   # additionally requires the agent's principal to be an active member.
   def add_funded_agent
     unless @current_collective.agent_funding?
-      return render status: 403, json: { error: 'Agents can only be funded by an agent funding collective' }
+      return render_funded_agent_error(403, 'Agents can only be funded by an agent funding collective')
     end
     unless @current_user.collective_member&.is_admin?
-      return render status: 403, json: { error: 'Unauthorized' }
+      return render_funded_agent_error(403, 'Unauthorized')
     end
-    ai_agent = User.find_by(id: params[:ai_agent_id])
-    if ai_agent.nil? || !ai_agent.ai_agent?
-      return render status: 404, json: { error: 'AI Agent not found' }
+    # Scoped to this tenant's agents: funding only operates where the
+    # collective lives (per-call membership lookups are tenant-scoped), so an
+    # agent from another tenant would attach and then be suspended forever.
+    ai_agent = User.where(user_type: "ai_agent")
+      .joins(:tenant_users).where(tenant_users: { tenant_id: @current_tenant.id })
+      .find_by(id: params[:ai_agent_id])
+    if ai_agent.nil?
+      return render_funded_agent_error(404, 'AI Agent not found')
     end
 
     ai_agent.funding_collective = @current_collective
     unless ai_agent.save
-      return render status: 422, json: { error: ai_agent.errors.full_messages.to_sentence }
+      return render_funded_agent_error(422, ai_agent.errors.full_messages.to_sentence)
     end
 
     respond_to do |format|
@@ -507,11 +513,11 @@ class CollectivesController < ApplicationController
 
   def remove_funded_agent
     unless @current_user.collective_member&.is_admin?
-      return render status: 403, json: { error: 'Unauthorized' }
+      return render_funded_agent_error(403, 'Unauthorized')
     end
     ai_agent = User.find_by(id: params[:ai_agent_id])
     if ai_agent.nil? || ai_agent.funding_collective_id != @current_collective.id
-      return render status: 404, json: { error: 'AI Agent is not funded by this collective' }
+      return render_funded_agent_error(404, 'AI Agent is not funded by this collective')
     end
 
     ai_agent.update!(funding_collective_id: nil)
@@ -953,6 +959,18 @@ class CollectivesController < ApplicationController
   # Only these types are user-creatable; chat and private_workspace
   # collectives are minted by their own internal flows.
   USER_CREATABLE_COLLECTIVE_TYPES = ["standard", "agent_funding"].freeze
+
+  # The funded-agent actions are called from both the settings page's plain
+  # HTML forms and JSON clients; errors must come back in the caller's format.
+  def render_funded_agent_error(status, message)
+    respond_to do |format|
+      format.json { render status: status, json: { error: message } }
+      format.html do
+        flash[:alert] = message
+        redirect_to "#{@current_collective.path}/settings"
+      end
+    end
+  end
 
   # Returns an error message when the requested collective type may not be
   # created by this user, nil when the request is fine. Creating an

--- a/app/controllers/collectives_controller.rb
+++ b/app/controllers/collectives_controller.rb
@@ -97,6 +97,14 @@ class CollectivesController < ApplicationController
   end
 
   def create_collective
+    if (error = collective_type_request_error)
+      return render_action_error({
+        action_name: "create_collective",
+        resource: nil,
+        error: error,
+      })
+    end
+
     begin
       collective = api_helper.create_collective
       render_action_success({
@@ -145,6 +153,11 @@ class CollectivesController < ApplicationController
   end
 
   def create
+    if (error = collective_type_request_error)
+      flash[:alert] = error
+      return redirect_to "/collectives/new"
+    end
+
     @collective = api_helper.create_collective
     flash[:notice] = "Collective #{@collective.name} created successfully."
     redirect_to @collective.path
@@ -173,6 +186,15 @@ class CollectivesController < ApplicationController
       active_collective_ai_agent_ids = @collective_ai_agents.pluck(:id)
       addable_ids = user_ai_agent_ids - active_collective_ai_agent_ids
       @addable_ai_agents = User.where(id: addable_ids).includes(:tenant_users).where(tenant_users: { tenant_id: @current_tenant.id })
+      # Agents on this funding collective's payroll, and members' agents that
+      # could be attached (their principal is an active member).
+      if @current_collective.agent_funding?
+        @funded_agents = User.where(funding_collective_id: @current_collective.id).order(:name)
+        active_member_ids = @current_collective.collective_members.where(archived_at: nil).pluck(:user_id)
+        @attachable_agents = User.where(user_type: "ai_agent", parent_id: active_member_ids)
+          .where.not(id: @funded_agents.pluck(:id))
+          .order(:name)
+      end
       # Automation counts for display
       @enabled_automations_count = @current_collective.automation_rules.where(enabled: true).count
       @total_automations_count = @current_collective.automation_rules.count
@@ -442,6 +464,64 @@ class CollectivesController < ApplicationController
       end
       format.html do
         flash[:notice] = "#{ai_agent.display_name} has been removed from #{@current_collective.name}"
+        redirect_to "#{@current_collective.path}/settings"
+      end
+    end
+  end
+
+  # Attach an agent to this funding collective's payroll: its LLM usage draws
+  # from the members' balances from the next call on. Admitting an agent
+  # spends everyone's money, so it is admin-only; the model validation
+  # additionally requires the agent's principal to be an active member.
+  def add_funded_agent
+    unless @current_collective.agent_funding?
+      return render status: 403, json: { error: 'Agents can only be funded by an agent funding collective' }
+    end
+    unless @current_user.collective_member&.is_admin?
+      return render status: 403, json: { error: 'Unauthorized' }
+    end
+    ai_agent = User.find_by(id: params[:ai_agent_id])
+    if ai_agent.nil? || !ai_agent.ai_agent?
+      return render status: 404, json: { error: 'AI Agent not found' }
+    end
+
+    ai_agent.funding_collective = @current_collective
+    unless ai_agent.save
+      return render status: 422, json: { error: ai_agent.errors.full_messages.to_sentence }
+    end
+
+    respond_to do |format|
+      format.json do
+        render json: {
+          ai_agent_id: ai_agent.id,
+          ai_agent_name: ai_agent.display_name,
+          ai_agent_path: ai_agent.path,
+        }
+      end
+      format.html do
+        flash[:notice] = "#{ai_agent.display_name} is now funded by #{@current_collective.name}"
+        redirect_to "#{@current_collective.path}/settings"
+      end
+    end
+  end
+
+  def remove_funded_agent
+    unless @current_user.collective_member&.is_admin?
+      return render status: 403, json: { error: 'Unauthorized' }
+    end
+    ai_agent = User.find_by(id: params[:ai_agent_id])
+    if ai_agent.nil? || ai_agent.funding_collective_id != @current_collective.id
+      return render status: 404, json: { error: 'AI Agent is not funded by this collective' }
+    end
+
+    ai_agent.update!(funding_collective_id: nil)
+
+    respond_to do |format|
+      format.json do
+        render json: { ai_agent_id: ai_agent.id, ai_agent_name: ai_agent.display_name }
+      end
+      format.html do
+        flash[:notice] = "#{ai_agent.display_name} is no longer funded by #{@current_collective.name}"
         redirect_to "#{@current_collective.path}/settings"
       end
     end
@@ -772,6 +852,13 @@ class CollectivesController < ApplicationController
     invite = Invite.find_by(code: params[:code]) if params[:code]
     invite ||= Invite.find_by(invited_user: current_user, collective: @current_collective)
     if invite && current_user
+      # Funded to join: accepting a funding-collective invite is consenting to
+      # have your own balance drawn on, so it requires working billing.
+      if @current_collective.agent_funding? && !current_user.funded_billing?
+        flash[:alert] = "Joining this collective means consenting to fund its agents from your own prepaid balance, " \
+                        "which requires active billing with prepaid credits. Set up billing at /billing first."
+        return redirect_to "#{@current_collective.path}/join"
+      end
       if invite.is_acceptable_by_user?(current_user)
         @current_user.accept_invite!(invite)
         clear_pending_invite! if pending_invite_code == invite.code
@@ -862,6 +949,26 @@ class CollectivesController < ApplicationController
 
   # POST /collectives/:collective_handle/deactivate
   private
+
+  # Only these types are user-creatable; chat and private_workspace
+  # collectives are minted by their own internal flows.
+  USER_CREATABLE_COLLECTIVE_TYPES = ["standard", "agent_funding"].freeze
+
+  # Returns an error message when the requested collective type may not be
+  # created by this user, nil when the request is fine. Creating an
+  # agent_funding collective makes you its first funding member, so it
+  # carries the same funded-billing requirement as joining one.
+  def collective_type_request_error
+    requested = params[:collective_type].presence || "standard"
+    return "Collective type #{requested.inspect} is not available." unless USER_CREATABLE_COLLECTIVE_TYPES.include?(requested)
+
+    if requested == "agent_funding" && !current_user.funded_billing?
+      return "Creating an agent funding collective makes you its first funding member, which requires " \
+             "active billing with prepaid credits. Set up billing at /billing first."
+    end
+
+    nil
+  end
 
   # Shared guard for the member-management actions. Renders the appropriate
   # action error and returns :handled when the request is not allowed;

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -68,6 +68,16 @@ class SignupController < ApplicationController
       return redirect_to invite_required_path
     end
 
+    # Funded to join: accepting a funding-collective invite is consenting to
+    # have your own balance drawn on, so it carries the same billing
+    # requirement as the in-app accept path. Gate before the join transaction
+    # so a blocked accept doesn't create the TenantUser either.
+    if invite.collective.agent_funding? && !@current_user.funded_billing?
+      flash[:alert] = "Joining #{invite.collective.name} means consenting to fund its agents from your own prepaid balance, " \
+                      "which requires active billing with prepaid credits."
+      return redirect_to invite_required_path
+    end
+
     requested_handle = params[:handle].presence
     retried = false
     begin

--- a/app/models/collective.rb
+++ b/app/models/collective.rb
@@ -31,6 +31,7 @@ class Collective < ApplicationRecord
   scope :standard, -> { where(collective_type: "standard") }
   scope :private_workspaces, -> { where(collective_type: "private_workspace") }
   scope :chat, -> { where(collective_type: "chat") }
+  scope :agent_funding, -> { where(collective_type: "agent_funding") }
   scope :listable, -> { where(collective_type: "standard") }
   scope :billable_types, -> { where(collective_type: ["standard", "private_workspace"]) }
 
@@ -57,7 +58,11 @@ class Collective < ApplicationRecord
     read_attribute(:has_heartbeat) ? true : false
   end
 
-  VALID_COLLECTIVE_TYPES = ["standard", "private_workspace", "chat"].freeze
+  # agent_funding: joining IS consenting to fund the collective's agents' LLM
+  # usage from your own prepaid balance (each member pays Stripe directly per
+  # call — the collective never holds funds). Unlisted, invite-only, not
+  # billable; see LLMGateway::PayerResolver for the payer draw.
+  VALID_COLLECTIVE_TYPES = ["standard", "private_workspace", "chat", "agent_funding"].freeze
 
   validates :collective_type, inclusion: { in: VALID_COLLECTIVE_TYPES }
   validate :handle_is_valid
@@ -190,6 +195,11 @@ class Collective < ApplicationRecord
   sig { returns(T::Boolean) }
   def chat?
     collective_type == "chat"
+  end
+
+  sig { returns(T::Boolean) }
+  def agent_funding?
+    collective_type == "agent_funding"
   end
 
   sig { returns(T::Boolean) }
@@ -670,6 +680,7 @@ class Collective < ApplicationRecord
   def create_identity_user!
     return if private_workspace?
     return if chat?
+    return if agent_funding? # funding collectives don't act or speak
     return if identity_user
     # The identity shares the collective's handle; without one there's nothing
     # to share, so defer to `handle_is_valid` to surface the blank-handle error
@@ -869,6 +880,9 @@ class Collective < ApplicationRecord
     raise "Cannot create invites for the main collective" if is_main_collective?
     raise "Cannot create invites for private workspaces" if private_workspace?
     raise "Cannot create invites for chat collectives" if chat?
+    # Funding membership is a consent to spend money; every invite names its
+    # invitee rather than circulating as an open link.
+    raise "Cannot create shareable invites for agent funding collectives" if agent_funding?
 
     invite = Invite.where(
       collective: self,

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -23,10 +23,15 @@ class Invite < ApplicationRecord
       errors.add(:collective, "cannot be a private workspace")
     elsif c.chat?
       errors.add(:collective, "cannot be a chat collective")
-    elsif c.collective_type != "standard"
-      errors.add(:collective, "must be a standard collective (got #{c.collective_type.inspect})")
+    elsif !INVITABLE_COLLECTIVE_TYPES.include?(c.collective_type)
+      errors.add(:collective, "must be an invitable collective type (got #{c.collective_type.inspect})")
     end
   end
+
+  # agent_funding is invite-only by design: the invite is the consent
+  # instrument for funding participation (shareable open links are refused at
+  # Collective#find_or_create_shareable_invite).
+  INVITABLE_COLLECTIVE_TYPES = ["standard", "agent_funding"].freeze
 
   sig { void }
   def set_tenant_id
@@ -73,7 +78,7 @@ class Invite < ApplicationRecord
     return false if c.is_main_collective?
     return false if c.private_workspace?
     return false if c.chat?
-    c.collective_type == "standard"
+    INVITABLE_COLLECTIVE_TYPES.include?(c.collective_type)
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -794,6 +794,16 @@ class User < ApplicationRecord
     billable_quantity == 0
   end
 
+  # Whether this user's own balance can be drawn on for pooled LLM funding:
+  # an active Stripe customer with a prepaid-credit subscription. Gates
+  # joining (and creating) agent_funding collectives; the same condition
+  # decides draw eligibility per call in LLMGateway::PayerResolver.
+  sig { returns(T::Boolean) }
+  def funded_billing?
+    customer = stripe_customer
+    customer.present? && customer.active? && customer.pricing_plan_subscription_id.present?
+  end
+
   sig { params(tenant: Tenant).returns(T::Boolean) }
   def requires_stripe_billing?(tenant)
     tenant.feature_enabled?("stripe_billing") && !stripe_billing_setup?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -259,6 +259,11 @@ class User < ApplicationRecord
       return
     end
 
+    if collective.archived?
+      errors.add(:funding_collective_id, "cannot be an archived collective")
+      return
+    end
+
     parent_membership = collective.collective_members.find_by(user_id: parent_id)
     if parent_membership.nil? || parent_membership.archived?
       errors.add(:funding_collective_id, "requires the agent's principal to be an active member of the funding collective")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,10 @@ class User < ApplicationRecord
   has_one :stripe_customer, as: :billable, class_name: "StripeCustomer"
   # For AI agents: which StripeCustomer pays for this agent's usage
   belongs_to :billing_customer, class_name: "StripeCustomer", foreign_key: "stripe_customer_id", optional: true
+  # AI agents only: the agent_funding collective whose members' balances fund
+  # this agent's LLM usage (drawn per call — see LLMGateway::PayerResolver).
+  # When set, it takes precedence over billing_customer for token spend.
+  belongs_to :funding_collective, class_name: "Collective", optional: true
 
   # User block associations
   has_many :user_blocks_given, class_name: "UserBlock", foreign_key: "blocker_id", dependent: :destroy
@@ -134,6 +138,7 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :system_role, inclusion: { in: SYSTEM_ROLES, allow_nil: true }
   validate :ai_agent_must_have_parent
+  validate :funding_collective_assignable, if: :funding_collective_id_changed?
   validate :agent_mode_is_immutable, if: :ai_agent?
   # collective_identity Users only exist as the spawn of a Collective; an
   # orphan (no backing Collective) is data corruption. Validated on update
@@ -233,6 +238,31 @@ class User < ApplicationRecord
     return unless persisted? && parent_id == id
 
     errors.add(:parent_id, "user cannot be its own parent")
+  end
+
+  # Runs only when the link changes (attach happens in request context, where
+  # the tenant thread scope makes the collective readable). Per-call
+  # enforcement of these same conditions lives in LLMGateway::PayerResolver,
+  # which must not trust a link that was valid at attach time.
+  sig { void }
+  def funding_collective_assignable
+    return if funding_collective_id.nil?
+
+    unless ai_agent?
+      errors.add(:funding_collective_id, "can only be set for AI agent users")
+      return
+    end
+
+    collective = funding_collective
+    if collective.nil? || !collective.agent_funding?
+      errors.add(:funding_collective_id, "must reference an agent_funding collective")
+      return
+    end
+
+    parent_membership = collective.collective_members.find_by(user_id: parent_id)
+    if parent_membership.nil? || parent_membership.archived?
+      errors.add(:funding_collective_id, "requires the agent's principal to be an active member of the funding collective")
+    end
   end
 
   sig { returns(T::Boolean) }

--- a/app/services/agent_runner_dispatch_service.rb
+++ b/app/services/agent_runner_dispatch_service.rb
@@ -58,12 +58,12 @@ class AgentRunnerDispatchService
     # billing_customer, are never charged, and route through LiteLLM rather
     # than the LLM gateway.
     #
-    # Pool-funded agents (LLM_POOL_CONFIG proof of concept) skip the
-    # individual checks entirely: they have no personal billing customer to
-    # verify or stamp — the gateway's select-payer picks a pool member per
-    # call, and the relayed Stripe 402 is the balance gate.
+    # Pool-funded agents (funding_collective set) skip the individual checks
+    # entirely: their spend draws from the collective's members, not a
+    # personal billing customer — the gateway's select-payer picks a funded
+    # member per call, and the relayed Stripe 402 is the balance gate.
     billing_customer = ai_agent.billing_customer
-    pool_funded = LLMGateway::PayerResolver.pool_customer_ids(ai_agent.id).any?
+    pool_funded = ai_agent.funding_collective_id.present?
     if tenant.feature_enabled?("stripe_billing") && !ai_agent.system? && !pool_funded
       # (a) The agent's identity must be paid for before we run a task — the
       # norm, unchanged. An agent's billing_customer is its principal's Stripe

--- a/app/services/api_helper.rb
+++ b/app/services/api_helper.rb
@@ -76,6 +76,11 @@ class ApiHelper
 
   sig { returns(Collective) }
   def create_collective
+    # Controllers gate which types a user may request (and the funded-billing
+    # requirement for agent_funding) before this runs — see
+    # CollectivesController#collective_type_request_error.
+    collective_type = params[:collective_type].presence || "standard"
+
     collective = T.let(nil, T.nilable(Collective))
     ActiveRecord::Base.transaction do
       collective = Collective.create!(
@@ -85,7 +90,10 @@ class ApiHelper
         created_by: current_user,
         timezone: params[:timezone],
         tempo: params[:tempo],
-        synchronization_mode: params[:synchronization_mode]
+        synchronization_mode: params[:synchronization_mode],
+        collective_type: collective_type,
+        # Funding collectives exist to pay for agents, not to be paid for.
+        billing_exempt: collective_type == "agent_funding"
       )
 
       # Apply optional settings
@@ -107,7 +115,10 @@ class ApiHelper
       # This is needed to ensure that all the models created in this transaction
       # are associated with the correct tenant and collective
       Collective.scope_thread_to_collective(handle: collective.handle, subdomain: T.must(collective.tenant).subdomain)
-      collective.add_user!(current_user, roles: ["admin", "representative"])
+      # No representative role on funding collectives — there is no identity
+      # user to represent.
+      creator_roles = collective.agent_funding? ? ["admin"] : ["admin", "representative"]
+      collective.add_user!(current_user, roles: creator_roles)
     end
     T.must(collective)
   end
@@ -871,6 +882,13 @@ class ApiHelper
       # invites and invites addressed to someone else must not grant
       # membership through the action route either.
       raise "Invite is not valid or has expired" unless invite.is_acceptable_by_user?(current_user)
+
+      # Same funded-to-join gate as the HTML flow: joining a funding
+      # collective is consenting to have your balance drawn on.
+      if current_collective.agent_funding? && !current_user.funded_billing?
+        raise "Joining an agent funding collective is consenting to fund its agents from your own prepaid balance, " \
+              "which requires active billing with prepaid credits. Set up billing at /billing first."
+      end
 
       current_user.accept_invite!(invite)
       collective_member = current_user.collective_members.find_by(collective: current_collective)

--- a/app/services/llm_gateway/payer_resolver.rb
+++ b/app/services/llm_gateway/payer_resolver.rb
@@ -3,23 +3,14 @@
 
 module LLMGateway
   # Resolves which Stripe customer pays for a billed LLM call, and verifies the
-  # payer is funded. This is the single home for payer-selection policy: today
-  # it resolves a task run to its stamped billing customer (one payer); the
-  # common-pool selection will extend this same seam.
+  # payer is funded. This is the single home for payer-selection policy: an
+  # agent funded by an agent_funding collective draws uniformly at random from
+  # its funded members' balances; otherwise the individual billing customer
+  # pays (the task run's stamped customer, or the agent's own).
   class PayerResolver
     extend T::Sig
 
     Result = Struct.new(:payer_customer_id, keyword_init: true)
-
-    # Proof-of-concept common pools, configured entirely by env var — no
-    # schema, no UI, removable by unsetting the var. Maps agent ids to the
-    # Stripe customers whose balances jointly fund that agent's calls:
-    #   LLM_POOL_CONFIG='{"<agent-id>": ["cus_a", "cus_b"]}'
-    # Each call picks a payer uniformly at random, so cost converges to an
-    # even split across the pool. The real pool feature (member consent,
-    # management UX) is deliberately not designed yet; only this resolver
-    # seam and the dispatch bypass will remain when it is.
-    POOL_CONFIG_ENV = "LLM_POOL_CONFIG"
 
     # A resolution failure that carries the wire error code and HTTP status the
     # gateway (and its callers) should surface.
@@ -47,21 +38,69 @@ module LLMGateway
 
     # Resolve the payer for a gateway call made directly by an agent (external
     # ingress — authenticated by its llm_gateway API key, no task run). Same
-    # funding policy as the task-run path: pool first, else the agent's own
-    # billing customer.
+    # funding policy as the task-run path: funding collective first, else the
+    # agent's own billing customer.
     sig { params(agent: User).returns(Result) }
     def self.resolve_for_agent(agent)
-      pool_result(agent.id, context: "agent=#{agent.id}") || funded_result(agent.billing_customer)
+      pool_result(agent, context: "agent=#{agent.id}") || funded_result(agent.billing_customer)
     end
 
-    sig { params(agent_id: String, context: String).returns(T.nilable(Result)) }
-    def self.pool_result(agent_id, context:)
-      pool = pool_customer_ids(agent_id)
-      return nil if pool.empty?
+    # The Stripe customers eligible to pay for this agent's calls: the funding
+    # collective's active human members whose own billing is funded (active
+    # customer with a prepaid-credit subscription). Members whose funding
+    # lapsed are skipped rather than pool-breaking. Lookups use
+    # tenant_scoped_only + explicit ids — never collective-scoped associations,
+    # which misbehave outside normal request scoping.
+    sig { params(agent: User).returns(T::Array[String]) }
+    def self.pool_customer_ids(agent)
+      collective_id = agent.funding_collective_id
+      return [] if collective_id.nil?
+
+      member_user_ids = CollectiveMember.tenant_scoped_only
+                                        .where(collective_id: collective_id, archived_at: nil)
+                                        .pluck(:user_id)
+      human_ids = User.where(id: member_user_ids, user_type: "human").pluck(:id)
+      StripeCustomer.where(billable_type: "User", billable_id: human_ids, active: true)
+                    .where.not(pricing_plan_subscription_id: [nil, ""])
+                    .pluck(:stripe_id)
+    end
+
+    sig { params(agent: User, context: String).returns(T.nilable(Result)) }
+    def self.pool_result(agent, context:)
+      return nil if agent.funding_collective_id.nil?
+
+      ensure_primary_active!(agent)
+
+      pool = pool_customer_ids(agent)
+      if pool.empty?
+        raise ResolutionError.new(
+          "pool_exhausted",
+          :payment_required,
+          "No funded members are available in the agent's funding collective."
+        )
+      end
 
       payer = T.must(pool.sample)
       Rails.logger.info("[LLMGateway] Pool payer selected #{context} payer=#{payer} pool_size=#{pool.size}")
       Result.new(payer_customer_id: payer)
+    end
+
+    # No primary, no service: the accountable principal must remain an active
+    # member of the funding collective (the attach-time validation can drift —
+    # members leave). Checked statelessly on every call.
+    sig { params(agent: User).void }
+    def self.ensure_primary_active!(agent)
+      membership = CollectiveMember.tenant_scoped_only.find_by(
+        collective_id: agent.funding_collective_id,
+        user_id: agent.parent_id
+      )
+      return if membership && membership.archived_at.nil?
+
+      raise ResolutionError.new(
+        "no_primary",
+        :forbidden,
+        "The agent's principal is no longer an active member of its funding collective; the agent is suspended."
+      )
     end
 
     # LLM usage must be funded: a prepaid-credit (pricing-plan) subscription
@@ -88,19 +127,6 @@ module LLMGateway
       Result.new(payer_customer_id: billing_customer.stripe_id)
     end
 
-    sig { params(agent_id: String).returns(T::Array[String]) }
-    def self.pool_customer_ids(agent_id)
-      raw = ENV.fetch(POOL_CONFIG_ENV, nil)
-      return [] if raw.blank?
-
-      config = JSON.parse(raw)
-      ids = config[agent_id]
-      ids.is_a?(Array) ? ids.grep(String).reject(&:blank?) : []
-    rescue JSON::ParserError => e
-      Rails.logger.error("[LLMGateway] Ignoring malformed #{POOL_CONFIG_ENV}: #{e.message}")
-      []
-    end
-
     sig { params(task_run: AiAgentTaskRun).void }
     def initialize(task_run)
       @task_run = task_run
@@ -108,7 +134,7 @@ module LLMGateway
 
     sig { returns(Result) }
     def resolve
-      pool = self.class.pool_result(T.must(@task_run.ai_agent_id), context: "task_run=#{@task_run.id}")
+      pool = self.class.pool_result(T.must(@task_run.ai_agent), context: "task_run=#{@task_run.id}")
       return pool if pool
 
       billing_customer = @task_run.billing_customer

--- a/app/services/llm_gateway/payer_resolver.rb
+++ b/app/services/llm_gateway/payer_resolver.rb
@@ -69,6 +69,7 @@ module LLMGateway
     def self.pool_result(agent, context:)
       return nil if agent.funding_collective_id.nil?
 
+      ensure_funding_collective_available!(agent)
       ensure_primary_active!(agent)
 
       pool = pool_customer_ids(agent)
@@ -83,6 +84,23 @@ module LLMGateway
       payer = T.must(pool.sample)
       Rails.logger.info("[LLMGateway] Pool payer selected #{context} payer=#{payer} pool_size=#{pool.size}")
       Result.new(payer_customer_id: payer)
+    end
+
+    # Archiving a funding collective is how the arrangement is wound down, so
+    # it must stop the spending; membership rows survive archiving, so the
+    # member-based checks alone would keep drawing. A collective outside the
+    # calling tenant suspends the agent the same way — the membership lookups
+    # below are scoped to the calling tenant and could never see it anyway.
+    sig { params(agent: User).void }
+    def self.ensure_funding_collective_available!(agent)
+      collective = Collective.tenant_scoped_only.find_by(id: agent.funding_collective_id)
+      return if collective && !collective.archived?
+
+      raise ResolutionError.new(
+        "funding_collective_unavailable",
+        :forbidden,
+        "The agent's funding collective is archived or unavailable; the agent is suspended."
+      )
     end
 
     # No primary, no service: the accountable principal must remain an active

--- a/app/views/collectives/join.html.erb
+++ b/app/views/collectives/join.html.erb
@@ -17,9 +17,20 @@
 
   <div class="pulse-resource-body">
     <% if @invite %>
-      <p class="pulse-body-text">
-        Click the button below to join collective <strong><%= @current_collective.name %></strong>.
-      </p>
+      <% if @current_collective.agent_funding? %>
+        <p class="pulse-body-text">
+          <strong><%= @current_collective.name %></strong> is an agent funding collective.
+          Joining is consenting to fund its agents: each LLM call one of its agents makes
+          is billed to one member's own prepaid balance, chosen at random per call, so cost
+          spreads evenly over time. The collective never holds funds. Joining requires
+          active billing with prepaid credits, and leaving the collective ends your
+          participation.
+        </p>
+      <% else %>
+        <p class="pulse-body-text">
+          Click the button below to join collective <strong><%= @current_collective.name %></strong>.
+        </p>
+      <% end %>
       <div class="pulse-form-actions">
         <%= button_to "Join Collective", "#{@current_collective.path}/join", method: :post, params: { code: @invite.code }, class: 'pulse-action-btn' %>
       </div>

--- a/app/views/collectives/join.md.erb
+++ b/app/views/collectives/join.md.erb
@@ -6,6 +6,13 @@ You are already a member of this collective.
 [Go to collective homepage](<%= @current_collective.path %>)
 <% elsif @invite %>
 You have been invited to join this collective.
+<% if @current_collective.agent_funding? %>
+
+This is an agent funding collective. Joining is consenting to fund its agents:
+each LLM call one of its agents makes is billed to one member's own prepaid
+balance, chosen at random per call. The collective never holds funds. Joining
+requires active billing with prepaid credits; leaving ends your participation.
+<% end %>
 <% else %>
 You need an invite code to join this collective.
 <% end %>

--- a/app/views/collectives/settings.html.erb
+++ b/app/views/collectives/settings.html.erb
@@ -309,6 +309,62 @@
       </section>
     <% end %>
 
+    <% if @current_collective.agent_funding? %>
+      <section class="pulse-settings-section">
+        <h2 class="pulse-section-title">Funded Agents</h2>
+        <p class="pulse-section-description">
+          Agents on this collective's payroll: each LLM call one of them makes is billed to
+          one member's own prepaid balance, chosen at random per call. An agent can be
+          attached only while its principal is an active member.
+        </p>
+        <% if @funded_agents.any? %>
+          <table class="pulse-table">
+            <thead>
+              <tr>
+                <th>Agent</th>
+                <th>Principal</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @funded_agents.each do |agent| %>
+                <tr>
+                  <td><%= link_to agent.display_name, agent.path %></td>
+                  <td>
+                    <% if agent.parent %>
+                      <%= link_to agent.parent.display_name, agent.parent.path %>
+                    <% else %>
+                      <em>Unknown</em>
+                    <% end %>
+                  </td>
+                  <td>
+                    <%= button_to "Detach", "#{@current_collective.path}/settings/remove_funded_agent",
+                                  method: :delete, params: { ai_agent_id: agent.id }, class: 'pulse-action-btn-danger' %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        <% else %>
+          <p class="pulse-empty-message"><em>No agents are funded by this collective yet.</em></p>
+        <% end %>
+
+        <% if @attachable_agents.any? %>
+          <h3 class="pulse-subsection-title">Attach a member's agent</h3>
+          <form action="<%= @current_collective.path %>/settings/add_funded_agent" method="post" class="pulse-inline-form">
+            <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
+            <select name="ai_agent_id" class="pulse-form-select">
+              <option value="">Select an agent...</option>
+              <% @attachable_agents.each do |agent| %>
+                <option value="<%= agent.id %>"><%= agent.display_name %></option>
+              <% end %>
+            </select>
+            <button type="submit" class="pulse-action-btn">Attach</button>
+          </form>
+        <% end %>
+      </section>
+    <% end %>
+
     <% if @current_collective.feature_enabled?('api') && !@current_collective.private_workspace? %>
       <section class="pulse-settings-section" data-controller="ai_agent-manager" data-ai_agent-manager-remove-url-value="<%= @current_collective.path %>/settings/remove_ai_agent">
         <h2 class="pulse-section-title">AI Agents in this Collective</h2>

--- a/app/views/signup/confirm_invite.html.erb
+++ b/app/views/signup/confirm_invite.html.erb
@@ -9,6 +9,16 @@
       on <code><%= @current_tenant.subdomain %>.<%= ENV['HOSTNAME'] %></code>
     </p>
 
+    <% if @invite.collective.agent_funding? %>
+      <p class="pulse-body-text" style="text-align:left;">
+        <strong><%= @invite.collective.name %></strong> is an agent funding collective.
+        Joining is consenting to fund its agents: each LLM call one of its agents makes
+        is billed to one member's own prepaid balance, chosen at random per call. The
+        collective never holds funds. Joining requires active billing with prepaid
+        credits; leaving ends your participation.
+      </p>
+    <% end %>
+
     <%= form_with url: accept_invite_path, method: :post, class: "pulse-auth-form", local: true do %>
       <%= render "shared/bot_protection_fields" %>
       <input type="hidden" name="code" value="<%= @invite.code %>">

--- a/app/views/signup/confirm_invite.md.erb
+++ b/app/views/signup/confirm_invite.md.erb
@@ -8,6 +8,13 @@ title: Confirm invite
 # You're invited to join <%= @invite.collective.name %>
 
 on `<%= @current_tenant.subdomain %>.<%= ENV['HOSTNAME'] %>`, as **@<%= @suggested_handle %>**.
+<% if @invite.collective.agent_funding? %>
+
+This is an agent funding collective. Joining is consenting to fund its agents:
+each LLM call one of its agents makes is billed to one member's own prepaid
+balance, chosen at random per call. The collective never holds funds. Joining
+requires active billing with prepaid credits; leaving ends your participation.
+<% end %>
 
 Accepting this invite (which creates your tenant and collective membership)
 is an interactive confirmation step — open this page in a browser to review

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -132,6 +132,15 @@
     </div>
   <% end %>
 
+  <% if @showing_user.ai_agent? && @showing_user.funding_collective %>
+    <div class="pulse-user-parent-info">
+      <span style="color: var(--color-fg-muted);">Funded by</span>
+      <a href="<%= @showing_user.funding_collective.path %>" class="pulse-user-parent-link">
+        <strong><%= @showing_user.funding_collective.name %></strong>
+      </a>
+    </div>
+  <% end %>
+
   <% if @showing_user.human? && @ai_agent_count && @ai_agent_count > 0 %>
     <div class="pulse-user-ai_agent-count">
       <%= octicon 'people', height: 14 %>

--- a/app/views/users/show.md.erb
+++ b/app/views/users/show.md.erb
@@ -25,6 +25,10 @@ Type: AI Agent
 
 Managed by: [<%= @showing_user.parent.display_name %>](<%= @showing_user.parent.path %>)
 <% end %>
+<% if @showing_user.ai_agent? && @showing_user.funding_collective %>
+
+Funded by: [<%= @showing_user.funding_collective.name %>](<%= @showing_user.funding_collective.path %>)
+<% end %>
 <% if @showing_user.human? && @ai_agent_count && @ai_agent_count > 0 %>
 
 Has <%= @ai_agent_count %> AI agent<%= @ai_agent_count == 1 ? "" : "s" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -580,6 +580,8 @@ Rails.application.routes.draw do
     post "#{prefix}/unarchive" => 'collectives#unarchive'
     post "#{prefix}/settings/add_ai_agent" => 'collectives#add_ai_agent'
     delete "#{prefix}/settings/remove_ai_agent" => 'collectives#remove_ai_agent'
+    post "#{prefix}/settings/add_funded_agent" => 'collectives#add_funded_agent'
+    delete "#{prefix}/settings/remove_funded_agent" => 'collectives#remove_funded_agent'
     get "#{prefix}/settings/actions" => 'collectives#actions_index_settings'
     get "#{prefix}/settings/actions/update_collective_settings" => 'collectives#describe_update_collective_settings'
     post "#{prefix}/settings/actions/update_collective_settings" => 'collectives#update_collective_settings_action'

--- a/db/migrate/20260711010000_add_funding_collective_to_users.rb
+++ b/db/migrate/20260711010000_add_funding_collective_to_users.rb
@@ -1,0 +1,12 @@
+class AddFundingCollectiveToUsers < ActiveRecord::Migration[7.2]
+  # An AI agent's token spend can be funded by an agent_funding collective
+  # (its members' balances, drawn per call) instead of its own billing
+  # customer. Deliberately NOT named collective_id: ApplicationRecord
+  # auto-scopes any table carrying that column name, and users must stay
+  # unscoped.
+  def change
+    add_column :users, :funding_collective_id, :uuid
+    add_index :users, :funding_collective_id, where: "funding_collective_id IS NOT NULL"
+    add_foreign_key :users, :collectives, column: :funding_collective_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2258,7 +2258,8 @@ CREATE TABLE public.users (
     email_confirmation_token character varying,
     email_confirmation_sent_at timestamp(6) without time zone,
     sessions_revoked_at timestamp(6) without time zone,
-    system_role character varying
+    system_role character varying,
+    funding_collective_id uuid
 );
 
 
@@ -5163,6 +5164,13 @@ CREATE UNIQUE INDEX index_user_lists_one_primary_per_owner_per_tenant ON public.
 --
 
 CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
+
+
+--
+-- Name: index_users_on_funding_collective_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_funding_collective_id ON public.users USING btree (funding_collective_id) WHERE (funding_collective_id IS NOT NULL);
 
 
 --
@@ -10242,6 +10250,14 @@ ALTER TABLE ONLY public.media_items
 
 
 --
+-- Name: users fk_rails_f7cabdd29c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT fk_rails_f7cabdd29c FOREIGN KEY (funding_collective_id) REFERENCES public.collectives(id);
+
+
+--
 -- Name: decision_participants fk_rails_f9c15d4765; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10312,6 +10328,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260711010000'),
 ('20260710010000'),
 ('20260709190000'),
 ('20260705220000'),

--- a/sorbet/rbi/dsl/collective.rbi
+++ b/sorbet/rbi/dsl/collective.rbi
@@ -182,6 +182,7 @@ class Collective
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         block: T.proc.params(object: ::Collective).void
       ).void
@@ -192,10 +193,11 @@ class Collective
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol
       ).returns(T::Enumerator[::Collective])
     end
-    def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
+    def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
 
     sig do
       params(
@@ -203,6 +205,7 @@ class Collective
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         block: T.proc.params(object: T::Array[::Collective]).void
       ).void
@@ -213,10 +216,11 @@ class Collective
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol
       ).returns(T::Enumerator[T::Enumerator[::Collective]])
     end
-    def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
+    def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
 
     sig do
       params(
@@ -298,6 +302,7 @@ class Collective
         finish: T.untyped,
         load: T.untyped,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         use_ranges: T.untyped,
         block: T.proc.params(object: PrivateRelation).void
@@ -310,11 +315,12 @@ class Collective
         finish: T.untyped,
         load: T.untyped,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         use_ranges: T.untyped
       ).returns(::ActiveRecord::Batches::BatchEnumerator)
     end
-    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, use_ranges: nil, &block); end
+    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, cursor: primary_key, order: :asc, use_ranges: nil, &block); end
 
     sig { params(record: T.untyped).returns(T::Boolean) }
     def include?(record); end
@@ -753,6 +759,20 @@ class Collective
     def events=(value); end
 
     sig { returns(T::Array[T.untyped]) }
+    def harmonic_bridge_setup_ids; end
+
+    sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+    def harmonic_bridge_setup_ids=(ids); end
+
+    # This method is created by ActiveRecord on the `Collective` class because it declared `has_many :harmonic_bridge_setups`.
+    # 🔗 [Rails guide for `has_many` association](https://guides.rubyonrails.org/association_basics.html#the-has-many-association)
+    sig { returns(::HarmonicBridgeSetup::PrivateCollectionProxy) }
+    def harmonic_bridge_setups; end
+
+    sig { params(value: T::Enumerable[::HarmonicBridgeSetup]).void }
+    def harmonic_bridge_setups=(value); end
+
+    sig { returns(T::Array[T.untyped]) }
     def heartbeat_ids; end
 
     sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
@@ -817,6 +837,34 @@ class Collective
 
     sig { params(value: T::Enumerable[::Link]).void }
     def links=(value); end
+
+    sig { returns(T::Array[T.untyped]) }
+    def mcp_tool_call_log_ids; end
+
+    sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+    def mcp_tool_call_log_ids=(ids); end
+
+    # This method is created by ActiveRecord on the `Collective` class because it declared `has_many :mcp_tool_call_logs`.
+    # 🔗 [Rails guide for `has_many` association](https://guides.rubyonrails.org/association_basics.html#the-has-many-association)
+    sig { returns(::McpToolCallLog::PrivateCollectionProxy) }
+    def mcp_tool_call_logs; end
+
+    sig { params(value: T::Enumerable[::McpToolCallLog]).void }
+    def mcp_tool_call_logs=(value); end
+
+    sig { returns(T::Array[T.untyped]) }
+    def mcp_tool_call_resource_ids; end
+
+    sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+    def mcp_tool_call_resource_ids=(ids); end
+
+    # This method is created by ActiveRecord on the `Collective` class because it declared `has_many :mcp_tool_call_resources`.
+    # 🔗 [Rails guide for `has_many` association](https://guides.rubyonrails.org/association_basics.html#the-has-many-association)
+    sig { returns(::McpToolCallResource::PrivateCollectionProxy) }
+    def mcp_tool_call_resources; end
+
+    sig { params(value: T::Enumerable[::McpToolCallResource]).void }
+    def mcp_tool_call_resources=(value); end
 
     sig { returns(T::Array[T.untyped]) }
     def media_item_ids; end
@@ -915,6 +963,20 @@ class Collective
 
     sig { params(value: T::Enumerable[::Option]).void }
     def options=(value); end
+
+    sig { returns(T::Array[T.untyped]) }
+    def refresh_token_ids; end
+
+    sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+    def refresh_token_ids=(ids); end
+
+    # This method is created by ActiveRecord on the `Collective` class because it declared `has_many :refresh_tokens`.
+    # 🔗 [Rails guide for `has_many` association](https://guides.rubyonrails.org/association_basics.html#the-has-many-association)
+    sig { returns(::RefreshToken::PrivateCollectionProxy) }
+    def refresh_tokens; end
+
+    sig { params(value: T::Enumerable[::RefreshToken]).void }
+    def refresh_tokens=(value); end
 
     sig { returns(T.nilable(::User)) }
     def reload_created_by; end
@@ -1098,6 +1160,34 @@ class Collective
     sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
     def user_item_status_ids=(ids); end
 
+    sig { returns(T::Array[T.untyped]) }
+    def user_list_ids; end
+
+    sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+    def user_list_ids=(ids); end
+
+    sig { returns(T::Array[T.untyped]) }
+    def user_list_member_ids; end
+
+    sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+    def user_list_member_ids=(ids); end
+
+    # This method is created by ActiveRecord on the `Collective` class because it declared `has_many :user_list_members`.
+    # 🔗 [Rails guide for `has_many` association](https://guides.rubyonrails.org/association_basics.html#the-has-many-association)
+    sig { returns(::UserListMember::PrivateCollectionProxy) }
+    def user_list_members; end
+
+    sig { params(value: T::Enumerable[::UserListMember]).void }
+    def user_list_members=(value); end
+
+    # This method is created by ActiveRecord on the `Collective` class because it declared `has_many :user_lists`.
+    # 🔗 [Rails guide for `has_many` association](https://guides.rubyonrails.org/association_basics.html#the-has-many-association)
+    sig { returns(::UserList::PrivateCollectionProxy) }
+    def user_lists; end
+
+    sig { params(value: T::Enumerable[::UserList]).void }
+    def user_lists=(value); end
+
     # This method is created by ActiveRecord on the `Collective` class because it declared `has_many :users, through: :collective_members`.
     # 🔗 [Rails guide for `has_many_through` association](https://guides.rubyonrails.org/association_basics.html#the-has-many-through-association)
     sig { returns(::User::PrivateCollectionProxy) }
@@ -1120,6 +1210,20 @@ class Collective
     sig { params(value: T::Enumerable[::Vote]).void }
     def votes=(value); end
 
+    sig { returns(T::Array[T.untyped]) }
+    def web_push_subscription_ids; end
+
+    sig { params(ids: T::Array[T.untyped]).returns(T::Array[T.untyped]) }
+    def web_push_subscription_ids=(ids); end
+
+    # This method is created by ActiveRecord on the `Collective` class because it declared `has_many :web_push_subscriptions`.
+    # 🔗 [Rails guide for `has_many` association](https://guides.rubyonrails.org/association_basics.html#the-has-many-association)
+    sig { returns(::WebPushSubscription::PrivateCollectionProxy) }
+    def web_push_subscriptions; end
+
+    sig { params(value: T::Enumerable[::WebPushSubscription]).void }
+    def web_push_subscriptions=(value); end
+
     # This method is created by ActiveRecord on the `Collective` class because it declared `has_many :webhook_deliveries`.
     # 🔗 [Rails guide for `has_many` association](https://guides.rubyonrails.org/association_basics.html#the-has-many-association)
     sig { returns(::WebhookDelivery::PrivateCollectionProxy) }
@@ -1136,6 +1240,9 @@ class Collective
   end
 
   module GeneratedAssociationRelationMethods
+    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+    def agent_funding(*args, &blk); end
+
     sig { returns(PrivateAssociationRelation) }
     def all; end
 
@@ -1290,6 +1397,9 @@ class Collective
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
     def with_attached_image(*args, &blk); end
+
+    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+    def with_heartbeat_for(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
     def with_recursive(*args, &blk); end
@@ -2441,6 +2551,9 @@ class Collective
   end
 
   module GeneratedRelationMethods
+    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+    def agent_funding(*args, &blk); end
+
     sig { returns(PrivateRelation) }
     def all; end
 
@@ -2595,6 +2708,9 @@ class Collective
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
     def with_attached_image(*args, &blk); end
+
+    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+    def with_heartbeat_for(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
     def with_recursive(*args, &blk); end

--- a/sorbet/rbi/dsl/invite.rbi
+++ b/sorbet/rbi/dsl/invite.rbi
@@ -146,6 +146,7 @@ class Invite
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         block: T.proc.params(object: ::Invite).void
       ).void
@@ -156,10 +157,11 @@ class Invite
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol
       ).returns(T::Enumerator[::Invite])
     end
-    def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
+    def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
 
     sig do
       params(
@@ -167,6 +169,7 @@ class Invite
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         block: T.proc.params(object: T::Array[::Invite]).void
       ).void
@@ -177,10 +180,11 @@ class Invite
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol
       ).returns(T::Enumerator[T::Enumerator[::Invite]])
     end
-    def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
+    def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
 
     sig do
       params(
@@ -247,6 +251,7 @@ class Invite
         finish: T.untyped,
         load: T.untyped,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         use_ranges: T.untyped,
         block: T.proc.params(object: PrivateRelation).void
@@ -259,11 +264,12 @@ class Invite
         finish: T.untyped,
         load: T.untyped,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         use_ranges: T.untyped
       ).returns(::ActiveRecord::Batches::BatchEnumerator)
     end
-    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, use_ranges: nil, &block); end
+    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, cursor: primary_key, order: :asc, use_ranges: nil, &block); end
 
     sig { params(record: T.untyped).returns(T::Boolean) }
     def include?(record); end

--- a/sorbet/rbi/dsl/user.rbi
+++ b/sorbet/rbi/dsl/user.rbi
@@ -410,6 +410,9 @@ class User
     sig { params(args: T.untyped, blk: T.untyped).returns(::StripeCustomer) }
     def build_billing_customer(*args, &blk); end
 
+    sig { params(args: T.untyped, blk: T.untyped).returns(::Collective) }
+    def build_funding_collective(*args, &blk); end
+
     sig { params(args: T.untyped, blk: T.untyped).returns(::ActiveStorage::Attachment) }
     def build_image_attachment(*args, &blk); end
 
@@ -470,6 +473,12 @@ class User
     sig { params(args: T.untyped, blk: T.untyped).returns(::StripeCustomer) }
     def create_billing_customer!(*args, &blk); end
 
+    sig { params(args: T.untyped, blk: T.untyped).returns(::Collective) }
+    def create_funding_collective(*args, &blk); end
+
+    sig { params(args: T.untyped, blk: T.untyped).returns(::Collective) }
+    def create_funding_collective!(*args, &blk); end
+
     sig { params(args: T.untyped, blk: T.untyped).returns(::ActiveStorage::Attachment) }
     def create_image_attachment(*args, &blk); end
 
@@ -521,6 +530,18 @@ class User
 
     sig { params(value: T::Enumerable[::DecisionParticipant]).void }
     def decision_participants=(value); end
+
+    sig { returns(T.nilable(::Collective)) }
+    def funding_collective; end
+
+    sig { params(value: T.nilable(::Collective)).void }
+    def funding_collective=(value); end
+
+    sig { returns(T::Boolean) }
+    def funding_collective_changed?; end
+
+    sig { returns(T::Boolean) }
+    def funding_collective_previously_changed?; end
 
     sig { returns(T::Array[T.untyped]) }
     def granted_trustee_grant_ids; end
@@ -669,6 +690,9 @@ class User
     sig { returns(T.nilable(::StripeCustomer)) }
     def reload_billing_customer; end
 
+    sig { returns(T.nilable(::Collective)) }
+    def reload_funding_collective; end
+
     sig { returns(T.nilable(::ActiveStorage::Attachment)) }
     def reload_image_attachment; end
 
@@ -683,6 +707,9 @@ class User
 
     sig { void }
     def reset_billing_customer; end
+
+    sig { void }
+    def reset_funding_collective; end
 
     sig { void }
     def reset_image_attachment; end
@@ -1268,6 +1295,51 @@ class User
     sig { void }
     def email_will_change!; end
 
+    sig { returns(T.nilable(::String)) }
+    def funding_collective_id; end
+
+    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+    def funding_collective_id=(value); end
+
+    sig { returns(T::Boolean) }
+    def funding_collective_id?; end
+
+    sig { returns(T.nilable(::String)) }
+    def funding_collective_id_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def funding_collective_id_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def funding_collective_id_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def funding_collective_id_change; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def funding_collective_id_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def funding_collective_id_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def funding_collective_id_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def funding_collective_id_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def funding_collective_id_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def funding_collective_id_previously_was; end
+
+    sig { returns(T.nilable(::String)) }
+    def funding_collective_id_was; end
+
+    sig { void }
+    def funding_collective_id_will_change!; end
+
     sig { returns(::String) }
     def id; end
 
@@ -1650,6 +1722,9 @@ class User
     def restore_email_confirmation_token!; end
 
     sig { void }
+    def restore_funding_collective_id!; end
+
+    sig { void }
     def restore_id!; end
 
     sig { void }
@@ -1741,6 +1816,12 @@ class User
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_email_confirmation_token?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def saved_change_to_funding_collective_id; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_funding_collective_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([::String, ::String])) }
     def saved_change_to_id; end
@@ -2269,6 +2350,9 @@ class User
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_email_confirmation_token?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_funding_collective_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/test/controllers/collectives_controller_test.rb
+++ b/test/controllers/collectives_controller_test.rb
@@ -1845,6 +1845,188 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
     assert_not cm.has_role?("representative"), "a non-admin agent must not grant roles"
   end
 
+  # === Agent funding collectives ===
+
+  def fund_user!(user, stripe_id: "cus_#{SecureRandom.hex(6)}")
+    StripeCustomer.create!(
+      billable: user, stripe_id: stripe_id, active: true, pricing_plan_subscription_id: "bpps_#{SecureRandom.hex(4)}"
+    )
+  end
+
+  def create_funding_collective(admin: @user)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    collective = Collective.create!(
+      tenant: @tenant,
+      created_by: admin,
+      name: "Agent Funding",
+      handle: "fund-#{SecureRandom.hex(4)}",
+      collective_type: "agent_funding"
+    )
+    cm = collective.add_user!(admin)
+    cm.add_role!("admin")
+    collective
+  ensure
+    Collective.clear_thread_scope
+    Tenant.clear_thread_scope
+  end
+
+  def invite_to(collective, user)
+    Invite.create!(
+      tenant: @tenant,
+      collective: collective,
+      created_by: @user,
+      invited_user: user,
+      code: SecureRandom.hex(8),
+      expires_at: 1.week.from_now
+    )
+  end
+
+  def member_of?(collective, user)
+    CollectiveMember.tenant_scoped_only(@tenant.id).where(archived_at: nil).exists?(collective_id: collective.id, user_id: user.id)
+  end
+
+  test "the join page shows funding consent copy for agent_funding collectives" do
+    funding = create_funding_collective
+    invitee = create_user(name: "Prospective Funder")
+    @tenant.add_user!(invitee)
+    invite = invite_to(funding, invitee)
+    sign_in_as(invitee, tenant: @tenant)
+
+    get "#{funding.path}/join", params: { code: invite.code }
+
+    assert_response :success
+    assert_match(/consenting to fund/i, response.body)
+    assert_match(/prepaid balance/i, response.body)
+  end
+
+  test "accepting an agent_funding invite requires funded billing" do
+    funding = create_funding_collective
+    invitee = create_user(name: "Unfunded")
+    @tenant.add_user!(invitee)
+    invite = invite_to(funding, invitee)
+    sign_in_as(invitee, tenant: @tenant)
+
+    post "#{funding.path}/join", params: { code: invite.code }
+
+    assert_redirected_to "#{funding.path}/join"
+    assert_match(/billing/i, flash[:alert])
+    assert_not member_of?(funding, invitee), "unfunded user must not become a funding member"
+  end
+
+  test "a funded user accepting an agent_funding invite becomes a member" do
+    funding = create_funding_collective
+    invitee = create_user(name: "Funded")
+    @tenant.add_user!(invitee)
+    fund_user!(invitee)
+    invite = invite_to(funding, invitee)
+    sign_in_as(invitee, tenant: @tenant)
+
+    post "#{funding.path}/join", params: { code: invite.code }
+
+    assert_redirected_to funding.path
+    assert member_of?(funding, invitee)
+  end
+
+  test "a funded user can create an agent_funding collective" do
+    fund_user!(@user)
+    sign_in_as(@user, tenant: @tenant)
+    handle = "fund-pool-#{SecureRandom.hex(4)}"
+
+    post "/collectives", params: { name: "Fund Pool", handle: handle, collective_type: "agent_funding" }
+
+    collective = Collective.tenant_scoped_only(@tenant.id).find_by(handle: handle)
+    assert collective, "expected the collective to be created"
+    assert collective.agent_funding?
+    assert collective.billing_exempt?, "funding collectives are not billable"
+    assert member_of?(collective, @user)
+  end
+
+  test "creating an agent_funding collective requires funded billing" do
+    sign_in_as(@user, tenant: @tenant)
+    handle = "fund-pool-#{SecureRandom.hex(4)}"
+
+    post "/collectives", params: { name: "Fund Pool", handle: handle, collective_type: "agent_funding" }
+
+    assert_nil Collective.tenant_scoped_only(@tenant.id).find_by(handle: handle)
+    assert_match(/billing/i, flash[:alert])
+  end
+
+  test "internal-only collective types cannot be created through the public path" do
+    sign_in_as(@user, tenant: @tenant)
+    handle = "sneaky-#{SecureRandom.hex(4)}"
+
+    post "/collectives", params: { name: "Sneaky", handle: handle, collective_type: "chat" }
+
+    assert_nil Collective.tenant_scoped_only(@tenant.id).find_by(handle: handle)
+  end
+
+  test "an admin can attach a member's agent to an agent_funding collective" do
+    funding = create_funding_collective
+    agent = create_ai_agent(parent: @user)
+    sign_in_as(@user, tenant: @tenant)
+
+    post "#{funding.path}/settings/add_funded_agent", params: { ai_agent_id: agent.id }
+
+    assert_response :redirect
+    assert_equal funding.id, agent.reload.funding_collective_id
+  end
+
+  test "non-admin members cannot attach agents" do
+    funding = create_funding_collective
+    member = create_user(name: "Plain Member")
+    @tenant.add_user!(member)
+    fund_user!(member)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    funding.add_user!(member)
+    agent = create_ai_agent(parent: member)
+    Tenant.clear_thread_scope
+    sign_in_as(member, tenant: @tenant)
+
+    post "#{funding.path}/settings/add_funded_agent", params: { ai_agent_id: agent.id }
+
+    assert_response :forbidden
+    assert_nil agent.reload.funding_collective_id
+  end
+
+  test "attach is refused on non-funding collectives" do
+    other = create_test_collective
+    agent = create_ai_agent(parent: @user)
+    sign_in_as(@user, tenant: @tenant)
+
+    post "#{other.path}/settings/add_funded_agent", params: { ai_agent_id: agent.id }
+
+    assert_response :forbidden
+    assert_nil agent.reload.funding_collective_id
+  end
+
+  test "attach fails clearly when the agent's principal is not a member" do
+    funding = create_funding_collective
+    outsider = create_user(name: "Outsider")
+    @tenant.add_user!(outsider)
+    agent = create_ai_agent(parent: outsider)
+    sign_in_as(@user, tenant: @tenant)
+
+    post "#{funding.path}/settings/add_funded_agent", params: { ai_agent_id: agent.id }
+
+    assert_response :unprocessable_entity
+    assert_nil agent.reload.funding_collective_id
+  end
+
+  test "an admin can detach a funded agent" do
+    funding = create_funding_collective
+    agent = create_ai_agent(parent: @user)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    agent.update!(funding_collective: funding)
+    Tenant.clear_thread_scope
+    sign_in_as(@user, tenant: @tenant)
+
+    delete "#{funding.path}/settings/remove_funded_agent", params: { ai_agent_id: agent.id }
+
+    assert_response :redirect
+    assert_nil agent.reload.funding_collective_id
+  end
+
   private
 
   def enable_stripe_billing_flag!(tenant)

--- a/test/controllers/collectives_controller_test.rb
+++ b/test/controllers/collectives_controller_test.rb
@@ -1964,6 +1964,7 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
   test "an admin can attach a member's agent to an agent_funding collective" do
     funding = create_funding_collective
     agent = create_ai_agent(parent: @user)
+    @tenant.add_user!(agent)
     sign_in_as(@user, tenant: @tenant)
 
     post "#{funding.path}/settings/add_funded_agent", params: { ai_agent_id: agent.id }
@@ -1981,22 +1982,45 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
     funding.add_user!(member)
     agent = create_ai_agent(parent: member)
     Tenant.clear_thread_scope
+    @tenant.add_user!(agent)
     sign_in_as(member, tenant: @tenant)
 
     post "#{funding.path}/settings/add_funded_agent", params: { ai_agent_id: agent.id }
 
+    assert_redirected_to "#{funding.path}/settings"
+    assert flash[:alert].present?, "expected an alert explaining the refusal"
+    assert_nil agent.reload.funding_collective_id
+  end
+
+  test "attach errors are JSON for JSON requests" do
+    funding = create_funding_collective
+    member = create_user(name: "Plain Member")
+    @tenant.add_user!(member)
+    fund_user!(member)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    funding.add_user!(member)
+    agent = create_ai_agent(parent: member)
+    Tenant.clear_thread_scope
+    @tenant.add_user!(agent)
+    sign_in_as(member, tenant: @tenant)
+
+    post "#{funding.path}/settings/add_funded_agent", params: { ai_agent_id: agent.id }, as: :json
+
     assert_response :forbidden
+    assert response.parsed_body["error"].present?
     assert_nil agent.reload.funding_collective_id
   end
 
   test "attach is refused on non-funding collectives" do
     other = create_test_collective
     agent = create_ai_agent(parent: @user)
+    @tenant.add_user!(agent)
     sign_in_as(@user, tenant: @tenant)
 
     post "#{other.path}/settings/add_funded_agent", params: { ai_agent_id: agent.id }
 
-    assert_response :forbidden
+    assert_redirected_to "#{other.path}/settings"
+    assert flash[:alert].present?
     assert_nil agent.reload.funding_collective_id
   end
 
@@ -2005,12 +2029,55 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
     outsider = create_user(name: "Outsider")
     @tenant.add_user!(outsider)
     agent = create_ai_agent(parent: outsider)
+    @tenant.add_user!(agent)
     sign_in_as(@user, tenant: @tenant)
 
     post "#{funding.path}/settings/add_funded_agent", params: { ai_agent_id: agent.id }
 
-    assert_response :unprocessable_entity
+    assert_redirected_to "#{funding.path}/settings"
+    assert_match(/member/i, flash[:alert])
     assert_nil agent.reload.funding_collective_id
+  end
+
+  test "an agent from another tenant cannot be attached" do
+    funding = create_funding_collective
+    agent = create_ai_agent(parent: @user)
+    other_tenant = create_tenant(subdomain: "other-fund-#{SecureRandom.hex(4)}")
+    other_tenant.add_user!(agent)
+    sign_in_as(@user, tenant: @tenant)
+
+    post "#{funding.path}/settings/add_funded_agent", params: { ai_agent_id: agent.id }, as: :json
+
+    assert_response :not_found
+    assert_nil agent.reload.funding_collective_id
+  end
+
+  test "the attach list only offers agents from this tenant" do
+    funding = create_funding_collective
+    local = create_ai_agent(parent: @user, name: "Local Fund Bot")
+    @tenant.add_user!(local)
+    foreign = create_ai_agent(parent: @user, name: "Foreign Fund Bot")
+    other_tenant = create_tenant(subdomain: "other-fund-#{SecureRandom.hex(4)}")
+    other_tenant.add_user!(foreign)
+    sign_in_as(@user, tenant: @tenant)
+
+    get "#{funding.path}/settings"
+
+    assert_response :success
+    assert_match "Local Fund Bot", response.body
+    assert_no_match(/Foreign Fund Bot/, response.body)
+  end
+
+  test "detaching an agent not funded by this collective redirects with an alert" do
+    funding = create_funding_collective
+    agent = create_ai_agent(parent: @user)
+    @tenant.add_user!(agent)
+    sign_in_as(@user, tenant: @tenant)
+
+    delete "#{funding.path}/settings/remove_funded_agent", params: { ai_agent_id: agent.id }
+
+    assert_redirected_to "#{funding.path}/settings"
+    assert flash[:alert].present?
   end
 
   test "an admin can detach a funded agent" do

--- a/test/controllers/internal/llm_gateway_controller_test.rb
+++ b/test/controllers/internal/llm_gateway_controller_test.rb
@@ -117,21 +117,14 @@ class Internal::LLMGatewayControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test "returns a pool customer for a pool-configured agent" do
-    previous = ENV.fetch(LLMGateway::PayerResolver::POOL_CONFIG_ENV, nil)
-    ENV[LLMGateway::PayerResolver::POOL_CONFIG_ENV] = { @ai_agent.id => ["cus_pool_a", "cus_pool_b"] }.to_json
+  test "returns a pool customer for a pool-funded agent" do
+    attach_funding_collective!(@ai_agent, ["cus_pool_a", "cus_pool_b"])
 
     # The unbilled run has no stamped customer — the pool alone funds it.
     select_payer(task_run_id: @unbilled_task_run.id, model: "anthropic/claude-sonnet-4.6")
 
     assert_response :success
     assert_includes ["cus_pool_a", "cus_pool_b"], JSON.parse(response.body)["payer_customer_id"]
-  ensure
-    if previous.nil?
-      ENV.delete(LLMGateway::PayerResolver::POOL_CONFIG_ENV)
-    else
-      ENV[LLMGateway::PayerResolver::POOL_CONFIG_ENV] = previous
-    end
   end
 
   test "rejects an unsigned request" do
@@ -159,16 +152,35 @@ class Internal::LLMGatewayControllerTest < ActionDispatch::IntegrationTest
     Collective.clear_thread_scope
   end
 
-  def with_pool_config(pool_by_agent_id)
-    previous = ENV.fetch(LLMGateway::PayerResolver::POOL_CONFIG_ENV, nil)
-    ENV[LLMGateway::PayerResolver::POOL_CONFIG_ENV] = pool_by_agent_id.to_json
-    yield
-  ensure
-    if previous.nil?
-      ENV.delete(LLMGateway::PayerResolver::POOL_CONFIG_ENV)
-    else
-      ENV[LLMGateway::PayerResolver::POOL_CONFIG_ENV] = previous
+  # Fund the agent through an agent_funding collective. The first stripe id
+  # funds @user (the agent's principal, who must be a member); each further id
+  # funds an additional member.
+  def attach_funding_collective!(agent, stripe_ids)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    funding = Collective.create!(
+      tenant: @tenant,
+      created_by: @user,
+      name: "Agent Funding",
+      handle: "fund-#{SecureRandom.hex(4)}",
+      collective_type: "agent_funding"
+    )
+    funding.add_user!(@user)
+    stripe_ids.each_with_index do |stripe_id, index|
+      member = @user
+      if index.positive?
+        member = create_user
+        @tenant.add_user!(member)
+        funding.add_user!(member)
+      end
+      StripeCustomer.create!(
+        billable: member, stripe_id: stripe_id, active: true, pricing_plan_subscription_id: "bpps_#{SecureRandom.hex(4)}"
+      )
     end
+    agent.update!(funding_collective: funding)
+    funding
+  ensure
+    Tenant.clear_thread_scope
+    Collective.clear_thread_scope
   end
 
   def select_payer_for_token(body_hash)
@@ -190,10 +202,9 @@ class Internal::LLMGatewayControllerTest < ActionDispatch::IntegrationTest
   test "token caller: returns a pool payer and the mapped model" do
     @tenant.enable_feature_flag!("llm_gateway")
     agent, token = create_gateway_agent_and_token
+    attach_funding_collective!(agent, ["cus_pool_a", "cus_pool_b"])
 
-    with_pool_config(agent.id => ["cus_pool_a", "cus_pool_b"]) do
-      select_payer_for_token(agent_token: token.plaintext_token, model: "anthropic/claude-sonnet-4.6")
-    end
+    select_payer_for_token(agent_token: token.plaintext_token, model: "anthropic/claude-sonnet-4.6")
 
     assert_response :success
     body = JSON.parse(response.body)
@@ -219,10 +230,9 @@ class Internal::LLMGatewayControllerTest < ActionDispatch::IntegrationTest
   test "token caller: blank model maps to the default model" do
     @tenant.enable_feature_flag!("llm_gateway")
     agent, token = create_gateway_agent_and_token
+    attach_funding_collective!(agent, ["cus_pool_a"])
 
-    with_pool_config(agent.id => ["cus_pool_a"]) do
-      select_payer_for_token(agent_token: token.plaintext_token)
-    end
+    select_payer_for_token(agent_token: token.plaintext_token)
 
     assert_response :success
     assert_equal StripeGatewayModelMapper::DEFAULT_MODEL, JSON.parse(response.body)["model"]
@@ -272,10 +282,9 @@ class Internal::LLMGatewayControllerTest < ActionDispatch::IntegrationTest
 
   test "token caller: 403 when the tenant flag is off" do
     agent, token = create_gateway_agent_and_token
+    attach_funding_collective!(agent, ["cus_pool_a"])
 
-    with_pool_config(agent.id => ["cus_pool_a"]) do
-      select_payer_for_token(agent_token: token.plaintext_token)
-    end
+    select_payer_for_token(agent_token: token.plaintext_token)
 
     assert_response :forbidden
     assert_openai_error("feature_disabled")
@@ -293,10 +302,9 @@ class Internal::LLMGatewayControllerTest < ActionDispatch::IntegrationTest
   test "token caller: 400 for a model the gateway cannot proxy" do
     @tenant.enable_feature_flag!("llm_gateway")
     agent, token = create_gateway_agent_and_token
+    attach_funding_collective!(agent, ["cus_pool_a"])
 
-    with_pool_config(agent.id => ["cus_pool_a"]) do
-      select_payer_for_token(agent_token: token.plaintext_token, model: "local-ollama-model")
-    end
+    select_payer_for_token(agent_token: token.plaintext_token, model: "local-ollama-model")
 
     assert_response :bad_request
     assert_openai_error("unsupported_model")

--- a/test/controllers/signup_controller_test.rb
+++ b/test/controllers/signup_controller_test.rb
@@ -601,7 +601,64 @@ class SignupControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # === Agent funding collectives ===
+
+  test "the confirmation page shows funding consent copy for agent_funding invites" do
+    funding = create_funding_collective
+    invite = create_invite(collective: funding, invited_user: @uninvited_user)
+    sign_in_without_membership(@uninvited_user)
+
+    get "/invite-required", params: { code: invite.code }
+
+    assert_response :success
+    assert_match(/consenting to fund/i, response.body)
+    assert_match(/prepaid balance/i, response.body)
+  end
+
+  test "accepting an agent_funding invite through signup requires funded billing" do
+    funding = create_funding_collective
+    invite = create_invite(collective: funding, invited_user: @uninvited_user)
+    sign_in_without_membership(@uninvited_user)
+
+    post "/invite-required/accept", params: { code: invite.code }
+
+    assert_redirected_to "/invite-required"
+    assert_match(/billing/i, flash[:alert])
+    assert_not @tenant.tenant_users.exists?(user: @uninvited_user), "the blocked accept must not join the tenant either"
+    assert_not CollectiveMember.tenant_scoped_only(@tenant.id).exists?(collective_id: funding.id, user_id: @uninvited_user.id)
+  end
+
+  test "a funded user can accept an agent_funding invite through signup" do
+    funding = create_funding_collective
+    StripeCustomer.create!(
+      billable: @uninvited_user,
+      stripe_id: "cus_#{SecureRandom.hex(6)}",
+      active: true,
+      pricing_plan_subscription_id: "bpps_#{SecureRandom.hex(4)}"
+    )
+    invite = create_invite(collective: funding, invited_user: @uninvited_user)
+    sign_in_without_membership(@uninvited_user)
+
+    post "/invite-required/accept", params: { code: invite.code }
+
+    assert_redirected_to funding.path
+    assert CollectiveMember.tenant_scoped_only(@tenant.id).exists?(collective_id: funding.id, user_id: @uninvited_user.id)
+  end
+
   private
+
+  def create_funding_collective
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    Collective.create!(
+      tenant: @tenant,
+      created_by: @host_user,
+      name: "Agent Funding",
+      handle: "fund-#{SecureRandom.hex(4)}",
+      collective_type: "agent_funding"
+    )
+  ensure
+    Tenant.clear_thread_scope
+  end
 
   def with_bot_protection
     original_force = ENV["FORCE_BOT_PROTECTION_IN_TEST"]

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -626,6 +626,29 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, "Has 1 AI agent"
   end
 
+  test "ai_agent profile shows its funding collective" do
+    ai_agent = create_ai_agent(parent: @user, name: "Pooled AiAgent")
+    @tenant.add_user!(ai_agent)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    funding = Collective.create!(
+      tenant: @tenant, created_by: @user, name: "Shared Fund",
+      handle: "fund-#{SecureRandom.hex(4)}", collective_type: "agent_funding"
+    )
+    funding.add_user!(@user)
+    ai_agent.update!(funding_collective: funding)
+    Tenant.clear_thread_scope
+
+    sign_in_as(@user, tenant: @tenant)
+    get "/u/#{ai_agent.handle}"
+    assert_response :success
+    assert_includes response.body, "Funded by"
+    assert_includes response.body, "Shared Fund"
+
+    get "/u/#{ai_agent.handle}", headers: { "Accept" => "text/markdown" }
+    assert_response :success
+    assert_includes response.body, "Funded by: [Shared Fund]"
+  end
+
   # === AiAgent Count Tests (Markdown) ===
 
   test "markdown person profile shows ai_agent count when they have ai_agents" do

--- a/test/models/collective_test.rb
+++ b/test/models/collective_test.rb
@@ -26,6 +26,52 @@ class CollectiveTest < ActiveSupport::TestCase
     assert_equal "test", collective.handle
   end
 
+  test "agent_funding is a valid collective type with the expected exclusions" do
+    tenant = create_tenant
+    user = create_user
+    collective = Collective.create!(
+      tenant: tenant,
+      created_by: user,
+      name: "Agent Funding",
+      handle: "funding",
+      collective_type: "agent_funding"
+    )
+
+    assert collective.agent_funding?
+    assert_not collective.listable?
+    assert_not Collective.listable.exists?(id: collective.id)
+    assert_not Collective.billable_types.exists?(id: collective.id)
+  end
+
+  test "agent_funding collectives get no identity user" do
+    tenant = create_tenant
+    user = create_user
+    collective = Collective.create!(
+      tenant: tenant,
+      created_by: user,
+      name: "Agent Funding",
+      handle: "funding",
+      collective_type: "agent_funding"
+    )
+
+    assert_nil collective.identity_user, "funding collectives don't act or speak; no identity"
+  end
+
+  test "agent_funding collectives refuse shareable invites" do
+    tenant = create_tenant
+    user = create_user
+    collective = Collective.create!(
+      tenant: tenant,
+      created_by: user,
+      name: "Agent Funding",
+      handle: "funding",
+      collective_type: "agent_funding"
+    )
+
+    error = assert_raises(RuntimeError) { collective.find_or_create_shareable_invite(user) }
+    assert_match(/funding/, error.message)
+  end
+
   test "Collective.handle_is_valid validation" do
     tenant = create_tenant
     user = create_user

--- a/test/models/invite_test.rb
+++ b/test/models/invite_test.rb
@@ -68,6 +68,22 @@ class InviteTest < ActiveSupport::TestCase
     end
   end
 
+  test "invite is valid for an agent_funding collective" do
+    funding = Collective.create!(
+      tenant: @tenant,
+      created_by: @user,
+      name: "Agent Funding",
+      handle: "fund-#{SecureRandom.hex(4)}",
+      collective_type: "agent_funding"
+    )
+    invitee = create_user
+    @tenant.add_user!(invitee)
+
+    invite = build_invite(collective: funding, invited_user: invitee)
+    assert invite.valid?, "expected invite to be valid: #{invite.errors.full_messages.join(', ')}"
+    assert invite.collective_invitable?
+  end
+
   test "is_acceptable_by_user? rejects legacy invites on the main collective" do
     # Simulates legacy data: an invite that existed before the validation was
     # added. Bypass validation to construct it.

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2048,5 +2048,64 @@ class UserTest < ActiveSupport::TestCase
     identity.name = "Renamed"
     assert identity.valid?, identity.errors.full_messages.to_sentence
   end
+
+  # === Funding collective ===
+
+  def create_funding_collective(members: [@user])
+    collective = Collective.create!(
+      tenant: @tenant,
+      created_by: @user,
+      name: "Agent Funding",
+      handle: "fund-#{SecureRandom.hex(4)}",
+      collective_type: "agent_funding"
+    )
+    members.each { |member| collective.add_user!(member) }
+    collective
+  end
+
+  test "an agent can be funded by an agent_funding collective its parent belongs to" do
+    funding = create_funding_collective
+    agent = create_ai_agent(parent: @user)
+
+    agent.funding_collective = funding
+    assert agent.valid?, agent.errors.full_messages.to_sentence
+    agent.save!
+    assert_equal funding.id, agent.reload.funding_collective_id
+  end
+
+  test "humans cannot have a funding collective" do
+    funding = create_funding_collective
+
+    @user.funding_collective = funding
+    assert_not @user.valid?
+    assert @user.errors[:funding_collective_id].any?
+  end
+
+  test "the funding collective must be agent_funding type" do
+    agent = create_ai_agent(parent: @user)
+
+    agent.funding_collective = @collective
+    assert_not agent.valid?
+    assert agent.errors[:funding_collective_id].join(" ").include?("agent_funding"), "expected a type error"
+  end
+
+  test "the agent's parent must be an active member of the funding collective" do
+    funding = create_funding_collective(members: [])
+    agent = create_ai_agent(parent: @user)
+
+    agent.funding_collective = funding
+    assert_not agent.valid?
+    assert agent.errors[:funding_collective_id].join(" ").include?("member")
+  end
+
+  test "an archived parent membership does not satisfy the funding link" do
+    funding = create_funding_collective
+    funding.collective_members.find_by!(user: @user).archive!
+    agent = create_ai_agent(parent: @user)
+
+    agent.funding_collective = funding
+    assert_not agent.valid?
+    assert agent.errors[:funding_collective_id].join(" ").include?("member")
+  end
 end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2107,5 +2107,15 @@ class UserTest < ActiveSupport::TestCase
     assert_not agent.valid?
     assert agent.errors[:funding_collective_id].join(" ").include?("member")
   end
+
+  test "an archived collective cannot be attached as a funding collective" do
+    funding = create_funding_collective
+    funding.update!(archived_at: Time.current, archived_by_id: @user.id)
+    agent = create_ai_agent(parent: @user)
+
+    agent.funding_collective = funding
+    assert_not agent.valid?
+    assert agent.errors[:funding_collective_id].join(" ").include?("archived")
+  end
 end
 

--- a/test/services/agent_runner_dispatch_service_test.rb
+++ b/test/services/agent_runner_dispatch_service_test.rb
@@ -487,30 +487,30 @@ class AgentRunnerDispatchServiceTest < ActiveSupport::TestCase
     redis.close
   end
 
-  # === Pool-configured agents (LLM_POOL_CONFIG proof of concept) ===
+  # === Pool-funded agents (agent_funding collective) ===
 
-  def with_pool_config(customer_ids, agent_id:)
-    previous = ENV.fetch(LLMGateway::PayerResolver::POOL_CONFIG_ENV, nil)
-    ENV[LLMGateway::PayerResolver::POOL_CONFIG_ENV] = { agent_id => customer_ids }.to_json
-    yield
-  ensure
-    if previous.nil?
-      ENV.delete(LLMGateway::PayerResolver::POOL_CONFIG_ENV)
-    else
-      ENV[LLMGateway::PayerResolver::POOL_CONFIG_ENV] = previous
-    end
+  def attach_funding_collective!(agent)
+    funding = Collective.create!(
+      tenant: @tenant,
+      created_by: @user,
+      name: "Agent Funding",
+      handle: "fund-#{SecureRandom.hex(4)}",
+      collective_type: "agent_funding",
+    )
+    funding.add_user!(@user)
+    agent.update!(funding_collective: funding)
+    funding
   end
 
-  test "dispatches a pool-configured agent with no individual billing through the gateway" do
+  test "dispatches a pool-funded agent with no individual billing through the gateway" do
     enable_stripe_billing_flag!(@tenant)
+    attach_funding_collective!(@ai_agent)
     # No billing customer, no subscription, no balance — the pool funds it.
     # Neither the identity check nor the balance preflight applies, so a
     # balance fetch here would be a bug.
     redis = Redis.new(url: ENV["REDIS_URL"])
     StripeService.stub :get_credit_balance, ->(_) { raise "must not fetch balance for a pool-funded task" } do
-      with_pool_config(["cus_pool_a", "cus_pool_b"], agent_id: @ai_agent.id) do
-        AgentRunnerDispatchService.dispatch(@task_run)
-      end
+      AgentRunnerDispatchService.dispatch(@task_run)
     end
 
     @task_run.reload
@@ -524,12 +524,10 @@ class AgentRunnerDispatchServiceTest < ActiveSupport::TestCase
     redis.close
   end
 
-  test "pool config does not apply to agents outside it" do
+  test "agents without a funding collective still need individual billing" do
     enable_stripe_billing_flag!(@tenant)
 
-    with_pool_config(["cus_pool_a"], agent_id: "some-other-agent") do
-      AgentRunnerDispatchService.dispatch(@task_run)
-    end
+    AgentRunnerDispatchService.dispatch(@task_run)
 
     @task_run.reload
     assert_equal "failed", @task_run.status

--- a/test/services/llm_gateway/payer_resolver_test.rb
+++ b/test/services/llm_gateway/payer_resolver_test.rb
@@ -18,87 +18,166 @@ module LLMGateway
         max_steps: 10,
         status: "running",
       )
-
-      @previous_pool_config = ENV.fetch(PayerResolver::POOL_CONFIG_ENV, nil)
     end
 
-    teardown do
-      if @previous_pool_config.nil?
-        ENV.delete(PayerResolver::POOL_CONFIG_ENV)
-      else
-        ENV[PayerResolver::POOL_CONFIG_ENV] = @previous_pool_config
-      end
+    def create_funding_collective(members: [@user])
+      collective = Collective.create!(
+        tenant: @tenant,
+        created_by: @user,
+        name: "Agent Funding",
+        handle: "fund-#{SecureRandom.hex(4)}",
+        collective_type: "agent_funding",
+      )
+      members.each { |member| collective.add_user!(member) }
+      collective
     end
 
-    def configure_pool!(customer_ids, agent_id: @ai_agent.id)
-      ENV[PayerResolver::POOL_CONFIG_ENV] = { agent_id => customer_ids }.to_json
+    def create_funded_member!(collective, stripe_id:)
+      member = create_user
+      @tenant.add_user!(member)
+      collective.add_user!(member)
+      fund!(member, stripe_id: stripe_id)
+      member
     end
 
-    test "resolves a pool-configured agent to one of the pool customers" do
-      configure_pool!(["cus_pool_a", "cus_pool_b", "cus_pool_c"])
+    def fund!(user, stripe_id:, active: true, pricing_plan_subscription_id: "bpps_#{SecureRandom.hex(4)}")
+      StripeCustomer.create!(
+        billable: user,
+        stripe_id: stripe_id,
+        active: active,
+        pricing_plan_subscription_id: pricing_plan_subscription_id,
+      )
+    end
+
+    def create_stamped_billing_customer!
+      billing_customer = StripeCustomer.create!(
+        billable: @ai_agent,
+        stripe_id: "cus_individual",
+        active: true,
+        pricing_plan_subscription_id: "bpps_test123",
+      )
+      @task_run.update!(stripe_customer_id: billing_customer.id)
+      billing_customer
+    end
+
+    test "resolves a funding-collective agent to a funded member's customer" do
+      funding = create_funding_collective
+      fund!(@user, stripe_id: "cus_primary")
+      create_funded_member!(funding, stripe_id: "cus_member_b")
+      @ai_agent.update!(funding_collective: funding)
 
       result = PayerResolver.resolve(@task_run)
-      assert_includes ["cus_pool_a", "cus_pool_b", "cus_pool_c"], result.payer_customer_id
+      assert_includes ["cus_primary", "cus_member_b"], result.payer_customer_id
     end
 
-    test "pool selection is uniformly random across calls" do
-      customers = ["cus_pool_a", "cus_pool_b", "cus_pool_c"]
-      configure_pool!(customers)
+    test "pool selection is uniformly random across funded members" do
+      funding = create_funding_collective
+      fund!(@user, stripe_id: "cus_pool_a")
+      create_funded_member!(funding, stripe_id: "cus_pool_b")
+      create_funded_member!(funding, stripe_id: "cus_pool_c")
+      @ai_agent.update!(funding_collective: funding)
 
       counts = Hash.new(0)
       300.times do
         counts[PayerResolver.resolve(@task_run).payer_customer_id] += 1
       end
 
-      customers.each do |cus|
+      ["cus_pool_a", "cus_pool_b", "cus_pool_c"].each do |cus|
         # Expected 100 of 300 each; 60 is ~5 standard deviations below the
         # mean, so a false failure is vanishingly unlikely.
         assert_operator counts[cus], :>=, 60, "expected #{cus} to be picked roughly uniformly, got #{counts.inspect}"
       end
     end
 
-    test "pool config takes precedence over a stamped billing customer" do
-      billing_customer = StripeCustomer.create!(
-        billable: @ai_agent,
-        stripe_id: "cus_individual",
-        active: true,
-        pricing_plan_subscription_id: "bpps_test123",
-      )
-      @task_run.update!(stripe_customer_id: billing_customer.id)
-      configure_pool!(["cus_pool_a"])
+    test "the funding collective takes precedence over a stamped billing customer" do
+      create_stamped_billing_customer!
+      funding = create_funding_collective
+      fund!(@user, stripe_id: "cus_pool_a")
+      @ai_agent.update!(funding_collective: funding)
 
       result = PayerResolver.resolve(@task_run)
       assert_equal "cus_pool_a", result.payer_customer_id
     end
 
-    test "falls back to the stamped billing customer when the agent is not in the pool config" do
-      billing_customer = StripeCustomer.create!(
-        billable: @ai_agent,
-        stripe_id: "cus_individual",
-        active: true,
-        pricing_plan_subscription_id: "bpps_test123",
-      )
-      @task_run.update!(stripe_customer_id: billing_customer.id)
-      configure_pool!(["cus_pool_a"], agent_id: "some-other-agent-id")
+    test "falls back to the stamped billing customer without a funding collective" do
+      create_stamped_billing_customer!
 
       result = PayerResolver.resolve(@task_run)
       assert_equal "cus_individual", result.payer_customer_id
     end
 
-    test "raises not_a_billed_task when there is no pool config and no billing customer" do
+    test "raises not_a_billed_task when there is no funding collective and no billing customer" do
       error = assert_raises(PayerResolver::ResolutionError) do
         PayerResolver.resolve(@task_run)
       end
       assert_equal "not_a_billed_task", error.code
     end
 
-    test "malformed pool config is ignored" do
-      ENV[PayerResolver::POOL_CONFIG_ENV] = "not valid json"
+    test "members whose funding lapsed are skipped in draws" do
+      funding = create_funding_collective
+      fund!(@user, stripe_id: "cus_active")
+      lapsed = create_user
+      @tenant.add_user!(lapsed)
+      funding.add_user!(lapsed)
+      fund!(lapsed, stripe_id: "cus_lapsed", active: false)
+      unsubscribed = create_user
+      @tenant.add_user!(unsubscribed)
+      funding.add_user!(unsubscribed)
+      fund!(unsubscribed, stripe_id: "cus_unsubscribed", pricing_plan_subscription_id: nil)
+      @ai_agent.update!(funding_collective: funding)
+
+      20.times do
+        assert_equal "cus_active", PayerResolver.resolve(@task_run).payer_customer_id
+      end
+    end
+
+    test "archived members are skipped in draws" do
+      funding = create_funding_collective
+      fund!(@user, stripe_id: "cus_active")
+      departed = create_funded_member!(funding, stripe_id: "cus_departed")
+      funding.collective_members.find_by!(user: departed).archive!
+      @ai_agent.update!(funding_collective: funding)
+
+      20.times do
+        assert_equal "cus_active", PayerResolver.resolve(@task_run).payer_customer_id
+      end
+    end
+
+    test "non-human members never fund" do
+      funding = create_funding_collective
+      fund!(@user, stripe_id: "cus_human")
+      funding.add_user!(@ai_agent)
+      fund!(@ai_agent, stripe_id: "cus_agent_self")
+      @ai_agent.update!(funding_collective: funding)
+
+      20.times do
+        assert_equal "cus_human", PayerResolver.resolve(@task_run).payer_customer_id
+      end
+    end
+
+    test "raises pool_exhausted when no member is funded" do
+      funding = create_funding_collective
+      @ai_agent.update!(funding_collective: funding)
 
       error = assert_raises(PayerResolver::ResolutionError) do
         PayerResolver.resolve(@task_run)
       end
-      assert_equal "not_a_billed_task", error.code
+      assert_equal "pool_exhausted", error.code
+      assert_equal :payment_required, error.http_status
+    end
+
+    test "raises no_primary when the principal's membership is archived after attach" do
+      funding = create_funding_collective
+      fund!(@user, stripe_id: "cus_primary")
+      create_funded_member!(funding, stripe_id: "cus_member_b")
+      @ai_agent.update!(funding_collective: funding)
+      funding.collective_members.find_by!(user: @user).archive!
+
+      error = assert_raises(PayerResolver::ResolutionError) do
+        PayerResolver.resolve(@task_run)
+      end
+      assert_equal "no_primary", error.code
+      assert_equal :forbidden, error.http_status
     end
 
     # === resolve_for_agent (external gateway calls — no task run) ===
@@ -115,16 +194,20 @@ module LLMGateway
       customer
     end
 
-    test "resolve_for_agent picks from the pool when the agent is pool-configured" do
-      configure_pool!(["cus_pool_a", "cus_pool_b"])
+    test "resolve_for_agent draws from the funding collective" do
+      funding = create_funding_collective
+      fund!(@user, stripe_id: "cus_pool_a")
+      @ai_agent.update!(funding_collective: funding)
 
       result = PayerResolver.resolve_for_agent(@ai_agent)
-      assert_includes ["cus_pool_a", "cus_pool_b"], result.payer_customer_id
+      assert_equal "cus_pool_a", result.payer_customer_id
     end
 
-    test "resolve_for_agent pool takes precedence over the agent's billing customer" do
+    test "resolve_for_agent funding collective takes precedence over the agent's billing customer" do
       create_agent_billing_customer!
-      configure_pool!(["cus_pool_a"])
+      funding = create_funding_collective
+      fund!(@user, stripe_id: "cus_pool_a")
+      @ai_agent.update!(funding_collective: funding)
 
       result = PayerResolver.resolve_for_agent(@ai_agent)
       assert_equal "cus_pool_a", result.payer_customer_id

--- a/test/services/llm_gateway/payer_resolver_test.rb
+++ b/test/services/llm_gateway/payer_resolver_test.rb
@@ -155,6 +155,19 @@ module LLMGateway
       end
     end
 
+    test "an archived funding collective suspends the agent" do
+      funding = create_funding_collective
+      fund!(@user, stripe_id: "cus_primary")
+      @ai_agent.update!(funding_collective: funding)
+      funding.update!(archived_at: Time.current, archived_by_id: @user.id)
+
+      error = assert_raises(PayerResolver::ResolutionError) do
+        PayerResolver.resolve(@task_run)
+      end
+      assert_equal "funding_collective_unavailable", error.code
+      assert_equal :forbidden, error.http_status
+    end
+
     test "raises pool_exhausted when no member is funded" do
       funding = create_funding_collective
       @ai_agent.update!(funding_collective: funding)


### PR DESCRIPTION
## Summary

The first real cut of common-pool LLM funding (#464), replacing the `LLM_POOL_CONFIG` env proof of concept with an `agent_funding` collective — the consent boundary for pooled funding. Design and v1 decisions are recorded in the plan doc's Stage 2 section (first three commits).

**The structure:** every agent keeps exactly one human **primary principal** (today's `parent`, unchanged — publicly listed, accountable, carries the seat subscription). Token spend can instead draw from an **`agent_funding` collective**: joining one IS consenting to fund its agents' LLM usage from your own prepaid balance, one member per call chosen uniformly at random, so cost converges to an even split. Each member pays Stripe directly per call — **the collective never holds funds** (the camp B posture is structural, not just policy).

## What's in the cut

**The type** — fourth `collective_type`, immutable like the others. Unlisted, not billable (`billing_exempt`), no identity user, and invite-only with *named* invitees: shareable open links are refused because the invite is the consent instrument.

**The funding link** — `users.funding_collective_id` (deliberately not named `collective_id`, which would trip ApplicationRecord's auto-scoping). Valid only on AI agents, only referencing an `agent_funding` collective, and only while the agent's principal is an active member — the accountable human always has skin in the game.

**Payer resolution** (`LLMGateway::PayerResolver`) — the pool branch is now DB-backed: funding collective → active human members → each member's funded billing customer → uniform-random draw. Members whose funding lapsed are skipped, not pool-breaking. Two per-call stateless guards:
- `no_primary` (403): the principal left the collective after attach → the agent is suspended ("no primary, no service")
- `pool_exhausted` (402): no funded member remains

Membership lookups use `tenant_scoped_only` + explicit ids — never collective-scoped associations, which misbehave outside request scoping. Both existing select-payer callers (task-run relay and the external `llm_gateway`-key ingress from #484) get pool support for free. Dispatch's pool bypass keys on `funding_collective_id`.

**The flows**
- *Funded to join:* accepting a funding-collective invite (HTML or action route) requires an active funded billing customer, so consent means the balance can actually be drawn on. The join page states the terms plainly.
- *Creation:* the public create path accepts `collective_type` for user-creatable types (`standard`, `agent_funding` — chat/workspace stay internal-only). Creating a funding collective makes you its first funding member, so it carries the same funded-billing gate.
- *Attach/detach:* admin-only settings actions (mirroring `add_ai_agent`), listing funded agents and members' attachable agents.
- *Transparency:* agent profiles show "Funded by ⟨collective⟩" (HTML + markdown); the member roster keeps normal collective visibility.

**Retired:** the `LLM_POOL_CONFIG` env PoC (#481) — resolver branch, dispatch check, and `.env.example` entry all deleted; it was built to be removable.

## Deliberately deferred to beta iteration (per the v1 decisions)

Renewable consent windows (membership consent is open-ended-until-exit for now), a Decision gate for agent admission (admin-only for now), dry-member 402 handling (still hostage to Stripe's zero-balance answer), per-member spend ceilings, and the usage-transparency view (realized vs fair-share — expected first fast-follow).

## Deploy notes

- Needs `--with-migrations` (adds `users.funding_collective_id`; no backfill, no destructive step).
- No env or DNS changes. The Stripe zero-balance blocker still gates real billed calls everywhere.

## Testing

Red-green throughout: ~30 new/rewritten tests across `collective_test`, `invite_test`, `user_test`, `payer_resolver_test` (fully rewritten to the DB-backed world, incl. 300-draw uniformity, lapsed/archived/non-human member exclusion, both guard codes), `agent_runner_dispatch_service_test`, `llm_gateway_controller_test` (both select-payer callers on real pools), `collectives_controller_test` (join gate, consent copy, create gates, attach/detach permission matrix), `users_controller_test` (profile line, both formats). Full targeted sweep: 621 runs green; `srb tc`, tenant-safety, and debug checks pass. Dev smoke: funding collective + funded member + attached agent resolves the pool through the real DB path.

One caveat for reviewers: two early local sweep runs reported an intermittent single failure whose detail wasn't captured; five subsequent full sweeps and all per-file reruns are clean. If CI surfaces it, I'll run it down before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)