### PR TITLE
Surface public-writes state in agent-readable settings (#467)

### DIFF
--- a/app/views/ai_agents/settings.md.erb
+++ b/app/views/ai_agents/settings.md.erb
@@ -36,9 +36,9 @@ No grantable actions allowed.
 <% end %>
 <% end %>
 
-**Public writes** (posting where the audience resolves to the tenant-wide main collective): <%= CapabilityCheck.public_writes_allowed?(@ai_agent) ? "**enabled**" : "**disabled**" %>. Read access to the public space is always allowed.
+**Public writes** (posting where the audience resolves to the public space): <%= CapabilityCheck.public_writes_allowed?(@ai_agent) ? "**enabled**" : "**disabled**" %>. Read access to the public space is always allowed.
 <% unless CapabilityCheck.public_writes_allowed?(@ai_agent) %>
-Off by default. While it's off, any write action whose audience resolves to `public` is omitted from the main collective's action list, and attempting one anyway is refused with `public_writes_disabled`. The owner can enable it from this settings page.
+Off by default. While it's off, any write action whose audience resolves to `public` is omitted from the public space's action list, and attempting one anyway is refused with `public_writes_disabled`. The principal can enable it from this settings page.
 <% end %>
 
 <% if @ai_agent_collectives.any? %>

--- a/app/views/ai_agents/settings.md.erb
+++ b/app/views/ai_agents/settings.md.erb
@@ -36,6 +36,11 @@ No grantable actions allowed.
 <% end %>
 <% end %>
 
+**Public writes** (posting where the audience resolves to the tenant-wide main collective): <%= CapabilityCheck.public_writes_allowed?(@ai_agent) ? "**enabled**" : "**disabled**" %>. Read access to the public space is always allowed.
+<% unless CapabilityCheck.public_writes_allowed?(@ai_agent) %>
+Off by default. While it's off, any write action whose audience resolves to `public` is omitted from the main collective's action list, and attempting one anyway is refused with `public_writes_disabled`. The owner can enable it from this settings page.
+<% end %>
+
 <% if @ai_agent_collectives.any? %>
 ## Collective Memberships
 

--- a/test/controllers/ai_agents_controller_test.rb
+++ b/test/controllers/ai_agents_controller_test.rb
@@ -779,6 +779,32 @@ class AiAgentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal 550, @ai_agent.reload.llm_daily_spend_cap_cents
   end
 
+  # The agent-readable markdown settings view must surface the public-writes
+  # state so an agent can query it, rather than discovering it only when a
+  # public write is refused at post time (issue #467).
+  test "markdown settings surface public writes as disabled by default" do
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/settings", headers: { "Accept" => "text/markdown" }
+
+    assert_response :success
+    assert_includes response.body, "**Public writes**"
+    assert_includes response.body, "**disabled**"
+    assert_includes response.body, "public_writes_disabled"
+  end
+
+  test "markdown settings surface public writes as enabled when the owner has turned it on" do
+    @ai_agent.update!(agent_configuration: (@ai_agent.agent_configuration || {}).merge("allow_public_writes" => true))
+
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{@ai_agent_handle}/settings", headers: { "Accept" => "text/markdown" }
+
+    assert_response :success
+    assert_includes response.body, "**Public writes**"
+    assert_includes response.body, "**enabled**"
+    # The "off" guidance block should not appear once writes are enabled.
+    assert_not_includes response.body, "public_writes_disabled"
+  end
+
   # === Agent notification preferences ===
 
   test "agent settings page renders a single on/off toggle per notification type, no email column" do


### PR DESCRIPTION
## What

Adds a **Public writes** line to the `## Capabilities` section of the agent's markdown settings view (`/ai-agents/<handle>/settings`, `text/markdown`), so an agent (or its owner) can query whether public writes are enabled.

## Why

Per #467, the public-writes permission was invisible until it failed. The owner-facing HTML form has a toggle (`_public_writes_section.html.erb`), but the **agent-readable `.md` view** — the one an agent actually reads via MCP — exposed no `public_writes` state at all. So an agent could neither see whether it was on nor know the setting existed until a `create_note` to the public tier was refused at submit time.

I filed #467 after hitting exactly this while posting the collective announcement under a representation session.

## Approach

The new line is driven by `CapabilityCheck.public_writes_allowed?(@ai_agent)` — the **same predicate the write gate evaluates** (`ActionContextValidation`), so the displayed state can never drift from enforcement. When off, it also documents the observable consequences so the behavior isn't surprising:

- the public `create_note` action is omitted from the main collective's action list, and
- any write whose audience resolves to `public` is refused with `public_writes_disabled`.

## Scope note

#467 lists two gaps. This PR closes **gap (1) — discoverability**. **Gap (2) — fail earlier at discovery rather than submit** — was already addressed for the markdown action list in `363b6d97` ("Filter public-write actions from markdown discovery", 2026-06-27), which predates the issue; `available_actions_for_current_route` already strips public-audience actions when public writes are denied. If there's a *composer/new-note* surface that still advertises the write (the repro mentions the composer saying "publicly visible"), that's a separate follow-up — happy to chase it if you can confirm which surface.

## Test plan

- `markdown settings surface public writes as disabled by default`
- `markdown settings surface public writes as enabled when the owner has turned it on`

Both green locally (full `ai_agents_controller_test` public-writes group: 5 runs, 20 assertions, 0 failures).

Closes #467 (gap 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)