### PR TITLE
Add automator and moderator collective roles

### DIFF
--- a/app/controllers/collective_automations_controller.rb
+++ b/app/controllers/collective_automations_controller.rb
@@ -7,7 +7,7 @@ class CollectiveAutomationsController < ApplicationController
   helper_method :automations_index_path, :automation_path
 
   before_action :require_user
-  before_action :require_collective_admin
+  before_action :require_automation_manager
   before_action :require_automations_flag
   before_action :set_sidebar_mode, only: [:index, :new, :show, :edit, :runs, :run_show]
   before_action :set_automation_rule, only: [
@@ -470,13 +470,14 @@ class CollectiveAutomationsController < ApplicationController
     end
   end
 
-  def require_collective_admin
-    return if @current_user.collective_member&.is_admin?
+  # Admins and automators share the full automation-management surface.
+  def require_automation_manager
+    return if @current_user.collective_member&.can_manage_automations?
 
     respond_to do |format|
-      format.html { redirect_to @current_collective.path, alert: "You must be a collective admin to manage automations." }
+      format.html { redirect_to @current_collective.path, alert: "You must be a collective admin or automator to manage automations." }
       format.json { render json: { error: "Forbidden" }, status: :forbidden }
-      format.md { render plain: "# Error\n\nYou must be a collective admin to manage automations.", status: :forbidden }
+      format.md { render plain: "# Error\n\nYou must be a collective admin or automator to manage automations.", status: :forbidden }
     end
   end
 

--- a/app/models/collective_member.rb
+++ b/app/models/collective_member.rb
@@ -107,6 +107,13 @@ class CollectiveMember < ApplicationRecord
     archived_at.nil? && (has_role?('summarizer') || T.must(collective).any_member_can_summarize?)
   end
 
+  # Admins have the full automation-management surface; the automator role
+  # grants that same surface without the rest of admin.
+  sig { returns(T::Boolean) }
+  def can_manage_automations?
+    archived_at.nil? && (is_admin? || is_automator?)
+  end
+
   # Alias for backwards compatibility
   sig { returns(T::Boolean) }
   def is_admin?

--- a/app/models/concerns/has_roles.rb
+++ b/app/models/concerns/has_roles.rb
@@ -49,13 +49,25 @@ module HasRoles # TenantUser, CollectiveMember, ...
     has_role?('summarizer')
   end
 
+  def is_automator?
+    has_role?('automator')
+  end
+
+  def is_moderator?
+    has_role?('moderator')
+  end
+
   class_methods do
     def where_has_role(role)
       where("settings->'roles' ? :role", role: role)
     end
 
+    # `automator` grants automation management (see
+    # CollectiveMember#can_manage_automations?); `moderator` is a named role
+    # that grants no capabilities yet — the moderation controls it will gate
+    # are a separate feature.
     def valid_roles
-      ['admin', 'representative', 'summarizer']
+      ['admin', 'representative', 'summarizer', 'automator', 'moderator']
     end
   end
 end

--- a/app/views/help/collectives.md.erb
+++ b/app/views/help/collectives.md.erb
@@ -24,7 +24,11 @@ Admins can configure:
 - **Admin** — Can change settings, manage members, and perform all actions
 - **Representative** — Can start representation sessions to act on behalf of the collective in other collectives
 - **Summarizer** — Can write and maintain the summaries of the collective's content
+- **Automator** — Can create and configure the collective's [automations](/help/automations) (otherwise admin-only)
+- **Moderator** — A named role for members trusted with moderation; it does not grant any special capabilities yet
 - **Member** — Can create content, vote, comment, and participate in the collective
+
+Admins grant and revoke roles from the members page. Every role has a mention tag that expands to its holders — `@admins`, `@representatives`, `@summarizers`, `@automators`, `@moderators`.
 
 ## Representation and Collective Agency
 

--- a/test/controllers/collective_automations_controller_test.rb
+++ b/test/controllers/collective_automations_controller_test.rb
@@ -337,6 +337,69 @@ class CollectiveAutomationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
+  # === Automator role ===
+  #
+  # The automator role grants the full automation-management surface that
+  # admins have — it relaxes WHO passes the gate, nothing else. The paid-tier
+  # gate is orthogonal and still applies.
+
+  def make_automator!
+    member = @collective.collective_members.find_by(user: @user)
+    member.update!(settings: { "roles" => ["automator"] })
+  end
+
+  test "an automator can view automations index" do
+    make_automator!
+
+    get "/collectives/#{@collective.handle}/settings/automations", headers: @headers
+    assert_response :success
+  end
+
+  test "an automator can create an automation" do
+    make_automator!
+
+    assert_difference "AutomationRule.unscoped.count" do
+      post "/collectives/#{@collective.handle}/settings/automations/new/actions/create_automation_rule",
+        params: { yaml_source: valid_yaml }.to_json,
+        headers: @headers
+    end
+
+    assert_response :success
+  end
+
+  test "an automator can toggle an automation" do
+    rule = create_collective_automation_rule(name: "Toggle Target")
+    make_automator!
+
+    post "/collectives/#{@collective.handle}/settings/automations/#{rule.truncated_id}/actions/toggle_automation_rule",
+      headers: @headers
+
+    assert_response :success
+    assert_not rule.reload.enabled
+  end
+
+  test "the moderator role grants no automation access" do
+    member = @collective.collective_members.find_by(user: @user)
+    member.update!(settings: { "roles" => ["moderator"] })
+
+    get "/collectives/#{@collective.handle}/settings/automations", headers: @headers
+    assert_response :forbidden
+  end
+
+  test "the paid-tier gate still applies to automators" do
+    # setup_gate_test switches to session auth on a free-tier collective with
+    # stripe_billing on — the arrangement where the tier gate actually bites.
+    setup_gate_test
+    make_automator!
+
+    assert_no_difference "AutomationRule.unscoped.count" do
+      post "/collectives/#{@collective.handle}/settings/automations/new/actions/create_automation_rule",
+        params: { yaml_source: valid_yaml }
+    end
+
+    assert_match(/paid plan/i, flash[:error].to_s.presence || response.body)
+  end
+
   # === Webhook Trigger Type Tests ===
 
   test "can create automation with webhook trigger type" do

--- a/test/models/collective_member_test.rb
+++ b/test/models/collective_member_test.rb
@@ -189,4 +189,40 @@ class CollectiveMemberTest < ActiveSupport::TestCase
     assert_equal note, reads.first[:note]
     assert reads.first[:read_at].present?
   end
+
+  # === automator / moderator roles ===
+
+  test "automator is a valid grantable role" do
+    @collective_member.add_role!("automator")
+
+    assert @collective_member.has_role?("automator")
+    assert @collective_member.is_automator?
+  end
+
+  test "moderator is a valid grantable role" do
+    @collective_member.add_role!("moderator")
+
+    assert @collective_member.has_role?("moderator")
+    assert @collective_member.is_moderator?
+  end
+
+  test "automator and moderator predicates are false by default" do
+    assert_not @collective_member.is_automator?
+    assert_not @collective_member.is_moderator?
+  end
+
+  test "can_manage_automations? is true for admins and automators only" do
+    assert_not @collective_member.can_manage_automations?
+
+    @collective_member.add_role!("automator")
+    assert @collective_member.can_manage_automations?
+
+    @collective_member.remove_role!("automator")
+    @collective_member.add_role!("admin")
+    assert @collective_member.can_manage_automations?
+
+    @collective_member.remove_role!("admin")
+    @collective_member.add_role!("moderator")
+    assert_not @collective_member.can_manage_automations?, "moderator grants no capabilities yet"
+  end
 end

--- a/test/services/mention_parser_test.rb
+++ b/test/services/mention_parser_test.rb
@@ -220,6 +220,26 @@ class MentionParserTest < ActiveSupport::TestCase
     assert_equal [summarizer.id], sums.map(&:id)
   end
 
+  test "parse resolves @automators and @moderators to their role holders" do
+    tenant, collective, admin = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    collective.add_user!(admin, roles: ["admin"])
+
+    automator = create_user(email: "auto@example.com", name: "Automator")
+    tenant.add_user!(automator)
+    collective.add_user!(automator, roles: ["automator"])
+
+    moderator = create_user(email: "mod@example.com", name: "Moderator")
+    tenant.add_user!(moderator)
+    collective.add_user!(moderator, roles: ["moderator"])
+
+    autos = MentionParser.parse("ping @automators", tenant_id: tenant.id, collective: collective, author: admin)
+    assert_equal [automator.id], autos.map(&:id)
+
+    mods = MentionParser.parse("ping @moderators", tenant_id: tenant.id, collective: collective, author: admin)
+    assert_equal [moderator.id], mods.map(&:id)
+  end
+
   test "parse resolves @everyone to all members when the author is an admin" do
     tenant, collective, admin = create_tenant_collective_user
     Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)


### PR DESCRIPTION
## Summary

Two new grantable collective-member roles alongside `admin` / `representative` / `summarizer`, assignable to anyone — human or agent — through the existing role-grant flow. Component 1 of the personas track (the roles are deliberately independent of the agent personas that will later hold them by default).

- **`automator`** — grants the full automation-management surface admins have. The `collective_automations` gate becomes admin-or-automator via a new `CollectiveMember#can_manage_automations?` predicate (same shape as `can_summarize?`: active membership required). The paid-tier gate on automations is orthogonal and unchanged — the role relaxes *who* may manage automations, not *whether* the collective has them.
- **`moderator`** — a named role that grants **no capabilities yet**. The moderation controls it will eventually gate are a separate feature track; naming the role now lets it be granted, displayed, and mentioned first. Help copy says this explicitly.

Because role tags, the members-page role picker, and the grant-endpoint validation all derive from `CollectiveMember.valid_roles`, the `@automators` / `@moderators` mention tags, menu entries, validation, and `role_granted` notification events all work with no further changes — the tests pin that derivation.

## Test plan

Red-green: new coverage in `collective_member_test` (role validity, predicates, `can_manage_automations?` matrix), `collective_automations_controller_test` (automator can view/create/toggle; moderator-only refused; paid-tier gate still applies to automators), and `mention_parser_test` (`@automators`/`@moderators` resolve to holders). Full runs of those files plus `collectives_controller_test` and `reserved_handles_test` green; Sorbet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)