### PR TITLE
Persona handle and mention-role restructuring

### DIFF
--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -47,7 +47,7 @@ class AutocompleteController < ApplicationController
     # collectives to avoid the tenant-wide handle collision). The mention
     # parser resolves "@trio" back to this collective's trio via the
     # collective.trio_user link.
-    trio_user_id = @current_collective.trio_user_id
+    trio_user_id = @current_collective.trio_user&.id
 
     results = tenant_users.map do |tu|
       display_handle = tu.user_id == trio_user_id ? MentionParser::TRIO_HANDLE : tu.handle

--- a/app/controllers/collectives_controller.rb
+++ b/app/controllers/collectives_controller.rb
@@ -1148,7 +1148,9 @@ class CollectivesController < ApplicationController
     @can_manage_members = @current_user&.collective_member&.is_admin? &&
       !@current_collective.private_workspace? &&
       !@current_collective.is_main_collective?
-    @manageable_roles = CollectiveMember.valid_roles
+    # Capability roles only: persona roles (trio) are activator-managed and
+    # never offered or accepted through the role-management surfaces.
+    @manageable_roles = CollectiveMember.capability_roles
   end
 
   def actions_index_members
@@ -1168,7 +1170,8 @@ class CollectivesController < ApplicationController
     return if member == :handled
 
     role = params[:role].to_s
-    unless CollectiveMember.valid_roles.include?(role)
+    # Capability roles only — persona roles are activator-managed.
+    unless CollectiveMember.capability_roles.include?(role)
       return render_action_error({ action_name: 'update_member_roles', resource: @current_collective, error: "Invalid role: #{role}." })
     end
 

--- a/app/controllers/collectives_controller.rb
+++ b/app/controllers/collectives_controller.rb
@@ -749,7 +749,7 @@ class CollectivesController < ApplicationController
     # Trio's attachment is automatic while the pool is open — detaching it
     # would leave a phantom state (trio active, pool open, every run
     # failing) that the next reconcile would silently undo.
-    if ai_agent.id == @current_collective.trio_user_id
+    if ai_agent.id == @current_collective.trio_user&.id
       return render_funded_agent_error(422, 'Trio is funded automatically while the pool is open — disable Trio or close the pool instead')
     end
 
@@ -1096,7 +1096,7 @@ class CollectivesController < ApplicationController
       })
     end
     # Same guard as the HTML endpoint: trio's attachment is automatic.
-    if ai_agent.id == @current_collective.trio_user_id
+    if ai_agent.id == @current_collective.trio_user&.id
       return render_action_error({
         action_name: 'detach_funded_agent',
         resource: @current_collective,

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -329,7 +329,7 @@ class UsersController < ApplicationController
     workspace.set_feature_flag!("trio", will_be_trio)
     TrioActivator.reconcile!(workspace)
 
-    flash[:notice] = "Workspace Trio is now #{workspace.trio_user_id.present? ? "enabled" : "disabled"}."
+    flash[:notice] = "Workspace Trio is now #{workspace.trio_user.present? ? "enabled" : "disabled"}."
     redirect_to "/settings"
   end
 

--- a/app/models/collective.rb
+++ b/app/models/collective.rb
@@ -11,7 +11,6 @@ class Collective < ApplicationRecord
   belongs_to :created_by, class_name: "User"
   belongs_to :updated_by, class_name: "User"
   belongs_to :identity_user, class_name: "User", optional: true
-  belongs_to :trio_user, class_name: "User", optional: true
   before_validation :create_identity_user!
   before_create :set_defaults
   after_update :sync_identity_user_handle!, if: :saved_change_to_handle?
@@ -370,7 +369,7 @@ class Collective < ApplicationRecord
     transaction do
       automation_rules.enabled.update_all(enabled: false)
       PAID_FEATURE_FLAGS.each { |flag| disable_feature_flag!(flag) }
-      TrioActivator.deactivate!(self) if trio_user_id.present?
+      TrioActivator.deactivate!(self) if trio_user.present?
       update!(tier: TIER_FREE)
     end
   end
@@ -478,6 +477,31 @@ class Collective < ApplicationRecord
   sig { params(flag_name: String).returns(T::Boolean) }
   def feature_enabled?(flag_name)
     FeatureFlagService.collective_enabled?(self, flag_name)
+  end
+
+  # The collective's ACTIVE persona agent: the unarchived member holding the
+  # persona role. Role presence IS activation state (the activator grants it
+  # on activate and removes it on deactivate), so this is nil while the
+  # persona is deactivated — the single source of truth; there is no persona
+  # FK column.
+  sig { params(persona_role: String).returns(T.nilable(User)) }
+  def persona_user(persona_role)
+    member = T.unsafe(collective_members.where(archived_at: nil)).where_has_role(persona_role).first
+    member&.user
+  end
+
+  # The persona agent ever seeded for this collective, active or
+  # deactivated — found through membership + the User's system_role, which
+  # outlives activation state. For the active persona use persona_user.
+  sig { params(system_role: String).returns(T.nilable(User)) }
+  def seeded_persona_user(system_role)
+    collective_members.joins(:user).where(users: { system_role: system_role }).first&.user
+  end
+
+  # The collective's active trio, or nil while trio is deactivated.
+  sig { returns(T.nilable(User)) }
+  def trio_user
+    persona_user(ReservedHandles::TRIO)
   end
 
   # Trio is on the pool payroll automatically: whenever an open pool and an
@@ -766,7 +790,7 @@ class Collective < ApplicationRecord
   def sync_trio_handle!
     return if handle.blank?
 
-    trio = collective_members.joins(:user).where(users: { system_role: "trio" }).first&.user
+    trio = seeded_persona_user(ReservedHandles::TRIO)
     return unless trio
 
     tenant_user = TenantUser.tenant_scoped_only(T.must(tenant_id)).find_by(user_id: trio.id)

--- a/app/models/collective.rb
+++ b/app/models/collective.rb
@@ -738,7 +738,10 @@ class Collective < ApplicationRecord
     # The identity shares the collective's handle; without one there's nothing
     # to share, so defer to `handle_is_valid` to surface the blank-handle error
     # rather than minting an orphan identity user with a placeholder handle.
+    # A reserved handle defers the same way — handle_is_valid rejects it with
+    # a friendly error instead of this callback raising mid-validation.
     return if handle.blank?
+    return if ReservedHandles.forbidden_for_collective?(handle)
 
     identity = User.create!(
       name: name,

--- a/app/models/collective.rb
+++ b/app/models/collective.rb
@@ -15,6 +15,7 @@ class Collective < ApplicationRecord
   before_validation :create_identity_user!
   before_create :set_defaults
   after_update :sync_identity_user_handle!, if: :saved_change_to_handle?
+  after_update :sync_trio_handle!, if: :saved_change_to_handle?
   tables = ActiveRecord::Base.connection.tables - [
     "tenants", "users", "tenant_users",
     "collectives", "api_tokens", "oauth_identities",
@@ -754,6 +755,28 @@ class Collective < ApplicationRecord
       tenant_id: T.must(tenant_id),
       base: T.must(handle),
       except_user_id: identity_user_id,
+    )
+    tenant_user.update!(handle: desired) unless tenant_user.handle.to_s.casecmp?(desired)
+  end
+
+  # Trio's handle embeds the collective's (`trio-<collective handle>`), so a
+  # collective rename renames its trio too. Found through membership +
+  # system_role so a deactivated trio (archived member) also follows renames.
+  sig { void }
+  def sync_trio_handle!
+    return if handle.blank?
+
+    trio = collective_members.joins(:user).where(users: { system_role: "trio" }).first&.user
+    return unless trio
+
+    tenant_user = TenantUser.tenant_scoped_only(T.must(tenant_id)).find_by(user_id: trio.id)
+    return unless tenant_user
+
+    desired = TenantUser.persona_handle_for(
+      tenant_id: T.must(tenant_id),
+      tag: "trio",
+      collective_handle: T.must(handle),
+      except_user_id: trio.id,
     )
     tenant_user.update!(handle: desired) unless tenant_user.handle.to_s.casecmp?(desired)
   end

--- a/app/models/collective.rb
+++ b/app/models/collective.rb
@@ -484,10 +484,33 @@ class Collective < ApplicationRecord
   # on activate and removes it on deactivate), so this is nil while the
   # persona is deactivated — the single source of truth; there is no persona
   # FK column.
+  #
+  # Memoized per instance (nil results included) — markdown rendering
+  # resolves @trio once per text node against one shared collective, and the
+  # old belongs_to gave that association caching for free. The activator
+  # invalidates via clear_persona_user_cache! when it changes the role;
+  # reload clears too.
   sig { params(persona_role: String).returns(T.nilable(User)) }
   def persona_user(persona_role)
+    @persona_user_cache = T.let(@persona_user_cache, T.nilable(T::Hash[String, T.nilable(User)]))
+    @persona_user_cache ||= {}
+    return @persona_user_cache.fetch(persona_role) if @persona_user_cache.key?(persona_role)
+
     member = T.unsafe(collective_members.where(archived_at: nil)).where_has_role(persona_role).first
-    member&.user
+    @persona_user_cache[persona_role] = member&.user
+  end
+
+  # Drop memoized persona lookups. Called by the persona activator after
+  # granting/removing a persona role on this instance, and on reload.
+  sig { void }
+  def clear_persona_user_cache!
+    @persona_user_cache = nil
+  end
+
+  sig { params(options: T.untyped).returns(Collective) }
+  def reload(options = nil)
+    clear_persona_user_cache!
+    super
   end
 
   # The persona agent ever seeded for this collective, active or

--- a/app/models/concerns/has_roles.rb
+++ b/app/models/concerns/has_roles.rb
@@ -62,12 +62,26 @@ module HasRoles # TenantUser, CollectiveMember, ...
       where("settings->'roles' ? :role", role: role)
     end
 
-    # `automator` grants automation management (see
+    # Grantable through the role endpoints and pickers, by admins, to any
+    # member. `automator` grants automation management (see
     # CollectiveMember#can_manage_automations?); `moderator` is a named role
     # that grants no capabilities yet — the moderation controls it will gate
     # are a separate feature.
-    def valid_roles
+    def capability_roles
       ['admin', 'representative', 'summarizer', 'automator', 'moderator']
+    end
+
+    # Reserved identity roles for the built-in agent personas. Managed only
+    # by the persona activator (granted on activation, removed on
+    # deactivation) — never grantable through the role endpoints. Mentions
+    # resolve through them: @trio → the member holding the trio role
+    # (ReservedHandles::AGENT_ROLES maps tag → persona role).
+    def persona_roles
+      ['trio']
+    end
+
+    def valid_roles
+      capability_roles + persona_roles
     end
   end
 end

--- a/app/models/reserved_handles.rb
+++ b/app/models/reserved_handles.rb
@@ -32,13 +32,15 @@ module ReservedHandles
   EVERYONE = "everyone"
   # @here (currently-active members) is intentionally deferred to a later pass.
 
-  # Each collective role maps to its pluralized tag (admin → @admins,
+  # Each capability role maps to its pluralized tag (admin → @admins,
   # representative → @representatives, summarizer → @summarizers). Keyed by tag
   # so resolution and reservation can look up the role a tag expands to. Derived
-  # from the role list, so it tracks new/custom roles automatically.
+  # from the capability role list, so it tracks new/custom roles automatically.
+  # Persona roles deliberately get no pluralized group tag — their singular
+  # tag lives in AGENT_ROLES.
   sig { returns(T::Hash[String, String]) }
   def self.role_tags
-    T.unsafe(CollectiveMember).valid_roles.index_by { |role| role.pluralize }
+    T.unsafe(CollectiveMember).capability_roles.index_by { |role| role.pluralize }
   end
 
   # @everyone plus every role tag: the handles a mention expands to a *set* of

--- a/app/models/reserved_handles.rb
+++ b/app/models/reserved_handles.rb
@@ -51,9 +51,11 @@ module ReservedHandles
   end
 
   # --- Agent-identity handles ----------------------------------------------
-  # handle => system_role required to claim it. Only the main collective's trio
-  # actually holds the literal handle; per-collective trios carry hex-suffixed
-  # handles and are reached through the collective-local resolution below.
+  # mention tag => persona role it resolves through (and the system_role
+  # required to claim the tag, or any `<tag>-*` handle, as a user handle).
+  # Persona handles follow `<tag>-<collective handle>`; no user holds the
+  # literal tag — @trio reaches the local persona via the collective-local
+  # role resolution.
   AGENT_ROLES = T.let({ "trio" => "trio" }.freeze, T::Hash[String, String])
 
   TRIO = "trio"
@@ -79,22 +81,39 @@ module ReservedHandles
   end
 
   # The system_role required to claim `handle` as a user, or nil when the handle
-  # carries no role gate.
+  # carries no role gate. Agent handles are reserved both as exact names and as
+  # prefixes: `<tag>-<collective handle>` is the persona handle pattern, so
+  # `trio-*` is claimable only by the matching system agent — otherwise a user
+  # could squat (and impersonate) a collective's future trio.
   sig { params(handle: T.nilable(String)).returns(T.nilable(String)) }
   def self.required_system_role(handle)
-    AGENT_ROLES[handle.to_s.downcase]
+    h = handle.to_s.downcase
+    exact = AGENT_ROLES[h]
+    return exact if exact
+
+    AGENT_ROLES.each do |tag, role|
+      return role if h.start_with?("#{tag}-")
+    end
+    nil
   end
 
   # True when `handle` may not be claimed by a user with the given system_role.
-  # Group tags are never a real user; an agent handle is claimable only by the
-  # matching system_role (identity users, which carry no system_role, are thus
-  # excluded from agent handles too).
-  sig { params(handle: T.nilable(String), system_role: T.nilable(String)).returns(T::Boolean) }
-  def self.forbidden_for_user?(handle, system_role: nil)
+  # Group tags are never a real user; an agent handle (exact or prefixed) is
+  # claimable only by the matching system_role. Collective identity users are
+  # a partial exception: their handle mirrors their collective's, and the
+  # collective-handle namespace has its own rules (forbidden_for_collective?
+  # allows agent names for backwards compatibility) — so an identity may sit
+  # inside an agent prefix (a collective named "trio" suffixes to
+  # "trio-xxxx"), but never on the exact agent tag itself.
+  sig { params(handle: T.nilable(String), system_role: T.nilable(String), collective_identity: T::Boolean).returns(T::Boolean) }
+  def self.forbidden_for_user?(handle, system_role: nil, collective_identity: false)
     return true if group_tag?(handle)
 
     required = required_system_role(handle)
-    !required.nil? && system_role != required
+    return false if required.nil?
+    return AGENT_ROLES.key?(handle.to_s.downcase) if collective_identity
+
+    system_role != required
   end
 
   # True when no collective may take `handle` as its handle. Group tags are

--- a/app/models/reserved_handles.rb
+++ b/app/models/reserved_handles.rb
@@ -99,30 +99,27 @@ module ReservedHandles
 
   # True when `handle` may not be claimed by a user with the given system_role.
   # Group tags are never a real user; an agent handle (exact or prefixed) is
-  # claimable only by the matching system_role. Collective identity users are
-  # a partial exception: their handle mirrors their collective's, and the
-  # collective-handle namespace has its own rules (forbidden_for_collective?
-  # allows agent names for backwards compatibility) — so an identity may sit
-  # inside an agent prefix (a collective named "trio" suffixes to
-  # "trio-xxxx"), but never on the exact agent tag itself.
-  sig { params(handle: T.nilable(String), system_role: T.nilable(String), collective_identity: T::Boolean).returns(T::Boolean) }
-  def self.forbidden_for_user?(handle, system_role: nil, collective_identity: false)
+  # claimable only by the matching system_role — no exceptions. Identity users
+  # carry no system_role, so they are excluded like everyone else; the
+  # collective handles they mirror are barred from the same namespace by
+  # forbidden_for_collective?, so the two reservations never conflict.
+  sig { params(handle: T.nilable(String), system_role: T.nilable(String)).returns(T::Boolean) }
+  def self.forbidden_for_user?(handle, system_role: nil)
     return true if group_tag?(handle)
 
     required = required_system_role(handle)
-    return false if required.nil?
-    return AGENT_ROLES.key?(handle.to_s.downcase) if collective_identity
-
-    system_role != required
+    !required.nil? && system_role != required
   end
 
   # True when no collective may take `handle` as its handle. Group tags are
   # reserved so a collective (via its identity user) can't shadow the tag; the
-  # "main" handle is reserved for the main collective. Agent handles are left
-  # claimable as collective handles for backwards compatibility.
+  # "main" handle is reserved for the main collective. Agent tags and their
+  # prefixes (`trio`, `trio-*`) are reserved unconditionally: a collective's
+  # identity user mirrors its handle, and the persona namespace admits no
+  # user but the matching system agent.
   sig { params(handle: T.nilable(String)).returns(T::Boolean) }
   def self.forbidden_for_collective?(handle)
     h = handle.to_s.downcase
-    COLLECTIVE_ONLY.include?(h) || group_tag?(h)
+    COLLECTIVE_ONLY.include?(h) || group_tag?(h) || !required_system_role(h).nil?
   end
 end

--- a/app/models/tenant_user.rb
+++ b/app/models/tenant_user.rb
@@ -71,11 +71,7 @@ class TenantUser < ApplicationRecord
     # can't slip past. Group tags are forbidden outright; agent handles require
     # the matching system_role.
     return if handle.blank?
-    return unless ReservedHandles.forbidden_for_user?(
-      handle,
-      system_role: T.must(user).system_role,
-      collective_identity: T.must(user).collective_identity?,
-    )
+    return unless ReservedHandles.forbidden_for_user?(handle, system_role: T.must(user).system_role)
 
     errors.add(:handle, "is reserved")
   end
@@ -123,10 +119,9 @@ class TenantUser < ApplicationRecord
     scope = tenant_scoped_only(tenant_id)
     scope = scope.where.not(user_id: except_user_id) if except_user_id.present?
     candidate = root
-    # Identity users can't take a group tag or an exact agent tag; a handle
-    # inside an agent prefix is fine (it mirrors a legitimately-claimed
-    # collective handle), so only the exact cases force a suffix.
-    candidate = "#{root}-#{SecureRandom.hex(2)}" if ReservedHandles.forbidden_for_user?(root, system_role: nil, collective_identity: true)
+    # Identity users never carry a system_role, so any group tag or agent
+    # handle is off-limits (forbidden_for_user? with a nil role rejects both).
+    candidate = "#{root}-#{SecureRandom.hex(2)}" if ReservedHandles.forbidden_for_user?(root, system_role: nil)
     candidate = "#{root}-#{SecureRandom.hex(2)}" while scope.exists?(handle: candidate)
     candidate
   end

--- a/app/models/tenant_user.rb
+++ b/app/models/tenant_user.rb
@@ -71,7 +71,11 @@ class TenantUser < ApplicationRecord
     # can't slip past. Group tags are forbidden outright; agent handles require
     # the matching system_role.
     return if handle.blank?
-    return unless ReservedHandles.forbidden_for_user?(handle, system_role: T.must(user).system_role)
+    return unless ReservedHandles.forbidden_for_user?(
+      handle,
+      system_role: T.must(user).system_role,
+      collective_identity: T.must(user).collective_identity?,
+    )
 
     errors.add(:handle, "is reserved")
   end
@@ -119,10 +123,24 @@ class TenantUser < ApplicationRecord
     scope = tenant_scoped_only(tenant_id)
     scope = scope.where.not(user_id: except_user_id) if except_user_id.present?
     candidate = root
-    # Identity users never carry a system_role, so any group tag or agent handle
-    # is off-limits (forbidden_for_user? with a nil role rejects both).
-    candidate = "#{root}-#{SecureRandom.hex(2)}" if ReservedHandles.forbidden_for_user?(root, system_role: nil)
+    # Identity users can't take a group tag or an exact agent tag; a handle
+    # inside an agent prefix is fine (it mirrors a legitimately-claimed
+    # collective handle), so only the exact cases force a suffix.
+    candidate = "#{root}-#{SecureRandom.hex(2)}" if ReservedHandles.forbidden_for_user?(root, system_role: nil, collective_identity: true)
     candidate = "#{root}-#{SecureRandom.hex(2)}" while scope.exists?(handle: candidate)
+    candidate
+  end
+
+  # The handle for a collective's persona agent: `<tag>-<collective handle>`,
+  # hex-suffixed only if a legacy squatter already holds the pattern (new
+  # claims of `<tag>-*` are reserved to matching system agents).
+  sig { params(tenant_id: String, tag: String, collective_handle: String, except_user_id: T.nilable(String)).returns(String) }
+  def self.persona_handle_for(tenant_id:, tag:, collective_handle:, except_user_id: nil)
+    base = "#{tag}-#{collective_handle}"
+    scope = tenant_scoped_only(tenant_id)
+    scope = scope.where.not(user_id: except_user_id) if except_user_id.present?
+    candidate = base
+    candidate = "#{base}-#{SecureRandom.hex(2)}" while scope.exists?(handle: candidate)
     candidate
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -554,14 +554,6 @@ class User < ApplicationRecord
     if collective_identity?
       collective = Collective.where(identity_user: self).first
       collective ? "collectives/" + T.must(collective.handle) : nil
-    elsif system_role == "trio"
-      # Trio's stored TenantUser handle is hex-suffixed for non-main
-      # collectives to avoid the tenant-wide handle collision, but the
-      # public-facing handle is always "trio" so mentions and profile
-      # links render consistently regardless of which collective the
-      # trio belongs to. UsersController#show makes /u/trio
-      # context-aware so the link resolves to the local trio.
-      MentionParser::TRIO_HANDLE
     else
       tenant_user&.handle
     end
@@ -571,8 +563,6 @@ class User < ApplicationRecord
   def path
     if collective_identity?
       Collective.where(identity_user: self).first&.path
-    elsif system_role == "trio"
-      "/u/#{MentionParser::TRIO_HANDLE}"
     else
       tenant_user&.path
     end

--- a/app/services/mention_parser.rb
+++ b/app/services/mention_parser.rb
@@ -109,10 +109,12 @@ class MentionParser
   end
 
   # Expand collective-local tags to the users they name, within `collective`:
-  #   @trio             → this collective's trio user
+  #   @trio             → the member holding the trio persona role (granted by
+  #                       the activator while trio is active — see
+  #                       ReservedHandles::AGENT_ROLES for the tag → role map).
   #   @admins /         → members holding that role (any member may use a role
   #   @representatives /   tag). The tags come from ReservedHandles.role_tags,
-  #   @summarizers / …     which is derived from the collective role list, so a
+  #   @summarizers / …     which is derived from the capability role list, so a
   #                        new/custom role's tag resolves here with no change.
   #   @everyone         → all members, but only when `author` is an admin.
   #                       Without a known admin author the tag expands to nobody,
@@ -130,9 +132,8 @@ class MentionParser
     wanted = handles.map(&:downcase)
     result = T.let([], T::Array[User])
 
-    if wanted.include?(TRIO_HANDLE)
-      trio = collective.trio_user
-      result << trio if trio
+    ReservedHandles::AGENT_ROLES.each do |tag, persona_role|
+      result.concat(collective.users_with_role(persona_role)) if wanted.include?(tag)
     end
 
     ReservedHandles.role_tags.each do |tag, role|
@@ -191,9 +192,9 @@ class MentionParser
       collective_path = collective.path
       handles.each do |handle|
         down = handle.downcase
-        if down == TRIO_HANDLE
-          trio_path = collective.trio_user&.path
-          paths[handle] = trio_path if trio_path
+        if (persona_role = ReservedHandles::AGENT_ROLES[down])
+          persona_path = collective.users_with_role(persona_role).first&.path
+          paths[handle] = persona_path if persona_path
         elsif ReservedHandles.group_tag?(down)
           # @everyone / @admins render as a link to the collective. Rendering is
           # display only — the admin-only gate on @everyone lives on the

--- a/app/services/trio_activator.rb
+++ b/app/services/trio_activator.rb
@@ -6,14 +6,15 @@
 # Activation either bootstraps fresh state (TrioSeeder creates the user
 # and joins it as a CollectiveMember; default automation rules are seeded)
 # or restores previously deactivated state (unarchives the CollectiveMember,
-# re-enables existing rules, re-links collective.trio_user). The restore
+# re-grants the trio persona role, re-enables existing rules). The restore
 # path preserves any user customizations to the default rules across
 # off→on→off→on cycles.
 #
-# Deactivation archives the trio's CollectiveMember in this collective,
-# disables its rules, and nulls out collective.trio_user_id. The trio User
-# row and its AutomationRule rows are kept so that a subsequent activation
-# can restore them.
+# Deactivation removes the trio persona role — the activation signal that
+# mention resolution, pool funding, and Collective#trio_user key off —
+# archives the trio's CollectiveMember, and disables its rules. The trio
+# User row and its AutomationRule rows are kept so that a subsequent
+# activation can restore them.
 class TrioActivator
   extend T::Sig
 
@@ -31,13 +32,14 @@ class TrioActivator
   # flag. Idempotent: if the flag is on and trio is already active, no-op;
   # likewise for the off case. Safe to call after every settings save.
   #
-  # Compares desired (`trio_enabled?`) to actual (`trio_user_id.present?`),
-  # not flag-transition deltas — a delta-based check would miss the first
-  # activation when the flag was already true via config default.
+  # Compares desired (`trio_enabled?`) to actual (the persona role being
+  # held — `trio_user.present?`), not flag-transition deltas — a delta-based
+  # check would miss the first activation when the flag was already true via
+  # config default.
   sig { params(collective: Collective).void }
   def self.reconcile!(collective)
     desired = collective.trio_enabled?
-    actual = collective.trio_user_id.present?
+    actual = collective.trio_user.present?
 
     if desired && !actual
       activate!(collective)
@@ -96,16 +98,16 @@ class TrioActivator
     ActiveRecord::Base.transaction do
       ensure_flag!(false)
 
-      trio = @collective.trio_user
+      trio = @collective.seeded_persona_user(ReservedHandles::TRIO)
       next unless trio
 
       member = @collective.collective_members.find_by(user_id: trio.id)
+      # Removing the persona role IS deactivation — mention resolution,
+      # reconcile!, pool funding, and Collective#trio_user all key off it.
       member&.remove_role!(ReservedHandles::TRIO)
       member&.archive!
 
       AutomationRule.where(ai_agent_id: trio.id).update_all(enabled: false)
-
-      @collective.update!(trio_user_id: nil)
     end
   end
 
@@ -122,18 +124,12 @@ class TrioActivator
     @collective.set_feature_flag!("trio", value)
   end
 
-  # Returns the trio User previously linked to this collective, even if its
+  # Returns the trio User previously seeded for this collective, even if its
   # CollectiveMember is currently archived. Returns nil if Trio has never
   # been activated here.
   sig { returns(T.nilable(User)) }
   def find_existing_trio
-    return @collective.trio_user if @collective.trio_user
-
-    member = @collective.collective_members
-      .joins(:user)
-      .where(users: { system_role: "trio" })
-      .first
-    member&.user
+    @collective.seeded_persona_user(ReservedHandles::TRIO)
   end
 
   sig { params(trio: User).returns(User) }
@@ -144,7 +140,6 @@ class TrioActivator
 
     AutomationRule.where(ai_agent_id: trio.id).update_all(enabled: true)
 
-    @collective.update!(trio_user: trio)
     @collective.ensure_trio_funded!
     trio
   end

--- a/app/services/trio_activator.rb
+++ b/app/services/trio_activator.rb
@@ -106,6 +106,7 @@ class TrioActivator
       # reconcile!, pool funding, and Collective#trio_user all key off it.
       member&.remove_role!(ReservedHandles::TRIO)
       member&.archive!
+      @collective.clear_persona_user_cache!
 
       AutomationRule.where(ai_agent_id: trio.id).update_all(enabled: false)
     end
@@ -154,11 +155,15 @@ class TrioActivator
   end
 
   # The persona role is activation state: granted here, removed on
-  # deactivate. Mention resolution (@trio) keys off it.
+  # deactivate. Mention resolution (@trio) keys off it. The memoized
+  # persona lookup on this instance is stale the moment the role changes —
+  # clear it, or a pre-activation nil read (reconcile!) would pin nil and
+  # ensure_trio_funded! would skip funding.
   sig { params(trio: User).void }
   def grant_persona_role!(trio)
     member = @collective.collective_members.find_by(user_id: trio.id)
     member&.add_role!(ReservedHandles::TRIO)
+    @collective.clear_persona_user_cache!
   end
 
   DEFAULT_AUTOMATIONS = T.let(

--- a/app/services/trio_activator.rb
+++ b/app/services/trio_activator.rb
@@ -100,6 +100,7 @@ class TrioActivator
       next unless trio
 
       member = @collective.collective_members.find_by(user_id: trio.id)
+      member&.remove_role!(ReservedHandles::TRIO)
       member&.archive!
 
       AutomationRule.where(ai_agent_id: trio.id).update_all(enabled: false)
@@ -139,6 +140,7 @@ class TrioActivator
   def restore!(trio)
     member = @collective.collective_members.find_by(user_id: trio.id)
     member.unarchive! if member&.archived?
+    grant_persona_role!(trio)
 
     AutomationRule.where(ai_agent_id: trio.id).update_all(enabled: true)
 
@@ -150,9 +152,18 @@ class TrioActivator
   sig { returns(User) }
   def bootstrap!
     trio = TrioSeeder.ensure_for(@collective)
+    grant_persona_role!(trio)
     self.class.seed_default_automations!(trio, T.must(@collective.tenant_id))
     @collective.ensure_trio_funded!
     trio
+  end
+
+  # The persona role is activation state: granted here, removed on
+  # deactivate. Mention resolution (@trio) keys off it.
+  sig { params(trio: User).void }
+  def grant_persona_role!(trio)
+    member = @collective.collective_members.find_by(user_id: trio.id)
+    member&.add_role!(ReservedHandles::TRIO)
   end
 
   DEFAULT_AUTOMATIONS = T.let(

--- a/app/services/trio_seeder.rb
+++ b/app/services/trio_seeder.rb
@@ -10,11 +10,10 @@
 #     principal — no human owner, no TrusteeGrant)
 #   - no StripeCustomer or ApiToken
 #
-# The main collective's trio claims the literal handle "trio" so its profile
-# lives at /u/trio via the normal handle index. Non-main collective trios
-# get hex-suffixed handles to avoid the tenant-wide (tenant_id, handle)
-# uniqueness collision; mention resolution for "@trio" inside those
-# collectives is handled by MentionParser via collective context.
+# Trio handles follow `trio-<collective handle>` — unique per tenant
+# (collective handles are) and pointing at the trio's own profile. The @trio
+# mention tag resolves collective-locally via the trio persona role
+# (MentionParser); no user holds the literal handle "trio".
 #
 # Idempotent. Safe to call multiple times — returns the existing trio_user
 # without modification on the second call (other than clearing any stale
@@ -100,6 +99,10 @@ class TrioSeeder
 
   sig { returns(String) }
   def pick_handle
-    @collective.is_main_collective? ? HANDLE : "#{HANDLE}-#{SecureRandom.hex(4)}"
+    TenantUser.persona_handle_for(
+      tenant_id: T.must(@collective.tenant_id),
+      tag: HANDLE,
+      collective_handle: T.must(@collective.handle),
+    )
   end
 end

--- a/app/services/trio_seeder.rb
+++ b/app/services/trio_seeder.rb
@@ -15,9 +15,10 @@
 # mention tag resolves collective-locally via the trio persona role
 # (MentionParser); no user holds the literal handle "trio".
 #
-# Idempotent. Safe to call multiple times — returns the existing trio_user
-# without modification on the second call (other than clearing any stale
-# cached identity_prompt in agent_configuration).
+# Idempotent. Safe to call multiple times — returns the collective's existing
+# trio without modification on the second call (other than clearing any stale
+# cached identity_prompt in agent_configuration). Activation state (the trio
+# persona role) is TrioActivator's job, not the seeder's.
 class TrioSeeder
   extend T::Sig
 
@@ -37,7 +38,7 @@ class TrioSeeder
   sig { returns(User) }
   def ensure
     ActiveRecord::Base.transaction do
-      existing = @collective.trio_user
+      existing = @collective.seeded_persona_user("trio")
       existing ? refresh(existing) : create
     end
   end
@@ -67,7 +68,6 @@ class TrioSeeder
     )
     tenant.add_user!(trio, handle: pick_handle)
     @collective.add_user!(trio)
-    @collective.update!(trio_user: trio)
     trio
   end
 

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -80,7 +80,7 @@
         collective-settings page, so the per-workspace flag is exposed here. %>
     <% workspace = @settings_user.private_workspace %>
     <% if workspace %>
-      <% trio_active = workspace.trio_user_id.present? %>
+      <% trio_active = workspace.trio_user.present? %>
       <% workspace_tier_locked = @current_tenant.feature_enabled?("stripe_billing") && !workspace.paid_tier? && !workspace.is_main_collective? %>
       <%= render 'shared/pulse_accordion', title: 'Workspace AI Assistant' do %>
         <div style="margin-bottom: 12px;">

--- a/db/migrate/20260717090000_drop_trio_user_id_from_collectives.rb
+++ b/db/migrate/20260717090000_drop_trio_user_id_from_collectives.rb
@@ -10,6 +10,27 @@
 #   3. Drop the column.
 class DropTrioUserIdFromCollectives < ActiveRecord::Migration[7.2]
   def up
+    # The persona namespace (trio, trio-*) is now reserved unconditionally for
+    # users AND collectives. Existing offenders wouldn't fail this migration —
+    # they'd wedge later, failing validation on their next save with no
+    # obvious cause. Fail HERE instead, loudly, so the conflict is resolved
+    # consciously (rename the user / collective) before the deploy completes.
+    offending_users = TenantUser.unscoped_for_system_job
+      .where("handle ILIKE 'trio' OR handle ILIKE 'trio-%'")
+      .joins(:user).where.not(users: { system_role: "trio" })
+      .pluck(:tenant_id, :handle)
+    offending_collectives = Collective.unscoped_for_system_job
+      .where("handle ILIKE 'trio' OR handle ILIKE 'trio-%'")
+      .pluck(:tenant_id, :handle)
+    if offending_users.any? || offending_collectives.any?
+      raise <<~MSG
+        Cannot migrate: the persona handle namespace (trio, trio-*) is reserved,
+        but existing rows hold reserved handles. Rename them, then rerun:
+          users (tenant_id, handle): #{offending_users.inspect}
+          collectives (tenant_id, handle): #{offending_collectives.inspect}
+      MSG
+    end
+
     say_with_time "backfilling trio persona roles" do
       execute(<<~SQL.squish)
         UPDATE collective_members cm
@@ -35,13 +56,17 @@ class DropTrioUserIdFromCollectives < ActiveRecord::Migration[7.2]
         tenant_user = TenantUser.unscoped_for_system_job.find_by(tenant_id: collective.tenant_id, user_id: cm.user_id)
         next unless tenant_user
 
-        desired = "trio-#{collective.handle}"
-        next if tenant_user.handle.to_s.casecmp?(desired)
+        base = "trio-#{collective.handle}"
+        next if tenant_user.handle.to_s.casecmp?(base)
 
-        taken = TenantUser.unscoped_for_system_job
-          .where(tenant_id: collective.tenant_id, handle: desired)
-          .where.not(user_id: cm.user_id)
-        desired = "#{desired}-#{SecureRandom.hex(2)}" if taken.exists?
+        taken = lambda do |candidate|
+          TenantUser.unscoped_for_system_job
+            .where(tenant_id: collective.tenant_id, handle: candidate)
+            .where.not(user_id: cm.user_id)
+            .exists?
+        end
+        desired = base
+        desired = "#{base}-#{SecureRandom.hex(2)}" while taken.call(desired)
         # update_columns: no validations/callbacks — legacy rows must rename
         # unconditionally, and nothing else may fire mid-migration.
         tenant_user.update_columns(handle: desired)

--- a/db/migrate/20260717090000_drop_trio_user_id_from_collectives.rb
+++ b/db/migrate/20260717090000_drop_trio_user_id_from_collectives.rb
@@ -1,0 +1,70 @@
+# The trio persona role on the CollectiveMember row is now the single source
+# of truth for "who is this collective's trio" (Collective#persona_user);
+# the trio_user_id column goes away. Three steps, order-dependent:
+#
+#   1. Backfill the persona role onto every ACTIVE trio's member row
+#      (active = trio_user_id set — the column's own semantics).
+#   2. Rename legacy trio handles ("trio", "trio-<hex4>") to the
+#      trio-<collective handle> pattern, suffixing on collision with a
+#      legacy squatter.
+#   3. Drop the column.
+class DropTrioUserIdFromCollectives < ActiveRecord::Migration[7.2]
+  def up
+    say_with_time "backfilling trio persona roles" do
+      execute(<<~SQL.squish)
+        UPDATE collective_members cm
+        SET settings = jsonb_set(
+          COALESCE(cm.settings, '{}'::jsonb),
+          '{roles}',
+          COALESCE(cm.settings->'roles', '[]'::jsonb) || '["trio"]'::jsonb
+        )
+        FROM collectives c
+        WHERE c.id = cm.collective_id
+          AND c.trio_user_id = cm.user_id
+          AND NOT (COALESCE(cm.settings->'roles', '[]'::jsonb) ? 'trio')
+      SQL
+    end
+
+    say_with_time "renaming trio handles to trio-<collective handle>" do
+      renamed = 0
+      trio_ids = User.unscoped_for_system_job.where(system_role: "trio").pluck(:id)
+      CollectiveMember.unscoped_for_system_job.where(user_id: trio_ids).find_each do |cm|
+        collective = Collective.unscoped_for_system_job.find_by(id: cm.collective_id)
+        next unless collective&.standard? && collective.handle.present?
+
+        tenant_user = TenantUser.unscoped_for_system_job.find_by(tenant_id: collective.tenant_id, user_id: cm.user_id)
+        next unless tenant_user
+
+        desired = "trio-#{collective.handle}"
+        next if tenant_user.handle.to_s.casecmp?(desired)
+
+        taken = TenantUser.unscoped_for_system_job
+          .where(tenant_id: collective.tenant_id, handle: desired)
+          .where.not(user_id: cm.user_id)
+        desired = "#{desired}-#{SecureRandom.hex(2)}" if taken.exists?
+        # update_columns: no validations/callbacks — legacy rows must rename
+        # unconditionally, and nothing else may fire mid-migration.
+        tenant_user.update_columns(handle: desired)
+        renamed += 1
+      end
+      renamed
+    end
+
+    remove_column :collectives, :trio_user_id
+  end
+
+  def down
+    add_column :collectives, :trio_user_id, :uuid
+
+    # Recompute the link from the persona role (the source of truth going
+    # forward, so nothing is lost). Handle renames are not reverted.
+    execute(<<~SQL.squish)
+      UPDATE collectives c
+      SET trio_user_id = cm.user_id
+      FROM collective_members cm
+      WHERE cm.collective_id = c.id
+        AND cm.archived_at IS NULL
+        AND COALESCE(cm.settings->'roles', '[]'::jsonb) ? 'trio'
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -425,7 +425,6 @@ CREATE TABLE public.collectives (
     billing_exempt boolean DEFAULT false NOT NULL,
     pending_billing_setup boolean DEFAULT false NOT NULL,
     collective_type character varying DEFAULT 'standard'::character varying NOT NULL,
-    trio_user_id uuid,
     tier character varying DEFAULT 'free'::character varying NOT NULL,
     archived_by_id uuid
 );
@@ -10613,6 +10612,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260717090000'),
 ('20260716120000'),
 ('20260716074003'),
 ('20260712120000'),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -392,11 +392,14 @@ created with `mention_filter: "self"`). For private workspaces, the opt-in
 toggle lives on the user-settings page; the same `TrioActivator` runs.
 
 `@trio` mentions resolve via `MentionParser.parse(..., collective:)`: the
-parser checks `collective.trio_user` when the text contains `@trio`. The
-main collective's trio claims the literal handle `"trio"` so its profile
-lives at `/u/trio` via the normal handle index; non-main collective trios
-get hex-suffixed handles to avoid the tenant-wide `(tenant_id, handle)`
-uniqueness collision.
+tag maps to the **trio persona role** (`ReservedHandles::AGENT_ROLES`), a
+reserved CollectiveMember role the activator grants on activation and
+removes on deactivation — the single source of truth for the collective's
+active trio (`Collective#persona_user`; there is no FK column). Trio
+handles follow `trio-<collective handle>` (unique per tenant, renamed in
+sync when the collective renames), each linking to the trio's own
+profile; no user holds the literal handle `"trio"`, and the `trio-*`
+prefix is reserved against squatting.
 
 ### Key Components
 

--- a/sorbet/rbi/dsl/collective.rbi
+++ b/sorbet/rbi/dsl/collective.rbi
@@ -534,9 +534,6 @@ class Collective
     def build_tenant(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-    def build_trio_user(*args, &blk); end
-
-    sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
     def build_updated_by(*args, &blk); end
 
     sig { returns(T::Array[T.untyped]) }
@@ -658,12 +655,6 @@ class Collective
 
     sig { params(args: T.untyped, blk: T.untyped).returns(::Tenant) }
     def create_tenant!(*args, &blk); end
-
-    sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-    def create_trio_user(*args, &blk); end
-
-    sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
-    def create_trio_user!(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(::User) }
     def create_updated_by(*args, &blk); end
@@ -1054,9 +1045,6 @@ class Collective
     def reload_tenant; end
 
     sig { returns(T.nilable(::User)) }
-    def reload_trio_user; end
-
-    sig { returns(T.nilable(::User)) }
     def reload_updated_by; end
 
     sig { returns(T::Array[T.untyped]) }
@@ -1104,9 +1092,6 @@ class Collective
 
     sig { void }
     def reset_tenant; end
-
-    sig { void }
-    def reset_trio_user; end
 
     sig { void }
     def reset_updated_by; end
@@ -1164,18 +1149,6 @@ class Collective
 
     sig { returns(T::Boolean) }
     def tenant_previously_changed?; end
-
-    sig { returns(T.nilable(::User)) }
-    def trio_user; end
-
-    sig { params(value: T.nilable(::User)).void }
-    def trio_user=(value); end
-
-    sig { returns(T::Boolean) }
-    def trio_user_changed?; end
-
-    sig { returns(T::Boolean) }
-    def trio_user_previously_changed?; end
 
     sig { returns(T::Array[T.untyped]) }
     def trustee_grant_ids; end
@@ -2165,9 +2138,6 @@ class Collective
     def restore_tier!; end
 
     sig { void }
-    def restore_trio_user_id!; end
-
-    sig { void }
     def restore_updated_at!; end
 
     sig { void }
@@ -2274,12 +2244,6 @@ class Collective
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_tier?(from: T.unsafe(nil), to: T.unsafe(nil)); end
-
-    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-    def saved_change_to_trio_user_id; end
-
-    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-    def saved_change_to_trio_user_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([::ActiveSupport::TimeWithZone, ::ActiveSupport::TimeWithZone])) }
     def saved_change_to_updated_at; end
@@ -2428,51 +2392,6 @@ class Collective
     sig { void }
     def tier_will_change!; end
 
-    sig { returns(T.nilable(::String)) }
-    def trio_user_id; end
-
-    sig { params(value: T.nilable(::String)).returns(T.nilable(::String)) }
-    def trio_user_id=(value); end
-
-    sig { returns(T::Boolean) }
-    def trio_user_id?; end
-
-    sig { returns(T.nilable(::String)) }
-    def trio_user_id_before_last_save; end
-
-    sig { returns(T.untyped) }
-    def trio_user_id_before_type_cast; end
-
-    sig { returns(T::Boolean) }
-    def trio_user_id_came_from_user?; end
-
-    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-    def trio_user_id_change; end
-
-    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-    def trio_user_id_change_to_be_saved; end
-
-    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-    def trio_user_id_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
-
-    sig { returns(T.nilable(::String)) }
-    def trio_user_id_in_database; end
-
-    sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
-    def trio_user_id_previous_change; end
-
-    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-    def trio_user_id_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
-
-    sig { returns(T.nilable(::String)) }
-    def trio_user_id_previously_was; end
-
-    sig { returns(T.nilable(::String)) }
-    def trio_user_id_was; end
-
-    sig { void }
-    def trio_user_id_will_change!; end
-
     sig { returns(::ActiveSupport::TimeWithZone) }
     def updated_at; end
 
@@ -2613,9 +2532,6 @@ class Collective
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_tier?(from: T.unsafe(nil), to: T.unsafe(nil)); end
-
-    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
-    def will_save_change_to_trio_user_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_updated_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end

--- a/test/controllers/collectives_controller_test.rb
+++ b/test/controllers/collectives_controller_test.rb
@@ -187,7 +187,7 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
     @tenant.enable_feature_flag!("trio")
     @collective.set_feature_flag!("trio", false)
     @collective.update!(tier: Collective::TIER_PAID)
-    assert_nil @collective.trio_user_id, "precondition: trio should be off"
+    assert_nil @collective.trio_user&.id, "precondition: trio should be off"
 
     sign_in_as(@user, tenant: @tenant)
     post "/collectives/#{@collective.handle}/settings",
@@ -195,8 +195,8 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
          headers: { "HTTP_REFERER" => "http://#{@tenant.subdomain}.#{ENV.fetch("HOSTNAME", nil)}/collectives/#{@collective.handle}/settings" }
 
     @collective.reload
-    assert_not_nil @collective.trio_user_id, "expected trio to be activated"
-    assert AutomationRule.where(ai_agent_id: @collective.trio_user_id).exists?, "expected default automations to be seeded"
+    assert_not_nil @collective.trio_user&.id, "expected trio to be activated"
+    assert AutomationRule.where(ai_agent_id: @collective.trio_user&.id).exists?, "expected default automations to be seeded"
   end
 
   test "disabling the trio feature flag deactivates trio for the collective" do
@@ -204,7 +204,7 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
     @collective.update!(tier: Collective::TIER_PAID)
     @collective.set_feature_flag!("trio", true)
     TrioActivator.activate!(@collective)
-    trio_id = T.must(@collective.reload.trio_user_id)
+    trio_id = T.must(@collective.reload.trio_user&.id)
 
     sign_in_as(@user, tenant: @tenant)
     post "/collectives/#{@collective.handle}/settings",
@@ -212,7 +212,7 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
          headers: { "HTTP_REFERER" => "http://#{@tenant.subdomain}.#{ENV.fetch("HOSTNAME", nil)}/collectives/#{@collective.handle}/settings" }
 
     @collective.reload
-    assert_nil @collective.trio_user_id, "expected trio to be deactivated"
+    assert_nil @collective.trio_user&.id, "expected trio to be deactivated"
     rules = AutomationRule.where(ai_agent_id: trio_id)
     assert rules.all? { |r| !r.enabled? }, "expected default automations to be disabled"
   end

--- a/test/controllers/collectives_controller_test.rb
+++ b/test/controllers/collectives_controller_test.rb
@@ -1474,6 +1474,28 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
     assert_not cm.has_role?("representative"), "expected the representative role to be revoked"
   end
 
+  test "persona roles cannot be granted through the role endpoint" do
+    member = add_member(name: "Would-be Trio")
+    sign_in_as(@user, tenant: @tenant)
+
+    post update_roles_path,
+         params: { user_handle: handle_for(member), role: "trio", grant: "true" },
+         headers: MEMBER_MGMT_MD
+
+    assert_response :unprocessable_entity
+    cm = @collective.collective_members.find_by(user: member)
+    assert_not cm.has_role?("trio"), "persona roles are activator-managed, never grantable"
+  end
+
+  test "the members page role menu offers only capability roles" do
+    add_member(name: "Regular Member")
+    sign_in_as(@user, tenant: @tenant)
+
+    get "/collectives/#{@collective.handle}/members"
+    assert_response :success
+    assert_no_match(/role trio/, response.body)
+  end
+
   test "non-admin cannot update member roles" do
     actor = add_member(name: "Not An Admin")
     target = add_member(name: "Target")

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -43,8 +43,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       headers: { "HTTP_REFERER" => "http://#{@tenant.subdomain}.#{ENV['HOSTNAME']}/settings" }
 
     workspace.reload
-    assert_not_nil workspace.trio_user_id, "expected trio to be activated in workspace"
-    assert AutomationRule.where(ai_agent_id: workspace.trio_user_id).exists?
+    assert_not_nil workspace.trio_user&.id, "expected trio to be activated in workspace"
+    assert AutomationRule.where(ai_agent_id: workspace.trio_user&.id).exists?
   end
 
   # Self-hosted (non-billing) tenants have no tier model. A free-tier
@@ -62,7 +62,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       headers: { "HTTP_REFERER" => "http://#{@tenant.subdomain}.#{ENV['HOSTNAME']}/settings" }
 
     workspace.reload
-    assert_not_nil workspace.trio_user_id, "self-hosted: trio should activate on free workspace"
+    assert_not_nil workspace.trio_user&.id, "self-hosted: trio should activate on free workspace"
   end
 
   test "workspace owner can disable Trio in their private workspace" do
@@ -71,7 +71,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     upgrade_collective_to_paid!(workspace, owner: @user)
     workspace.set_feature_flag!("trio", true)
     TrioActivator.activate!(workspace)
-    trio_id = T.must(workspace.reload.trio_user_id)
+    trio_id = T.must(workspace.reload.trio_user&.id)
 
     sign_in_as(@user, tenant: @tenant)
     post "/settings/workspace_trio",
@@ -79,7 +79,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       headers: { "HTTP_REFERER" => "http://#{@tenant.subdomain}.#{ENV['HOSTNAME']}/settings" }
 
     workspace.reload
-    assert_nil workspace.trio_user_id, "expected trio to be deactivated in workspace"
+    assert_nil workspace.trio_user&.id, "expected trio to be deactivated in workspace"
     assert AutomationRule.where(ai_agent_id: trio_id).none? { |r| r.enabled? }
   end
 
@@ -95,7 +95,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     # No handle in the route: the toggle applies to other_user's own workspace,
     # so @user's workspace is structurally untouchable here.
-    assert_nil T.must(@user.private_workspace).reload.trio_user_id
+    assert_nil T.must(@user.private_workspace).reload.trio_user&.id
   end
 
   # === Workspace Trio paid-tier gate ===
@@ -112,7 +112,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       headers: { "HTTP_REFERER" => "http://#{@tenant.subdomain}.#{ENV['HOSTNAME']}/settings" }
 
     workspace.reload
-    assert_nil workspace.trio_user_id, "trio should not be activated on a free workspace"
+    assert_nil workspace.trio_user&.id, "trio should not be activated on a free workspace"
     assert flash[:error].to_s.downcase.include?("paid")
   end
 
@@ -129,7 +129,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       headers: { "HTTP_REFERER" => "http://#{@tenant.subdomain}.#{ENV['HOSTNAME']}/settings" }
 
     workspace.reload
-    assert_not_nil workspace.trio_user_id, "trio should activate when workspace is paid"
+    assert_not_nil workspace.trio_user&.id, "trio should activate when workspace is paid"
   end
 
   test "workspace owner can always disable Trio (no paid-tier requirement on disable)" do
@@ -146,7 +146,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       headers: { "HTTP_REFERER" => "http://#{@tenant.subdomain}.#{ENV['HOSTNAME']}/settings" }
 
     workspace.reload
-    assert_nil workspace.trio_user_id
+    assert_nil workspace.trio_user&.id
   end
 
   private

--- a/test/models/collective_member_test.rb
+++ b/test/models/collective_member_test.rb
@@ -211,6 +211,21 @@ class CollectiveMemberTest < ActiveSupport::TestCase
     assert_not @collective_member.is_moderator?
   end
 
+  # === persona roles ===
+
+  test "trio is a valid role but not a capability role" do
+    assert_includes CollectiveMember.valid_roles, "trio"
+    assert_not_includes CollectiveMember.capability_roles, "trio"
+    # The activator manages persona roles through the normal role machinery.
+    @collective_member.add_role!("trio")
+    assert @collective_member.has_role?("trio")
+  end
+
+  test "capability roles are exactly the grantable ones" do
+    assert_equal ["admin", "representative", "summarizer", "automator", "moderator"],
+                 CollectiveMember.capability_roles
+  end
+
   test "can_manage_automations? is true for admins and automators only" do
     assert_not @collective_member.can_manage_automations?
 

--- a/test/models/collective_test.rb
+++ b/test/models/collective_test.rb
@@ -251,14 +251,15 @@ class CollectiveTest < ActiveSupport::TestCase
     assert_equal "bar-team", identity_tu.handle
   end
 
-  test "Collective#trio_user is nil by default and links to a User when set" do
+  test "Collective#trio_user resolves through the persona role" do
     tenant = create_tenant
     user = create_user
+    tenant.add_user!(user)
     collective = Collective.create!(
       tenant: tenant,
       created_by: user,
-      name: "Trio FK Collective",
-      handle: "trio-fk-collective"
+      name: "Trio Role Collective",
+      handle: "trio-role-collective"
     )
     assert_nil collective.trio_user
 
@@ -269,10 +270,23 @@ class CollectiveTest < ActiveSupport::TestCase
       system_role: "trio",
       parent_id: nil
     )
-    collective.update!(trio_user: trio)
+    tenant.add_user!(trio)
+    Tenant.scope_thread_to_tenant(subdomain: tenant.subdomain)
+    collective.add_user!(trio)
+    member = collective.collective_members.find_by!(user_id: trio.id)
 
-    assert_equal trio.id, collective.reload.trio_user_id
-    assert_equal trio, collective.trio_user
+    # Seeded but not active: membership alone doesn't resolve.
+    assert_nil collective.trio_user
+    assert_equal trio.id, collective.seeded_persona_user("trio")&.id
+
+    member.add_role!("trio")
+    assert_equal trio.id, collective.trio_user&.id
+
+    # An archived member (deactivated) stops resolving even with the role.
+    member.archive!
+    assert_nil collective.trio_user
+  ensure
+    Tenant.clear_thread_scope
   end
 
   test "Collective.within_file_upload_limit? returns true when usage is below limit" do

--- a/test/models/collective_test.rb
+++ b/test/models/collective_test.rb
@@ -284,12 +284,14 @@ class CollectiveTest < ActiveSupport::TestCase
     assert_nil collective.trio_user
     assert_equal trio.id, collective.seeded_persona_user("trio")&.id
 
+    # Direct role mutation (tests only — production writes go through the
+    # activator, which invalidates the memo): reload for a fresh read.
     member.add_role!("trio")
-    assert_equal trio.id, collective.trio_user&.id
+    assert_equal trio.id, collective.reload.trio_user&.id
 
     # An archived member (deactivated) stops resolving even with the role.
     member.archive!
-    assert_nil collective.trio_user
+    assert_nil collective.reload.trio_user
   ensure
     Tenant.clear_thread_scope
   end
@@ -1710,6 +1712,47 @@ class CollectiveTest < ActiveSupport::TestCase
     collective.update!(tier: Collective::TIER_PAID)
 
     assert_not collective.funding_pools_available?
+  end
+
+  test "persona_user is memoized within an instance" do
+    tenant = create_tenant(subdomain: "memo-#{SecureRandom.hex(4)}")
+    user = create_user
+    tenant.add_user!(user)
+    collective = Collective.create!(tenant: tenant, created_by: user, name: "Memo", handle: "memo-#{SecureRandom.hex(2)}")
+    Tenant.scope_thread_to_tenant(subdomain: tenant.subdomain)
+    TrioActivator.activate!(collective)
+    collective = Collective.find(collective.id)
+
+    queries = 0
+    counter = ->(*_args, payload) { queries += 1 unless payload[:name] == "SCHEMA" || payload[:cached] }
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+      collective.trio_user
+      first_pass = queries
+      3.times { collective.trio_user }
+      assert_equal first_pass, queries,
+        "repeated persona_user calls on one instance must not re-query (markdown rendering calls this per text node)"
+    end
+  ensure
+    Tenant.clear_thread_scope
+  end
+
+  test "activator role changes invalidate the persona_user memo on the same instance" do
+    tenant = create_tenant(subdomain: "memo2-#{SecureRandom.hex(4)}")
+    user = create_user
+    tenant.add_user!(user)
+    collective = Collective.create!(tenant: tenant, created_by: user, name: "Memo2", handle: "memo2-#{SecureRandom.hex(2)}")
+    Tenant.scope_thread_to_tenant(subdomain: tenant.subdomain)
+
+    # Read-before-activate on the SAME instance — the reconcile! flow. A
+    # naive memo would pin nil and ensure_trio_funded! would skip funding.
+    assert_nil collective.trio_user
+    TrioActivator.activate!(collective)
+    assert_not_nil collective.trio_user, "activation must invalidate the memoized nil"
+
+    TrioActivator.deactivate!(collective)
+    assert_nil collective.trio_user, "deactivation must invalidate the memoized user"
+  ensure
+    Tenant.clear_thread_scope
   end
 
   test "renaming a collective renames its trio's handle to match" do

--- a/test/models/collective_test.rb
+++ b/test/models/collective_test.rb
@@ -1693,6 +1693,21 @@ class CollectiveTest < ActiveSupport::TestCase
     assert_not collective.funding_pools_available?
   end
 
+  test "renaming a collective renames its trio's handle to match" do
+    tenant = create_tenant(subdomain: "rn-#{SecureRandom.hex(4)}")
+    user = create_user
+    tenant.add_user!(user)
+    collective = Collective.create!(tenant: tenant, created_by: user, name: "Band", handle: "band-#{SecureRandom.hex(2)}")
+    Tenant.scope_thread_to_tenant(subdomain: tenant.subdomain)
+    trio = TrioActivator.activate!(collective)
+
+    collective.update!(handle: "orchestra-#{SecureRandom.hex(2)}")
+
+    assert_equal "trio-#{collective.handle}", trio.tenant_users.find_by(tenant_id: tenant.id).handle
+  ensure
+    Tenant.clear_thread_scope
+  end
+
   test "pools are unavailable to non-standard collectives" do
     collective = pool_ready_collective
     upgrade_collective_to_paid!(collective)

--- a/test/models/collective_test.rb
+++ b/test/models/collective_test.rb
@@ -234,12 +234,17 @@ class CollectiveTest < ActiveSupport::TestCase
     assert_match(/\Afoo-team-[0-9a-f]{4}\z/, identity_tu.handle)
   end
 
-  test "identity user handle is suffixed when the collective handle is reserved for system agents" do
+  test "a collective cannot claim an agent tag or its prefix as a handle" do
     tenant = create_tenant
     user = create_user
-    collective = Collective.create!(tenant: tenant, created_by: user, name: "Trio", handle: "trio")
-    identity_tu = TenantUser.tenant_scoped_only(tenant.id).find_by(user_id: collective.identity_user_id)
-    assert_match(/\Atrio-[0-9a-f]{4}\z/, identity_tu.handle)
+
+    exact = Collective.new(tenant: tenant, created_by: user, name: "Trio", handle: "trio")
+    assert_not exact.valid?
+    assert_includes exact.errors[:handle], "is reserved"
+
+    prefixed = Collective.new(tenant: tenant, created_by: user, name: "Trio Fans", handle: "trio-fans")
+    assert_not prefixed.valid?
+    assert_includes prefixed.errors[:handle], "is reserved"
   end
 
   test "renaming the collective syncs the identity user handle" do
@@ -258,8 +263,8 @@ class CollectiveTest < ActiveSupport::TestCase
     collective = Collective.create!(
       tenant: tenant,
       created_by: user,
-      name: "Trio Role Collective",
-      handle: "trio-role-collective"
+      name: "Persona Role Collective",
+      handle: "persona-role-collective"
     )
     assert_nil collective.trio_user
 

--- a/test/models/reserved_handles_test.rb
+++ b/test/models/reserved_handles_test.rb
@@ -69,19 +69,17 @@ class ReservedHandlesTest < ActiveSupport::TestCase
     assert_not ReservedHandles.forbidden_for_user?("triofan", system_role: nil)
   end
 
-  test "collective identity users may sit inside an agent prefix but never on the exact tag" do
-    # A collective named "trio-fans" is legal; its identity mirrors the handle.
-    assert_not ReservedHandles.forbidden_for_user?("trio-fans", system_role: nil, collective_identity: true)
-    # The exact tag stays off-limits even for identities.
-    assert ReservedHandles.forbidden_for_user?("trio", system_role: nil, collective_identity: true)
-  end
 
-  test "forbidden_for_collective? blocks main and group tags but not agent handles" do
+  test "forbidden_for_collective? blocks main, group tags, and the agent namespace" do
     assert ReservedHandles.forbidden_for_collective?("main")
     assert ReservedHandles.forbidden_for_collective?("everyone")
     assert ReservedHandles.forbidden_for_collective?("ADMINS")
-    # Agent handles stay claimable as collective handles (backwards compatible).
-    assert_not ReservedHandles.forbidden_for_collective?("trio")
+    # The agent namespace — exact tags and their prefixes — is reserved
+    # unconditionally: identity users mirror collective handles, and no user
+    # but the matching system agent may hold trio/trio-*.
+    assert ReservedHandles.forbidden_for_collective?("trio")
+    assert ReservedHandles.forbidden_for_collective?("trio-fans")
+    assert_not ReservedHandles.forbidden_for_collective?("triofan")
     assert_not ReservedHandles.forbidden_for_collective?("alice")
   end
 end

--- a/test/models/reserved_handles_test.rb
+++ b/test/models/reserved_handles_test.rb
@@ -60,6 +60,22 @@ class ReservedHandlesTest < ActiveSupport::TestCase
     assert_not ReservedHandles.forbidden_for_user?("alice", system_role: nil)
   end
 
+  test "forbidden_for_user? reserves persona handle prefixes for matching system agents" do
+    assert ReservedHandles.forbidden_for_user?("trio-engineering", system_role: nil)
+    assert ReservedHandles.forbidden_for_user?("TRIO-Engineering", system_role: nil)
+    assert ReservedHandles.forbidden_for_user?("trio-engineering", system_role: "something-else")
+    assert_not ReservedHandles.forbidden_for_user?("trio-engineering", system_role: "trio")
+    # No dash, no reservation — only the prefix pattern is claimed.
+    assert_not ReservedHandles.forbidden_for_user?("triofan", system_role: nil)
+  end
+
+  test "collective identity users may sit inside an agent prefix but never on the exact tag" do
+    # A collective named "trio-fans" is legal; its identity mirrors the handle.
+    assert_not ReservedHandles.forbidden_for_user?("trio-fans", system_role: nil, collective_identity: true)
+    # The exact tag stays off-limits even for identities.
+    assert ReservedHandles.forbidden_for_user?("trio", system_role: nil, collective_identity: true)
+  end
+
   test "forbidden_for_collective? blocks main and group tags but not agent handles" do
     assert ReservedHandles.forbidden_for_collective?("main")
     assert ReservedHandles.forbidden_for_collective?("everyone")

--- a/test/models/reserved_handles_test.rb
+++ b/test/models/reserved_handles_test.rb
@@ -9,14 +9,24 @@ class ReservedHandlesTest < ActiveSupport::TestCase
     assert_not ReservedHandles.group_tag?(nil)
   end
 
-  test "role_tags and group_tags are derived from the collective role list" do
-    # One pluralized tag per role, so new/custom roles reserve automatically.
-    expected = CollectiveMember.valid_roles.index_by(&:pluralize)
+  test "role_tags and group_tags are derived from the capability role list" do
+    # One pluralized tag per capability role, so new/custom roles reserve
+    # automatically. Persona roles (trio) deliberately don't get a pluralized
+    # group tag — their singular tag comes from AGENT_ROLES.
+    expected = CollectiveMember.capability_roles.index_by(&:pluralize)
     assert_equal expected, ReservedHandles.role_tags
-    # Every role's tag is a group tag, plus @everyone.
+    # Every capability role's tag is a group tag, plus @everyone.
     assert ReservedHandles.group_tag?("representatives")
     assert ReservedHandles.group_tag?("summarizers")
+    assert_not ReservedHandles.group_tag?("trios")
     assert_equal(["everyone"] + expected.keys, ReservedHandles.group_tags)
+  end
+
+  test "every agent tag maps to a valid persona role" do
+    ReservedHandles::AGENT_ROLES.each_value do |persona_role|
+      assert_includes CollectiveMember.valid_roles, persona_role
+      assert_not_includes CollectiveMember.capability_roles, persona_role
+    end
   end
 
   test "collective_local? covers group tags and agent handles" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -540,24 +540,16 @@ class UserTest < ActiveSupport::TestCase
     assert_nil agent.system_role
   end
 
-  test "trio system agent's handle is always 'trio' regardless of stored TenantUser handle" do
+  test "trio reports its real stored handle and links to its own profile" do
     trio = User.create!(
       email: "trio_#{SecureRandom.hex(4)}@system.harmonic.local",
       name: "Trio", user_type: "ai_agent", system_role: "trio",
     )
     @tenant.add_user!(trio, handle: "trio-abc12345")
 
-    assert_equal "trio", trio.handle, "expected trio's handle to be 'trio' even when TenantUser stores a hex-suffixed value"
-  end
-
-  test "trio system agent's path is always /u/trio regardless of stored TenantUser handle" do
-    trio = User.create!(
-      email: "trio_#{SecureRandom.hex(4)}@system.harmonic.local",
-      name: "Trio", user_type: "ai_agent", system_role: "trio",
-    )
-    @tenant.add_user!(trio, handle: "trio-abc12345")
-
-    assert_equal "/u/trio", trio.path
+    assert_equal "trio-abc12345", trio.handle,
+      "system agents have no magic handle — the @trio mention tag resolves via the persona role instead"
+    assert_equal "/u/trio-abc12345", trio.path
   end
 
   test "creating a system ai_agent does not create a TrusteeGrant" do

--- a/test/services/automation_mention_filter_test.rb
+++ b/test/services/automation_mention_filter_test.rb
@@ -276,16 +276,17 @@ class AutomationMentionFilterTest < ActiveSupport::TestCase
 
   # === @trio (per-collective system agent) ===
 
-  test "self filter matches when @trio is mentioned and agent is the collective's trio_user" do
+  test "self filter matches when @trio is mentioned and agent is the collective's trio" do
     trio = User.create!(
       email: "trio_#{SecureRandom.hex(4)}@system.harmonic.local",
       name: "Trio", user_type: "ai_agent", system_role: "trio", parent_id: nil,
     )
-    # Trio's stored handle is intentionally non-"trio" (random hex). The literal
-    # string @trio is resolved by the MentionParser via collective.trio_user, so
+    # Trio's stored handle is intentionally non-"trio". The literal string
+    # @trio is resolved by the MentionParser via the trio persona role, so
     # the handle index never collides across collectives.
     @tenant.add_user!(trio, handle: "trio-#{SecureRandom.hex(4)}")
     @collective.add_user!(trio)
+    @collective.collective_members.find_by!(user_id: trio.id).add_role!("trio")
     @collective.update!(trio_user: trio)
 
     note = create_note(text: "Hey @trio, what should we do?")

--- a/test/services/automation_mention_filter_test.rb
+++ b/test/services/automation_mention_filter_test.rb
@@ -287,7 +287,6 @@ class AutomationMentionFilterTest < ActiveSupport::TestCase
     @tenant.add_user!(trio, handle: "trio-#{SecureRandom.hex(4)}")
     @collective.add_user!(trio)
     @collective.collective_members.find_by!(user_id: trio.id).add_role!("trio")
-    @collective.update!(trio_user: trio)
 
     note = create_note(text: "Hey @trio, what should we do?")
     event = create_event_for_note(note)
@@ -303,7 +302,7 @@ class AutomationMentionFilterTest < ActiveSupport::TestCase
     )
     @tenant.add_user!(other_trio, handle: "trio-#{SecureRandom.hex(4)}")
     other_collective.add_user!(other_trio)
-    other_collective.update!(trio_user: other_trio)
+    other_collective.collective_members.find_by!(user_id: other_trio.id).add_role!("trio")
 
     note = create_note(text: "Hey @trio")
     event = create_event_for_note(note)

--- a/test/services/mention_parser_test.rb
+++ b/test/services/mention_parser_test.rb
@@ -66,7 +66,6 @@ class MentionParserTest < ActiveSupport::TestCase
     tenant.add_user!(trio, handle: handle) unless trio.tenant_users.exists?(tenant_id: tenant.id)
     collective.add_user!(trio) unless collective.user_is_member?(trio)
     collective.collective_members.find_by!(user_id: trio.id).add_role!("trio")
-    collective.update!(trio_user: trio)
   end
 
   test "parse resolves @trio to the collective's trio when collective is provided" do

--- a/test/services/mention_parser_test.rb
+++ b/test/services/mention_parser_test.rb
@@ -477,7 +477,10 @@ class MentionParserTest < ActiveSupport::TestCase
 
     result = MentionParser.resolve_paths("hi @trio", tenant_id: tenant.id, collective: collective)
 
-    assert_equal({ "trio" => "/u/trio" }, result)
+    # The @trio tag links to the local trio's own profile (its real handle),
+    # not to a shared /u/trio.
+    assert_equal({ "trio" => trio.reload.path }, result)
+    assert_match(%r{\A/u/trio-}, result["trio"])
   end
 
   # === extract_handles tests ===

--- a/test/services/mention_parser_test.rb
+++ b/test/services/mention_parser_test.rb
@@ -60,7 +60,16 @@ class MentionParserTest < ActiveSupport::TestCase
 
   # === @trio special case ===
 
-  test "parse resolves @trio to the collective's trio_user when collective is provided" do
+  # Mirrors TrioActivator's activation state: tenant handle, membership, and
+  # the trio persona role — which @trio resolution keys off.
+  def activate_trio!(tenant, collective, trio, handle: "trio-#{SecureRandom.hex(4)}")
+    tenant.add_user!(trio, handle: handle) unless trio.tenant_users.exists?(tenant_id: tenant.id)
+    collective.add_user!(trio) unless collective.user_is_member?(trio)
+    collective.collective_members.find_by!(user_id: trio.id).add_role!("trio")
+    collective.update!(trio_user: trio)
+  end
+
+  test "parse resolves @trio to the collective's trio when collective is provided" do
     tenant, collective, user = create_tenant_collective_user
     Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
 
@@ -71,7 +80,7 @@ class MentionParserTest < ActiveSupport::TestCase
       system_role: "trio",
       parent_id: nil,
     )
-    collective.update!(trio_user: trio)
+    activate_trio!(tenant, collective, trio)
 
     result = MentionParser.parse("hi @trio please help", tenant_id: tenant.id, collective: collective)
 
@@ -79,10 +88,28 @@ class MentionParserTest < ActiveSupport::TestCase
     assert_not_includes result.map(&:id), user.id  # @trio in text doesn't grab any other user
   end
 
-  test "parse returns nothing for @trio when collective has no trio_user" do
+  test "@trio resolves through the persona role, not the trio_user link" do
     tenant, collective, _user = create_tenant_collective_user
     Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
-    assert_nil collective.trio_user, "precondition"
+    trio = User.create!(
+      email: "trio_#{SecureRandom.hex(4)}@system.harmonic.local",
+      name: "Trio", user_type: "ai_agent", system_role: "trio", parent_id: nil,
+    )
+    tenant.add_user!(trio, handle: "trio-#{SecureRandom.hex(4)}")
+    collective.add_user!(trio)
+    # Membership WITHOUT the persona role — a deactivated trio's state.
+    result = MentionParser.parse("@trio", tenant_id: tenant.id, collective: collective)
+    assert_equal [], result, "a member without the persona role must not resolve"
+
+    collective.collective_members.find_by!(user_id: trio.id).add_role!("trio")
+    result = MentionParser.parse("@trio", tenant_id: tenant.id, collective: collective)
+    assert_equal [trio.id], result.map(&:id), "the persona role alone must resolve"
+  end
+
+  test "parse returns nothing for @trio when collective has no active trio" do
+    tenant, collective, _user = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    assert_empty collective.users_with_role("trio"), "precondition"
 
     result = MentionParser.parse("hi @trio please help", tenant_id: tenant.id, collective: collective)
 
@@ -96,7 +123,7 @@ class MentionParserTest < ActiveSupport::TestCase
       email: "trio_#{SecureRandom.hex(4)}@system.harmonic.local",
       name: "Trio", user_type: "ai_agent", system_role: "trio", parent_id: nil,
     )
-    collective.update!(trio_user: trio)
+    activate_trio!(tenant, collective, trio)
 
     # No collective kwarg → @trio just looks for a user with handle "trio"
     # (and trio's stored handle is random hex, not "trio"), so resolves to nothing.
@@ -119,16 +146,14 @@ class MentionParserTest < ActiveSupport::TestCase
       email: "main_trio_#{SecureRandom.hex(4)}@system.harmonic.local",
       name: "Main Trio", user_type: "ai_agent", system_role: "trio", parent_id: nil,
     )
-    tenant.add_user!(main_trio, handle: "trio")  # claims the literal handle
-    main_collective.update!(trio_user: main_trio)
+    activate_trio!(tenant, main_collective, main_trio, handle: "trio")  # claims the literal handle
 
     other_collective = create_collective(tenant: tenant, created_by: user, handle: "other-#{SecureRandom.hex(4)}")
     other_trio = User.create!(
       email: "other_trio_#{SecureRandom.hex(4)}@system.harmonic.local",
       name: "Other Trio", user_type: "ai_agent", system_role: "trio", parent_id: nil,
     )
-    tenant.add_user!(other_trio, handle: "trio-#{SecureRandom.hex(4)}")
-    other_collective.update!(trio_user: other_trio)
+    activate_trio!(tenant, other_collective, other_trio)
 
     result = MentionParser.parse("@trio", tenant_id: tenant.id, collective: other_collective)
 
@@ -149,8 +174,8 @@ class MentionParserTest < ActiveSupport::TestCase
       email: "trio_b_#{SecureRandom.hex(4)}@system.harmonic.local",
       name: "Trio B", user_type: "ai_agent", system_role: "trio", parent_id: nil,
     )
-    collective_a.update!(trio_user: trio_a)
-    collective_b.update!(trio_user: trio_b)
+    activate_trio!(tenant, collective_a, trio_a)
+    activate_trio!(tenant, collective_b, trio_b)
 
     result_a = MentionParser.parse("@trio", tenant_id: tenant.id, collective: collective_a)
     result_b = MentionParser.parse("@trio", tenant_id: tenant.id, collective: collective_b)
@@ -159,7 +184,7 @@ class MentionParserTest < ActiveSupport::TestCase
     assert_equal [trio_b.id], result_b.map(&:id)
   end
 
-  test "parse_for_notification resolves @trio to the collective's trio_user" do
+  test "parse_for_notification resolves @trio to the collective's trio" do
     tenant, collective, user = create_tenant_collective_user
     Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
 
@@ -167,9 +192,7 @@ class MentionParserTest < ActiveSupport::TestCase
       email: "trio_#{SecureRandom.hex(4)}@system.harmonic.local",
       name: "Trio", user_type: "ai_agent", system_role: "trio", parent_id: nil,
     )
-    tenant.add_user!(trio, handle: "trio-#{SecureRandom.hex(4)}")
-    collective.add_user!(trio)
-    collective.update!(trio_user: trio)
+    activate_trio!(tenant, collective, trio)
 
     result = MentionParser.parse_for_notification(
       "@trio help us out", tenant_id: tenant.id, collective: collective, exclude_user: user,
@@ -450,8 +473,7 @@ class MentionParserTest < ActiveSupport::TestCase
       email: "trio_#{SecureRandom.hex(4)}@system.harmonic.local",
       name: "Trio", user_type: "ai_agent", system_role: "trio", parent_id: nil,
     )
-    tenant.add_user!(trio, handle: "trio-#{SecureRandom.hex(4)}")
-    collective.update!(trio_user: trio)
+    activate_trio!(tenant, collective, trio)
 
     result = MentionParser.resolve_paths("hi @trio", tenant_id: tenant.id, collective: collective)
 

--- a/test/services/notification_dispatcher_test.rb
+++ b/test/services/notification_dispatcher_test.rb
@@ -90,7 +90,7 @@ class NotificationDispatcherTest < ActiveSupport::TestCase
     )
     tenant.add_user!(trio, handle: "trio-#{SecureRandom.hex(4)}")
     collective.add_user!(trio)
-    collective.update!(trio_user: trio)
+    collective.collective_members.find_by!(user_id: trio.id).add_role!("trio")
 
     create_note(
       tenant: tenant,

--- a/test/services/trio_activator_test.rb
+++ b/test/services/trio_activator_test.rb
@@ -207,6 +207,32 @@ class TrioActivatorTest < ActiveSupport::TestCase
     assert_nil member.reload.archived_at, "expected CollectiveMember to be unarchived"
   end
 
+  # === Persona role (mention resolution keys off it) ===
+
+  test "activate! grants the trio persona role" do
+    trio = TrioActivator.activate!(@collective)
+
+    member = T.must(@collective.collective_members.find_by(user_id: trio.id))
+    assert member.has_role?("trio")
+  end
+
+  test "deactivate! removes the trio persona role" do
+    trio = TrioActivator.activate!(@collective)
+    TrioActivator.deactivate!(@collective)
+
+    member = T.must(@collective.collective_members.find_by(user_id: trio.id))
+    assert_not member.has_role?("trio"), "a deactivated trio must drop the persona role"
+  end
+
+  test "reactivation restores the trio persona role" do
+    trio = TrioActivator.activate!(@collective)
+    TrioActivator.deactivate!(@collective)
+    TrioActivator.activate!(@collective)
+
+    member = T.must(@collective.collective_members.find_by(user_id: trio.id))
+    assert member.has_role?("trio")
+  end
+
   # === Auto-funding from the collective's pool ===
 
   def open_pool!

--- a/test/services/trio_activator_test.rb
+++ b/test/services/trio_activator_test.rb
@@ -21,7 +21,7 @@ class TrioActivatorTest < ActiveSupport::TestCase
   test "activate! creates a trio user for the collective" do
     TrioActivator.activate!(@collective)
 
-    assert_not_nil @collective.reload.trio_user_id
+    assert_not_nil @collective.reload.trio_user&.id
     assert_equal "trio", T.must(@collective.trio_user).system_role
   end
 
@@ -77,13 +77,13 @@ class TrioActivatorTest < ActiveSupport::TestCase
 
   # === deactivate! ===
 
-  test "deactivate! nils out collective.trio_user_id" do
+  test "deactivate! makes collective.trio_user nil" do
     TrioActivator.activate!(@collective)
-    assert_not_nil @collective.reload.trio_user_id
+    assert_not_nil @collective.reload.trio_user&.id
 
     TrioActivator.deactivate!(@collective)
 
-    assert_nil @collective.reload.trio_user_id
+    assert_nil @collective.reload.trio_user&.id
   end
 
   test "deactivate! archives the trio's CollectiveMember" do
@@ -114,30 +114,30 @@ class TrioActivatorTest < ActiveSupport::TestCase
     assert_nothing_raised do
       TrioActivator.deactivate!(@collective)
     end
-    assert_nil @collective.reload.trio_user_id
+    assert_nil @collective.reload.trio_user&.id
   end
 
   # === reconcile! ===
 
-  test "reconcile! activates when flag is on and trio_user_id is nil" do
+  test "reconcile! activates when flag is on and trio is inactive" do
     @tenant.enable_feature_flag!("trio")
     @collective.set_feature_flag!("trio", true)
-    assert_nil @collective.reload.trio_user_id, "precondition: trio inactive"
+    assert_nil @collective.reload.trio_user&.id, "precondition: trio inactive"
 
     TrioActivator.reconcile!(@collective)
 
-    assert_not_nil @collective.reload.trio_user_id
+    assert_not_nil @collective.reload.trio_user&.id
   end
 
-  test "reconcile! deactivates when flag is off and trio_user_id is set" do
+  test "reconcile! deactivates when flag is off and trio is active" do
     TrioActivator.activate!(@collective)
-    assert_not_nil @collective.reload.trio_user_id, "precondition: trio active"
+    assert_not_nil @collective.reload.trio_user&.id, "precondition: trio active"
     @tenant.disable_feature_flag!("trio")
     @collective.set_feature_flag!("trio", false)
 
     TrioActivator.reconcile!(@collective)
 
-    assert_nil @collective.reload.trio_user_id
+    assert_nil @collective.reload.trio_user&.id
   end
 
   test "activate! sets the explicit trio feature flag to true" do

--- a/test/services/trio_seeder_test.rb
+++ b/test/services/trio_seeder_test.rb
@@ -49,10 +49,12 @@ class TrioSeederTest < ActiveSupport::TestCase
     assert_equal first.id, second.id
   end
 
-  test "ensure_for assigns collective.trio_user" do
+  test "ensure_for seeds the trio without activating it" do
     trio = TrioSeeder.ensure_for(@main)
 
-    assert_equal trio.id, @main.reload.trio_user_id
+    # Activation state (the persona role) is TrioActivator's job.
+    assert_equal trio.id, @main.reload.seeded_persona_user("trio")&.id
+    assert_nil @main.trio_user
   end
 
   test "trio is a CollectiveMember of its collective" do
@@ -168,8 +170,8 @@ class TrioSeederTest < ActiveSupport::TestCase
     trio_other = TrioSeeder.ensure_for(other)
 
     assert_not_equal trio_main.id, trio_other.id
-    assert_equal trio_main.id, @main.reload.trio_user_id
-    assert_equal trio_other.id, other.reload.trio_user_id
+    assert_equal trio_main.id, @main.reload.seeded_persona_user("trio")&.id
+    assert_equal trio_other.id, other.reload.seeded_persona_user("trio")&.id
   end
 
   test "TrioSeeder is the only production source creating system_role: 'trio' users" do

--- a/test/services/trio_seeder_test.rb
+++ b/test/services/trio_seeder_test.rb
@@ -61,19 +61,28 @@ class TrioSeederTest < ActiveSupport::TestCase
     assert @main.user_is_member?(trio)
   end
 
-  test "main collective's trio has handle 'trio'" do
-    trio = TrioSeeder.ensure_for(@main)
+  test "trio's handle follows trio-[collective_handle] for every collective" do
+    other = create_collective(tenant: @tenant, created_by: @owner, handle: "garden-#{SecureRandom.hex(2)}")
 
-    assert_equal "trio", trio.tenant_users.find_by(tenant_id: @tenant.id).handle
+    main_trio = TrioSeeder.ensure_for(@main)
+    other_trio = TrioSeeder.ensure_for(other)
+
+    assert_equal "trio-#{@main.handle}", main_trio.tenant_users.find_by(tenant_id: @tenant.id).handle
+    assert_equal "trio-#{other.handle}", other_trio.tenant_users.find_by(tenant_id: @tenant.id).handle
   end
 
-  test "non-main collective's trio has a 'trio-<hex>' handle" do
-    other = create_collective(tenant: @tenant, created_by: @owner)
+  test "a squatted persona handle falls back to a suffixed one" do
+    other = create_collective(tenant: @tenant, created_by: @owner, handle: "sqd-#{SecureRandom.hex(2)}")
+    squatter = create_user(email: "sq_#{SecureRandom.hex(4)}@example.com")
+    squatter_tu = @tenant.add_user!(squatter)
+    # Bypass validation the way a legacy row would exist: claimed before the
+    # prefix was reserved.
+    squatter_tu.update_column(:handle, "trio-#{other.handle}")
+
     trio = TrioSeeder.ensure_for(other)
     handle = trio.tenant_users.find_by(tenant_id: @tenant.id).handle
 
-    assert_match(/\Atrio-[a-f0-9]+\z/, handle)
-    assert_not_equal "trio", handle
+    assert_match(/\Atrio-#{Regexp.escape(other.handle)}-[a-f0-9]+\z/, handle)
   end
 
   test "trio is configured as an internal ai_agent" do


### PR DESCRIPTION
## Summary

Component 2 of the personas track: cut the special cases tying every collective's trio to a shared public `/u/trio` identity, and make the **persona role** — a reserved, activator-managed CollectiveMember role — the single source of truth for a collective's active trio. Everything melody/counterpoint will need later becomes an *entry* in these mechanisms, not a new mechanism.

## Changes (one commit each)

1. **Persona roles.** `CollectiveMember` roles split into capability roles (grantable: admin/representative/summarizer/automator/moderator) and persona roles (`trio`) — reserved identity roles managed only by `TrioActivator` (granted on activate/restore, removed on deactivate). The role-grant endpoint and members-page picker offer capability roles only; the pluralized group-tag derivation skips persona roles (no `@trios` — the singular `@trio` tag lives in `ReservedHandles::AGENT_ROLES`).
2. **Mention resolution via the role.** `MentionParser`'s trio branch becomes generic: each `AGENT_ROLES` tag resolves to the members holding its persona role, in both parse and link rendering — the same `users_with_role` path capability tags use. A member without the role (a deactivated trio) resolves to nothing.
3. **Handles.** Every trio's handle is **`trio-[collective_handle]`** (unique per tenant; no main-collective special case), linking to the trio's *own* profile. The `User#handle`/`#path` overrides are gone; `/u/trio` no longer resolves. Collective renames cascade to the trio's handle (`sync_trio_handle!`, beside the identity-user precedent), including for deactivated trios.
4. **`collectives.trio_user_id` is dropped.** `Collective#persona_user(role)` resolves the active persona (unarchived member holding the role); `#seeded_persona_user(system_role)` finds the persona ever seeded (outlives activation). `#trio_user` survives as a reader, so most call sites read unchanged. `TrioSeeder` now seeds without activating — activation state is solely the role.
5. **The persona namespace is reserved unconditionally.** `trio` and any `trio-*` handle are claimable only by a matching system agent — no exceptions. This now applies to **collective handles** too, which is a behavior change: until now a collective could still be named `trio` (deliberately left allowed when the reserved-handle registry was introduced, for backwards compatibility). The reason collectives must be covered: every collective mints an identity user whose handle mirrors the collective's handle, so a collective named `trio-fans` would force a *user* handle inside the reserved namespace — the two namespaces have to be reserved together or the rule leaks. A reserved collective handle surfaces as a normal "handle is reserved" validation error.

## Query behavior

Dropping the `belongs_to` also dropped its association caching, and `persona_user`'s hottest caller is markdown rendering (`resolve_paths` runs per text node against one shared collective instance — a feed of N `@trio`-mentioning fragments would have cost ~3N queries). `persona_user` is therefore **memoized per collective instance** (nil results included), restoring the old caching semantics; the activator — the only production writer of persona roles — invalidates the memo when it grants/removes the role, and `reload` clears it. A query-count test pins the caching; an activator-cycle test pins the invalidation (a pre-activation nil read must not pin nil and starve `ensure_trio_funded!`). No new in-loop N+1s: the one looping caller (mention autocomplete) hoists the lookup into a local before iterating.

## Migration

Backfills the trio persona role onto every active trio's member row, renames legacy trio handles (`trio`, `trio-<hex4>`) to the new pattern (suffix-on-collision loop), then drops the column; `down` recomputes the column from the role. **Fail-fast guard:** if any non-trio user or any collective holds a reserved handle, the migration aborts with the offending `(tenant_id, handle)` pairs — resolving the conflict consciously at deploy time beats rows that mysteriously fail validation on their next save.

## Rollout notes

- **Check prod for offenders before deploy**: users or collectives with `trio`/`trio-*` handles (dev had none). The migration guard will list them if any exist.
- `/u/trio` stops resolving (no user holds the literal handle). Old stored text mentioning hex handles (`@trio-a1b2c3d4`) becomes dead text; `@trio` mentions re-resolve on render and keep working.
- Main-collective trios get `trio-<32-hex>` handles (main collectives have random hex handles) — accepted consequence of no special cases.

## Test plan

Red-green throughout: new/updated coverage in `reserved_handles_test` (capability/persona derivation, prefix reservation, collective namespace), `collective_member_test`, `trio_activator_test` (role lifecycle), `mention_parser_test` (role-based resolution mechanism pinned: link without role resolves nothing; role alone resolves), `trio_seeder_test` (handle pattern, squatter fallback, seeds-without-activating), `collective_test` (`persona_user` semantics, rename sync, namespace validation), plus conversions across users/autocomplete/collectives controller and notification/automation-filter tests. Verified live in dev: migration ran (5 handles renamed), full deactivate→dark / reactivate→restored-with-pool-funding cycle works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
