### PR TITLE
Fix sys-admin task run steps for runs on other tenants

### DIFF
--- a/app/controllers/system_admin_controller.rb
+++ b/app/controllers/system_admin_controller.rb
@@ -164,7 +164,12 @@ class SystemAdminController < ApplicationController
   def show_task_run
     @page_title = "Task Run"
     @task_run = AiAgentTaskRun.unscoped_for_admin(@current_user).find(params[:id])
-    @task_run.agent_session_steps.load
+    # AgentSessionStep is tenant-scoped, and this dashboard only runs on the
+    # primary tenant while the run may belong to any tenant — loading steps
+    # through the association would silently filter them to empty.
+    @steps = AgentSessionStep.unscoped_for_admin(@current_user)
+      .where(ai_agent_task_run_id: @task_run.id)
+      .order(:position)
 
     respond_to do |format|
       format.html

--- a/app/views/shared/_task_run_steps_timeline.html.erb
+++ b/app/views/shared/_task_run_steps_timeline.html.erb
@@ -1,4 +1,4 @@
-<% steps_data = task_run.agent_session_steps.map(&:to_step_hash) %>
+<% steps_data = (local_assigns[:steps] || task_run.agent_session_steps).map(&:to_step_hash) %>
 <% show_debug = defined?(debug) && debug %>
 <% is_redacted = defined?(redacted) && redacted %>
 

--- a/app/views/system_admin/show_task_run.html.erb
+++ b/app/views/system_admin/show_task_run.html.erb
@@ -121,8 +121,8 @@
   <%= octicon 'list-ordered', height: 12 %> Execution Steps (<%= @task_run.steps_count %>)
 </div>
 
-<% if @task_run.agent_session_steps.any? %>
-  <%= render 'shared/task_run_steps_timeline', task_run: @task_run, debug: false, redacted: redacted %>
+<% if @steps.any? %>
+  <%= render 'shared/task_run_steps_timeline', task_run: @task_run, steps: @steps, debug: false, redacted: redacted %>
 <% else %>
   <p class="pulse-text-secondary">No step data recorded.</p>
 <% end %>

--- a/app/views/system_admin/show_task_run.md.erb
+++ b/app/views/system_admin/show_task_run.md.erb
@@ -36,7 +36,7 @@
 
 ## Execution Steps
 
-<% @task_run.agent_session_steps.each_with_index do |step_record, index| -%>
+<% @steps.each_with_index do |step_record, index| -%>
 <% step = step_record.to_step_hash.with_indifferent_access -%>
 <% detail = step[:detail].is_a?(Hash) ? step[:detail].with_indifferent_access : {} -%>
 ### Step <%= index + 1 %>: <%= step[:type].upcase.tr("_", " ") %> (<%= Time.parse(step[:timestamp]).strftime("%H:%M:%S") %>)

--- a/test/controllers/system_admin_controller_test.rb
+++ b/test/controllers/system_admin_controller_test.rb
@@ -302,6 +302,47 @@ class SystemAdminControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/SENSITIVE_SCRATCHPAD/, response.body)
   end
 
+  test "sys_admin sees steps for a task run on another tenant" do
+    @primary_tenant.add_user!(@sys_admin_user)
+
+    # Agent, run, and steps all live on the OTHER tenant while the dashboard
+    # is only reachable on the primary tenant. AgentSessionStep is
+    # tenant-scoped, so loading steps through the run's association would
+    # silently filter them to empty.
+    Collective.scope_thread_to_collective(subdomain: @other_tenant.subdomain, handle: nil)
+    ai_agent = User.create!(
+      name: "Melody",
+      email: "melody-#{SecureRandom.hex(4)}@system.harmonic.local",
+      user_type: "ai_agent",
+      system_role: "melody",
+    )
+    @other_tenant.add_user!(ai_agent)
+    task_run = AiAgentTaskRun.create!(
+      tenant: @other_tenant,
+      ai_agent: ai_agent,
+      initiated_by: @sys_admin_user,
+      task: "Cross-tenant task",
+      max_steps: 10,
+      status: "completed",
+      success: true,
+      steps_count: 2,
+      completed_at: Time.current,
+    )
+    task_run.agent_session_steps.create!(position: 0, step_type: "fetch_page", detail: { "path" => "/n/some-note" })
+    task_run.agent_session_steps.create!(position: 1, step_type: "done", detail: { "message" => "CROSS_TENANT_DONE_MESSAGE" })
+
+    host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"
+    sign_in_as_admin(@sys_admin_user, tenant: @primary_tenant)
+
+    get system_admin_task_run_path(task_run.id)
+    assert_response :success
+
+    assert_no_match(/No step data recorded/, response.body)
+    assert_match "FETCH PAGE", response.body
+    # System agent → steps render unredacted, including on another tenant
+    assert_match "CROSS_TENANT_DONE_MESSAGE", response.body
+  end
+
   test "sys_admin can filter task runs by status" do
     @primary_tenant.add_user!(@sys_admin_user)
     host! "#{@primary_tenant.subdomain}.#{ENV['HOSTNAME']}"


### PR DESCRIPTION
## What

The system-admin agent-runner dashboard only runs on the primary tenant, but task runs can belong to any tenant — and in production right now, the only active agents (the Trio personas) run on the sandbox tenant. `show_task_run` loaded the run itself with `unscoped_for_admin`, then loaded its steps through the `agent_session_steps` association, which carries the tenant default scope. For a run on another tenant the association silently filtered every step out: the page showed a positive steps count and the "full step details are visible" note for system agents, followed by "No step data recorded."

## How

- `show_task_run` loads steps via `AgentSessionStep.unscoped_for_admin(@current_user).where(ai_agent_task_run_id: ...)` and passes them to the views.
- The shared steps-timeline partial accepts an optional `steps:` local and falls back to the association — its other caller (the principal-facing `/ai-agents` run page) is same-tenant by construction and unchanged.
- HTML and markdown admin views both fixed.

## Testing

Red-green: new test creates a system-agent task run with steps on a second tenant and views it from the primary-tenant dashboard — it reproduced "No step data recorded" before the fix, and now asserts the steps render, unredacted (pinning the system-agent redaction exemption cross-tenant as well). Full `system_admin_controller_test` (32 runs) and `ai_agents_controller_test` (122 runs) green; Sorbet clean.

## Why now

This is the quickest path to inspecting the 2026-07-18 Trio mention-loop incident runs (18 comments, ~$5): the step timelines it unblocks are the diagnostic for why runs hit max steps and why some failed. The broader collective-admin run-visibility work is planned separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)