### PR TITLE
CI: shard controller tests into two parallel jobs (#506)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,10 @@ jobs:
             paths: test/models test/components test/helpers test/mailers
           - name: services
             paths: test/services test/jobs test/channels
-          - name: controllers
-            paths: test/controllers
+          - name: controllers-1
+            shard: 0
+          - name: controllers-2
+            shard: 1
           - name: integration
             paths: test/integration
 
@@ -178,7 +180,17 @@ jobs:
           AUTH_SUBDOMAIN: auth
           REDIS_URL: redis://localhost:6379/0
           COVERAGE: true
-        run: bundle exec rails test ${{ matrix.group.paths }}
+        run: |
+          if [ -n "${{ matrix.group.shard }}" ]; then
+            # Sharded group: deterministic round-robin over sorted controller test
+            # files (NR % 2). Self-balancing by file count; bump the modulus to add shards.
+            FILES=$(find test/controllers -name '*_test.rb' | sort | awk "NR % 2 == ${{ matrix.group.shard }}")
+            echo "Shard ${{ matrix.group.shard }} running:"
+            echo "$FILES"
+            bundle exec rails test $FILES
+          else
+            bundle exec rails test ${{ matrix.group.paths }}
+          fi
 
       - name: Upload coverage results
         if: always()


### PR DESCRIPTION
Closes #506.

The `rails-tests (controllers)` matrix job is the slowest group, often more than double any other. This splits it into two parallel shards.

## What changed

Replaced the single `controllers` matrix entry with two shard entries (`controllers-1` shard 0, `controllers-2` shard 1). The **Run tests** step now branches on whether the entry carries `paths` (unchanged behavior) or `shard`:

```bash
FILES=$(find test/controllers -name '*_test.rb' | sort | awk "NR % 2 == ${{ matrix.group.shard }}")
bundle exec rails test $FILES
```

Deterministic round-robin over sorted filenames — zero new gems, self-balancing by file count, generalizes to N shards by changing the modulus. Splits **32/32** today.

## Finding on the PARALLEL_WORKERS note

The issue suggested checking whether the CI invocation caps Rails' in-job parallel workers below the runner's 4 vCPUs. It does — but **intentionally**: `test/test_helper.rb` gates parallelization on coverage —

```ruby
parallelize(workers: ENV['COVERAGE'] ? 1 : :number_of_processors)
```

— and the CI **Run tests** step always sets `COVERAGE: true`. So every rails-tests job runs single-process; raising the worker count would break coverage collection rather than speed things up. That's exactly why sharding across *jobs* is the right lever here, not more workers within one job.

## Notes

- Coverage artifacts get unique names (`coverage-controllers-1`/`-2`) and are still globbed by the `coverage-*` collate step, so the merged threshold check is unaffected.
- The static-analysis "all test directories covered by CI matrix" guard keys off directory names (`controllers`), not matrix entry names, so it stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)