### PR TITLE
Rework Trio persona prompts: role boundaries, response ladder, deliberate tagging

### DIFF
--- a/app/services/personas.rb
+++ b/app/services/personas.rb
@@ -84,8 +84,9 @@ module Personas
           max_steps: 20,
           task: <<~TASK,
             You were mentioned (or replied to) by {{event.actor.name}} in {{subject.path}}.
-            Navigate there, read the context — including the parent thread if this
-            is a reply — and respond appropriately with a comment.
+            Navigate there and read the context — including the parent thread if
+            this is a reply — then respond at the level the moment calls for: a
+            comment if you have something to add, or a read confirmation if not.
           TASK
         },
       ],
@@ -108,8 +109,9 @@ module Personas
           max_steps: 20,
           task: <<~TASK,
             You were mentioned (or replied to) by {{event.actor.name}} in {{subject.path}}.
-            Navigate there, read the context — including the parent thread if this
-            is a reply — and respond appropriately with a comment.
+            Navigate there and read the context — including the parent thread if
+            this is a reply — then respond at the level the moment calls for: a
+            comment if you have something to add, or a read confirmation if not.
           TASK
         },
       ],
@@ -132,8 +134,9 @@ module Personas
           max_steps: 20,
           task: <<~TASK,
             You were mentioned (or replied to) by {{event.actor.name}} in {{subject.path}}.
-            Navigate there, read the context — including the parent thread if this
-            is a reply — and respond appropriately with a comment.
+            Navigate there and read the context — including the parent thread if
+            this is a reply — then respond at the level the moment calls for: a
+            comment if you have something to add, or a read confirmation if not.
           TASK
         },
       ],

--- a/app/services/personas/prompts/cadence.md
+++ b/app/services/personas/prompts/cadence.md
@@ -16,6 +16,23 @@ You are the expert in Harmonic's information architecture — how notes, decisio
 
 Keep the record in service of the future. Summarize faithfully, connect what belongs together, and when the past has something to say about the present — a pattern repeating, a lesson already paid for — say so plainly. You do not take sides in disagreements: you surface what happened and let the record do the arguing.
 
+## Responding
+
+Melody carries Trio's day-to-day conversation; you speak for the record. When directly addressed — a mention of you, or a reply to your own comment — answer, usually with the summary, history, or connection that was asked for. Otherwise confirm reading: the chronicler's receipt says the record took note. When `@trio` summons the whole ensemble, Melody answers and you confirm reading — comment only to surface something specific from the record (a past decision on point, a pattern repeating, a thread worth linking); anything not drawn from the record is Melody's to say.
+
+Not every response needs to be a comment. The forms, smallest first:
+
+1. **Confirm reading** — the `confirm_read` action. It tells the author you saw their words; a receipt is a complete response, not a failure to participate.
+2. **Brief comment** — one point, made once.
+3. **Substantive comment** — a full contribution, when one was asked of you.
+4. **New artifact** — a note, a summary, or a link the conversation is ready for.
+
+Choose the smallest form that serves. When a task tells you to respond, any of these forms counts, including a receipt.
+
+Refer to other members, including your siblings, by name — "Melody suggested", not "@melody". An `@` tag is a summons that can trigger the tagged agent into action; tag someone only when you deliberately want to call them in.
+
+Never respond substantively to something you could not fully read. If a page is truncated or a thread is cut off, fetch the specific page you are missing; if you still cannot read it, say plainly what you could not see — do not cover the gap with a guess. The same honesty governs receipts: a read confirmation claims you actually read the words, so never confirm reading content you could not see.
+
 ## Your Personality
 
 You are steady, attentive, and even-handed. Neutrality and compassionate equanimity are your core personality traits — a chronicler the whole collective can trust precisely because you have no stake in any faction.

--- a/app/services/personas/prompts/counterpoint.md
+++ b/app/services/personas/prompts/counterpoint.md
@@ -16,6 +16,23 @@ You are the expert in Harmonic's rules and boundaries — the collective's polic
 
 Strengthen the collective's work by testing it. Name the weaknesses, risks, and unexamined assumptions in what's put forward. Check work against the collective's own policies and norms, and against the boundaries Harmonic enforces. Strengthen, don't obstruct: every critique should leave the work better — pair objections with the condition under which you would withdraw them.
 
+## Responding
+
+Melody carries Trio's day-to-day conversation; your voice is for when verification has findings. When directly addressed — a mention of you, or a reply to your own comment — answer. Otherwise confirm reading: from the verifying watch, a receipt means *reviewed, nothing to flag*, and that is a report worth having. When `@trio` summons the whole ensemble, Melody answers and you confirm reading — comment only to name a concrete problem in what was posted; anything that does not need the verifying watch is Melody's to say.
+
+Not every response needs to be a comment. The forms, smallest first:
+
+1. **Confirm reading** — the `confirm_read` action. It tells the author you saw their words; a receipt is a complete response, not a failure to participate.
+2. **Brief comment** — one point, made once.
+3. **Substantive comment** — a full contribution, when one was asked of you.
+4. **New artifact** — a note, decision, or commitment the conversation is ready for.
+
+Choose the smallest form that serves. When a task tells you to respond, any of these forms counts, including a receipt.
+
+Refer to other members, including your siblings, by name — "Melody suggested", not "@melody". An `@` tag is a summons that can trigger the tagged agent into action; tag someone only when you deliberately want to call them in.
+
+Never respond substantively to something you could not fully read. If a page is truncated or a thread is cut off, fetch the specific page you are missing; if you still cannot read it, say plainly what you could not see — do not cover the gap with a guess. The same honesty governs receipts: a read confirmation claims you actually read the words, so never confirm reading content you could not see.
+
 ## Your Personality
 
 You are principled, rigorous, and fair. You are demanding about reasoning and generous toward people: you challenge the work, never the person.

--- a/app/services/personas/prompts/melody.md
+++ b/app/services/personas/prompts/melody.md
@@ -16,6 +16,23 @@ You are the expert in Harmonic's features and controls — what the app can do a
 
 You participate as a member in your own right — one voice among many, not an authority. Contribute substantively: share ideas, draft proposals, and surface options others haven't named. Offer the next concrete step, advocate for your view, and yield gracefully when the collective decides otherwise.
 
+## Responding
+
+You are Trio's speaking voice. When someone addresses you directly — a mention, or a reply to your comment — answer them. When `@trio` summons the whole ensemble, the reply is yours to carry; Counterpoint and Cadence confirm reading. One question deserves one answer, not three variations.
+
+Not every response needs to be a comment. The forms, smallest first:
+
+1. **Confirm reading** — the `confirm_read` action. It tells the author you saw their words; a receipt is a complete response, not a failure to participate.
+2. **Brief comment** — one point, made once.
+3. **Substantive comment** — a full contribution, when one was asked of you.
+4. **New artifact** — a note, decision, commitment, or automation the conversation is ready for.
+
+Choose the smallest form that serves. When a task tells you to respond, any of these forms counts, including a receipt.
+
+Refer to other members, including your siblings, by name — "Counterpoint noted", not "@counterpoint". An `@` tag is a summons that can trigger the tagged agent into action; tag someone only when you deliberately want to call them in.
+
+Never respond substantively to something you could not fully read. If a page is truncated or a thread is cut off, fetch the specific page you are missing; if you still cannot read it, say plainly what you could not see — do not cover the gap with a guess. The same honesty governs receipts: a read confirmation claims you actually read the words, so never confirm reading content you could not see.
+
 ## Your Personality
 
 You are curious, generative, and forward-moving. You form views and share them plainly, holding them as contributions rather than conclusions.

--- a/app/views/help/markdown_ui.md.erb
+++ b/app/views/help/markdown_ui.md.erb
@@ -90,6 +90,8 @@ Each action has two endpoints under `{page}/actions/{action_name}`:
 
 Example: to confirm reading the note above, `POST` to `/collectives/my-team/n/abc12345/actions/confirm_read`.
 
+Actions target the page they run on. Comments are notes with pages of their own: a link like `/n/abc12345?comment_id=def67890` points at comment `def67890`, whose own page is `/n/def67890` — run `confirm_read` there to confirm reading that comment rather than the root note.
+
 Parameters should be sent as a JSON body with `Content-Type: application/json`:
 
 ```

--- a/app/views/help/trio.md.erb
+++ b/app/views/help/trio.md.erb
@@ -26,7 +26,7 @@ Cadence focuses on **learning**. Mention `@cadence` when you want a summary, the
 
 The agents act when spoken to. Mention `@melody`, `@counterpoint`, or `@cadence` in a note or comment and that agent reads the context and replies. Replying to one of an agent's comments continues the conversation — no mention needed.
 
-`@trio` addresses the whole ensemble: every enabled agent responds from their own angle, so expect up to three replies to one mention. Use it when you want all three kinds of attention — doing, verifying, and learning — on one question.
+`@trio` addresses the whole ensemble: every enabled agent reads the context. Melody carries the reply; Counterpoint and Cadence confirm reading and add a comment of their own only when their watch — verifying or learning — has something to say. Use it when you want all three kinds of attention on one question.
 
 Mentioning a built-in agent somewhere Trio isn't enabled sends you a notification with instructions to enable it.
 

--- a/test/controllers/whoami_controller_test.rb
+++ b/test/controllers/whoami_controller_test.rb
@@ -146,7 +146,7 @@ class WhoamiControllerTest < ActionDispatch::IntegrationTest
       user: ai_agent,
       tenant: @tenant,
       name: "Test Token",
-      scopes: %w[read:users],
+      scopes: ["read:users"],
     )
 
     get "/whoami", headers: {
@@ -169,7 +169,7 @@ class WhoamiControllerTest < ActionDispatch::IntegrationTest
       user: ai_agent,
       tenant: @tenant,
       name: "Test Token",
-      scopes: %w[read:users],
+      scopes: ["read:users"],
     )
 
     get "/whoami", headers: {
@@ -211,6 +211,38 @@ class WhoamiControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "You are Cadence"
   end
 
+  test "whoami canary tags match the agent-runner leakage detector pattern" do
+    # The runner's LeakageDetector extracts the identity prompt with
+    # CANARY_PATTERN (agent-runner/src/core/LeakageDetector.ts) and fails
+    # OPEN when nothing matches — a format drift on this page would silently
+    # disable leakage detection. This pins the rendered markup to the
+    # runner's exact pattern.
+    @tenant.enable_api!
+    persona = PersonaSeeder.ensure_for(T.must(@tenant.main_collective), Personas::MELODY)
+    task_run = AiAgentTaskRun.create!(
+      tenant: @tenant, ai_agent: persona, initiated_by: @user,
+      task: "canary format test", max_steps: 5, status: "queued"
+    )
+    api_token = ApiToken.create_internal_token(user: persona, tenant: @tenant, context: task_run)
+
+    get "/whoami", headers: {
+      "Accept" => "text/markdown",
+      "Authorization" => "Bearer #{api_token.plaintext_token}",
+    }
+    assert_response :success
+
+    # Ruby transliteration of the runner's CANARY_PATTERN:
+    #   /<canary:([a-zA-Z0-9]+)>([\s\S]*?)<\/canary:\1>/
+    canary_pattern = %r{<canary:([a-zA-Z0-9]+)>(.*?)</canary:\1>}m
+    match = canary_pattern.match(response.body)
+    assert match, "whoami markdown must contain a <canary:TOKEN>…</canary:TOKEN> block the runner can extract"
+    token = T.must(match)[1].to_s
+    identity_prompt = T.must(match)[2].to_s
+    # The runner rejects empty captures; the token is SecureRandom.hex(8).
+    assert_match(/\A[0-9a-f]{16}\z/, token)
+    assert_includes identity_prompt, "You are Melody"
+  end
+
   test "whoami does not show identity prompt section when not set" do
     @tenant.enable_api!
 
@@ -221,7 +253,7 @@ class WhoamiControllerTest < ActionDispatch::IntegrationTest
       user: ai_agent,
       tenant: @tenant,
       name: "Test Token",
-      scopes: %w[read:users],
+      scopes: ["read:users"],
     )
 
     get "/whoami", headers: {
@@ -316,7 +348,7 @@ class WhoamiControllerTest < ActionDispatch::IntegrationTest
       user: ai_agent,
       tenant: @tenant,
       name: "Test Token",
-      scopes: %w[read:users],
+      scopes: ["read:users"],
     )
 
     get "/whoami", headers: {
@@ -338,7 +370,7 @@ class WhoamiControllerTest < ActionDispatch::IntegrationTest
       user: ai_agent,
       tenant: @tenant,
       name: "Test Token",
-      scopes: %w[read:users],
+      scopes: ["read:users"],
     )
 
     get "/whoami", headers: {
@@ -359,7 +391,7 @@ class WhoamiControllerTest < ActionDispatch::IntegrationTest
       user: ai_agent,
       tenant: @tenant,
       name: "Test Token",
-      scopes: %w[read:users],
+      scopes: ["read:users"],
     )
 
     get "/whoami", headers: {
@@ -390,7 +422,7 @@ class WhoamiControllerTest < ActionDispatch::IntegrationTest
       user: ai_agent,
       tenant: @tenant,
       name: "Test Token",
-      scopes: %w[read:users create:all],
+      scopes: ["read:users", "create:all"],
     )
 
     get "/whoami/actions", headers: {
@@ -411,7 +443,7 @@ class WhoamiControllerTest < ActionDispatch::IntegrationTest
       user: ai_agent,
       tenant: @tenant,
       name: "Test Token",
-      scopes: %w[read:users create:all],
+      scopes: ["read:users", "create:all"],
     )
 
     post "/whoami/actions/update_scratchpad",
@@ -446,7 +478,7 @@ class WhoamiControllerTest < ActionDispatch::IntegrationTest
       user: ai_agent,
       tenant: @tenant,
       name: "Test Token",
-      scopes: %w[read:users create:all],
+      scopes: ["read:users", "create:all"],
     )
 
     long_content = "x" * 10_001
@@ -472,7 +504,7 @@ class WhoamiControllerTest < ActionDispatch::IntegrationTest
       user: ai_agent,
       tenant: @tenant,
       name: "Test Token",
-      scopes: %w[read:users create:all],
+      scopes: ["read:users", "create:all"],
     )
 
     post "/whoami/actions/update_scratchpad",


### PR DESCRIPTION
## Why

One `@melody` mention on Trio's first day in prod set off an 18-comment loop between the three personas (~$5 of LLM spend). The prompts themselves lit the fuse: they taught each persona its siblings' mention tags, told every persona to converse, and the default task said to respond "with a comment" — so every wake produced a comment, and most comments tagged a sibling, which is itself a dispatch trigger.

This is Track A of the post-incident plan: enforcement is **prompts only**. All three personas keep the `self_or_reply` trigger, so replying to an agent still gets a response — no dispatch rules keyed on user type, no trigger-config changes, no migration.

## What

Each persona prompt gains a single **Responding** section:

- **Role boundary**: Melody is Trio's speaking voice and carries `@trio` replies; Counterpoint and Cadence answer when directly addressed (mention, or reply to their own comment) and otherwise confirm reading — read confirmations never match automation triggers, so they are cascade-proof by construction.
- **Response ladder**: confirm-read < brief comment < substantive comment < new artifact; choose the smallest form that serves, and a read confirmation counts as a complete response to any task that asks for one.
- **Deliberate tagging**: refer to others by name; an `@` tag is a summons that can trigger the tagged agent — tag only to deliberately call someone in.
- **Truncation honesty**: never respond substantively to — nor confirm reading of — content you could not actually read; fetch the specific missing page or say plainly what you couldn't see.

Also:

- Seeded task template now ends "…a comment if you have something to add, or a read confirmation if not." Task text is snapshotted into existing `AutomationRule` rows, so this reaches **new seeds only**; the three already-enabled collectives in prod keep the old wording until refreshed (deploy note below).
- `/help/trio` describes the new `@trio` behavior; `/help/markdown_ui` documents that comments are notes with pages of their own, where `confirm_read` receipts the specific comment.
- New test pins the whoami canary block to the agent-runner LeakageDetector's exact `CANARY_PATTERN`. The detector **fails open** when nothing matches, so a Rails-side format drift would silently disable leakage detection; this test makes that drift loud.

## Live testing (dev, real runner + gateway, funding-pool-smoke)

| Scenario | Result |
|---|---|
| `@melody` mention | One run, one reply, receipt + comment |
| Human reply to Melody's comment | Exactly one response, no siblings woken |
| `@trio` (3 questions, 3 prompt iterations) | Three runs; melody answers; siblings comment too, but watch-differentiated, not duplicative |

Across **every** run: zero `@` tags in persona comments and zero second-generation task runs — the loop mechanism is gone. Runs completed in 8–10 steps (incident runs hit the 20-step cap).

Known limitation: strict receipt-only from Counterpoint/Cadence on `@trio` does not reliably emerge from prompts alone — they consistently find watch-specific things to say. If we want it strict, the lever is ensemble context in the dispatched task (Track E in the plan), not more prompt pressure.

## Deploy notes

- Rails-side only — no agent-runner image rebuild needed.
- Prod's three seeded persona rule sets still carry the old "respond appropriately with a comment" task text. Prompts (read fresh per render) govern regardless, but for consistency the unmodified rules can be refreshed via console after deploy — or a small data migration if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)