### PR TITLE
Surface role/group tags in @mention autocomplete (#465)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -792,6 +792,13 @@ ul.attachments-list {
   object-fit: cover;
 }
 
+/* Group tags (@everyone, @representatives, …) render a group glyph instead of
+   an avatar, tinted apart from a person's avatar so a broadcast mention reads
+   as a set of people (#465). */
+.mention-avatar-group {
+  background-color: var(--color-neutral-emphasis);
+}
+
 .mention-info {
   display: flex;
   flex-direction: column;

--- a/app/assets/stylesheets/pulse/_components.css
+++ b/app/assets/stylesheets/pulse/_components.css
@@ -2711,6 +2711,13 @@ a.pulse-activity-title:hover {
   object-fit: cover;
 }
 
+/* Group tags (@everyone, @representatives, …) render a group glyph instead of
+   an avatar, tinted apart from a person's avatar so a broadcast mention reads
+   as a set of people (#465). */
+.mention-avatar-group {
+  background-color: var(--color-neutral-emphasis);
+}
+
 .mention-info {
   display: flex;
   flex-direction: column;

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -7,10 +7,30 @@ class AutocompleteController < ApplicationController
   # Returns JSON list of users matching the search query for @mention autocomplete
   # Scoped to members of the current collective
   # If query is blank, returns 10 collective members sorted alphabetically by handle
+  #
+  # Group tags (@everyone and the role tags @admins/@representatives/…) are not
+  # users, so the member search below never surfaces them; they're injected
+  # separately so typing "@rep" discovers "@representatives" the same way it
+  # finds a person (#465).
   def users
     query = params[:q].to_s.strip.downcase
     return render json: [] if @current_collective.blank?
 
+    # Group tags surface regardless of the member-search early-returns below
+    # (which fire when the collective has no other/searchable members), so a
+    # role tag is still discoverable in a collective where you're the only one
+    # composing.
+    tag_results = group_tag_suggestions(query)
+
+    render json: (tag_results + member_suggestions(query)).first(10)
+  end
+
+  private
+
+  # The user half of the autocomplete: collective members matching `query`,
+  # plus the @trio magic handle. Returns [] (not a rendered response) so #users
+  # can merge it with the group-tag suggestions.
+  def member_suggestions(query)
     # Get user IDs who are members of the current collective (excluding current user)
     collective_member_ids = CollectiveMember
       .where(tenant_id: @current_tenant.id, collective_id: @current_collective.id, archived_at: nil)
@@ -24,7 +44,7 @@ class AutocompleteController < ApplicationController
       .flatten.uniq - [@current_user.id]
     collective_member_ids -= block_ids if block_ids.any?
 
-    return render json: [] if collective_member_ids.empty?
+    return [] if collective_member_ids.empty?
 
     # Search tenant users by handle or display_name, limited to collective members
     tenant_users = TenantUser
@@ -77,10 +97,47 @@ class AutocompleteController < ApplicationController
       end
     end
 
-    render json: results
+    results
   end
 
-  private
+  # Group-tag suggestions matching `query`: the role tags (@admins,
+  # @representatives, @summarizers, …) and @everyone. A role tag is offered only
+  # when someone in the collective actually holds that role, so we never suggest
+  # a mention that would expand to nobody. @everyone is offered only to admins,
+  # mirroring its admin-only delivery gate (MentionParser.resolve_collective_local)
+  # so a non-admin isn't shown a tag they can't fan out. Handles come straight
+  # from ReservedHandles, so a new/custom role's tag surfaces here with no change.
+  def group_tag_suggestions(query)
+    suggestions = ReservedHandles.role_tags.filter_map do |tag, role|
+      next unless tag_matches?(tag, query)
+      next if @current_collective.users_with_role(role).empty?
+
+      group_tag_result(tag)
+    end
+
+    everyone = ReservedHandles::EVERYONE
+    if tag_matches?(everyone, query) && @current_collective.admin?(@current_user)
+      suggestions << group_tag_result(everyone)
+    end
+
+    suggestions
+  end
+
+  # A tag matches when the typed query is a prefix of it (so "@rep" offers
+  # "@representatives"), or when nothing's been typed yet.
+  def tag_matches?(tag, query)
+    query.empty? || tag.start_with?(query)
+  end
+
+  def group_tag_result(tag)
+    {
+      id: "group:#{tag}",
+      handle: tag,
+      display_name: tag.titleize,
+      avatar_url: nil,
+      group: true,
+    }
+  end
 
   def require_user
     return if current_user

--- a/app/javascript/controllers/mention_autocomplete_controller.test.ts
+++ b/app/javascript/controllers/mention_autocomplete_controller.test.ts
@@ -213,6 +213,44 @@ describe("MentionAutocompleteController", () => {
     expect(dropdownElement.style.display).toBe("none")
   })
 
+  it("renders group tags with a group glyph, sorted ahead of people", async () => {
+    // Server returns a person and a group tag for the query "rep".
+    const mockResults = [
+      { id: "1", handle: "reppy-person", display_name: "Reppy Person", avatar_url: null },
+      { id: "group:representatives", handle: "representatives", display_name: "Representatives", avatar_url: null, group: true },
+    ]
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResults),
+    })
+    vi.stubGlobal("fetch", mockFetch)
+
+    const inputElement = document.querySelector("[data-mention-autocomplete-target='input']") as HTMLTextAreaElement
+    const dropdownElement = document.querySelector(
+      "[data-mention-autocomplete-target='dropdown']"
+    ) as HTMLElement
+
+    inputElement.value = "@rep"
+    inputElement.selectionStart = 4
+    inputElement.dispatchEvent(new Event("input"))
+
+    await vi.advanceTimersByTimeAsync(200)
+
+    await vi.waitFor(() => {
+      expect(dropdownElement.innerHTML).toContain("representatives")
+    })
+
+    // Group tag renders with the group avatar class and an svg glyph, not initials.
+    expect(dropdownElement.innerHTML).toContain("mention-avatar-group")
+    expect(dropdownElement.innerHTML).toContain("<svg")
+
+    // The group tag sorts ahead of the person, so it's the first (selected) item.
+    const items = dropdownElement.querySelectorAll(".mention-item")
+    expect(items[0].innerHTML).toContain("representatives")
+    expect(items[1].innerHTML).toContain("reppy-person")
+  })
+
   it("filters cached results immediately without waiting for server", async () => {
     const mockUsers = [
       { id: "1", handle: "alice", display_name: "Alice Smith", avatar_url: null },

--- a/app/javascript/controllers/mention_autocomplete_controller.ts
+++ b/app/javascript/controllers/mention_autocomplete_controller.ts
@@ -5,6 +5,9 @@ interface UserResult {
   handle: string
   display_name: string
   avatar_url: string | null
+  // True for group tags (@everyone, @admins, @representatives, …) — a mention
+  // that expands to a set of users rather than naming one person (#465).
+  group?: boolean
 }
 
 /**
@@ -127,7 +130,7 @@ export default class MentionAutocompleteController extends Controller<HTMLElemen
 
     // If no query, return first 10 users sorted alphabetically
     if (!query) {
-      return [...this.cachedUsers].sort((a, b) => a.handle.localeCompare(b.handle)).slice(0, 10)
+      return [...this.cachedUsers].sort(this.compareResults).slice(0, 10)
     }
 
     const lowerQuery = query.toLowerCase()
@@ -136,8 +139,21 @@ export default class MentionAutocompleteController extends Controller<HTMLElemen
         (user) =>
           user.handle.toLowerCase().includes(lowerQuery) || user.display_name.toLowerCase().includes(lowerQuery)
       )
-      .sort((a, b) => a.handle.localeCompare(b.handle))
+      .sort(this.compareResults)
       .slice(0, 10)
+  }
+
+  /**
+   * Sort group tags (@everyone, @representatives, …) ahead of people, then
+   * alphabetically by handle within each. Group tags are high-value, broadcast
+   * mentions, so surfacing them first keeps them from being pushed out of the
+   * top-10 slice by a long list of members.
+   */
+  private compareResults = (a: UserResult, b: UserResult): number => {
+    if (!!a.group !== !!b.group) {
+      return a.group ? -1 : 1
+    }
+    return a.handle.localeCompare(b.handle)
   }
 
   private handleKeydown(event: KeyboardEvent): void {
@@ -280,11 +296,17 @@ export default class MentionAutocompleteController extends Controller<HTMLElemen
     this.dropdownTarget.innerHTML = this.results
       .map(
         (user, index) => `
-        <div class="mention-item ${index === this.selectedIndex ? "mention-item-selected" : ""}"
+        <div class="mention-item ${index === this.selectedIndex ? "mention-item-selected" : ""} ${user.group ? "mention-item-group" : ""}"
              data-index="${index}"
              data-action="click->mention-autocomplete#clickResult">
-          <span class="mention-avatar">
-            ${user.avatar_url ? `<img src="${user.avatar_url}" alt="" />` : this.getInitials(user.display_name)}
+          <span class="mention-avatar ${user.group ? "mention-avatar-group" : ""}">
+            ${
+              user.group
+                ? this.groupIcon()
+                : user.avatar_url
+                  ? `<img src="${user.avatar_url}" alt="" />`
+                  : this.getInitials(user.display_name)
+            }
           </span>
           <span class="mention-info">
             <span class="mention-display-name">${this.escapeHtml(user.display_name)}</span>
@@ -493,6 +515,17 @@ export default class MentionAutocompleteController extends Controller<HTMLElemen
     const div = document.createElement("div")
     div.textContent = text
     return div.innerHTML
+  }
+
+  /**
+   * A small "group of people" glyph shown in place of an avatar for group tags,
+   * so a broadcast mention reads as a set rather than a person (#465).
+   */
+  private groupIcon(): string {
+    return `<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
+      <path d="M5.5 3.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5ZM1 12.5C1 10.6 2.9 9.5 5.5 9.5S10 10.6 10 12.5V13H1v-.5Z"/>
+      <path d="M11 8a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm-.6 1.51c.2-.01.4-.01.6-.01 2.4 0 4 1 4 2.75V13h-3.5v-.5c0-1.2-.5-2.2-1.1-2.99Z"/>
+    </svg>`
   }
 
   private getInitials(name: string): string {

--- a/test/controllers/autocomplete_controller_test.rb
+++ b/test/controllers/autocomplete_controller_test.rb
@@ -47,6 +47,78 @@ class AutocompleteControllerTest < ActionDispatch::IntegrationTest
     assert_equal "trio", trio_entry["handle"]
   end
 
+  # === Role / Group Tag Autocomplete (#465) ===
+
+  test "role tag surfaces in autocomplete when a member holds the role" do
+    rep = create_user(email: "rep@example.com", name: "Rep Person")
+    @tenant.add_user!(rep)
+    @collective.add_user!(rep)
+    @collective.collective_members.find_by(user: rep).add_role!("representative")
+
+    sign_in_as(@user, tenant: @tenant)
+    get "/collectives/#{@collective.handle}/autocomplete/users",
+      params: { q: "rep" }, headers: { "Accept" => "application/json" }
+    assert_response :success
+
+    json = JSON.parse(response.body)
+    tag = json.find { |e| e["handle"] == "representatives" }
+    assert tag, "expected @representatives to appear for query 'rep'"
+    assert_equal true, tag["group"], "role tag should be flagged as a group"
+    assert_nil tag["avatar_url"]
+  end
+
+  test "role tag is absent when no member holds the role" do
+    # No summarizers in the collective, so @summarizers would notify nobody.
+    sign_in_as(@user, tenant: @tenant)
+    get "/collectives/#{@collective.handle}/autocomplete/users",
+      params: { q: "sum" }, headers: { "Accept" => "application/json" }
+    assert_response :success
+
+    json = JSON.parse(response.body)
+    assert_nil json.find { |e| e["handle"] == "summarizers" },
+      "should not suggest a role tag that expands to nobody"
+  end
+
+  test "everyone tag is offered to admins" do
+    @collective.collective_members.find_by(user: @user).add_role!("admin")
+
+    sign_in_as(@user, tenant: @tenant)
+    get "/collectives/#{@collective.handle}/autocomplete/users",
+      params: { q: "every" }, headers: { "Accept" => "application/json" }
+    assert_response :success
+
+    json = JSON.parse(response.body)
+    tag = json.find { |e| e["handle"] == "everyone" }
+    assert tag, "admins should be offered @everyone"
+    assert_equal true, tag["group"]
+  end
+
+  test "everyone tag is hidden from non-admins" do
+    # @user is a plain member here (no admin role granted).
+    sign_in_as(@user, tenant: @tenant)
+    get "/collectives/#{@collective.handle}/autocomplete/users",
+      params: { q: "every" }, headers: { "Accept" => "application/json" }
+    assert_response :success
+
+    json = JSON.parse(response.body)
+    assert_nil json.find { |e| e["handle"] == "everyone" },
+      "non-admins can't fan out @everyone, so it shouldn't be suggested"
+  end
+
+  test "role tag only prefix-matches the query" do
+    @collective.collective_members.find_by(user: @user).add_role!("admin")
+
+    sign_in_as(@user, tenant: @tenant)
+    # "min" is a substring of "admins" but not a prefix — should not match.
+    get "/collectives/#{@collective.handle}/autocomplete/users",
+      params: { q: "min" }, headers: { "Accept" => "application/json" }
+    assert_response :success
+
+    json = JSON.parse(response.body)
+    assert_nil json.find { |e| e["handle"] == "admins" },
+      "role tag should match on prefix, not arbitrary substring"
+  end
+
   # === Unauthenticated Access Tests ===
 
   test "unauthenticated user gets 401 for users autocomplete" do


### PR DESCRIPTION
Closes #465.

## Problem

Role tags (`@representatives`, `@admins`, `@summarizers`) and `@everyone` deliver notifications correctly, but they never appeared in the `@` mention autocomplete. Typing `@rep` suggested nothing, so a user had to already know the tag and type it out by hand — a pure discovery gap.

## Cause

`AutocompleteController#users` only searched collective members. Group tags aren't user records, so they were never in the result set.

## Fix

**Backend** — inject group-tag suggestions alongside the member results:

- Role tags come from `ReservedHandles.role_tags` (derived from the collective role list), so a new/custom role's tag surfaces here with no change.
- A role tag is offered **only when a member actually holds that role**, so we never suggest a mention that would expand to nobody.
- `@everyone` is offered **only to admins**, mirroring its admin-only delivery gate (`MentionParser.resolve_collective_local`) — a non-admin isn't shown a tag they can't fan out.
- Tags **prefix-match** the query (`@rep` → `@representatives`) and are computed independently of the member-search early-returns, so they stay discoverable even in a collective where you're the only member composing.

**Frontend** — group tags sort ahead of people and render a small group glyph instead of an avatar, so a broadcast mention reads as a set rather than a person. The result shape gains an optional `group` flag; everything else is unchanged.

## Testing

- `test/controllers/autocomplete_controller_test.rb` — role tag surfaces when held / hidden when unheld; `@everyone` shown to admins, hidden from non-admins; prefix-not-substring matching. (21 runs green.)
- `mention_autocomplete_controller.test.ts` — group tag renders the glyph + `mention-avatar-group` class and sorts ahead of people. (9 tests green.)
- `tsc --noEmit` clean; `srb tc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)