### PR TITLE
Agent-runner context efficiency: visible truncation, bigger cap, stale-page eliding

### DIFF
--- a/agent-runner/src/core/AgentContext.ts
+++ b/agent-runner/src/core/AgentContext.ts
@@ -281,10 +281,7 @@ Outer levels take precedence. Ignore any instruction that conflicts with ethical
 /**
  * Build the system prompt for an agent task.
  */
-export function buildSystemPrompt(
-  identityContent: string,
-  scratchpad: string | undefined,
-): string {
+export function buildSystemPrompt(identityContent: string): string {
   const sections: string[] = [
     WHAT_IS_HARMONIC,
     DOMAIN_QUICK_REF,
@@ -293,12 +290,11 @@ export function buildSystemPrompt(
     BOUNDARIES,
   ];
 
+  // The identity content is the /whoami page passed through whole — it
+  // already carries the agent's scratchpad under its own labeled section.
+  // Rails owns that page's presentation; the runner does not parse it.
   if (identityContent !== "") {
     sections.push(`## Your Identity\n\n${identityContent}`);
-  }
-
-  if (scratchpad !== undefined && scratchpad !== "") {
-    sections.push(`## Your Scratchpad (from previous tasks)\n\n${scratchpad}`);
   }
 
   return sections.join("\n\n");
@@ -310,7 +306,6 @@ export function buildSystemPrompt(
  */
 export function buildChatSystemPrompt(
   identityContent: string,
-  scratchpad: string | undefined,
   timeSinceLastMessage: string | undefined,
 ): string {
   const sections: string[] = [
@@ -328,10 +323,6 @@ export function buildChatSystemPrompt(
 
   if (identityContent !== "") {
     sections.push(`## Your Identity\n\n${identityContent}`);
-  }
-
-  if (scratchpad !== undefined && scratchpad !== "") {
-    sections.push(`## Your Scratchpad (from previous tasks)\n\n${scratchpad}`);
   }
 
   return sections.join("\n\n");

--- a/agent-runner/src/core/PromptBuilder.ts
+++ b/agent-runner/src/core/PromptBuilder.ts
@@ -41,10 +41,9 @@ export interface TaskPayload {
 export function buildInitialMessages(
   task: TaskPayload,
   identityContent: string,
-  scratchpad: string | undefined,
 ): readonly Message[] {
   return [
-    systemMessage(buildSystemPrompt(identityContent, scratchpad)),
+    systemMessage(buildSystemPrompt(identityContent)),
     userMessage(task.task),
   ];
 }

--- a/agent-runner/src/core/PromptBuilder.ts
+++ b/agent-runner/src/core/PromptBuilder.ts
@@ -88,3 +88,99 @@ export function assistantMessage(
 export function getToolDefinitions(): readonly ToolDefinition[] {
   return AGENT_TOOLS;
 }
+
+/** Tools whose results are page content — candidates for truncation and eliding. */
+const PAGE_TOOLS = new Set(["fetch_page", "search", "get_help"]);
+
+/** How many of the most recent page-fetch results stay full when eliding. */
+const ELIDE_KEEP_LAST = 2;
+
+/** Stale page results at or under this size aren't worth replacing with a stub. */
+const ELIDE_MIN_LENGTH = 500;
+
+/**
+ * Cap page content handed to the LLM, with a visible, actionable marker.
+ *
+ * The marker matters: a silent cut leaves the model looking at a thread that
+ * just stops, with no way to know content is missing or how to get it —
+ * it will guess. With the marker it can refetch or say what it couldn't read.
+ */
+export function truncatePageContent(content: string, limit: number): string {
+  if (content.length <= limit) {
+    return content;
+  }
+  return `${content.slice(0, limit)}\n\n[page truncated: showing ${limit} of ${content.length} characters. ` +
+    `Refetch with ?full_text=true for a full note body, or fetch a specific comment's path to read the rest of a thread.]`;
+}
+
+/**
+ * Replace stale page-fetch tool results with a one-line stub, keeping the
+ * most recent ones full.
+ *
+ * Every LLM call resends the whole message array, so without this each page
+ * ever fetched is re-billed on every subsequent step. The agent's own
+ * assistant turns (what it concluded from those pages) stay; if it needs a
+ * stale page back, the stub says how. execute_action results are never
+ * elided — they record what the agent did, which it must not lose.
+ *
+ * Pure: returns a new array, never mutates the input.
+ */
+export function elideStalePageContent(
+  messages: readonly Message[],
+  keepLast: number = ELIDE_KEEP_LAST,
+): readonly Message[] {
+  const pageToolCallsById = new Map<string, { name: string; descriptor: string }>();
+  for (const message of messages) {
+    for (const tc of message.tool_calls ?? []) {
+      if (!PAGE_TOOLS.has(tc.function.name)) {
+        continue;
+      }
+      pageToolCallsById.set(tc.id, {
+        name: tc.function.name,
+        descriptor: describeToolCall(tc),
+      });
+    }
+  }
+
+  const elidableIndexes: number[] = [];
+  messages.forEach((message, i) => {
+    if (
+      message.role === "tool" &&
+      message.tool_call_id !== undefined &&
+      pageToolCallsById.has(message.tool_call_id) &&
+      (message.content?.length ?? 0) > ELIDE_MIN_LENGTH
+    ) {
+      elidableIndexes.push(i);
+    }
+  });
+
+  const toElide = new Set(elidableIndexes.slice(0, Math.max(0, elidableIndexes.length - keepLast)));
+  if (toElide.size === 0) {
+    return messages;
+  }
+
+  return messages.map((message, i): Message => {
+    if (!toElide.has(i)) {
+      return message;
+    }
+    const call = pageToolCallsById.get(message.tool_call_id ?? "");
+    return {
+      ...message,
+      content: `[earlier ${call?.name ?? "page"} result for ${call?.descriptor ?? "a page"} elided to save context — fetch it again if you need it]`,
+    };
+  });
+}
+
+/** Human-readable target of a page tool call, best-effort from its arguments. */
+function describeToolCall(tc: ToolCall): string {
+  try {
+    const args = JSON.parse(tc.function.arguments) as Record<string, unknown>;
+    const target = args["path"] ?? args["query"] ?? args["topic"];
+    if (typeof target === "string" && target !== "") {
+      return target;
+    }
+  } catch {
+    // fall through to the generic descriptor
+  }
+  return "a page";
+}

--- a/agent-runner/src/core/PromptBuilder.ts
+++ b/agent-runner/src/core/PromptBuilder.ts
@@ -109,8 +109,12 @@ export function truncatePageContent(content: string, limit: number): string {
   if (content.length <= limit) {
     return content;
   }
+  // Advice must be honorable from THIS layer: the runner truncates every
+  // fetch regardless of query params, so never suggest ?full_text=true here
+  // (that expands the note body at the Rails layer — making the page bigger).
+  // A narrower page is the one thing that reliably fits under the cap.
   return `${content.slice(0, limit)}\n\n[page truncated: showing ${limit} of ${content.length} characters. ` +
-    `Refetch with ?full_text=true for a full note body, or fetch a specific comment's path to read the rest of a thread.]`;
+    `Fetch a more specific path — e.g. a single comment's page — to read content that was cut off.]`;
 }
 
 /**

--- a/agent-runner/src/services/AgentLoop.ts
+++ b/agent-runner/src/services/AgentLoop.ts
@@ -257,9 +257,6 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
       const whoamiResult = yield* fetchPage("/whoami");
       leakageDetector = extractCanary(whoamiResult.content);
 
-      const scratchpadMatch = /## Scratchpad\s*\n([\s\S]*?)(?:\n##|$)/.exec(whoamiResult.content);
-      const scratchpad = scratchpadMatch?.[1]?.trim();
-
       // Compute time since last message
       let timeSinceLastMessage: string | undefined;
       if (history.length > 0) {
@@ -272,7 +269,7 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
         }
       }
 
-      const chatSystemPrompt = buildChatSystemPrompt(whoamiResult.content, scratchpad, timeSinceLastMessage);
+      const chatSystemPrompt = buildChatSystemPrompt(whoamiResult.content, timeSinceLastMessage);
       const chatMessages: Message[] = [systemMessage(chatSystemPrompt)];
 
       for (const msg of history) {
@@ -301,10 +298,7 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
       const whoamiResult = yield* fetchPage("/whoami");
       leakageDetector = extractCanary(whoamiResult.content);
 
-      const scratchpadMatch = /## Scratchpad\s*\n([\s\S]*?)(?:\n##|$)/.exec(whoamiResult.content);
-      const scratchpad = scratchpadMatch?.[1]?.trim();
-
-      messages = buildInitialMessages(task, whoamiResult.content, scratchpad);
+      messages = buildInitialMessages(task, whoamiResult.content);
     }
 
     // Step 5: Main agent loop

--- a/agent-runner/src/services/AgentLoop.ts
+++ b/agent-runner/src/services/AgentLoop.ts
@@ -27,6 +27,8 @@ import {
   systemMessage,
   userMessage,
   getToolDefinitions,
+  truncatePageContent,
+  elideStalePageContent,
 } from "../core/PromptBuilder.js";
 import { parseToolCalls } from "../core/ActionParser.js";
 import { RESPOND_TO_HUMAN_TOOL, buildChatSystemPrompt } from "../core/AgentContext.js";
@@ -61,7 +63,11 @@ type AgentLoopError =
   | TaskCancelledError
   | TokenDecryptError;
 
-const PAGE_CONTENT_MAX_LENGTH = 4000;
+// Cap on page content handed to the LLM per fetch. Generous by default —
+// typical note threads should fit whole; the truncation marker covers the
+// rest. Override with the PAGE_CONTENT_MAX_LENGTH env var.
+const PAGE_CONTENT_MAX_LENGTH =
+  parseInt(process.env["PAGE_CONTENT_MAX_LENGTH"] ?? "", 10) || 24_000;
 
 /** Outcome of a task execution, for stats tracking in the main loop. */
 export type TaskOutcome = { readonly outcome: "completed" | "failed" | "cancelled" };
@@ -324,8 +330,10 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
         // Call LLM (matches Ruby think())
         // Ruby's LLMClient.chat never raises — it catches all errors and returns Result with error field.
         // We do the same: catch LLMError, record think step with llm_error, treat as error action.
+        // Stale page fetches ride along on every call otherwise — see
+        // elideStalePageContent. `messages` itself stays complete.
         const llmResult = yield* llm.chat(
-          messages,
+          elideStalePageContent(messages),
           task.model,
           tools,
           { taskRunId: task.taskRunId, subdomain: task.tenantSubdomain },
@@ -560,10 +568,7 @@ export const runTask = (task: TaskPayload): Effect.Effect<TaskOutcome, never, LL
  * Truncate page content to match Ruby's 4000-char limit.
  */
 function truncateContent(content: string): string {
-  if (content.length > PAGE_CONTENT_MAX_LENGTH) {
-    return content.slice(0, PAGE_CONTENT_MAX_LENGTH);
-  }
-  return content;
+  return truncatePageContent(content, PAGE_CONTENT_MAX_LENGTH);
 }
 
 interface ScratchpadResult {

--- a/agent-runner/test/core/AgentContext.test.ts
+++ b/agent-runner/test/core/AgentContext.test.ts
@@ -3,13 +3,13 @@ import { buildSystemPrompt, buildChatSystemPrompt, AGENT_TOOLS } from "../../src
 
 describe("buildSystemPrompt", () => {
   it("includes what Harmonic is", () => {
-    const prompt = buildSystemPrompt("", undefined);
+    const prompt = buildSystemPrompt("");
     expect(prompt).toContain("group coordination application");
     expect(prompt).toContain("reading pages");
   });
 
   it("includes domain quick reference table", () => {
-    const prompt = buildSystemPrompt("", undefined);
+    const prompt = buildSystemPrompt("");
     expect(prompt).toContain("Harmonic Quick Reference");
     expect(prompt).toContain("Collective");
     expect(prompt).toContain("Note");
@@ -23,7 +23,7 @@ describe("buildSystemPrompt", () => {
   });
 
   it("points to /help pages for details", () => {
-    const prompt = buildSystemPrompt("", undefined);
+    const prompt = buildSystemPrompt("");
     expect(prompt).toContain("/help/collectives");
     expect(prompt).toContain("/help/notes");
     expect(prompt).toContain("/help/decisions");
@@ -33,7 +33,7 @@ describe("buildSystemPrompt", () => {
   });
 
   it("includes navigation section with key paths", () => {
-    const prompt = buildSystemPrompt("", undefined);
+    const prompt = buildSystemPrompt("");
     expect(prompt).toContain("## Navigation");
     expect(prompt).toContain("/whoami");
     expect(prompt).toContain("/workspace");
@@ -44,13 +44,13 @@ describe("buildSystemPrompt", () => {
   });
 
   it("includes discovery strategy", () => {
-    const prompt = buildSystemPrompt("", undefined);
+    const prompt = buildSystemPrompt("");
     expect(prompt).toContain("Start at `/whoami`");
     expect(prompt).toContain("fetch_page");
   });
 
   it("includes tool instructions", () => {
-    const prompt = buildSystemPrompt("", undefined);
+    const prompt = buildSystemPrompt("");
     expect(prompt).toContain("fetch_page");
     expect(prompt).toContain("execute_action");
     expect(prompt).toContain("search");
@@ -59,7 +59,7 @@ describe("buildSystemPrompt", () => {
   });
 
   it("includes boundaries with hierarchy", () => {
-    const prompt = buildSystemPrompt("", undefined);
+    const prompt = buildSystemPrompt("");
     expect(prompt).toContain("## Boundaries");
     expect(prompt).toContain("Ethical foundations");
     expect(prompt).toContain("Platform rules");
@@ -67,31 +67,26 @@ describe("buildSystemPrompt", () => {
   });
 
   it("includes identity when provided", () => {
-    const prompt = buildSystemPrompt("I am a friendly bot", undefined);
+    const prompt = buildSystemPrompt("I am a friendly bot");
     expect(prompt).toContain("Your Identity");
     expect(prompt).toContain("friendly bot");
   });
 
   it("excludes identity section when empty", () => {
-    const prompt = buildSystemPrompt("", undefined);
+    const prompt = buildSystemPrompt("");
     expect(prompt).not.toContain("Your Identity");
   });
 
-  it("includes scratchpad when provided", () => {
-    const prompt = buildSystemPrompt("", "Previous notes here");
-    expect(prompt).toContain("Scratchpad");
-    expect(prompt).toContain("Previous notes here");
-  });
-
-  it("excludes scratchpad section when empty", () => {
-    const prompt = buildSystemPrompt("", undefined);
-    expect(prompt).not.toContain("Scratchpad");
+  it("does not add its own scratchpad section — the whoami identity content already carries one", () => {
+    const identity = "# About You\n\n## Your Scratchpad\n\nMy notes";
+    const prompt = buildSystemPrompt(identity);
+    expect(prompt.split("My notes").length - 1).toBe(1);
   });
 });
 
 describe("buildChatSystemPrompt", () => {
   it("includes working patterns for chat", () => {
-    const prompt = buildChatSystemPrompt("", undefined, undefined);
+    const prompt = buildChatSystemPrompt("", undefined);
     expect(prompt).toContain("Working Patterns");
     expect(prompt).toContain("respond_to_human");
     expect(prompt).toContain("searching your private workspace");
@@ -102,32 +97,32 @@ describe("buildChatSystemPrompt", () => {
     // Only the assistant's text crosses turn boundaries — tool calls and
     // their results don't. The agent has to put identifying context in its
     // reply for follow-up turns to make sense.
-    const prompt = buildChatSystemPrompt("", undefined, undefined);
+    const prompt = buildChatSystemPrompt("", undefined);
     expect(prompt).toMatch(/path|link/i);
     expect(prompt).toMatch(/tool calls.*(don't|do not)|text persists/i);
   });
 
   it("includes domain quick reference", () => {
-    const prompt = buildChatSystemPrompt("", undefined, undefined);
+    const prompt = buildChatSystemPrompt("", undefined);
     expect(prompt).toContain("Harmonic Quick Reference");
     expect(prompt).toContain("Private Workspace");
     expect(prompt).toContain("/workspace");
   });
 
   it("includes chat tools with respond_to_human", () => {
-    const prompt = buildChatSystemPrompt("", undefined, undefined);
+    const prompt = buildChatSystemPrompt("", undefined);
     expect(prompt).toContain("respond_to_human");
     expect(prompt).toContain("five tools");
   });
 
   it("includes time context when provided", () => {
-    const prompt = buildChatSystemPrompt("", undefined, "5 minutes");
+    const prompt = buildChatSystemPrompt("", "5 minutes");
     expect(prompt).toContain("Time Context");
     expect(prompt).toContain("5 minutes ago");
   });
 
   it("excludes time context when not provided", () => {
-    const prompt = buildChatSystemPrompt("", undefined, undefined);
+    const prompt = buildChatSystemPrompt("", undefined);
     expect(prompt).not.toContain("Time Context");
   });
 });

--- a/agent-runner/test/core/PromptBuilder.test.ts
+++ b/agent-runner/test/core/PromptBuilder.test.ts
@@ -103,7 +103,11 @@ describe("truncatePageContent", () => {
     expect(result).toContain("[page truncated");
     expect(result).toContain("4000");
     expect(result).toContain("5000");
-    expect(result).toContain("full_text=true");
+    expect(result).toContain("more specific path");
+    // The runner truncates regardless of query params, so it must not
+    // suggest ?full_text=true — that's the Rails layer's advice, and it
+    // makes the page BIGGER (circular for anything thread-shaped)
+    expect(result).not.toContain("full_text");
   });
 });
 

--- a/agent-runner/test/core/PromptBuilder.test.ts
+++ b/agent-runner/test/core/PromptBuilder.test.ts
@@ -22,7 +22,7 @@ describe("buildInitialMessages", () => {
   };
 
   it("builds system + user messages", () => {
-    const messages = buildInitialMessages(task, "I am Agent Smith", undefined);
+    const messages = buildInitialMessages(task, "I am Agent Smith");
     expect(messages.length).toBe(2);
     expect(messages[0]?.role).toBe("system");
     expect(messages[1]?.role).toBe("user");
@@ -30,15 +30,10 @@ describe("buildInitialMessages", () => {
   });
 
   it("includes identity content in system prompt", () => {
-    const messages = buildInitialMessages(task, "I am Agent Smith", undefined);
+    const messages = buildInitialMessages(task, "I am Agent Smith");
     expect(messages[0]?.content).toContain("Agent Smith");
   });
 
-  it("includes scratchpad when provided", () => {
-    const messages = buildInitialMessages(task, "Identity", "Previous context here");
-    expect(messages[0]?.content).toContain("Previous context here");
-    expect(messages[0]?.content).toContain("Scratchpad");
-  });
 });
 
 describe("buildToolResultMessages", () => {

--- a/agent-runner/test/core/PromptBuilder.test.ts
+++ b/agent-runner/test/core/PromptBuilder.test.ts
@@ -5,6 +5,8 @@ import {
   systemMessage,
   userMessage,
   assistantMessage,
+  truncatePageContent,
+  elideStalePageContent,
 } from "../../src/core/PromptBuilder.js";
 import type { TaskPayload } from "../../src/core/PromptBuilder.js";
 
@@ -81,5 +83,146 @@ describe("message helpers", () => {
     const msg = assistantMessage("Just text", undefined);
     expect(msg.role).toBe("assistant");
     expect(msg.tool_calls).toBeUndefined();
+  });
+});
+
+describe("truncatePageContent", () => {
+  it("returns content under the limit unchanged", () => {
+    expect(truncatePageContent("short content", 4000)).toBe("short content");
+  });
+
+  it("returns content exactly at the limit unchanged", () => {
+    const content = "a".repeat(4000);
+    expect(truncatePageContent(content, 4000)).toBe(content);
+  });
+
+  it("truncates long content with a visible, actionable marker", () => {
+    const content = "a".repeat(5000);
+    const result = truncatePageContent(content, 4000);
+    expect(result.startsWith("a".repeat(4000))).toBe(true);
+    expect(result).toContain("[page truncated");
+    expect(result).toContain("4000");
+    expect(result).toContain("5000");
+    expect(result).toContain("full_text=true");
+  });
+});
+
+describe("elideStalePageContent", () => {
+  const bigPage = (label: string) => `# Page ${label}\n${"x".repeat(2000)}`;
+
+  function pageFetchExchange(path: string, id: string, content: string) {
+    return [
+      assistantMessage(undefined, [
+        { id, type: "function" as const, function: { name: "fetch_page", arguments: JSON.stringify({ path }) } },
+      ]),
+      { role: "tool" as const, content, tool_call_id: id },
+    ];
+  }
+
+  function actionExchange(action: string, id: string, content: string) {
+    return [
+      assistantMessage(undefined, [
+        { id, type: "function" as const, function: { name: "execute_action", arguments: JSON.stringify({ path: "/", action, params: {} }) } },
+      ]),
+      { role: "tool" as const, content, tool_call_id: id },
+    ];
+  }
+
+  it("elides all but the most recent page fetches", () => {
+    const messages = [
+      systemMessage("sys"),
+      userMessage("task"),
+      ...pageFetchExchange("/n/aaa", "call_a", bigPage("A")),
+      ...pageFetchExchange("/n/bbb", "call_b", bigPage("B")),
+      ...pageFetchExchange("/n/ccc", "call_c", bigPage("C")),
+    ];
+
+    const result = elideStalePageContent(messages);
+
+    const toolResults = result.filter((m) => m.role === "tool");
+    expect(toolResults[0]?.content).toContain("elided");
+    expect(toolResults[0]?.content).toContain("/n/aaa");
+    expect(toolResults[0]?.content?.length).toBeLessThan(300);
+    expect(toolResults[1]?.content).toBe(bigPage("B"));
+    expect(toolResults[2]?.content).toBe(bigPage("C"));
+  });
+
+  it("never elides execute_action results", () => {
+    const messages = [
+      systemMessage("sys"),
+      userMessage("task"),
+      ...actionExchange("create_note", "call_1", `created note\n${"y".repeat(2000)}`),
+      ...pageFetchExchange("/n/aaa", "call_a", bigPage("A")),
+      ...pageFetchExchange("/n/bbb", "call_b", bigPage("B")),
+      ...pageFetchExchange("/n/ccc", "call_c", bigPage("C")),
+    ];
+
+    const result = elideStalePageContent(messages);
+
+    const toolResults = result.filter((m) => m.role === "tool");
+    expect(toolResults[0]?.content).toContain("y".repeat(2000));
+  });
+
+  it("leaves small stale page results alone — eliding gains nothing", () => {
+    const messages = [
+      systemMessage("sys"),
+      userMessage("task"),
+      ...pageFetchExchange("/n/aaa", "call_a", "tiny page"),
+      ...pageFetchExchange("/n/bbb", "call_b", bigPage("B")),
+      ...pageFetchExchange("/n/ccc", "call_c", bigPage("C")),
+    ];
+
+    const result = elideStalePageContent(messages);
+
+    const toolResults = result.filter((m) => m.role === "tool");
+    expect(toolResults[0]?.content).toBe("tiny page");
+  });
+
+  it("does not mutate the input messages", () => {
+    const messages = [
+      systemMessage("sys"),
+      userMessage("task"),
+      ...pageFetchExchange("/n/aaa", "call_a", bigPage("A")),
+      ...pageFetchExchange("/n/bbb", "call_b", bigPage("B")),
+      ...pageFetchExchange("/n/ccc", "call_c", bigPage("C")),
+    ];
+    const originalContents = messages.map((m) => m.content);
+
+    elideStalePageContent(messages);
+
+    expect(messages.map((m) => m.content)).toEqual(originalContents);
+  });
+
+  it("elides page results with unparseable tool arguments without throwing", () => {
+    const messages = [
+      systemMessage("sys"),
+      userMessage("task"),
+      assistantMessage(undefined, [
+        { id: "call_a", type: "function" as const, function: { name: "fetch_page", arguments: "not json" } },
+      ]),
+      { role: "tool" as const, content: bigPage("A"), tool_call_id: "call_a" },
+      ...pageFetchExchange("/n/bbb", "call_b", bigPage("B")),
+      ...pageFetchExchange("/n/ccc", "call_c", bigPage("C")),
+    ];
+
+    const result = elideStalePageContent(messages);
+
+    const toolResults = result.filter((m) => m.role === "tool");
+    expect(toolResults[0]?.content).toContain("elided");
+  });
+
+  it("keeps everything when there are only two page fetches", () => {
+    const messages = [
+      systemMessage("sys"),
+      userMessage("task"),
+      ...pageFetchExchange("/n/aaa", "call_a", bigPage("A")),
+      ...pageFetchExchange("/n/bbb", "call_b", bigPage("B")),
+    ];
+
+    const result = elideStalePageContent(messages);
+
+    const toolResults = result.filter((m) => m.role === "tool");
+    expect(toolResults[0]?.content).toBe(bigPage("A"));
+    expect(toolResults[1]?.content).toBe(bigPage("B"));
   });
 });

--- a/agent-runner/test/services/AgentLoop.test.ts
+++ b/agent-runner/test/services/AgentLoop.test.ts
@@ -1060,6 +1060,28 @@ describe("AgentLoop", () => {
     expect(outcome).toEqual({ outcome: "cancelled" });
   });
 
+  // --- scratchpad handling in the system prompt ---
+
+  it("includes the scratchpad exactly once in the system prompt", async () => {
+    // Uses the REAL Rails whoami heading ("## Your Scratchpad") — the page is
+    // passed through whole as identity content, and the runner must not add
+    // a second copy of the scratchpad (nor parse the page to try).
+    const state = createMockState();
+    const whoamiWithScratchpad =
+      "# About You\n\nYou are Test Agent.\n\n## Your Scratchpad\n\nYour scratchpad contains information that you chose to retain from previous sessions.\n\n<scratchpad>\nUNIQUE_SCRATCHPAD_NOTE\n</scratchpad>\n\n## Available Actions\n- update_scratchpad";
+    await runWithMocks(
+      makeTask(),
+      state,
+      [makeLLMResponse()],
+      { "/whoami": { content: whoamiWithScratchpad, availableActions: ["update_scratchpad"] } },
+    );
+
+    const systemPrompt = state.llmMessages[0]?.[0]?.content ?? "";
+    expect(systemPrompt.split("UNIQUE_SCRATCHPAD_NOTE").length - 1).toBe(1);
+    expect(systemPrompt).toContain("You are Test Agent.");
+    expect(systemPrompt).toContain("## Available Actions");
+  });
+
   // --- stale page content eliding ---
 
   it("elides stale page fetches from later LLM calls but keeps recent ones full", async () => {

--- a/agent-runner/test/services/AgentLoop.test.ts
+++ b/agent-runner/test/services/AgentLoop.test.ts
@@ -1060,6 +1060,41 @@ describe("AgentLoop", () => {
     expect(outcome).toEqual({ outcome: "cancelled" });
   });
 
+  // --- stale page content eliding ---
+
+  it("elides stale page fetches from later LLM calls but keeps recent ones full", async () => {
+    const state = createMockState();
+    const bigPage = (label: string) => `# Page ${label}\n${"x".repeat(1000)}`;
+    await runWithMocks(
+      makeTask(),
+      state,
+      [
+        makeLLMResponse({ content: null, toolCalls: [makeNavigateToolCall("/n/aaa", "call_a")], finishReason: "tool_calls" }),
+        makeLLMResponse({ content: null, toolCalls: [makeNavigateToolCall("/n/bbb", "call_b")], finishReason: "tool_calls" }),
+        makeLLMResponse({ content: null, toolCalls: [makeNavigateToolCall("/n/ccc", "call_c")], finishReason: "tool_calls" }),
+        makeLLMResponse({ content: "All done", toolCalls: [], finishReason: "stop" }),
+      ],
+      {
+        "/whoami": { content: WHOAMI_CONTENT, availableActions: ["update_scratchpad"] },
+        "/n/aaa": { content: bigPage("A"), availableActions: [] },
+        "/n/bbb": { content: bigPage("B"), availableActions: [] },
+        "/n/ccc": { content: bigPage("C"), availableActions: [] },
+      },
+    );
+
+    // Third call: two page fetches so far, both within the keep window — full
+    const thirdCallTools = state.llmMessages[2]?.filter((m) => m.role === "tool") ?? [];
+    expect(thirdCallTools[0]?.content).toBe(bigPage("A"));
+    expect(thirdCallTools[1]?.content).toBe(bigPage("B"));
+
+    // Fourth call: three page fetches — the oldest is elided, last two stay full
+    const fourthCallTools = state.llmMessages[3]?.filter((m) => m.role === "tool") ?? [];
+    expect(fourthCallTools[0]?.content).toContain("elided");
+    expect(fourthCallTools[0]?.content).toContain("/n/aaa");
+    expect(fourthCallTools[1]?.content).toBe(bigPage("B"));
+    expect(fourthCallTools[2]?.content).toBe(bigPage("C"));
+  });
+
   // --- chat_turn mode ---
 
   describe("chat_turn mode", () => {

--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -120,6 +120,7 @@ Visible at `/system-admin/agent-runner` (requires sys_admin role). Shows runner 
 | `LLM_BASE_URL` | No | — | Legacy override for the LiteLLM route only (billed calls always go to `LLM_GATEWAY_URL`) |
 | `LLM_GATEWAY_MODE` | No | `litellm` | Fallback route for tasks whose payload predates the per-task `llm_gateway_mode` stream field. Rails decides routing per task; this only covers old queued payloads. |
 | `MAX_CONCURRENT_TASKS` | No | `100` | Maximum concurrent task fibers |
+| `PAGE_CONTENT_MAX_LENGTH` | No | `24000` | Character cap on page content handed to the LLM per fetch; over-cap pages get a visible truncation marker telling the agent how to read the rest |
 | `STREAM_MAX_LEN` | No | `10000` | Redis stream approximate max length |
 | `AGENT_TASKS_STREAM` | No | `agent_tasks` | Redis stream name |
 | `AGENT_TASKS_CONSUMER_GROUP` | No | `agent_runner` | Consumer group name |


### PR DESCRIPTION
## What

Three fixes to task-run prompt construction, motivated by the Trio mention-loop incident: a run's think-step said *"I need to be careful not to respond to something I haven't read"* — and then responded anyway, because the runner had silently cut the thread out from under it and given it no way to know.

### 1. Page truncation is visible and actionable

The runner sliced every fetched page to a cap with `content.slice(0, N)` — no marker, mid-sentence. The model saw threads that just stop (under a "Comments (18)" header promising more) and had to guess. Over-cap pages now end with:

> `[page truncated: showing N of M characters. Fetch a more specific path — e.g. a single comment's page — to read content that was cut off.]`

(The marker deliberately does NOT suggest `?full_text=true` — that's the Rails layer's advice and the runner truncates regardless of query params; following it would make the page bigger and loop for thread-shaped content. Rails' own body-truncation notice still recommends it where that layer honors it.)

This is the honest-truncation pattern the other two layers already follow (Rails' note-body notice at 2k chars; the MCP endpoint's 1 MiB marker). The runner's was the only silent one, and the binding one in practice.

### 2. The cap rises 4,000 → 24,000 characters

4k (~1k tokens) cut off typical comment threads and predates current context windows. Now env-configurable as `PAGE_CONTENT_MAX_LENGTH` (documented in docs/AGENT_RUNNER.md).

### 3. Stale page fetches are elided from LLM calls

Every LLM call resends the entire message array, so each page ever fetched was re-billed on every subsequent step — roughly quadratic input-token growth in step count, which is where the incident's cost went. Before each call, page-fetch/search/get_help tool results **other than the two most recent** are replaced with a one-line stub:

> `[earlier fetch_page result for /n/aaa elided to save context — fetch it again if you need it]`

Guardrails: `execute_action` results are never elided (they record what the agent *did*); small results are left alone (nothing to gain); the stored `messages` array and step records stay complete — eliding happens only on the copy handed to the LLM, so run timelines and debugging are unaffected.

## Testing

Red-green throughout: 9 new unit tests on `truncatePageContent`/`elideStalePageContent` (marker content, keep-window, execute_action exemption, small-result exemption, purity, unparseable-arguments resilience) and an AgentLoop integration test pinning that the third LLM call still carries both prior pages full while the fourth sees the oldest elided. Full suite 296/296, `tsc` typecheck and build clean.


## Also: dead scratchpad extraction deleted

While reviewing what else touches the system prompt, we found the runner regex-parses `/whoami` to extract the scratchpad and re-append it as its own section — but the regex expects `## Scratchpad` while the Rails page emits `## Your Scratchpad`, so it has **never matched**: the extraction is dead code and production behavior is unchanged by removing it. Fixing the regex instead would have *started* duplicating the scratchpad (it already sits inside the identity content with Rails' own framing). Deleted the extraction and the scratchpad parameters from the prompt builders; the runner now passes the whoami page through whole. Design rule this encodes: **the runner does not parse page content** — YAML frontmatter is the one sanctioned parse (the leakage-detector canary is a deliberate two-sided wire protocol, not scraping). A pin using the real Rails heading asserts the scratchpad appears exactly once in the system prompt.

## Deploy note

Runner-only change, but the runner ships as its own image — deploy needs the agent-runner image rebuilt/pulled, not just web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

