### PR TITLE
Add usage-transparency views for LLM gateway funding pools

### DIFF
--- a/app/controllers/billing_controller.rb
+++ b/app/controllers/billing_controller.rb
@@ -23,6 +23,7 @@ class BillingController < ApplicationController
 
     load_billing_inventory
     load_credit_balance
+    load_funding_report
   end
 
   # POST /billing/setup
@@ -319,6 +320,12 @@ class BillingController < ApplicationController
     else
       0
     end
+  end
+
+  def load_funding_report
+    return unless current_tenant&.feature_enabled?("stripe_billing")
+
+    @funding_report = LLMGateway::UsageReport.funding_report(current_user)
   end
 
   def load_billing_inventory

--- a/app/controllers/collectives_controller.rb
+++ b/app/controllers/collectives_controller.rb
@@ -519,6 +519,7 @@ class CollectivesController < ApplicationController
     @current_user_enrollment = @current_user && @pool_enrollments.find { |e| e.user_id == @current_user.id }
     @current_user_enrolled = @current_user_enrollment.present?
     @funded_agents = @funding_pool.funded_agents.order(:name)
+    @usage_report = LLMGateway::UsageReport.pool_report(@funding_pool)
     respond_to do |format|
       format.html
       format.md

--- a/app/services/llm_gateway/usage_report.rb
+++ b/app/services/llm_gateway/usage_report.rb
@@ -1,0 +1,120 @@
+# typed: true
+# frozen_string_literal: true
+
+module LLMGateway
+  # Read-only usage rollups over the LLM usage ledger, for the two transparency
+  # surfaces: a funding pool's page (who spent from the pool, and on which
+  # agents) and a member's billing page (which pools they fund, and which of
+  # their agents spent their credits). All cost sums are over completed rows
+  # within the reporting window — pending rows carry no cost, so they surface
+  # only as counts.
+  class UsageReport
+    extend T::Sig
+
+    WINDOW = 30.days
+
+    sig { params(pool: FundingPool, window: ActiveSupport::Duration).returns(T::Hash[Symbol, T.untyped]) }
+    def self.pool_report(pool, window: WINDOW)
+      completed = LLMUsageRecord.completed.where(funding_pool_id: pool.id, completed_at: window.ago..)
+      spend_by_customer = completed.group(:payer_stripe_customer_id).sum(:estimated_cost_cents)
+      spend_by_agent = completed.group(:ai_agent_id).sum(:estimated_cost_cents)
+
+      pending = LLMUsageRecord.where(funding_pool_id: pool.id, status: "pending")
+
+      {
+        total_cents: spend_by_customer.values.sum,
+        member_rows: pool_member_rows(pool, spend_by_customer),
+        agent_rows: agent_rows(spend_by_agent),
+        pending_count: pending.count,
+        stale_pending_count: pending.where(occurred_at: ...LLMUsageRecord::PENDING_RESERVATION_WINDOW.ago).count,
+      }
+    end
+
+    sig { params(user: User, window: ActiveSupport::Duration).returns(T.nilable(T::Hash[Symbol, T.untyped])) }
+    def self.funding_report(user, window: WINDOW)
+      customer = user.stripe_customer
+      return nil if customer.nil?
+
+      completed = LLMUsageRecord.completed.where(payer_stripe_customer_id: customer.stripe_id, completed_at: window.ago..)
+      pool_draws = completed.where.not(funding_pool_id: nil)
+      drawn_by_pool = pool_draws.group(:funding_pool_id).sum(:estimated_cost_cents)
+      spend_by_agent = completed.group(:ai_agent_id).sum(:estimated_cost_cents)
+
+      {
+        enrollment_rows: funding_enrollment_rows(user, drawn_by_pool),
+        agent_rows: agent_rows(spend_by_agent),
+        total_billed_cents: completed.sum(:estimated_cost_cents),
+        pool_draw_cents: pool_draws.sum(:estimated_cost_cents),
+      }
+    end
+
+    # One row per active enrollment (zero-spend members included), plus a row
+    # for any customer with window spend who is no longer actively enrolled
+    # (withdrawn members whose past draws still show up). Sorted by spend, then
+    # name.
+    sig do
+      params(pool: FundingPool, spend_by_customer: T::Hash[String, T.untyped]).returns(T::Array[T::Hash[Symbol, T.untyped]])
+    end
+    def self.pool_member_rows(pool, spend_by_customer)
+      enrolled_user_ids = FundingPoolEnrollment.tenant_scoped_only(pool.tenant_id)
+        .where(funding_pool_id: pool.id, archived_at: nil)
+        .pluck(:user_id)
+      users_by_id = User.where(id: enrolled_user_ids).index_by(&:id)
+      stripe_id_by_user = StripeCustomer.where(billable_type: "User", billable_id: enrolled_user_ids)
+        .pluck(:billable_id, :stripe_id).to_h
+      enrolled_stripe_ids = stripe_id_by_user.values
+
+      rows = enrolled_user_ids.filter_map do |user_id|
+        user = users_by_id[user_id]
+        next if user.nil?
+
+        stripe_id = stripe_id_by_user[user_id]
+        spend = (stripe_id && spend_by_customer[stripe_id]) || 0
+        { user: user, spend_cents: spend }
+      end
+
+      withdrawn_stripe_ids = spend_by_customer.keys - enrolled_stripe_ids
+      user_id_by_stripe_id = StripeCustomer.where(billable_type: "User", stripe_id: withdrawn_stripe_ids)
+        .pluck(:stripe_id, :billable_id).to_h
+      withdrawn_users = User.where(id: user_id_by_stripe_id.values).index_by(&:id)
+      withdrawn_stripe_ids.each do |stripe_id|
+        user = withdrawn_users[user_id_by_stripe_id[stripe_id]]
+        next if user.nil?
+
+        rows << { user: user, spend_cents: spend_by_customer[stripe_id] }
+      end
+
+      rows.sort_by { |row| [-row[:spend_cents], row[:user].display_name.to_s] }
+    end
+
+    # The user's active enrollments across every tenant, each with the amount
+    # this pool has drawn from the user in the window. Pool and collective are
+    # loaded by explicit tenant scope — associations off a cross-tenant row
+    # misbehave under the current request's scoping.
+    sig { params(user: User, drawn_by_pool: T::Hash[String, T.untyped]).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+    def self.funding_enrollment_rows(user, drawn_by_pool)
+      FundingPoolEnrollment.for_user_across_tenants(user).active.map do |enrollment|
+        pool = FundingPool.tenant_scoped_only(enrollment.tenant_id).find_by(id: enrollment.funding_pool_id)
+        collective = pool && Collective.tenant_scoped_only(enrollment.tenant_id).find_by(id: pool.collective_id)
+        {
+          enrollment: enrollment,
+          pool_name_or_collective_name: collective&.name,
+          drawn_cents: drawn_by_pool[enrollment.funding_pool_id] || 0,
+        }
+      end
+    end
+
+    # Agents with any completed spend in the grouped scope, spend descending.
+    sig { params(spend_by_agent: T::Hash[String, T.untyped]).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
+    def self.agent_rows(spend_by_agent)
+      agents_by_id = User.where(id: spend_by_agent.keys).index_by(&:id)
+      rows = spend_by_agent.filter_map do |agent_id, spend|
+        agent = agents_by_id[agent_id]
+        next if agent.nil? || spend.to_f <= 0
+
+        { agent: agent, spend_cents: spend }
+      end
+      rows.sort_by { |row| -row[:spend_cents] }
+    end
+  end
+end

--- a/app/services/llm_gateway/usage_report.rb
+++ b/app/services/llm_gateway/usage_report.rb
@@ -99,6 +99,7 @@ module LLMGateway
         {
           enrollment: enrollment,
           pool_name_or_collective_name: collective&.name,
+          pool_url: collective && "#{collective.url}/pool",
           drawn_cents: drawn_by_pool[enrollment.funding_pool_id] || 0,
         }
       end

--- a/app/views/billing/_funding_section.html.erb
+++ b/app/views/billing/_funding_section.html.erb
@@ -11,7 +11,7 @@
         <tbody>
           <% @funding_report[:enrollment_rows].each do |row| %>
             <tr>
-              <td><%= octicon 'people', height: 14 %> <%= row[:pool_name_or_collective_name] %></td>
+              <td><%= octicon 'people', height: 14 %> <% if row[:pool_url] %><%= link_to row[:pool_name_or_collective_name], row[:pool_url], class: "pulse-link" %><% else %><%= row[:pool_name_or_collective_name] %><% end %></td>
               <td style="text-align: right; color: var(--color-fg-muted);">
                 ceiling <%= number_to_currency(row[:enrollment].draw_cap_cents / 100.0) %>/<%= row[:enrollment].draw_cap_period %>
               </td>

--- a/app/views/billing/_funding_section.html.erb
+++ b/app/views/billing/_funding_section.html.erb
@@ -1,0 +1,38 @@
+<%# Pool funding this user provides: which collectives they help fund, how much
+    has been drawn from their credits, and which of their agents spent it. Shown
+    only when there is something to show — an enrollment or billed usage. %>
+<% if @funding_report && (@funding_report[:enrollment_rows].any? || @funding_report[:total_billed_cents].to_f > 0) %>
+  <section class="pulse-section" style="margin-bottom: 24px;">
+    <h2 class="pulse-section-title">Funding you provide</h2>
+
+    <% if @funding_report[:enrollment_rows].any? %>
+      <p class="pulse-muted" style="margin-bottom: 12px;">Collectives whose agents you fund from your prepaid credits.</p>
+      <table class="pulse-table" style="max-width: 640px; margin-bottom: 16px;">
+        <tbody>
+          <% @funding_report[:enrollment_rows].each do |row| %>
+            <tr>
+              <td><%= octicon 'people', height: 14 %> <%= row[:pool_name_or_collective_name] %></td>
+              <td style="text-align: right; color: var(--color-fg-muted);">
+                ceiling <%= number_to_currency(row[:enrollment].draw_cap_cents / 100.0) %>/<%= row[:enrollment].draw_cap_period %>
+              </td>
+              <td style="text-align: right;"><%= number_to_currency(row[:drawn_cents].to_f / 100) %> drawn (last 30 days)</td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+
+    <% if @funding_report[:agent_rows].any? %>
+      <p style="font-weight: 600; margin-bottom: 8px;">Your agents' usage (last 30 days)</p>
+      <ul class="pulse-list" style="margin-bottom: 16px;">
+        <% @funding_report[:agent_rows].each do |row| %>
+          <li><%= row[:agent].display_name %> — <%= number_to_currency(row[:spend_cents].to_f / 100) %></li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <p>
+      Billed to your credits: <strong><%= number_to_currency(@funding_report[:total_billed_cents].to_f / 100) %></strong> (last 30 days)<% if @funding_report[:pool_draw_cents].to_f > 0 %>, of which <%= number_to_currency(@funding_report[:pool_draw_cents].to_f / 100) %> via funding pools<% end %>.
+    </p>
+  </section>
+<% end %>

--- a/app/views/billing/_funding_section.md.erb
+++ b/app/views/billing/_funding_section.md.erb
@@ -1,0 +1,25 @@
+<%# Pool funding this user provides — the markdown counterpart of the HTML
+    funding section. Shown only when there is something to show: an active
+    enrollment or billed usage. %>
+<% if @funding_report && (@funding_report[:enrollment_rows].any? || @funding_report[:total_billed_cents].to_f > 0) %>
+## Funding you provide
+<% if @funding_report[:enrollment_rows].any? -%>
+
+Collectives whose agents you fund from your prepaid credits:
+
+| Collective | Ceiling | Drawn (last 30 days) |
+|------------|---------|----------------------|
+<% @funding_report[:enrollment_rows].each do |row| -%>
+| <%= row[:pool_name_or_collective_name] %> | <%= format("$%.2f", row[:enrollment].draw_cap_cents / 100.0) %>/<%= row[:enrollment].draw_cap_period %> | <%= format("$%.2f", row[:drawn_cents].to_f / 100) %> |
+<% end -%>
+<% end -%>
+<% if @funding_report[:agent_rows].any? -%>
+
+Your agents' usage (last 30 days):
+<% @funding_report[:agent_rows].each do |row| -%>
+* <%= row[:agent].display_name %> — <%= format("$%.2f", row[:spend_cents].to_f / 100) %>
+<% end -%>
+<% end -%>
+
+Billed to your credits: **<%= format("$%.2f", @funding_report[:total_billed_cents].to_f / 100) %>** (last 30 days)<%= format(", of which $%.2f via funding pools", @funding_report[:pool_draw_cents].to_f / 100) if @funding_report[:pool_draw_cents].to_f > 0 %>.
+<% end %>

--- a/app/views/billing/_funding_section.md.erb
+++ b/app/views/billing/_funding_section.md.erb
@@ -10,7 +10,7 @@ Collectives whose agents you fund from your prepaid credits:
 | Collective | Ceiling | Drawn (last 30 days) |
 |------------|---------|----------------------|
 <% @funding_report[:enrollment_rows].each do |row| -%>
-| <%= row[:pool_name_or_collective_name] %> | <%= format("$%.2f", row[:enrollment].draw_cap_cents / 100.0) %>/<%= row[:enrollment].draw_cap_period %> | <%= format("$%.2f", row[:drawn_cents].to_f / 100) %> |
+| <% if row[:pool_url] %>[<%= row[:pool_name_or_collective_name] %>](<%= row[:pool_url] %>)<% else %><%= row[:pool_name_or_collective_name] %><% end %> | <%= format("$%.2f", row[:enrollment].draw_cap_cents / 100.0) %>/<%= row[:enrollment].draw_cap_period %> | <%= format("$%.2f", row[:drawn_cents].to_f / 100) %> |
 <% end -%>
 <% end -%>
 <% if @funding_report[:agent_rows].any? -%>

--- a/app/views/billing/show.html.erb
+++ b/app/views/billing/show.html.erb
@@ -125,6 +125,7 @@
       <% end %>
 
       <%= render "billing/credits_section" %>
+      <%= render "billing/funding_section" %>
 
     <% elsif @billable_quantity && @billable_quantity == 0 %>
       <%# === No subscription needed — nothing billable yet (or fully exempt) === %>
@@ -141,6 +142,7 @@
           credits are a separate one-time top-up that powers internal agents. %>
       <% if @current_tenant&.feature_enabled?("stripe_billing") %>
         <%= render "billing/credits_section" %>
+        <%= render "billing/funding_section" %>
       <% end %>
 
       <section class="pulse-section" style="margin-bottom: 24px;">

--- a/app/views/billing/show.md.erb
+++ b/app/views/billing/show.md.erb
@@ -75,7 +75,7 @@ Add funds to run AI agents.
 <% end %>
 
 To add credits, visit `/billing` in your browser and use the "Add Funds" button.
-
+<%= render "billing/funding_section" %>
 <% elsif @billable_quantity && @billable_quantity == 0 %>
 ## Status
 
@@ -94,7 +94,7 @@ Billable items will show up here when created. AI agents cost $3/month each.
 <% @active_collectives&.each do |collective| %>
 | <%= collective.name %> (collective) |
 <% end %>
-
+<%= render "billing/funding_section" %>
 <% else %>
 ## Status
 

--- a/app/views/collectives/pool.html.erb
+++ b/app/views/collectives/pool.html.erb
@@ -51,12 +51,29 @@
       you may be enrolled in count against those pools' ceilings, not this one's.
     </p>
 
+    <p class="pulse-body-text">
+      <strong>Usage (last 30 days):</strong>
+      <%= number_to_currency(@usage_report[:total_cents].to_f / 100) %>
+      <% if @usage_report[:pending_count] > 0 %>
+        — <%= pluralize(@usage_report[:pending_count], "call") %> in flight<%= ", #{@usage_report[:stale_pending_count]} stale" if @usage_report[:stale_pending_count] > 0 %>.
+      <% end %>
+    </p>
+
+    <% agent_spend_by_id = @usage_report[:agent_rows].to_h { |r| [r[:agent]&.id, r[:spend_cents]] } %>
+    <% enrolled_user_ids = @pool_enrollments.map(&:user_id) %>
+
     <section class="pulse-settings-section">
       <h2 class="pulse-section-title">Enrolled Members</h2>
-      <% if @pool_enrollments.any? %>
+      <% if @usage_report[:member_rows].any? %>
         <ul class="pulse-list">
-          <% @pool_enrollments.each do |enrollment| %>
-            <li><%= link_to enrollment.user.display_name, enrollment.user.path %></li>
+          <% @usage_report[:member_rows].each do |row| %>
+            <li>
+              <%= link_to row[:user].display_name, row[:user].path %>
+              <% unless enrolled_user_ids.include?(row[:user].id) %>
+                <span class="pulse-muted">(withdrawn)</span>
+              <% end %>
+              <span class="pulse-muted">— <%= number_to_currency(row[:spend_cents].to_f / 100) %> (last 30 days)</span>
+            </li>
           <% end %>
         </ul>
       <% else %>
@@ -66,7 +83,6 @@
 
     <section class="pulse-settings-section">
       <h2 class="pulse-section-title">Funded Agents</h2>
-      <% enrolled_user_ids = @pool_enrollments.map(&:user_id) %>
       <% if @funded_agents.any? %>
         <ul class="pulse-list">
           <% @funded_agents.each do |agent| %>
@@ -74,6 +90,9 @@
               <%= link_to agent.display_name, agent.path %>
               <% if agent.parent %>
                 <span class="pulse-muted">— principal <%= link_to agent.parent.display_name, agent.parent.path %></span>
+              <% end %>
+              <% if agent_spend_by_id[agent.id] %>
+                <span class="pulse-muted">— <%= number_to_currency(agent_spend_by_id[agent.id].to_f / 100) %> (last 30 days)</span>
               <% end %>
               <% unless agent.parent_id && enrolled_user_ids.include?(agent.parent_id) %>
                 <span class="pulse-muted">— not running: principal not enrolled. Runs again when the principal re-enrolls, or when it is detached and given its own billing.</span>

--- a/app/views/collectives/pool.md.erb
+++ b/app/views/collectives/pool.md.erb
@@ -17,6 +17,25 @@ Each LLM call an attached agent makes is billed to one enrolled member's own pre
 <% enrolled_user_ids = @pool_enrollments.map(&:user_id) -%>
 | Funded agents | <%= @funded_agents.any? ? @funded_agents.map { |a| "[#{a.display_name}](#{a.path})#{" (not running — principal not enrolled)" unless a.parent_id && enrolled_user_ids.include?(a.parent_id)}" }.join(", ") : "(none yet)" %> |
 | Your enrollment | <%= @current_user_enrolled ? format("Enrolled — this pool's agents can draw from your prepaid balance, up to your own ceiling of $%.2f per day (or the pool's ceiling, whichever is lower)", @current_user_enrollment.draw_cap_cents / 100.0) : "Not enrolled" %> |
+| Spend (last 30 days) | <%= format("$%.2f", @usage_report[:total_cents].to_f / 100) %> |
+<% if @usage_report[:pending_count] > 0 -%>
+| Calls in flight | <%= @usage_report[:pending_count] %><%= " (#{@usage_report[:stale_pending_count]} stale)" if @usage_report[:stale_pending_count] > 0 %> |
+<% end -%>
+<% if @usage_report[:member_rows].any? { |r| r[:spend_cents].to_f > 0 } -%>
+
+Member spend (last 30 days):
+<% @usage_report[:member_rows].each do |row| -%>
+<% next if row[:spend_cents].to_f <= 0 -%>
+* <%= row[:user].display_name %><%= " (withdrawn)" unless @pool_enrollments.any? { |e| e.user_id == row[:user].id } %> — <%= format("$%.2f", row[:spend_cents].to_f / 100) %>
+<% end -%>
+<% end -%>
+<% if @usage_report[:agent_rows].any? -%>
+
+Agent spend (last 30 days):
+<% @usage_report[:agent_rows].each do |row| -%>
+* <%= row[:agent].display_name %> — <%= format("$%.2f", row[:spend_cents].to_f / 100) %>
+<% end -%>
+<% end -%>
 
 The pool stops drawing from a member once its draws from them reach the ceiling for the day; each member also sets their own ceiling when enrolling, and the lower of the two applies. Ceilings are per pool — draws by other pools count against those pools' ceilings, not this one's.
 

--- a/test/controllers/billing_controller_test.rb
+++ b/test/controllers/billing_controller_test.rb
@@ -1063,6 +1063,9 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Funding you provide/i, response.body)
     assert_match(/\$2\.75/, response.body)
     assert_match(/Funded Bot/, response.body)
+    pool_href = "#{Collective.tenant_scoped_only(pool.tenant_id).find(pool.collective_id).url}/pool"
+    assert_match(/<a[^>]+href="#{Regexp.escape(pool_href)}"[^>]*>[^<]*Pool Collective/, response.body,
+                 "expected the collective name to link to its pool page")
   end
 
   test "show hides the funding section for a subscriber with no pool funding" do
@@ -1109,6 +1112,9 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match(/Funding you provide/i, response.body)
     assert_match(/\$1\.50/, response.body)
+    pool_href = "#{Collective.tenant_scoped_only(pool.tenant_id).find(pool.collective_id).url}/pool"
+    assert_match("[Pool Collective](#{pool_href})", response.body,
+                 "expected the collective name to render as a markdown link to its pool page")
   end
 
   private

--- a/test/controllers/billing_controller_test.rb
+++ b/test/controllers/billing_controller_test.rb
@@ -1048,7 +1048,103 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
       "Agent should be pending when sync discovers subscription is cancelled"
   end
 
+  # === Funding you provide ===
+
+  test "show renders the funding-you-provide section for an enrolled member with pool draws" do
+    pool = setup_pool_funding!(stripe_id: "cus_funder")
+    agent = create_ai_agent(parent: @user, name: "Funded Bot")
+    @tenant.add_user!(agent)
+    record_funding_spend!(pool, stripe_id: "cus_funder", cents: 275, agent: agent)
+    sign_in_as(@user, tenant: @tenant)
+
+    get "/billing"
+
+    assert_response :success
+    assert_match(/Funding you provide/i, response.body)
+    assert_match(/\$2\.75/, response.body)
+    assert_match(/Funded Bot/, response.body)
+  end
+
+  test "show hides the funding section for a subscriber with no pool funding" do
+    StripeCustomer.create!(billable: @user, stripe_id: "cus_plain", stripe_subscription_id: "sub_plain", active: true)
+    sign_in_as(@user, tenant: @tenant)
+
+    get "/billing"
+
+    assert_response :success
+    assert_no_match(/Funding you provide/i, response.body)
+  end
+
+  test "the markdown billing page shows the funding section to a free account funding a pool" do
+    # An app admin owes no per-identity fee (billable_quantity 0), so their
+    # customer's active flag is legitimately false — yet they can still fund
+    # pools from prepaid credits, and their /billing markdown must say so.
+    @user.update!(app_admin: true)
+    pool = setup_pool_funding!(stripe_id: "cus_free_funder", active: false)
+    agent = create_ai_agent(parent: @user, name: "Free Funded Bot")
+    @tenant.add_user!(agent)
+    record_funding_spend!(pool, stripe_id: "cus_free_funder", cents: 325, agent: agent)
+    sign_in_as(@user, tenant: @tenant)
+
+    get "/billing", headers: { "Accept" => "text/markdown" }
+
+    assert_response :success
+    assert_match(/nothing to pay/i, response.body, "expected the free-account branch")
+    assert_match(/Funding you provide/i, response.body)
+    assert_match(/\$3\.25/, response.body)
+  ensure
+    @user.update!(app_admin: false)
+    @user.reload.stripe_customer&.destroy
+  end
+
+  test "the markdown billing page includes the funding section" do
+    pool = setup_pool_funding!(stripe_id: "cus_funder_md")
+    agent = create_ai_agent(parent: @user, name: "MD Funded Bot")
+    @tenant.add_user!(agent)
+    record_funding_spend!(pool, stripe_id: "cus_funder_md", cents: 150, agent: agent)
+    sign_in_as(@user, tenant: @tenant)
+
+    get "/billing", headers: { "Accept" => "text/markdown" }
+
+    assert_response :success
+    assert_match(/Funding you provide/i, response.body)
+    assert_match(/\$1\.50/, response.body)
+  end
+
   private
+
+  # Fund @user, open a pool on a fresh standard collective, and enroll them —
+  # the minimum arrangement for the funding-you-provide section to have content.
+  def setup_pool_funding!(stripe_id:, active: true)
+    StripeCustomer.create!(
+      billable: @user, stripe_id: stripe_id, active: active, pricing_plan_subscription_id: "bpps_#{SecureRandom.hex(4)}"
+    )
+    FeatureFlagService.config["funding_pools"] ||= {}
+    FeatureFlagService.config["funding_pools"]["app_enabled"] = true
+    @tenant.enable_feature_flag!("funding_pools")
+    collective = create_test_collective(name: "Pool Collective")
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    collective.enable_feature_flag!("funding_pools")
+    pool = FundingPool.create!(tenant: @tenant, collective: collective, created_by: @user, member_draw_cap_cents: 500)
+    pool.enroll!(@user, draw_cap_cents: 500)
+    pool
+  ensure
+    Tenant.clear_thread_scope
+  end
+
+  def record_funding_spend!(pool, stripe_id:, cents:, agent:)
+    LLMUsageRecord.create!(
+      selection_id: "sel_#{SecureRandom.uuid}",
+      status: "completed",
+      ai_agent_id: agent.id,
+      payer_stripe_customer_id: stripe_id,
+      origin_tenant_id: @tenant.id,
+      funding_pool_id: pool.id,
+      estimated_cost_cents: cents,
+      occurred_at: Time.current,
+      completed_at: Time.current,
+    )
+  end
 
   def enable_stripe_billing_flag!(tenant)
     FeatureFlagService.config["stripe_billing"] ||= {}

--- a/test/controllers/collectives_controller_test.rb
+++ b/test/controllers/collectives_controller_test.rb
@@ -2649,6 +2649,69 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
 
   # === Member-facing pool page ===
 
+  def record_pool_spend!(pool, stripe_id:, cents:, agent:)
+    LLMUsageRecord.create!(
+      selection_id: "sel_#{SecureRandom.uuid}",
+      status: "completed",
+      ai_agent_id: agent.id,
+      payer_stripe_customer_id: stripe_id,
+      origin_tenant_id: @tenant.id,
+      funding_pool_id: pool.id,
+      estimated_cost_cents: cents,
+      occurred_at: Time.current,
+      completed_at: Time.current,
+    )
+  end
+
+  test "the pool page shows member and agent spend for the last 30 days" do
+    collective = create_test_collective
+    enable_funding_pools!(collective)
+    pool = create_pool!(collective)
+    fund_user!(@user, stripe_id: "cus_pool_spend")
+    enroll!(pool, @user)
+    alpha = create_ai_agent(parent: @user, name: "Alpha Bot")
+    beta = create_ai_agent(parent: @user, name: "Beta Bot")
+    @tenant.add_user!(alpha)
+    @tenant.add_user!(beta)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    alpha.update!(funding_pool: pool)
+    beta.update!(funding_pool: pool)
+    Tenant.clear_thread_scope
+    record_pool_spend!(pool, stripe_id: "cus_pool_spend", cents: 100, agent: alpha)
+    record_pool_spend!(pool, stripe_id: "cus_pool_spend", cents: 50, agent: beta)
+    sign_in_as(@user, tenant: @tenant)
+
+    get "#{collective.path}/pool"
+
+    assert_response :success
+    assert_match(/Usage \(last 30 days\)/, response.body)
+    assert_match(/\$1\.50/, response.body) # member total and pool total
+    assert_match(/\$1\.00/, response.body) # Alpha Bot's spend
+    assert_match(/\$0\.50/, response.body) # Beta Bot's spend
+  end
+
+  test "the markdown pool page shows spend figures" do
+    collective = create_test_collective
+    enable_funding_pools!(collective)
+    pool = create_pool!(collective)
+    fund_user!(@user, stripe_id: "cus_pool_md")
+    enroll!(pool, @user)
+    agent = create_ai_agent(parent: @user, name: "Ledger Bot")
+    @tenant.add_user!(agent)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    agent.update!(funding_pool: pool)
+    Tenant.clear_thread_scope
+    record_pool_spend!(pool, stripe_id: "cus_pool_md", cents: 275, agent: agent)
+    sign_in_as(@user, tenant: @tenant)
+
+    get "#{collective.path}/pool", headers: { "Accept" => "text/markdown" }
+
+    assert_response :success
+    assert_match(/Spend \(last 30 days\)/, response.body)
+    assert_match(/\$2\.75/, response.body)
+    assert_match(/Ledger Bot/, response.body)
+  end
+
   def add_funded_member!(collective, name: "Pool Member")
     member = create_user(name: name)
     @tenant.add_user!(member)

--- a/test/services/llm_gateway/payer_resolver_test.rb
+++ b/test/services/llm_gateway/payer_resolver_test.rb
@@ -278,14 +278,18 @@ module LLMGateway
     end
 
     test "a call opened yesterday but completed today counts toward the daily cap" do
-      create_stamped_billing_customer!
-      @ai_agent.update!(llm_daily_spend_cap_cents: 100)
-      record_spend!("cus_individual", 100, occurred_at: 25.hours.ago, completed_at: 1.minute.ago)
+      # Anchored at noon so "1 minute ago" cannot slip past the cap's
+      # midnight-UTC boundary when the test itself runs near midnight.
+      travel_to Time.utc(2026, 7, 15, 12) do
+        create_stamped_billing_customer!
+        @ai_agent.update!(llm_daily_spend_cap_cents: 100)
+        record_spend!("cus_individual", 100, occurred_at: 25.hours.ago, completed_at: 1.minute.ago)
 
-      error = assert_raises(PayerResolver::ResolutionError) do
-        PayerResolver.resolve(@task_run)
+        error = assert_raises(PayerResolver::ResolutionError) do
+          PayerResolver.resolve(@task_run)
+        end
+        assert_equal "spend_cap_exceeded", error.code
       end
-      assert_equal "spend_cap_exceeded", error.code
     end
 
     test "the daily spend cap also gates pool-funded agents" do

--- a/test/services/llm_gateway/usage_report_test.rb
+++ b/test/services/llm_gateway/usage_report_test.rb
@@ -181,5 +181,43 @@ module LLMGateway
 
       assert_equal 100, report[:total_billed_cents]
     end
+
+    test "funding_report includes a pool_url linking each enrollment to the collective's pool page" do
+      pool = create_funding_pool!(primary_stripe_id: "cus_primary")
+
+      report = UsageReport.funding_report(@user)
+
+      enrollment_row = report[:enrollment_rows].find { |r| r[:enrollment].funding_pool_id == pool.id }
+      assert_not_nil enrollment_row
+      assert_equal "#{@collective.url}/pool", enrollment_row[:pool_url]
+    end
+
+    test "funding_report pool_url for a cross-tenant enrollment carries the other tenant's subdomain" do
+      create_funding_pool!(primary_stripe_id: "cus_primary")
+      other_tenant, _other_collective, cross_pool = create_cross_tenant_pool!(subdomain: "othertenant")
+
+      report = UsageReport.funding_report(@user)
+
+      cross_row = report[:enrollment_rows].find { |r| r[:enrollment].funding_pool_id == cross_pool.id }
+      assert_not_nil cross_row
+      assert_includes cross_row[:pool_url], other_tenant.subdomain
+      assert cross_row[:pool_url].end_with?("/pool"), "expected the pool page path"
+    end
+
+    # A pool in a second tenant that @user is also enrolled in, exercising the
+    # cross-tenant URL path (the /billing page's tenant differs from the pool's).
+    def create_cross_tenant_pool!(subdomain:)
+      other_tenant = create_tenant(subdomain: subdomain, name: "Other Tenant")
+      other_tenant.add_user!(@user)
+      other_collective = create_collective(tenant: other_tenant, created_by: @user, handle: "cross-#{SecureRandom.hex(4)}")
+      other_collective.add_user!(@user)
+      pool = FundingPool.create!(tenant: other_tenant, collective: other_collective, created_by: @user, member_draw_cap_cents: 500)
+      Tenant.scope_thread_to_tenant(subdomain: subdomain)
+      pool.enroll!(@user, draw_cap_cents: 500)
+      [other_tenant, other_collective, pool]
+    ensure
+      Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+      Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    end
   end
 end

--- a/test/services/llm_gateway/usage_report_test.rb
+++ b/test/services/llm_gateway/usage_report_test.rb
@@ -1,0 +1,185 @@
+# typed: false
+
+require "test_helper"
+
+module LLMGateway
+  class UsageReportTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::TimeHelpers
+
+    setup do
+      @tenant, @collective, @user = create_tenant_collective_user
+      @tenant.enable_feature_flag!("internal_ai_agents")
+      Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+      @ai_agent = create_ai_agent(parent: @user)
+    end
+
+    def create_funding_pool!(primary_stripe_id: "cus_primary", primary_cap: 500)
+      FeatureFlagService.config["funding_pools"] ||= {}
+      FeatureFlagService.config["funding_pools"]["app_enabled"] = true
+      @tenant.enable_feature_flag!("funding_pools")
+      @collective.enable_feature_flag!("funding_pools")
+      pool = FundingPool.create!(tenant: @tenant, collective: @collective, created_by: @user, member_draw_cap_cents: 500)
+      fund!(@user, stripe_id: primary_stripe_id)
+      pool.enroll!(@user, draw_cap_cents: primary_cap)
+      pool
+    end
+
+    def create_enrolled_member!(pool, stripe_id:, cap: 500, name: "Pool Member")
+      member = create_user(name: name)
+      @tenant.add_user!(member)
+      @collective.add_user!(member)
+      fund!(member, stripe_id: stripe_id)
+      pool.enroll!(member, draw_cap_cents: cap)
+      member
+    end
+
+    def create_other_pool!
+      other = create_collective(tenant: @tenant, created_by: @user, handle: "other-#{SecureRandom.hex(4)}")
+      other.add_user!(@user)
+      FundingPool.create!(tenant: @tenant, collective: other, created_by: @user, member_draw_cap_cents: 500)
+    end
+
+    def fund!(user, stripe_id:, active: true, pricing_plan_subscription_id: "bpps_#{SecureRandom.hex(4)}")
+      StripeCustomer.create!(
+        billable: user,
+        stripe_id: stripe_id,
+        active: active,
+        pricing_plan_subscription_id: pricing_plan_subscription_id,
+      )
+    end
+
+    def record_spend!(stripe_id, cents, funding_pool_id: nil, agent: @ai_agent, status: "completed",
+                      occurred_at: Time.current, completed_at: occurred_at)
+      LLMUsageRecord.create!(
+        selection_id: "sel_#{SecureRandom.uuid}",
+        status: status,
+        ai_agent_id: agent.id,
+        payer_stripe_customer_id: stripe_id,
+        origin_tenant_id: @tenant.id,
+        funding_pool_id: funding_pool_id,
+        estimated_cost_cents: status == "completed" ? cents : nil,
+        occurred_at: occurred_at,
+        completed_at: status == "completed" ? completed_at : nil,
+      )
+    end
+
+    def open_call!(stripe_id, funding_pool_id: nil, agent: @ai_agent, occurred_at: Time.current)
+      LLMUsageRecord.create!(
+        selection_id: "sel_#{SecureRandom.uuid}",
+        status: "pending",
+        ai_agent_id: agent.id,
+        payer_stripe_customer_id: stripe_id,
+        origin_tenant_id: @tenant.id,
+        funding_pool_id: funding_pool_id,
+        occurred_at: occurred_at,
+      )
+    end
+
+    # === pool_report ===
+
+    test "pool_report sums completed spend per member and per agent within the window" do
+      pool = create_funding_pool!(primary_stripe_id: "cus_primary")
+      member_b = create_enrolled_member!(pool, stripe_id: "cus_member_b", name: "Member B")
+      agent_2 = create_ai_agent(parent: @user, name: "Agent Two")
+      record_spend!("cus_primary", 100, funding_pool_id: pool.id, agent: @ai_agent)
+      record_spend!("cus_member_b", 250, funding_pool_id: pool.id, agent: agent_2)
+
+      report = UsageReport.pool_report(pool)
+
+      assert_equal 350, report[:total_cents]
+      member_spend = report[:member_rows].to_h { |r| [r[:user].id, r[:spend_cents]] }
+      assert_equal 100, member_spend[@user.id]
+      assert_equal 250, member_spend[member_b.id]
+      agent_spend = report[:agent_rows].to_h { |r| [r[:agent].id, r[:spend_cents]] }
+      assert_equal 100, agent_spend[@ai_agent.id]
+      assert_equal 250, agent_spend[agent_2.id]
+    end
+
+    test "pool_report excludes failed rows, other pools, and rows older than the window" do
+      pool = create_funding_pool!(primary_stripe_id: "cus_primary")
+      other_pool = create_other_pool!
+      record_spend!("cus_primary", 100, funding_pool_id: pool.id)
+      record_spend!("cus_primary", 500, funding_pool_id: pool.id, occurred_at: 40.days.ago, completed_at: 40.days.ago)
+      record_spend!("cus_primary", 700, funding_pool_id: other_pool.id)
+      record_spend!("cus_primary", 900, funding_pool_id: pool.id, status: "failed")
+
+      report = UsageReport.pool_report(pool)
+
+      assert_equal 100, report[:total_cents]
+    end
+
+    test "pool_report includes zero-spend active enrollees" do
+      pool = create_funding_pool!(primary_stripe_id: "cus_primary")
+      member_b = create_enrolled_member!(pool, stripe_id: "cus_member_b", name: "Member B")
+      record_spend!("cus_primary", 100, funding_pool_id: pool.id)
+
+      report = UsageReport.pool_report(pool)
+
+      row = report[:member_rows].find { |r| r[:user].id == member_b.id }
+      assert_not_nil row, "a zero-spend active enrollee must still appear"
+      assert_equal 0, row[:spend_cents]
+    end
+
+    test "pool_report includes a withdrawn member who has window spend" do
+      pool = create_funding_pool!(primary_stripe_id: "cus_primary")
+      departed = create_enrolled_member!(pool, stripe_id: "cus_departed", name: "Departed Member")
+      record_spend!("cus_departed", 80, funding_pool_id: pool.id)
+      pool.enrollments.find_by!(user: departed).withdraw!
+
+      report = UsageReport.pool_report(pool)
+
+      row = report[:member_rows].find { |r| r[:user].id == departed.id }
+      assert_not_nil row, "a withdrawn member with window spend must still appear"
+      assert_equal 80, row[:spend_cents]
+    end
+
+    test "pool_report counts pending and stale pending rows" do
+      pool = create_funding_pool!(primary_stripe_id: "cus_primary")
+      open_call!("cus_primary", funding_pool_id: pool.id, occurred_at: 1.minute.ago)
+      open_call!("cus_primary", funding_pool_id: pool.id, occurred_at: 16.minutes.ago)
+
+      report = UsageReport.pool_report(pool)
+
+      assert_equal 2, report[:pending_count]
+      assert_equal 1, report[:stale_pending_count]
+    end
+
+    # === funding_report ===
+
+    test "funding_report returns nil for a user with no stripe customer" do
+      other = create_user(name: "No Customer")
+      @tenant.add_user!(other)
+
+      assert_nil UsageReport.funding_report(other)
+    end
+
+    test "funding_report reports per-enrollment draws, agents, and totals; direct spend counts but is not a pool draw" do
+      pool = create_funding_pool!(primary_stripe_id: "cus_primary")
+      agent_2 = create_ai_agent(parent: @user, name: "Agent Two")
+      record_spend!("cus_primary", 100, funding_pool_id: pool.id, agent: @ai_agent)
+      record_spend!("cus_primary", 40, funding_pool_id: nil, agent: agent_2)
+
+      report = UsageReport.funding_report(@user)
+
+      assert_equal 140, report[:total_billed_cents]
+      assert_equal 100, report[:pool_draw_cents]
+      enrollment_row = report[:enrollment_rows].find { |r| r[:enrollment].funding_pool_id == pool.id }
+      assert_not_nil enrollment_row
+      assert_equal 100, enrollment_row[:drawn_cents]
+      agent_spend = report[:agent_rows].to_h { |r| [r[:agent].id, r[:spend_cents]] }
+      assert_equal 100, agent_spend[@ai_agent.id]
+      assert_equal 40, agent_spend[agent_2.id]
+    end
+
+    test "funding_report excludes rows paid by a different customer" do
+      pool = create_funding_pool!(primary_stripe_id: "cus_primary")
+      create_enrolled_member!(pool, stripe_id: "cus_member_b", name: "Member B")
+      record_spend!("cus_primary", 100, funding_pool_id: pool.id)
+      record_spend!("cus_member_b", 999, funding_pool_id: pool.id)
+
+      report = UsageReport.funding_report(@user)
+
+      assert_equal 100, report[:total_billed_cents]
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds the usage-transparency surfaces for funding pools: members can now see where pool money goes, and funders can see what their credits paid for. This is the legibility/variance-mitigation companion to the random-draw billing model.

- **New `LLMGateway::UsageReport` service** — read-only rollups over the usage ledger. All cost sums cover completed calls anchored on `completed_at` within a 30-day window; pending calls carry no cost yet, so they surface as counts only. Queries ride the existing `(funding_pool_id, payer_stripe_customer_id, completed_at)` index.
- **Pool page** (HTML + markdown): total spend for the window, per-member incidence (zero-spend enrollees included; withdrawn members with window spend shown and marked), per-agent breakdown, and in-flight / stale-pending call visibility.
- **/billing "Funding you provide"** (HTML + markdown): the user's active pool enrollments across all tenants — each collective name linking to its pool page via `Collective#url`, so cross-tenant links carry the right subdomain — with ceiling and drawn amounts, spend billed to their credits broken down by agent, and a total with the pool-draw share. Rendered for both active subscribers and free accounts (admins/exempt users fund pools too, per #493), shown only when there's something to show.

## Test plan

- New `test/services/llm_gateway/usage_report_test.rb` (9 tests): per-member/per-agent sums, window and status filtering, zero-spend and withdrawn members, pending/stale counts, cross-tenant enrollments and pool URLs, payer isolation.
- Billing + collectives controller tests (7 new): HTML and markdown rendering on both pages, free-account markdown coverage, section hidden when there's nothing to show, pool-page links.
- Full runs of all touched test files green; rubocop clean on changed lines; `srb tc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)