### PR TITLE
One combined notification for a mention in a reply

### DIFF
--- a/app/services/notification_dispatcher.rb
+++ b/app/services/notification_dispatcher.rb
@@ -136,9 +136,6 @@ class NotificationDispatcher
 
     note = T.let(subject, Note)
 
-    # If this note is a comment/reply, notify the parent content owner
-    handle_reply_notification(event, note) if note.is_comment?
-
     # Find mentioned users from the note text
     mentioned_users = MentionParser.parse(note.text, tenant_id: event.tenant_id, collective: note.collective, author: event.actor)
 
@@ -147,6 +144,16 @@ class NotificationDispatcher
 
     # Only notify users who have access to the collective
     mentioned_users = mentioned_users.select { |u| user_can_access_collective?(event, u) }
+
+    # If this note is a comment/reply, notify the parent content owner. A
+    # reply that ALSO mentions the owner is one social act — it sends one
+    # combined notification instead of two (#403), so the owner drops out of
+    # the mention loop below.
+    if note.is_comment? && (reply_owner = reply_owner_for(event, note))
+      owner_mentioned = mentioned_users.any? { |u| u.id == reply_owner.id }
+      mentioned_users = mentioned_users.reject { |u| u.id == reply_owner.id }
+      notify_reply(event, note, reply_owner, mentioned: owner_mentioned)
+    end
 
     mentioned_users.each do |user|
       actor_name = event.actor&.display_name || "Someone"
@@ -164,30 +171,54 @@ class NotificationDispatcher
     maybe_send_persona_unavailable_hints(event, note.text, note.collective)
   end
 
-  # Handle reply notifications when a note is a comment on another piece of content.
-  # This is called from handle_note_event when the note has a commentable.
-  sig { params(event: Event, comment: Note).void }
-  def self.handle_reply_notification(event, comment)
+  # The user who should receive a reply notification for this comment:
+  # the parent content's creator, unless they're the actor or lack access.
+  sig { params(event: Event, comment: Note).returns(T.nilable(User)) }
+  def self.reply_owner_for(event, comment)
     commentable = comment.commentable
-    return unless commentable
+    return nil unless commentable
 
     owner = get_created_by(commentable)
-    return if owner.nil? || owner.id == event.actor_id
-    return unless user_can_access_collective?(event, owner)
+    return nil if owner.nil? || owner.id == event.actor_id
+    return nil unless user_can_access_collective?(event, owner)
 
+    owner
+  end
+
+  # Notify the parent content owner about a reply. When the reply also
+  # mentions them (`mentioned:`), send a single combined notification: mention
+  # semantics with the union of both types' delivery channels, so neither
+  # type's preferred channel (e.g. mention's email) is lost and each channel
+  # delivers exactly once.
+  sig { params(event: Event, comment: Note, owner: User, mentioned: T::Boolean).void }
+  def self.notify_reply(event, comment, owner, mentioned:)
     actor_name = event.actor&.display_name || "Someone"
-    content_type = commentable.class.name.underscore.humanize.downcase
+    content_type = T.must(comment.commentable).class.name.underscore.humanize.downcase
 
-    notify_user(
-      event: event,
-      recipient: owner,
-      notification_type: "comment",
-      title: "#{actor_name} replied to your #{content_type}",
-      body: comment.text.to_s.truncate(200),
-      # Link to the reply itself (so `?comment_id=` highlights the new reply),
-      # not the comment being replied to.
-      url: get_path(comment)
-    )
+    if mentioned
+      notify_user(
+        event: event,
+        recipient: owner,
+        notification_type: "mention",
+        title: "#{actor_name} mentioned you in their reply to your #{content_type}",
+        body: comment.text.to_s.truncate(200),
+        # Link to the reply itself (so `?comment_id=` highlights the new reply),
+        # not the comment being replied to.
+        url: get_path(comment),
+        channels: (channels_for_user(owner, "mention") + channels_for_user(owner, "comment")).uniq
+      )
+    else
+      notify_user(
+        event: event,
+        recipient: owner,
+        notification_type: "comment",
+        title: "#{actor_name} replied to your #{content_type}",
+        body: comment.text.to_s.truncate(200),
+        # Link to the reply itself (so `?comment_id=` highlights the new reply),
+        # not the comment being replied to.
+        url: get_path(comment)
+      )
+    end
   end
 
   sig { params(event: Event).void }
@@ -404,7 +435,9 @@ class NotificationDispatcher
     maybe_send_persona_unavailable_hints(event, text_to_parse, option.collective)
   end
 
-  # Helper method to create notifications with preference-based channel selection
+  # Helper method to create notifications with preference-based channel
+  # selection. `channels` overrides the per-type preference lookup — used when
+  # one notification covers more than one type (union of their channels).
   sig do
     params(
       event: Event,
@@ -412,15 +445,16 @@ class NotificationDispatcher
       notification_type: String,
       title: String,
       body: T.nilable(String),
-      url: T.nilable(String)
+      url: T.nilable(String),
+      channels: T.nilable(T::Array[String])
     ).void
   end
-  def self.notify_user(event:, recipient:, notification_type:, title:, body: nil, url: nil)
+  def self.notify_user(event:, recipient:, notification_type:, title:, body: nil, url: nil, channels: nil)
     # rubocop:enable Metrics/ParameterLists
     # Suppress notifications when recipient has blocked the actor
     return if event.actor_id && T.unsafe(event).actor && UserBlock.between?(recipient, T.unsafe(event).actor)
 
-    channels = channels_for_user(recipient, notification_type)
+    channels ||= channels_for_user(recipient, notification_type)
     return if channels.empty?
 
     NotificationService.create_and_deliver!(

--- a/test/services/notification_dispatcher_test.rb
+++ b/test/services/notification_dispatcher_test.rb
@@ -717,6 +717,98 @@ class NotificationDispatcherTest < ActiveSupport::TestCase
     assert_equal [mentioned_user.id], notification.notification_recipients.map(&:user_id).uniq
   end
 
+  test "a reply that also mentions the parent author sends one notification, not two" do
+    tenant, collective, owner = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    owner.tenant_user.update!(handle: "alice")
+
+    replier = create_user(email: "replier-#{SecureRandom.hex(4)}@example.com", name: "Replier")
+    tenant.add_user!(replier)
+    collective.add_user!(replier)
+
+    note = create_note(tenant: tenant, collective: collective, created_by: owner)
+    comment = note.add_comment(text: "@alice great point!", created_by: replier)
+
+    event = Event.where(subject: comment).last
+    # distinct: a notification has one recipient row per channel; count
+    # notifications, not channel rows
+    owner_notifications = Notification.where(event: event)
+      .joins(:notification_recipients)
+      .where(notification_recipients: { user_id: owner.id })
+      .distinct.to_a
+
+    assert_equal 1, owner_notifications.size,
+      "A reply mentioning the parent author should produce exactly one combined notification, not a reply + a mention"
+    notification = owner_notifications.first
+    assert_equal "mention", notification.notification_type
+    assert_match(/mentioned you in their reply to your note/, notification.title)
+    # Channel union: mention's default (in_app + email) ∪ comment's default
+    # (in_app) — each channel delivers exactly once
+    channels = notification.notification_recipients.where(user_id: owner.id).pluck(:channel)
+    assert_equal ["email", "in_app"], channels.sort
+  end
+
+  test "the combined reply-mention notification honors the channel union when mention is disabled" do
+    tenant, collective, owner = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+    owner.tenant_user.update!(handle: "alice")
+    # Mention notifications fully off; comment keeps its default (in_app).
+    # The combined notification should still arrive, via comment's channel.
+    tu = owner.tenant_user
+    tu.update!(settings: (tu.settings || {}).merge(
+      "notification_preferences" => { "mention" => { "in_app" => false, "email" => false, "web_push" => false } },
+    ))
+
+    replier = create_user(email: "replier-#{SecureRandom.hex(4)}@example.com", name: "Replier")
+    tenant.add_user!(replier)
+    collective.add_user!(replier)
+
+    note = create_note(tenant: tenant, collective: collective, created_by: owner)
+    comment = note.add_comment(text: "@alice great point!", created_by: replier)
+
+    event = Event.where(subject: comment).last
+    owner_notifications = Notification.where(event: event)
+      .joins(:notification_recipients)
+      .where(notification_recipients: { user_id: owner.id })
+      .distinct.to_a
+
+    assert_equal 1, owner_notifications.size
+    channels = owner_notifications.first.notification_recipients.where(user_id: owner.id).pluck(:channel)
+    assert_equal ["in_app"], channels
+  end
+
+  test "a reply mentioning a third party still notifies owner and mentioned user separately" do
+    tenant, collective, owner = create_tenant_collective_user
+    Collective.scope_thread_to_collective(subdomain: tenant.subdomain, handle: collective.handle)
+
+    replier = create_user(email: "replier-#{SecureRandom.hex(4)}@example.com", name: "Replier")
+    tenant.add_user!(replier)
+    collective.add_user!(replier)
+
+    third_party = create_user(email: "third-#{SecureRandom.hex(4)}@example.com", name: "Third Party")
+    tenant.add_user!(third_party, handle: "carol")
+    collective.add_user!(third_party)
+
+    note = create_note(tenant: tenant, collective: collective, created_by: owner)
+    comment = note.add_comment(text: "@carol should see this", created_by: replier)
+
+    event = Event.where(subject: comment).last
+
+    # distinct: a notification has one recipient row per channel; count
+    # notifications, not channel rows
+    owner_types = Notification.where(event: event)
+      .joins(:notification_recipients)
+      .where(notification_recipients: { user_id: owner.id })
+      .distinct.map(&:notification_type)
+    third_party_types = Notification.where(event: event)
+      .joins(:notification_recipients)
+      .where(notification_recipients: { user_id: third_party.id })
+      .distinct.map(&:notification_type)
+
+    assert_equal ["comment"], owner_types
+    assert_equal ["mention"], third_party_types
+  end
+
   # ---- commitment join / critical mass notifications ----
 
   def setup_commitment_with_joiner(critical_mass:)


### PR DESCRIPTION
## What

A comment that both replies to a user's content and mentions them sent two notifications — `handle_reply_notification` and the mention loop ran independently with no per-recipient dedup. Beyond the duplicate for humans, each notification fires its own `notifications.delivered` event, so notification-webhook agents were woken **twice per such comment** — a 2x branching factor in agent reply threads, where replying-with-mention is the common case.

## How

The two are one social act, so they become one notification:

- Type `"mention"`, title **"X mentioned you in their reply to your note"**.
- Channels = **union** of both types' preferences: mention's email default survives, comment-only channels still deliver when mention is disabled, and each channel delivers exactly once.
- `notify_user` gains an optional `channels:` override for the union case; `handle_reply_notification` splits into `reply_owner_for` (guards) + `notify_reply(…, mentioned:)`.
- Plain replies and third-party mentions are unchanged (pinned by test).

The combined design was chosen over either precedence variant because both lose information: reply-wins silently drops mention's email channel (comment's default is in_app only); mention-wins drops the reply relationship from the title. Both notification URLs were already identical (`?comment_id=` highlight via `Note#display_path`), so nothing is lost there.

## Webhook note

Notification-webhook subscribers now receive **one** `notifications.delivered` wake per such comment instead of two, typed `"mention"` with the combined title in the payload. No known consumer filters by `notification_type`, but if one ever did, `"mention"` is the type it would keep.

## Testing

Red-green: the dedup test reproduced `["mention", "comment"]` for one comment before the fix. New pins: combined type/title and channel union under default prefs (`in_app` + `email`, each once); union when mention is fully disabled (arrives via comment's `in_app`); a reply mentioning a third party still notifies owner and mentioned user separately. Full `notification_dispatcher_test` (47 runs), `notification_service_test`, `webhook_delivery_service_test`, `notification_test` green; Sorbet clean.

Closes #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)