### PR TITLE
Run migrations before starting containers in deploy.sh

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -165,9 +165,11 @@ docker compose -f docker-compose.production.yml stop sidekiq
 # 2. Enable maintenance mode
 ./scripts/maintenance.sh on
 
-# 3. Deploy
+# 3. Deploy — migrate in a one-off container from the NEW image (an `exec`
+# into the still-running old container wouldn't have the new migration
+# files), then start web so it boots against the migrated schema
 docker compose -f docker-compose.production.yml pull
-docker compose -f docker-compose.production.yml exec web bundle exec rails db:migrate
+docker compose -f docker-compose.production.yml run --rm web bundle exec rails db:migrate
 docker compose -f docker-compose.production.yml up -d web
 
 # 4. Disable maintenance mode
@@ -232,7 +234,11 @@ docker compose -f docker-compose.production.yml logs sidekiq --tail 50
 ### Migrations Not Applied
 
 ```bash
-docker compose -f docker-compose.production.yml exec web bundle exec rails db:migrate
+docker compose -f docker-compose.production.yml run --rm web bundle exec rails db:migrate
+# Then restart the Rails processes: they cache the schema at boot, and a
+# process that booted pre-migration keeps querying the old column list
+# (PG::UndefinedColumn on dropped columns) until restarted.
+docker compose -f docker-compose.production.yml restart web sidekiq
 ```
 
 ### View Logs

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,6 +5,14 @@
 # Usage:
 #   ./scripts/deploy.sh --skip-migrations
 #   ./scripts/deploy.sh --with-migrations
+#
+# With migrations, the order is migrate FIRST, then start the app containers.
+# Rails caches each table's column list at boot; migrating under an
+# already-running process leaves it generating SQL against the old schema
+# (e.g. eager loads selecting a dropped column by name) until restarted.
+# The migration runs in a one-off container from the newly pulled image, so
+# it sees the new migration files; the long-running containers then boot
+# against the migrated schema.
 
 set -e
 cd "$(dirname "$0")/.."
@@ -18,7 +26,7 @@ elif [ "$1" = "--skip-migrations" ]; then
 else
   echo "Usage: $0 --with-migrations | --skip-migrations"
   echo ""
-  echo "  --with-migrations   Pull, restart, then run database migrations"
+  echo "  --with-migrations   Pull, run database migrations, then restart"
   echo "  --skip-migrations   Pull and restart only"
   exit 1
 fi
@@ -26,13 +34,13 @@ fi
 echo "Pulling latest images..."
 docker compose -f "$COMPOSE_FILE" pull
 
+if [ "$RUN_MIGRATIONS" = true ]; then
+  echo "Running database migrations (one-off container, new image)..."
+  docker compose -f "$COMPOSE_FILE" run --rm web bundle exec rails db:migrate
+fi
+
 echo "Restarting containers..."
 docker compose -f "$COMPOSE_FILE" up -d
-
-if [ "$RUN_MIGRATIONS" = true ]; then
-  echo "Running database migrations..."
-  docker compose -f "$COMPOSE_FILE" exec web bundle exec rails db:migrate
-fi
 
 echo ""
 echo "Deploy complete."


### PR DESCRIPTION
## Summary

`deploy.sh --with-migrations` started the new containers first and then migrated inside the running web container. Rails caches each table's column list at boot, so a process booted pre-migration keeps generating SQL against the old schema until restarted — the 1.49.0 deploy's column drop left prod raising `PG::UndefinedColumn: users.funding_collective_id` on every page that eager-loads users (e.g. `/ai-agents`) until a manual `restart web`.

## Changes

- **`scripts/deploy.sh`**: the `--with-migrations` path is now pull → **migrate → start**. The migration runs in a one-off container from the newly pulled image (`docker compose run --rm web`), so it has the new migration files and no long-running process is serving on a stale schema cache afterward. Header comment records the reasoning.
- **`docs/DEPLOYMENT.md` downtime runbook**: had a subtler version of the same bug — it migrated via `exec web` into the *old* still-running container, which doesn't have the new migration files at all (silent no-op, then new code boots against an unmigrated database). Now uses `run --rm` with an explanatory comment.
- **`docs/DEPLOYMENT.md` troubleshooting**: the "Migrations Not Applied" recipe now ends with `restart web sidekiq` and describes the stale-schema-cache symptom, so the next person hitting `PG::UndefinedColumn` after a manual migrate finds the answer in the doc.

## Notes

- Known tradeoff (unchanged by this PR): between migrate and start, the old code briefly serves against the new schema. For destructive migrations the zero-downtime discipline is expand/contract across two releases; at current scale the seconds-long window is acceptable, and the downtime runbook covers the maintenance-mode path.
- Verified service names against `docker-compose.production.yml`; `bash -n` clean. The one-off `run` container publishes no ports, so it can't conflict with the still-running web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)