### PR TITLE
Rework funding pool page: usage tables and max-possible draw

### DIFF
--- a/app/assets/stylesheets/pulse/_components.css
+++ b/app/assets/stylesheets/pulse/_components.css
@@ -2373,6 +2373,17 @@ a.pulse-activity-title:hover {
   color: var(--color-accent-fg);
 }
 
+/* Row belonging to the current user (e.g. their own enrollment or agent). */
+.pulse-table tr.pulse-row-you {
+  background: var(--color-accent-subtle);
+}
+
+/* Totals row set off from the body rows. */
+.pulse-table tr.pulse-table-total td {
+  border-top: 2px solid var(--color-border-default);
+  border-bottom: none;
+}
+
 /* Empty State */
 .pulse-empty-message {
   font-size: 14px;

--- a/app/models/funding_pool.rb
+++ b/app/models/funding_pool.rb
@@ -18,9 +18,7 @@ class FundingPool < ApplicationRecord
   # rather than block the deletion with a foreign-key violation.
   has_many :funded_agents, class_name: "User", dependent: :nullify, inverse_of: :funding_pool
 
-  # The windows a draw ceiling can cover. Every UI surface currently writes
-  # "day"; week/month are live in the schema and resolver, awaiting a period
-  # selector in the UI.
+  # The windows a draw ceiling can cover.
   DRAW_CAP_PERIODS = ["day", "week", "month"].freeze
 
   validates :collective_id, uniqueness: { message: "already has a funding pool" }

--- a/app/models/funding_pool_enrollment.rb
+++ b/app/models/funding_pool_enrollment.rb
@@ -17,6 +17,12 @@ class FundingPoolEnrollment < ApplicationRecord
 
   scope :active, -> { where(archived_at: nil) }
 
+  # How many of a period's windows a rolling 30-day span can touch, rounded up
+  # to whole windows: 30 days, ~5 weeks (30 / 7), or 2 calendar months (a
+  # 30-day span straddles one boundary). Used to translate a ceiling into a
+  # 30-day maximum draw.
+  WINDOWS_PER_30_DAYS = { "day" => 30, "week" => 5, "month" => 2 }.freeze
+
   before_validation :set_scope_from_pool
   validates :user_id, uniqueness: { scope: :funding_pool_id }
   # The member's own ceiling on this pool's draws, stated as part of the
@@ -37,6 +43,13 @@ class FundingPoolEnrollment < ApplicationRecord
   sig { returns(T::Boolean) }
   def archived?
     archived_at.present?
+  end
+
+  # The most this ceiling could allow to be drawn in a 30-day window: the
+  # ceiling times the number of its windows a 30-day span can touch.
+  sig { returns(Integer) }
+  def draw_cap_per_30_days_cents
+    draw_cap_cents * WINDOWS_PER_30_DAYS.fetch(draw_cap_period)
   end
 
   private

--- a/app/services/llm_gateway/usage_report.rb
+++ b/app/services/llm_gateway/usage_report.rb
@@ -50,15 +50,17 @@ module LLMGateway
 
     # One row per active enrollment (zero-spend members included), plus a row
     # for any customer with window spend who is no longer actively enrolled
-    # (withdrawn members whose past draws still show up). Sorted by spend, then
-    # name.
+    # (withdrawn members whose past draws still show up). Active rows carry
+    # their enrollment (for ceiling and enrollment date); withdrawn rows carry
+    # none. Sorted by spend, then name.
     sig do
       params(pool: FundingPool, spend_by_customer: T::Hash[String, T.untyped]).returns(T::Array[T::Hash[Symbol, T.untyped]])
     end
     def self.pool_member_rows(pool, spend_by_customer)
-      enrolled_user_ids = FundingPoolEnrollment.tenant_scoped_only(pool.tenant_id)
+      enrollment_by_user_id = FundingPoolEnrollment.tenant_scoped_only(pool.tenant_id)
         .where(funding_pool_id: pool.id, archived_at: nil)
-        .pluck(:user_id)
+        .index_by(&:user_id)
+      enrolled_user_ids = enrollment_by_user_id.keys
       users_by_id = User.where(id: enrolled_user_ids).index_by(&:id)
       stripe_id_by_user = StripeCustomer.where(billable_type: "User", billable_id: enrolled_user_ids)
         .pluck(:billable_id, :stripe_id).to_h
@@ -70,7 +72,7 @@ module LLMGateway
 
         stripe_id = stripe_id_by_user[user_id]
         spend = (stripe_id && spend_by_customer[stripe_id]) || 0
-        { user: user, spend_cents: spend }
+        { user: user, spend_cents: spend, enrollment: enrollment_by_user_id[user_id] }
       end
 
       withdrawn_stripe_ids = spend_by_customer.keys - enrolled_stripe_ids
@@ -81,7 +83,7 @@ module LLMGateway
         user = withdrawn_users[user_id_by_stripe_id[stripe_id]]
         next if user.nil?
 
-        rows << { user: user, spend_cents: spend_by_customer[stripe_id] }
+        rows << { user: user, spend_cents: spend_by_customer[stripe_id], enrollment: nil }
       end
 
       rows.sort_by { |row| [-row[:spend_cents], row[:user].display_name.to_s] }

--- a/app/views/collectives/pool.html.erb
+++ b/app/views/collectives/pool.html.erb
@@ -62,20 +62,88 @@
     <% agent_spend_by_id = @usage_report[:agent_rows].to_h { |r| [r[:agent]&.id, r[:spend_cents]] } %>
     <% enrolled_user_ids = @pool_enrollments.map(&:user_id) %>
 
+    <% member_count = @pool_enrollments.size %>
+    <% if member_count > 0 %>
+      <section class="pulse-settings-section">
+        <h2 class="pulse-section-title">Maximum Possible Draw</h2>
+        <p class="pulse-body-text">
+          This pool draws at most its per-member ceiling from each enrolled
+          member per period. So the most it can draw in total is that ceiling
+          times the number of enrolled members:
+        </p>
+        <p class="pulse-body-text">
+          <strong><%= number_to_currency(@funding_pool.member_draw_cap_cents / 100.0) %></strong> / <%= @funding_pool.member_draw_cap_period %> / member
+          × <%= pluralize(member_count, "member") %>
+          = <strong><%= number_to_currency(@funding_pool.member_draw_cap_cents * member_count / 100.0) %> / <%= @funding_pool.member_draw_cap_period %></strong>
+        </p>
+      </section>
+    <% end %>
+
     <section class="pulse-settings-section">
       <h2 class="pulse-section-title">Enrolled Members</h2>
       <% if @usage_report[:member_rows].any? %>
-        <ul class="pulse-list">
-          <% @usage_report[:member_rows].each do |row| %>
-            <li>
-              <%= link_to row[:user].display_name, row[:user].path %>
-              <% unless enrolled_user_ids.include?(row[:user].id) %>
-                <span class="pulse-muted">(withdrawn)</span>
-              <% end %>
-              <span class="pulse-muted">— <%= number_to_currency(row[:spend_cents].to_f / 100) %> (last 30 days)</span>
-            </li>
-          <% end %>
-        </ul>
+        <table class="pulse-table">
+          <thead>
+            <tr>
+              <th>Member</th>
+              <th>Enrolled</th>
+              <th>Ceiling</th>
+              <th style="text-align: right;">Max possible per 30 days</th>
+              <th style="text-align: right;">Last 30 days (actual)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @usage_report[:member_rows].each do |row| %>
+              <% enrollment = row[:enrollment] %>
+              <tr class="<%= 'pulse-row-you' if @current_user && row[:user].id == @current_user.id %>">
+                <td>
+                  <%= link_to row[:user].display_name, row[:user].path %>
+                  <% if enrollment.nil? %>
+                    <span class="pulse-muted">(withdrawn)</span>
+                  <% end %>
+                </td>
+                <td>
+                  <% if enrollment %>
+                    <%= enrollment.created_at.strftime("%b %-d, %Y") %>
+                  <% else %>
+                    <span class="pulse-muted">—</span>
+                  <% end %>
+                </td>
+                <td>
+                  <% if enrollment %>
+                    <%= number_to_currency(enrollment.draw_cap_cents / 100.0) %> / <%= enrollment.draw_cap_period %>
+                  <% else %>
+                    <span class="pulse-muted">—</span>
+                  <% end %>
+                </td>
+                <td style="text-align: right;">
+                  <% if enrollment %>
+                    <% mult = FundingPoolEnrollment::WINDOWS_PER_30_DAYS.fetch(enrollment.draw_cap_period) %>
+                    <% windows = case enrollment.draw_cap_period
+                                 when "week" then "#{mult} weeks (ceil(30 / 7))"
+                                 when "month" then "#{mult} months (a 30-day span can cross a month boundary)"
+                                 else "#{mult} days"
+                                 end %>
+                    <% max_str = number_to_currency(enrollment.draw_cap_per_30_days_cents / 100.0) %>
+                    <span title="<%= number_to_currency(enrollment.draw_cap_cents / 100.0) %>/<%= enrollment.draw_cap_period %> × <%= windows %> = <%= max_str %>"><%= max_str %></span>
+                  <% else %>
+                    <span class="pulse-muted">—</span>
+                  <% end %>
+                </td>
+                <td style="text-align: right;"><%= number_to_currency(row[:spend_cents].to_f / 100) %></td>
+              </tr>
+            <% end %>
+          </tbody>
+          <tfoot>
+            <tr class="pulse-table-total">
+              <td><strong>Total</strong></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td style="text-align: right;"><strong><%= number_to_currency(@usage_report[:member_rows].sum { |r| r[:spend_cents] }.to_f / 100) %></strong></td>
+            </tr>
+          </tfoot>
+        </table>
       <% else %>
         <p class="pulse-empty-message"><em>No members are enrolled yet.</em></p>
       <% end %>
@@ -84,22 +152,49 @@
     <section class="pulse-settings-section">
       <h2 class="pulse-section-title">Funded Agents</h2>
       <% if @funded_agents.any? %>
-        <ul class="pulse-list">
-          <% @funded_agents.each do |agent| %>
-            <li>
-              <%= link_to agent.display_name, agent.path %>
-              <% if agent.parent %>
-                <span class="pulse-muted">— principal <%= link_to agent.parent.display_name, agent.parent.path %></span>
-              <% end %>
-              <% if agent_spend_by_id[agent.id] %>
-                <span class="pulse-muted">— <%= number_to_currency(agent_spend_by_id[agent.id].to_f / 100) %> (last 30 days)</span>
-              <% end %>
-              <% unless agent.parent_id && enrolled_user_ids.include?(agent.parent_id) %>
-                <span class="pulse-muted">— not running: principal not enrolled. Runs again when the principal re-enrolls, or when it is detached and given its own billing.</span>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
+        <table class="pulse-table">
+          <thead>
+            <tr>
+              <th>Agent</th>
+              <th>Principal</th>
+              <th style="text-align: right;">Last 30 days</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @funded_agents.each do |agent| %>
+              <% is_you = @current_user && (agent.id == @current_user.id || agent.parent_id == @current_user.id) %>
+              <tr class="<%= 'pulse-row-you' if is_you %>">
+                <td>
+                  <%= link_to agent.display_name, agent.path %>
+                  <% unless agent.parent_id && enrolled_user_ids.include?(agent.parent_id) %>
+                    <br><span class="pulse-muted" style="font-size: 12px;">Not running: principal not enrolled. Runs again when the principal re-enrolls, or when it is detached and given its own billing.</span>
+                  <% end %>
+                </td>
+                <td>
+                  <% if agent.parent %>
+                    <%= link_to agent.parent.display_name, agent.parent.path %>
+                  <% else %>
+                    <span class="pulse-muted">—</span>
+                  <% end %>
+                </td>
+                <td style="text-align: right;">
+                  <% if agent_spend_by_id[agent.id] %>
+                    <%= number_to_currency(agent_spend_by_id[agent.id].to_f / 100) %>
+                  <% else %>
+                    <span class="pulse-muted">—</span>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+          <tfoot>
+            <tr class="pulse-table-total">
+              <td><strong>Total</strong></td>
+              <td></td>
+              <td style="text-align: right;"><strong><%= number_to_currency(@funded_agents.sum { |a| agent_spend_by_id[a.id] || 0 }.to_f / 100) %></strong></td>
+            </tr>
+          </tfoot>
+        </table>
       <% else %>
         <p class="pulse-empty-message"><em>No agents are funded by this pool yet.</em></p>
       <% end %>

--- a/test/controllers/collectives_controller_test.rb
+++ b/test/controllers/collectives_controller_test.rb
@@ -2918,6 +2918,89 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
     assert_match(/\$0\.50/, response.body) # Beta Bot's spend
   end
 
+  test "the pool page renders member and agent tables and highlights the current user's rows" do
+    collective = create_test_collective
+    enable_funding_pools!(collective)
+    pool = create_pool!(collective)
+    fund_user!(@user, stripe_id: "cus_you")
+    enroll!(pool, @user)
+    agent = create_ai_agent(parent: @user, name: "Your Bot")
+    @tenant.add_user!(agent)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    agent.update!(funding_pool: pool)
+    Tenant.clear_thread_scope
+    sign_in_as(@user, tenant: @tenant)
+
+    get "#{collective.path}/pool"
+
+    assert_response :success
+    assert_match(%r{<th[^>]*>\s*Ceiling}, response.body)
+    assert_match(%r{<th[^>]*>\s*Enrolled}, response.body)
+    assert_match(%r{<th[^>]*>\s*Max possible per 30 days}, response.body)
+    assert_match(%r{<th[^>]*>\s*Principal}, response.body)
+    # The current user is highlighted both as an enrolled member and as the
+    # principal of a funded agent.
+    assert response.body.scan("pulse-row-you").size >= 2,
+           "expected the current user's member row and their agent's row to be highlighted"
+    # Each table carries a totals row summing the last-30-days column.
+    assert response.body.scan("pulse-table-total").size >= 2,
+           "expected a totals row on both the members and agents tables"
+    # The $5.00/day ceiling translates to a 30-day max of $150.00 (× 30 days),
+    # with the calculation exposed as a title tooltip.
+    assert_includes response.body, "title=\"$5.00/day × 30 days = $150.00\""
+  end
+
+  test "the pool page totals do not truncate fractional cents" do
+    collective = create_test_collective
+    enable_funding_pools!(collective)
+    pool = create_pool!(collective)
+    fund_user!(@user, stripe_id: "cus_frac")
+    enroll!(pool, @user)
+    agent = create_ai_agent(parent: @user, name: "Frac Bot")
+    @tenant.add_user!(agent)
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    agent.update!(funding_pool: pool)
+    Tenant.clear_thread_scope
+    record_pool_spend!(pool, stripe_id: "cus_frac", cents: 64.66044, agent: agent)
+    sign_in_as(@user, tenant: @tenant)
+
+    get "#{collective.path}/pool"
+
+    assert_response :success
+    # The member and agent totals round the same fractional sum; the agent
+    # total must not be truncated to $0.64.
+    assert_not_includes response.body, "$0.64"
+    assert_operator response.body.scan("$0.65").size, :>=, 2
+  end
+
+  test "the pool page shows the maximum possible draw as pool ceiling times member count" do
+    collective = create_test_collective
+    enable_funding_pools!(collective)
+    pool = create_pool!(collective) # pool ceiling $5.00 / day
+    fund_user!(@user)
+    enroll!(pool, @user, draw_cap_cents: 500)
+    # A second member who sets a *lower* personal ceiling — the maximum is the
+    # pool ceiling times member count, independent of what members choose.
+    frugal = add_funded_member!(collective, name: "Frugal Member")
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    pool.enroll!(frugal, draw_cap_cents: 100, draw_cap_period: "day")
+    Tenant.clear_thread_scope
+    sign_in_as(@user, tenant: @tenant)
+
+    get "#{collective.path}/pool"
+
+    assert_response :success
+    assert_match(/Maximum Possible Draw/, response.body)
+    # $5.00 / day / member × 2 members = $10.00 / day
+    assert_match(%r{/ day / member}, response.body)
+    assert_match(/2 members/, response.body)
+    assert_match(%r{\$10\.00 / day}, response.body) # $5.00 pool ceiling × 2 members
+    assert_match(/Last 30 days \(actual\)/, response.body)
+    # Only the actual-spend column is totaled; the max-possible column is not,
+    # to avoid drawing the eye to a hypothetical sum.
+    refute_match(/\$180\.00/, response.body)
+  end
+
   test "the markdown pool page shows spend figures" do
     collective = create_test_collective
     enable_funding_pools!(collective)

--- a/test/models/funding_pool_enrollment_test.rb
+++ b/test/models/funding_pool_enrollment_test.rb
@@ -27,6 +27,12 @@ class FundingPoolEnrollmentTest < ActiveSupport::TestCase
     member
   end
 
+  test "draw_cap_per_30_days_cents translates each period to a 30-day maximum" do
+    assert_equal 3000, FundingPoolEnrollment.new(draw_cap_cents: 100, draw_cap_period: "day").draw_cap_per_30_days_cents
+    assert_equal 5000, FundingPoolEnrollment.new(draw_cap_cents: 1000, draw_cap_period: "week").draw_cap_per_30_days_cents
+    assert_equal 4000, FundingPoolEnrollment.new(draw_cap_cents: 2000, draw_cap_period: "month").draw_cap_per_30_days_cents
+  end
+
   test "a funded collective member can enroll" do
     enrollment = @pool.enroll!(@user, draw_cap_cents: 500)
     assert enrollment.persisted?

--- a/test/services/llm_gateway/usage_report_test.rb
+++ b/test/services/llm_gateway/usage_report_test.rb
@@ -133,6 +133,23 @@ module LLMGateway
       assert_equal 80, row[:spend_cents]
     end
 
+    test "pool_report member rows carry the active enrollment; withdrawn rows carry none" do
+      pool = create_funding_pool!(primary_stripe_id: "cus_primary", primary_cap: 500)
+      departed = create_enrolled_member!(pool, stripe_id: "cus_departed", name: "Departed Member")
+      record_spend!("cus_departed", 80, funding_pool_id: pool.id)
+      pool.enrollments.find_by!(user: departed).withdraw!
+
+      report = UsageReport.pool_report(pool)
+
+      active_row = report[:member_rows].find { |r| r[:user].id == @user.id }
+      assert_not_nil active_row[:enrollment], "an active enrollee row should carry its enrollment"
+      assert_equal 500, active_row[:enrollment].draw_cap_cents
+
+      withdrawn_row = report[:member_rows].find { |r| r[:user].id == departed.id }
+      assert_not_nil withdrawn_row, "a withdrawn member with window spend should still appear"
+      assert_nil withdrawn_row[:enrollment], "a withdrawn row should carry no active enrollment"
+    end
+
     test "pool_report counts pending and stale pending rows" do
       pool = create_funding_pool!(primary_stripe_id: "cus_primary")
       open_call!("cus_primary", funding_pool_id: pool.id, occurred_at: 1.minute.ago)


### PR DESCRIPTION
## What

Reworks the funding pool page (`/collectives/:handle/pool`) to make usage and exposure legible at a glance.

### Members & agents as tables
- **Enrolled Members**: Member · Enrolled · Ceiling · Max possible per 30 days · Last 30 days (actual)
- **Funded Agents**: Agent · Principal · Last 30 days
- The current user's rows are highlighted (as a member, and as an agent or an agent's principal).

### Maximum Possible Draw section
A single, member-choice-independent upper bound stated in the pool's own unit, with the arithmetic shown:

> $5.00 / day / member × 4 members = $20.00 / day

The pool's per-member ceiling is enforced on every member regardless of their personal ceiling, so `pool ceiling × member count` is a true maximum.

### Per-member "Max possible per 30 days"
Translates each member's ceiling into a 30-day window using nominal round-up multipliers — day ×30, week ×5 (`ceil(30 / 7)`), month ×2 (a 30-day span can cross a month boundary) — with the full calculation exposed as a hover tooltip (e.g. `$5.00/day × 30 days = $150.00`). These are ceilings, not actual draws; the adjacent column is labelled "Last 30 days (actual)" to keep the contrast clear.

### Fixes
- The agents-table total was truncating fractional cents (`.to_i`), rounding a $0.65 pool down to $0.64. Now sums the raw value.

## Notes
- `UsageReport.pool_report` now carries the active enrollment through each member row (for ceiling + enrollment date; withdrawn rows carry none).
- Only the actual-spend column is totaled — the max-possible column deliberately has no totals-row sum, to avoid drawing the eye to a hypothetical figure.
- No schema changes.

## Testing
- `test/models/funding_pool_enrollment_test.rb` — 30-day translation per period
- `test/controllers/collectives_controller_test.rb` — table headers, row highlighting, fractional-cents total, max-possible tooltip, Maximum Possible Draw arithmetic
- `test/services/llm_gateway/usage_report_test.rb` — enrollment carried on member rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)