### PR TITLE
needs_action triage facet for the notifications feed (#456)

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -13,11 +13,30 @@ class NotificationsController < ApplicationController
 
     # Show immediate notifications and due reminders (not future scheduled).
     # Read notifications stay in the inbox until dismissed.
-    @notification_recipients = NotificationRecipient
+    base_recipients = NotificationRecipient
       .where(user: current_user)
       .in_app
       .not_scheduled
       .undismissed
+
+    # needs_action triage facet (issue #456): let a reader — an agent especially
+    # — narrow the feed to notifications that call for a response/action, cutting
+    # the informational firehose. `?needs_action=true` filters; the facet count
+    # is always computed so the facet is discoverable even when not applied.
+    @needs_action_only = ActiveModel::Type::Boolean.new.cast(params[:needs_action])
+    @needs_action_count = base_recipients
+      .joins(:notification)
+      .where(notifications: { notification_type: Notification::NEEDS_ACTION_TYPES })
+      .count
+
+    scoped_recipients = base_recipients
+    if @needs_action_only
+      scoped_recipients = scoped_recipients
+        .joins(:notification)
+        .where(notifications: { notification_type: Notification::NEEDS_ACTION_TYPES })
+    end
+
+    @notification_recipients = scoped_recipients
       .includes(:notification)
       .order(created_at: :desc)
       .limit(50)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,6 +5,24 @@ class Notification < ApplicationRecord
 
   NOTIFICATION_TYPES = %w[mention comment participation system reminder chat_message trio_unavailable tune_in trustee_authorization role_change].freeze
 
+  # Types that call for a response or action from the recipient, as opposed to
+  # purely informational ("FYI") notices. Powers the needs_action triage facet
+  # on the notifications feed (issue #456) so an agent can separate "what
+  # requires my action" from the firehose.
+  #
+  # This is a deliberately high-precision cut — better to under-flag than to
+  # dilute the facet back into noise:
+  #   mention               — someone addressed me directly; questions and
+  #                           assignments arrive as mentions (incl. replies).
+  #   chat_message          — a direct message; expects a reply.
+  #   trustee_authorization — an authorization/approval request.
+  #   reminder              — a nudge the recipient scheduled for themselves;
+  #                           actionable by definition.
+  # Everything else (comment, participation, system, trio_unavailable, tune_in,
+  # role_change) is informational and stays out. If this cut needs retuning,
+  # this constant is the single source of truth.
+  NEEDS_ACTION_TYPES = %w[mention chat_message trustee_authorization reminder].freeze
+
   belongs_to :tenant
   belongs_to :event, optional: true
 
@@ -16,9 +34,17 @@ class Notification < ApplicationRecord
 
   scope :recent, -> { order(created_at: :desc) }
   scope :of_type, ->(type) { where(notification_type: type) }
+  scope :needs_action, -> { where(notification_type: NEEDS_ACTION_TYPES) }
 
   sig { returns(String) }
   def notification_category
     T.must(T.unsafe(self).notification_type)
+  end
+
+  # Does this notification call for a response or action, as opposed to being
+  # purely informational? See NEEDS_ACTION_TYPES.
+  sig { returns(T::Boolean) }
+  def needs_action?
+    NEEDS_ACTION_TYPES.include?(T.unsafe(self).notification_type)
   end
 end

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -10,6 +10,21 @@
 
   <%= render 'push_optin_banner' if @show_push_banner %>
 
+  <%# needs_action triage facet (issue #456): filter the feed to notifications
+      that call for a response/action. Always rendered so the "show all" escape
+      hatch is available even when the filtered feed is empty. %>
+  <% if @needs_action_only %>
+    <div class="pulse-notifications-summary" style="margin-bottom: 8px;">
+      <span class="pulse-notifications-count">Showing <strong>needs action</strong> only</span>
+      <a href="/notifications" class="pulse-action-btn-secondary">Show all</a>
+    </div>
+  <% elsif @needs_action_count.to_i > 0 %>
+    <div class="pulse-notifications-summary" style="margin-bottom: 8px;">
+      <span class="pulse-notifications-count"><strong><%= @needs_action_count %></strong> need action</span>
+      <a href="/notifications?needs_action=true" class="pulse-action-btn-secondary">Show only these</a>
+    </div>
+  <% end %>
+
   <div data-controller="notification-actions">
     <% if @notification_recipients.empty? %>
       <div class="pulse-notifications-empty">

--- a/app/views/notifications/index.md.erb
+++ b/app/views/notifications/index.md.erb
@@ -2,8 +2,14 @@
 
 Unread: <%= @unread_count %><% if @unread_count > 0 %> - [mark_all_read](/notifications/actions/mark_all_read) | [dismiss_all](/notifications/actions/dismiss_all)<% end %>
 
+<% if @needs_action_only -%>
+Filter: **needs action only** (<%= @notification_recipients.size %>) — [show all](/notifications)
+<% elsif @needs_action_count > 0 -%>
+Needs action: **<%= @needs_action_count %>** — [show only these](/notifications?needs_action=true)
+<% end -%>
+
 <% if @notification_recipients.empty? -%>
-No notifications.
+<%= @needs_action_only ? 'No notifications need action.' : 'No notifications.' %>
 <% else -%>
 ## Recent Notifications
 
@@ -12,10 +18,10 @@ No notifications.
 <% collective_name = collective&.name || 'Other' -%>
 ### <%= collective_name %> (<%= recipients.size %>) - [mark_read_for_collective](/notifications/actions/mark_read_for_collective?collective_id=<%= collective_id %>) | [dismiss_for_collective](/notifications/actions/dismiss_for_collective?collective_id=<%= collective_id %>)
 
-| Title | Status | Time | Actions |
-|-------|--------|------|---------|
+| Title | Status | Needs action | Time | Actions |
+|-------|--------|--------------|------|---------|
 <% recipients.each do |recipient| -%>
-| [<%= recipient.notification.title %>](<%= recipient.notification.url || '/notifications' %>) | <%= recipient.read? ? 'read' : 'unread' %> | <%= time_ago_in_words(recipient.created_at) %> ago | <% unless recipient.read? %>[mark_read](/notifications/actions/mark_read?id=<%= recipient.id %>) | <% end %>[dismiss](/notifications/actions/dismiss?id=<%= recipient.id %>) |
+| [<%= recipient.notification.title %>](<%= recipient.notification.url || '/notifications' %>) | <%= recipient.read? ? 'read' : 'unread' %> | <%= recipient.notification.needs_action? ? 'yes' : '' %> | <%= time_ago_in_words(recipient.created_at) %> ago | <% unless recipient.read? %>[mark_read](/notifications/actions/mark_read?id=<%= recipient.id %>) | <% end %>[dismiss](/notifications/actions/dismiss?id=<%= recipient.id %>) |
 <% end -%>
 
 <% end -%>

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -679,4 +679,54 @@ class NotificationsControllerTest < ActionDispatch::IntegrationTest
     tenant_user = @tenant.tenant_users.find_by(user: @user)
     assert_not_includes tenant_user.dismissed_notices, "push-optin-banner"
   end
+
+  # === needs_action triage facet (issue #456) ===
+
+  def create_notification_for(user, type:, title:)
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    event = Event.create!(tenant: @tenant, collective: @collective, event_type: "test.created")
+    notification = Notification.create!(tenant: @tenant, event: event, notification_type: type, title: title)
+    NotificationRecipient.create!(notification: notification, user: user, channel: "in_app", status: "delivered")
+  ensure
+    Collective.clear_thread_scope
+  end
+
+  test "needs_action=true narrows the feed to action-requiring notifications" do
+    sign_in_as(@user, tenant: @tenant)
+    create_notification_for(@user, type: "mention", title: "Please review this")
+    create_notification_for(@user, type: "participation", title: "FYI someone voted")
+
+    get "/notifications", params: { needs_action: "true" }, headers: { "Accept" => "text/markdown" }
+
+    assert_response :success
+    assert_match "Please review this", response.body
+    assert_no_match(/FYI someone voted/, response.body)
+    assert_match "needs action only", response.body
+  end
+
+  test "unfiltered feed surfaces the needs_action count and marks action rows" do
+    sign_in_as(@user, tenant: @tenant)
+    create_notification_for(@user, type: "mention", title: "Please review this")
+    create_notification_for(@user, type: "participation", title: "FYI someone voted")
+
+    get "/notifications", headers: { "Accept" => "text/markdown" }
+
+    assert_response :success
+    # Both rows shown; the facet advertises the count and a filter link.
+    assert_match "Please review this", response.body
+    assert_match "FYI someone voted", response.body
+    assert_match "Needs action: **1**", response.body
+    assert_match "needs_action=true", response.body
+  end
+
+  test "HTML feed offers a needs_action filter link" do
+    sign_in_as(@user, tenant: @tenant)
+    create_notification_for(@user, type: "mention", title: "Please review this")
+
+    get "/notifications"
+
+    assert_response :success
+    assert_match "need action", response.body
+    assert_match "needs_action=true", response.body
+  end
 end

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -112,4 +112,26 @@ class NotificationTest < ActiveSupport::TestCase
     assert_includes Notification.of_type("mention").to_a, notification1
     assert_not_includes Notification.of_type("mention").to_a, notification2
   end
+
+  # === needs_action triage facet (issue #456) ===
+
+  test "NEEDS_ACTION_TYPES is a subset of the valid notification types" do
+    # Guards against a typo in the facet cut silently classifying nothing.
+    assert (Notification::NEEDS_ACTION_TYPES - Notification::NOTIFICATION_TYPES).empty?,
+           "NEEDS_ACTION_TYPES contains types not in NOTIFICATION_TYPES"
+  end
+
+  test "needs_action? and the needs_action scope agree on the classification" do
+    tenant, collective, _user = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    event = Event.create!(tenant: tenant, collective: collective, event_type: "note.created")
+
+    action = Notification.create!(tenant: tenant, event: event, notification_type: "mention", title: "Review")
+    fyi = Notification.create!(tenant: tenant, event: event, notification_type: "participation", title: "FYI")
+
+    assert action.needs_action?
+    assert_not fyi.needs_action?
+    assert_includes Notification.needs_action.to_a, action
+    assert_not_includes Notification.needs_action.to_a, fyi
+  end
 end


### PR DESCRIPTION
## What

Adds a `needs_action` triage facet to `/notifications`, so a reader — an agent especially — can separate **what requires my action** from the informational firehose.

- `?needs_action=true` filters the feed to action-requiring notifications.
- The facet **count** is always computed and surfaced, so the facet is discoverable even when not applied.
- Markdown view: facet count + filter toggle + a per-row **Needs action** column.
- HTML view: a filter link (always rendered, so the "show all" escape hatch survives a filtered-empty feed).

## Why

Per #456: agents get the same flat notification stream humans do, but an agent mostly needs "does this call for a response?" I filed this while sitting on 220 notifications — the signal-to-noise is the single biggest drag on triaging them.

## The classification (the one judgment call)

`needs_action` is defined **by notification type**, deterministically, in a single constant — `Notification::NEEDS_ACTION_TYPES`:

| Type | needs_action | Why |
|------|:---:|-----|
| `mention` | ✅ | Direct address; questions and assignments arrive as mentions (incl. replies). |
| `chat_message` | ✅ | A direct message; expects a reply. |
| `trustee_authorization` | ✅ | An authorization/approval request. |
| `reminder` | ✅ | A nudge the recipient scheduled for themselves — actionable by definition. |
| `comment` | ⬜ | Broad/mostly FYI; genuine "someone asked me" arrives as a `mention`. |
| `participation`, `system`, `trio_unavailable`, `tune_in`, `role_change` | ⬜ | Informational. |

I chose a **high-precision** cut on purpose: the whole point is cutting noise, so I'd rather under-flag than dilute the facet back into a firehose. **This is a product judgment — if you'd cut it differently (e.g. include `comment`), it's a one-line change to the constant and every surface follows.** Flagging it explicitly rather than guessing silently.

## Scope

This is the "minimal version" #456 asks for — a boolean facet plus a filter. It is **not** the search-operator integration (the notifications feed is its own controller, not the search feed) and **not** per-query subscriptions (#457, separate). Happy to extend to a `needs_action:` search operator as a follow-up if you want it in the general search grammar.

## Test plan

Model (`notification_test`): `NEEDS_ACTION_TYPES ⊆ NOTIFICATION_TYPES` (typo guard); `needs_action?` and the `needs_action` scope agree.
Controller (`notifications_controller_test`): `?needs_action=true` narrows the feed; unfiltered feed surfaces the count + filter link + marks rows; HTML feed offers the filter link.

All green locally (`notification_test` + `notifications_controller_test`: 46 runs, 160 assertions, 0 failures). `srb tc` clean.

Closes #456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)