### PR TITLE
Stamp draw-authorization receipts on the LLM usage ledger

### DIFF
--- a/app/controllers/internal/llm_gateway_controller.rb
+++ b/app/controllers/internal/llm_gateway_controller.rb
@@ -27,10 +27,9 @@ module Internal
 
       result = LLMGateway::PayerResolver.resolve(task_run)
       selection_id = open_usage_record(
+        result,
         ai_agent_id: T.must(task_run.ai_agent_id),
-        payer_customer_id: result.payer_customer_id,
         origin_tenant_id: T.must(task_run.tenant_id),
-        funding_pool_id: result.funding_pool_id,
         task_run_id: task_run.id,
       )
       render json: { payer_customer_id: result.payer_customer_id, selection_id: selection_id }
@@ -64,10 +63,9 @@ module Internal
 
       token.token_used!
       selection_id = open_usage_record(
+        result,
         ai_agent_id: T.must(token.user_id),
-        payer_customer_id: result.payer_customer_id,
         origin_tenant_id: tenant.id,
-        funding_pool_id: result.funding_pool_id,
         api_token_id: token.id,
         model: model,
       )
@@ -132,30 +130,35 @@ module Internal
 
     private
 
-    # Opens the pending ledger row for a resolved selection. The ledger is
-    # advisory (gating/accounting) — a failure to open it must not block the
-    # billed call itself, so this logs and returns nil rather than raising;
-    # the gateway skips record-usage when no selection id came back.
+    # Opens the pending ledger row for a resolved selection, stamping the
+    # draw's receipt (payer, pool, and the ceilings it was authorized against)
+    # from the resolver result. The ledger is advisory (gating/accounting) — a
+    # failure to open it must not block the billed call itself, so this logs
+    # and returns nil rather than raising; the gateway skips record-usage when
+    # no selection id came back.
     sig do
       params(
+        result: LLMGateway::PayerResolver::Result,
         ai_agent_id: String,
-        payer_customer_id: String,
         origin_tenant_id: String,
-        funding_pool_id: T.nilable(String),
         task_run_id: T.nilable(String),
         api_token_id: T.nilable(String),
         model: T.nilable(String),
       ).returns(T.nilable(String))
     end
-    def open_usage_record(ai_agent_id:, payer_customer_id:, origin_tenant_id:, funding_pool_id: nil,
-                          task_run_id: nil, api_token_id: nil, model: nil)
+    def open_usage_record(result, ai_agent_id:, origin_tenant_id:, task_run_id: nil, api_token_id: nil, model: nil)
       record = LLMUsageRecord.create!(
         selection_id: "sel_#{SecureRandom.uuid}",
         status: "pending",
         ai_agent_id: ai_agent_id,
-        payer_stripe_customer_id: payer_customer_id,
+        payer_stripe_customer_id: result.payer_customer_id,
         origin_tenant_id: origin_tenant_id,
-        funding_pool_id: funding_pool_id,
+        funding_pool_id: result.funding_pool_id,
+        funding_pool_enrollment_id: result.funding_pool_enrollment_id,
+        enrollment_draw_cap_cents: result.enrollment_draw_cap_cents,
+        enrollment_draw_cap_period: result.enrollment_draw_cap_period,
+        pool_member_draw_cap_cents: result.pool_member_draw_cap_cents,
+        pool_member_draw_cap_period: result.pool_member_draw_cap_period,
         ai_agent_task_run_id: task_run_id,
         api_token_id: api_token_id,
         model: model,

--- a/app/services/llm_gateway/payer_resolver.rb
+++ b/app/services/llm_gateway/payer_resolver.rb
@@ -13,7 +13,26 @@ module LLMGateway
     # funding_pool_id names the pool a draw came from (nil when the agent's
     # own billing customer pays) — stamped on the usage ledger for
     # point-in-time attribution, since the agent's pool link is mutable.
-    Result = Struct.new(:payer_customer_id, :funding_pool_id, keyword_init: true)
+    #
+    # The remaining fields are the draw's receipt: the ceilings it was
+    # authorized against, so a dispute can be settled from the ledger alone
+    # rather than reconstructed through the mutable enrollment. All nil on the
+    # individual-billing path, where no pool authorized the draw.
+    Result = Struct.new(
+      :payer_customer_id,
+      :funding_pool_id,
+      :funding_pool_enrollment_id,
+      :enrollment_draw_cap_cents,
+      :enrollment_draw_cap_period,
+      :pool_member_draw_cap_cents,
+      :pool_member_draw_cap_period,
+      keyword_init: true,
+    )
+
+    # One member eligible to pay for a pool draw, carrying the enrollment terms
+    # that authorize it so the selected candidate can be stamped as the draw's
+    # receipt without a second lookup.
+    Candidate = Struct.new(:stripe_id, :enrollment_id, :cap_cents, :cap_period, keyword_init: true)
 
     # A resolution failure that carries the wire error code and HTTP status the
     # gateway (and its callers) should surface.
@@ -77,21 +96,24 @@ module LLMGateway
     # sampled candidate, not per member. Lookups use tenant_scoped_only +
     # explicit ids — never collective-scoped associations, which misbehave
     # outside normal request scoping.
-    sig { params(pool: FundingPool).returns(T::Array[String]) }
-    def self.pool_customer_ids(pool)
+    sig { params(pool: FundingPool).returns(T::Array[Candidate]) }
+    def self.pool_candidates(pool)
       enrollment_caps = FundingPoolEnrollment.tenant_scoped_only
         .where(funding_pool_id: pool.id, archived_at: nil)
-        .pluck(:user_id, :draw_cap_cents, :draw_cap_period)
-        .to_h { |user_id, cents, period| [user_id, [cents, period]] }
+        .pluck(:user_id, :id, :draw_cap_cents, :draw_cap_period)
+        .to_h { |user_id, id, cents, period| [user_id, [id, cents, period]] }
       member_user_ids = CollectiveMember.tenant_scoped_only
         .where(collective_id: pool.collective_id, user_id: enrollment_caps.keys, archived_at: nil)
         .pluck(:user_id)
       human_ids = User.where(id: member_user_ids, user_type: "human").pluck(:id)
-      member_caps_by_stripe_id = StripeCustomer.where(billable_type: "User", billable_id: human_ids)
+      candidates_by_stripe_id = StripeCustomer.where(billable_type: "User", billable_id: human_ids)
         .where.not(pricing_plan_subscription_id: [nil, ""])
         .pluck(:billable_id, :stripe_id)
-        .to_h { |user_id, stripe_id| [stripe_id, enrollment_caps[user_id]] }
-      under_draw_caps(member_caps_by_stripe_id, pool)
+        .to_h do |user_id, stripe_id|
+          enrollment_id, cents, period = enrollment_caps[user_id]
+          [stripe_id, Candidate.new(stripe_id: stripe_id, enrollment_id: enrollment_id, cap_cents: cents, cap_period: period)]
+        end
+      under_draw_caps(candidates_by_stripe_id, pool)
     end
 
     # The start of the window a (cents, period) ceiling covers. UTC calendar
@@ -112,12 +134,12 @@ module LLMGateway
     # either bound drops out of the draw until that window rolls over (draws
     # by other pools don't count — each ceiling is a promise about THIS
     # pool's reach into a member's balance).
-    sig { params(member_caps_by_stripe_id: T::Hash[String, T.untyped], pool: FundingPool).returns(T::Array[String]) }
-    def self.under_draw_caps(member_caps_by_stripe_id, pool)
-      stripe_ids = member_caps_by_stripe_id.keys
-      return stripe_ids if stripe_ids.empty?
+    sig { params(candidates_by_stripe_id: T::Hash[String, Candidate], pool: FundingPool).returns(T::Array[Candidate]) }
+    def self.under_draw_caps(candidates_by_stripe_id, pool)
+      stripe_ids = candidates_by_stripe_id.keys
+      return candidates_by_stripe_id.values if stripe_ids.empty?
 
-      periods = ([pool.member_draw_cap_period] + member_caps_by_stripe_id.values.compact.map(&:last)).compact.uniq
+      periods = ([pool.member_draw_cap_period] + candidates_by_stripe_id.values.map(&:cap_period)).compact.uniq
       base = LLMUsageRecord.where(payer_stripe_customer_id: stripe_ids, funding_pool_id: pool.id)
       drawn_by_period = periods.to_h do |period|
         sums = base.where(completed_at: draw_cap_window_start(period)..)
@@ -132,14 +154,13 @@ module LLMGateway
         .count
       reserve = LLMUsageRecord.pending_reserve_cents
 
-      stripe_ids.reject do |stripe_id|
-        reserved = in_flight.fetch(stripe_id, 0) * reserve
+      candidates_by_stripe_id.values.reject do |candidate|
+        reserved = in_flight.fetch(candidate.stripe_id, 0) * reserve
         at_bound = lambda do |cents, period|
-          cents && drawn_by_period.fetch(period, {}).fetch(stripe_id, 0) + reserved >= cents
+          cents && drawn_by_period.fetch(period, {}).fetch(candidate.stripe_id, 0) + reserved >= cents
         end
-        member_cents, member_period = member_caps_by_stripe_id[stripe_id]
         at_bound.call(pool.member_draw_cap_cents, pool.member_draw_cap_period) ||
-          at_bound.call(member_cents, member_period)
+          at_bound.call(candidate.cap_cents, candidate.cap_period)
       end
     end
 
@@ -150,13 +171,13 @@ module LLMGateway
       pool = ensure_funding_pool_available!(agent)
       ensure_primary_active!(agent, pool)
 
-      candidates = pool_customer_ids(pool)
+      candidates = pool_candidates(pool)
       # Sample first, verify the balance of only the sampled member (falling
       # through to the next on a dry balance): the gate can reach for Stripe
       # on a stale snapshot, so verifying the whole pool would put one Stripe
       # round-trip per member on the per-call path. A funded pool costs one
       # check; the worst case (everyone dry) still checks each member once.
-      payer = candidates.shuffle.find { |stripe_id| BalanceGate.funded?(stripe_id) }
+      payer = candidates.shuffle.find { |candidate| BalanceGate.funded?(candidate.stripe_id) }
       if payer.nil?
         raise ResolutionError.new(
           "pool_exhausted",
@@ -165,8 +186,16 @@ module LLMGateway
         )
       end
 
-      Rails.logger.info("[LLMGateway] Pool payer selected #{context} payer=#{payer} pool_size=#{candidates.size}")
-      Result.new(payer_customer_id: payer, funding_pool_id: pool.id)
+      Rails.logger.info("[LLMGateway] Pool payer selected #{context} payer=#{payer.stripe_id} pool_size=#{candidates.size}")
+      Result.new(
+        payer_customer_id: payer.stripe_id,
+        funding_pool_id: pool.id,
+        funding_pool_enrollment_id: payer.enrollment_id,
+        enrollment_draw_cap_cents: payer.cap_cents,
+        enrollment_draw_cap_period: payer.cap_period,
+        pool_member_draw_cap_cents: pool.member_draw_cap_cents,
+        pool_member_draw_cap_period: pool.member_draw_cap_period,
+      )
     end
 
     # Closing a pool (or archiving its collective) is how the arrangement is

--- a/db/migrate/20260716074003_add_draw_authorization_snapshot_to_llm_usage_records.rb
+++ b/db/migrate/20260716074003_add_draw_authorization_snapshot_to_llm_usage_records.rb
@@ -1,0 +1,22 @@
+class AddDrawAuthorizationSnapshotToLLMUsageRecords < ActiveRecord::Migration[7.2]
+  # A pool draw's receipt: the terms it was authorized against, snapshotted at
+  # selection time so a later dispute can be settled from the ledger alone
+  # rather than reconstructed through the mutable enrollment. All nullable —
+  # NULL means either an individual-payer draw (no pool authorized it) or a row
+  # opened before receipts existed. The historical ceiling was never recorded
+  # and the enrollment is mutable, so there is nothing honest to backfill.
+  #
+  # funding_pool_enrollment_id is a soft pointer, deliberately not a foreign
+  # key: the enrollment row is destroyed with its pool, but the receipt must
+  # outlive both (the same point-in-time reasoning that keeps
+  # payer_stripe_customer_id a bare string, not an FK).
+  def change
+    change_table :llm_usage_records, bulk: true do |t|
+      t.uuid :funding_pool_enrollment_id
+      t.integer :enrollment_draw_cap_cents
+      t.string :enrollment_draw_cap_period
+      t.integer :pool_member_draw_cap_cents
+      t.string :pool_member_draw_cap_period
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -910,7 +910,12 @@ CREATE TABLE public.llm_usage_records (
     completed_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    funding_pool_id uuid
+    funding_pool_id uuid,
+    funding_pool_enrollment_id uuid,
+    enrollment_draw_cap_cents integer,
+    enrollment_draw_cap_period character varying,
+    pool_member_draw_cap_cents integer,
+    pool_member_draw_cap_period character varying
 );
 
 
@@ -10608,6 +10613,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260716074003'),
 ('20260712120000'),
 ('20260712110000'),
 ('20260712100000'),

--- a/sorbet/rbi/dsl/llm_usage_record.rbi
+++ b/sorbet/rbi/dsl/llm_usage_record.rbi
@@ -930,6 +930,96 @@ class LLMUsageRecord
     sig { void }
     def created_at_will_change!; end
 
+    sig { returns(T.nilable(::Integer)) }
+    def enrollment_draw_cap_cents; end
+
+    sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+    def enrollment_draw_cap_cents=(value); end
+
+    sig { returns(T::Boolean) }
+    def enrollment_draw_cap_cents?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def enrollment_draw_cap_cents_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def enrollment_draw_cap_cents_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def enrollment_draw_cap_cents_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+    def enrollment_draw_cap_cents_change; end
+
+    sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+    def enrollment_draw_cap_cents_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def enrollment_draw_cap_cents_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def enrollment_draw_cap_cents_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+    def enrollment_draw_cap_cents_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def enrollment_draw_cap_cents_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def enrollment_draw_cap_cents_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def enrollment_draw_cap_cents_was; end
+
+    sig { void }
+    def enrollment_draw_cap_cents_will_change!; end
+
+    sig { returns(T.nilable(::String)) }
+    def enrollment_draw_cap_period; end
+
+    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+    def enrollment_draw_cap_period=(value); end
+
+    sig { returns(T::Boolean) }
+    def enrollment_draw_cap_period?; end
+
+    sig { returns(T.nilable(::String)) }
+    def enrollment_draw_cap_period_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def enrollment_draw_cap_period_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def enrollment_draw_cap_period_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def enrollment_draw_cap_period_change; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def enrollment_draw_cap_period_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def enrollment_draw_cap_period_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def enrollment_draw_cap_period_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def enrollment_draw_cap_period_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def enrollment_draw_cap_period_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def enrollment_draw_cap_period_previously_was; end
+
+    sig { returns(T.nilable(::String)) }
+    def enrollment_draw_cap_period_was; end
+
+    sig { void }
+    def enrollment_draw_cap_period_will_change!; end
+
     sig { returns(T.nilable(::BigDecimal)) }
     def estimated_cost_cents; end
 
@@ -974,6 +1064,51 @@ class LLMUsageRecord
 
     sig { void }
     def estimated_cost_cents_will_change!; end
+
+    sig { returns(T.nilable(::String)) }
+    def funding_pool_enrollment_id; end
+
+    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+    def funding_pool_enrollment_id=(value); end
+
+    sig { returns(T::Boolean) }
+    def funding_pool_enrollment_id?; end
+
+    sig { returns(T.nilable(::String)) }
+    def funding_pool_enrollment_id_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def funding_pool_enrollment_id_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def funding_pool_enrollment_id_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def funding_pool_enrollment_id_change; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def funding_pool_enrollment_id_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def funding_pool_enrollment_id_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def funding_pool_enrollment_id_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def funding_pool_enrollment_id_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def funding_pool_enrollment_id_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def funding_pool_enrollment_id_previously_was; end
+
+    sig { returns(T.nilable(::String)) }
+    def funding_pool_enrollment_id_was; end
+
+    sig { void }
+    def funding_pool_enrollment_id_will_change!; end
 
     sig { returns(T.nilable(::String)) }
     def funding_pool_id; end
@@ -1380,6 +1515,96 @@ class LLMUsageRecord
     sig { void }
     def payer_stripe_customer_id_will_change!; end
 
+    sig { returns(T.nilable(::Integer)) }
+    def pool_member_draw_cap_cents; end
+
+    sig { params(value: T.nilable(::Integer)).returns(T.nilable(::Integer)) }
+    def pool_member_draw_cap_cents=(value); end
+
+    sig { returns(T::Boolean) }
+    def pool_member_draw_cap_cents?; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def pool_member_draw_cap_cents_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def pool_member_draw_cap_cents_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def pool_member_draw_cap_cents_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+    def pool_member_draw_cap_cents_change; end
+
+    sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+    def pool_member_draw_cap_cents_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def pool_member_draw_cap_cents_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def pool_member_draw_cap_cents_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+    def pool_member_draw_cap_cents_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def pool_member_draw_cap_cents_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::Integer)) }
+    def pool_member_draw_cap_cents_previously_was; end
+
+    sig { returns(T.nilable(::Integer)) }
+    def pool_member_draw_cap_cents_was; end
+
+    sig { void }
+    def pool_member_draw_cap_cents_will_change!; end
+
+    sig { returns(T.nilable(::String)) }
+    def pool_member_draw_cap_period; end
+
+    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
+    def pool_member_draw_cap_period=(value); end
+
+    sig { returns(T::Boolean) }
+    def pool_member_draw_cap_period?; end
+
+    sig { returns(T.nilable(::String)) }
+    def pool_member_draw_cap_period_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def pool_member_draw_cap_period_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def pool_member_draw_cap_period_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def pool_member_draw_cap_period_change; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def pool_member_draw_cap_period_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def pool_member_draw_cap_period_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def pool_member_draw_cap_period_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def pool_member_draw_cap_period_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def pool_member_draw_cap_period_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::String)) }
+    def pool_member_draw_cap_period_previously_was; end
+
+    sig { returns(T.nilable(::String)) }
+    def pool_member_draw_cap_period_was; end
+
+    sig { void }
+    def pool_member_draw_cap_period_will_change!; end
+
     sig { void }
     def restore_ai_agent_id!; end
 
@@ -1396,7 +1621,16 @@ class LLMUsageRecord
     def restore_created_at!; end
 
     sig { void }
+    def restore_enrollment_draw_cap_cents!; end
+
+    sig { void }
+    def restore_enrollment_draw_cap_period!; end
+
+    sig { void }
     def restore_estimated_cost_cents!; end
+
+    sig { void }
+    def restore_funding_pool_enrollment_id!; end
 
     sig { void }
     def restore_funding_pool_id!; end
@@ -1424,6 +1658,12 @@ class LLMUsageRecord
 
     sig { void }
     def restore_payer_stripe_customer_id!; end
+
+    sig { void }
+    def restore_pool_member_draw_cap_cents!; end
+
+    sig { void }
+    def restore_pool_member_draw_cap_period!; end
 
     sig { void }
     def restore_selection_id!; end
@@ -1464,11 +1704,29 @@ class LLMUsageRecord
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_created_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
+    sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+    def saved_change_to_enrollment_draw_cap_cents; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_enrollment_draw_cap_cents?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def saved_change_to_enrollment_draw_cap_period; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_enrollment_draw_cap_period?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
     sig { returns(T.nilable([T.nilable(::BigDecimal), T.nilable(::BigDecimal)])) }
     def saved_change_to_estimated_cost_cents; end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_estimated_cost_cents?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def saved_change_to_funding_pool_enrollment_id; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_funding_pool_enrollment_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
     def saved_change_to_funding_pool_id; end
@@ -1523,6 +1781,18 @@ class LLMUsageRecord
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_payer_stripe_customer_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([T.nilable(::Integer), T.nilable(::Integer)])) }
+    def saved_change_to_pool_member_draw_cap_cents; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_pool_member_draw_cap_cents?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
+    def saved_change_to_pool_member_draw_cap_period; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_pool_member_draw_cap_period?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([::String, ::String])) }
     def saved_change_to_selection_id; end
@@ -1693,7 +1963,16 @@ class LLMUsageRecord
     def will_save_change_to_created_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_enrollment_draw_cap_cents?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_enrollment_draw_cap_period?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_estimated_cost_cents?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_funding_pool_enrollment_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_funding_pool_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
@@ -1721,6 +2000,12 @@ class LLMUsageRecord
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_payer_stripe_customer_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_pool_member_draw_cap_cents?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_pool_member_draw_cap_period?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_selection_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/test/controllers/internal/llm_gateway_controller_test.rb
+++ b/test/controllers/internal/llm_gateway_controller_test.rb
@@ -357,6 +357,35 @@ class Internal::LLMGatewayControllerTest < ActionDispatch::IntegrationTest
     assert_equal "cus_pool_a", record.payer_stripe_customer_id
   end
 
+  test "a pool draw stamps the terms it was authorized against on the usage record" do
+    pool = attach_funding_pool!(@ai_agent, ["cus_pool_a"])
+    enrollment = pool.enrollments.find_by!(user: @user)
+
+    select_payer(task_run_id: @unbilled_task_run.id)
+
+    assert_response :success
+    selection_id = JSON.parse(response.body)["selection_id"]
+    record = LLMUsageRecord.find_by!(selection_id: selection_id)
+    assert_equal enrollment.id, record.funding_pool_enrollment_id
+    assert_equal 500, record.enrollment_draw_cap_cents
+    assert_equal "day", record.enrollment_draw_cap_period
+    assert_equal 500, record.pool_member_draw_cap_cents
+    assert_equal "day", record.pool_member_draw_cap_period
+  end
+
+  test "an individual billing draw stamps no authorizing terms" do
+    select_payer(task_run_id: @task_run.id)
+
+    assert_response :success
+    selection_id = JSON.parse(response.body)["selection_id"]
+    record = LLMUsageRecord.find_by!(selection_id: selection_id)
+    assert_nil record.funding_pool_enrollment_id
+    assert_nil record.enrollment_draw_cap_cents
+    assert_nil record.enrollment_draw_cap_period
+    assert_nil record.pool_member_draw_cap_cents
+    assert_nil record.pool_member_draw_cap_period
+  end
+
   test "a failed payer resolution opens no usage record" do
     select_payer(task_run_id: @unbilled_task_run.id)
 
@@ -403,6 +432,30 @@ class Internal::LLMGatewayControllerTest < ActionDispatch::IntegrationTest
     # (812 × $3.00 + 344 × $15.00) / 1M tokens = $0.007596 → 0.7596¢
     assert_in_delta 0.7596, record.estimated_cost_cents.to_f, 0.0001
     assert_not_nil record.completed_at, "spend sums anchor on completion time, so record-usage must stamp it"
+  end
+
+  test "completing a pool draw preserves its authorizing-terms receipt" do
+    pool = attach_funding_pool!(@ai_agent, ["cus_pool_a"])
+    enrollment = pool.enrollments.find_by!(user: @user)
+    select_payer(task_run_id: @unbilled_task_run.id)
+    selection_id = JSON.parse(response.body)["selection_id"]
+
+    prices = { "anthropic/claude-sonnet-4.6" => { input_per_million: "3.00", output_per_million: "15.00" } }
+    GatewayModelCatalog.stub :prices, prices do
+      record_usage(selection_id: selection_id, model: "anthropic/claude-sonnet-4.6",
+                   input_tokens: 812, output_tokens: 344, status: "ok")
+    end
+
+    assert_response :success
+    record = LLMUsageRecord.find_by!(selection_id: selection_id)
+    assert_equal "completed", record.status
+    # The receipt is stamped at selection and must outlive completion: settling
+    # a dispute reads the terms off the completed row.
+    assert_equal enrollment.id, record.funding_pool_enrollment_id
+    assert_equal 500, record.enrollment_draw_cap_cents
+    assert_equal "day", record.enrollment_draw_cap_period
+    assert_equal 500, record.pool_member_draw_cap_cents
+    assert_equal "day", record.pool_member_draw_cap_period
   end
 
   test "record-usage is idempotent on the selection id" do

--- a/test/services/llm_gateway/payer_resolver_test.rb
+++ b/test/services/llm_gateway/payer_resolver_test.rb
@@ -126,6 +126,33 @@ module LLMGateway
       assert_nil result.funding_pool_id
     end
 
+    test "a pool result carries the terms the draw was authorized against" do
+      pool = create_funding_pool!(primary_cap: 300)
+      @ai_agent.update!(funding_pool: pool)
+      enrollment = pool.enrollments.find_by!(user: @user)
+
+      result = PayerResolver.resolve(@task_run)
+
+      assert_equal "cus_primary", result.payer_customer_id
+      assert_equal enrollment.id, result.funding_pool_enrollment_id
+      assert_equal 300, result.enrollment_draw_cap_cents, "the selected member's own ceiling"
+      assert_equal "day", result.enrollment_draw_cap_period
+      assert_equal 500, result.pool_member_draw_cap_cents, "the pool's per-member ceiling"
+      assert_equal "day", result.pool_member_draw_cap_period
+    end
+
+    test "an individual billing result carries no authorizing terms" do
+      create_stamped_billing_customer!
+
+      result = PayerResolver.resolve(@task_run)
+
+      assert_nil result.funding_pool_enrollment_id
+      assert_nil result.enrollment_draw_cap_cents
+      assert_nil result.enrollment_draw_cap_period
+      assert_nil result.pool_member_draw_cap_cents
+      assert_nil result.pool_member_draw_cap_period
+    end
+
     test "falls back to the stamped billing customer without a funding pool" do
       create_stamped_billing_customer!
 


### PR DESCRIPTION
## What

Every pool draw now records, at selection time, the ceilings it was authorized against — the member's enrollment ceiling and the pool's per-member ceiling — plus the enrollment id. The usage ledger row becomes a self-contained receipt.

## Why

The dispute this guards against: a member believes the pool drew their credits unfairly. Settling it requires proving, *at the moment of each draw*, whether the member was enrolled and what ceiling they had consented to. Today those terms are read live in `PayerResolver` and discarded, and the enrollment row is mutable + reused (ceiling overwritten, withdrawal timestamp erased on rejoin) — so the terms-at-draw-time were unreconstructable. Now each draw is self-justifying and the dispute is settleable from the ledger alone.

## How

- **`PayerResolver`** threads each eligible member's terms through selection via a new `Candidate` struct, so the chosen payer's ceiling is captured with no extra query. The resolver `Result` carries the receipt.
- **Gateway controller** writes the five fields when opening the pending ledger row. Both ingress paths (task-run and direct-token) are covered, so external-agent-on-pool draws get receipts too.
- Both caps are snapshotted because both are enforced independently.

## Schema

Five nullable columns on `llm_usage_records`: `funding_pool_enrollment_id`, `enrollment_draw_cap_cents/period`, `pool_member_draw_cap_cents/period`.

- **No backfill.** NULL means either an individual-payer draw (no pool authorized it) or a pre-receipt row. The historical ceiling was never recorded, so there is nothing honest to backfill — the guarantee is forward-only from deploy.
- **`funding_pool_enrollment_id` is a soft pointer, not an FK.** The enrollment row dies with its pool, but the receipt must outlive both; the snapshotted cap values stand on their own (same point-in-time reasoning that keeps `payer_stripe_customer_id` a bare string). The existing `funding_pool_id` FK *restricts* pool deletion, so a pool with draw history can't be destroyed out from under its receipts.

## Tests

Red→green throughout:
- `PayerResolver`: a pool result carries the member ceiling and pool ceiling distinctly; an individual result carries none.
- Controller: a pool draw stamps the receipt; an individual draw stamps none; **a completed draw preserves its receipt** (guards the audit against a future refactor).

Full suites green (86 resolver + controller runs), Sorbet clean, RBI regenerated.

## Follow-ups (not in this PR)

- Member-facing itemized "draws from my credits" view — surfaces this data so a dispute doesn't require a DB query.
- Layer 2 (append-only enrollment event log) — needed only when caps become collective-set/per-principal, or for disputes about enrollment state during a window with no draws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)