### PR TITLE
Let persona managers dispatch manual task runs

### DIFF
--- a/app/controllers/ai_agents_controller.rb
+++ b/app/controllers/ai_agents_controller.rb
@@ -218,7 +218,7 @@ class AiAgentsController < ApplicationController
   def run_task
     return render status: :forbidden, plain: "403 Unauthorized - Only human accounts can run AI agent tasks" unless current_user&.human?
 
-    @ai_agent = find_ai_agent_by_handle
+    @ai_agent = find_ai_agent_for_run_views
     return render status: :not_found, plain: "404 Not Found" unless @ai_agent
     return render status: :not_found, plain: "404 Not Found" unless @ai_agent.internal_ai_agent?
 
@@ -230,7 +230,7 @@ class AiAgentsController < ApplicationController
   def execute_task
     return render status: :forbidden, plain: "403 Unauthorized - Only human accounts can run AI agent tasks" unless current_user&.human?
 
-    @ai_agent = find_ai_agent_by_handle
+    @ai_agent = find_ai_agent_for_run_views
     return render status: :not_found, plain: "404 Not Found" unless @ai_agent
     return render status: :not_found, plain: "404 Not Found" unless @ai_agent.internal_ai_agent?
 
@@ -776,14 +776,16 @@ class AiAgentsController < ApplicationController
       .first
   end
 
-  # The task-run surfaces (runs / show_run / cancel_run) resolve the agent
-  # for its parent as usual, and additionally for the principal collective's
-  # automation managers — active admins and automators — when the agent is
-  # collective-principaled (its parent is the collective's identity user,
-  # e.g. the Trio personas). The collective is the accountable principal, so
-  # the humans who answer for it and manage its automations must be able to
-  # inspect what its agents did; a task run is an automation's execution
-  # detail. Everything else on /ai-agents stays parent-only.
+  # The task-run surfaces (runs / show_run / cancel_run / run_task /
+  # execute_task) resolve the agent for its parent as usual, and additionally
+  # for the principal collective's automation managers — active admins and
+  # automators — when the agent is collective-principaled (its parent is the
+  # collective's identity user, e.g. the Trio personas). The collective is
+  # the accountable principal, so the humans who answer for it and manage its
+  # automations must be able to inspect what its agents did and dispatch runs
+  # themselves — rule authorship already lets them make the agent run on
+  # triggers, so manual dispatch grants nothing beyond what they hold.
+  # Everything else on /ai-agents stays parent-only.
   def find_ai_agent_for_run_views
     find_ai_agent_by_handle || find_collective_principaled_agent_for_manager
   end

--- a/test/controllers/ai_agents_controller_test.rb
+++ b/test/controllers/ai_agents_controller_test.rb
@@ -566,6 +566,81 @@ class AiAgentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "queued", task_run.status
   end
 
+  test "collective admin can open the run-new-task page for a collective-principaled agent" do
+    _collective, persona, admin, _member = create_persona_collective_with_members
+
+    sign_in_as(admin, tenant: @tenant)
+    get "/ai-agents/#{persona_handle(persona)}/run"
+    assert_response :success
+    assert_match persona.name, response.body
+  end
+
+  test "collective automator can dispatch a task run for a collective-principaled agent" do
+    collective, persona, _admin, _member = create_persona_collective_with_members
+    automator = create_user(email: "automator-#{SecureRandom.hex(4)}@example.com", name: "Automator")
+    @tenant.add_user!(automator)
+    collective.add_user!(automator, roles: ["automator"])
+
+    sign_in_as(automator, tenant: @tenant)
+    assert_difference -> { AiAgentTaskRun.count }, 1 do
+      post "/ai-agents/#{persona_handle(persona)}/run", params: { task: "Manual persona task" }
+    end
+    assert_response :redirect
+
+    task_run = AiAgentTaskRun.order(created_at: :desc).first
+    assert_equal automator.id, task_run.initiated_by_id
+    assert_equal 0, task_run.chain_depth
+  end
+
+  test "pool-funded persona dispatch by an admin skips the individual billing gate" do
+    collective, persona, admin, _member = create_persona_collective_with_members
+    enable_stripe_billing_flag!(@tenant)
+    FeatureFlagService.config["funding_pools"] ||= {}
+    FeatureFlagService.config["funding_pools"]["app_enabled"] = true
+    @tenant.enable_feature_flag!("funding_pools")
+    collective.enable_feature_flag!("funding_pools")
+    pool = FundingPool.create!(tenant: @tenant, collective: collective, created_by: admin, member_draw_cap_cents: 500)
+    persona.update!(funding_pool: pool)
+
+    sign_in_as(admin, tenant: @tenant)
+    assert_difference -> { AiAgentTaskRun.count }, 1 do
+      post "/ai-agents/#{persona_handle(persona)}/run", params: { task: "Pool-funded task" }
+    end
+
+    assert_response :redirect
+    assert_no_match %r{/billing}, response.headers["Location"]
+  end
+
+  test "plain member cannot open or dispatch run-new-task for a collective-principaled agent" do
+    _collective, persona, _admin, member = create_persona_collective_with_members
+
+    sign_in_as(member, tenant: @tenant)
+    get "/ai-agents/#{persona_handle(persona)}/run"
+    assert_response :not_found
+
+    assert_no_difference -> { AiAgentTaskRun.count } do
+      post "/ai-agents/#{persona_handle(persona)}/run", params: { task: "Nope" }
+    end
+    assert_response :not_found
+  end
+
+  test "workspace persona dispatch stays owner-only" do
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    workspace = @user.private_workspace
+    persona = PersonaSeeder.ensure_for(workspace, Personas::MELODY)
+    Tenant.clear_thread_scope
+    other = create_user(email: "not-owner-#{SecureRandom.hex(4)}@example.com", name: "Not Owner")
+    @tenant.add_user!(other)
+
+    sign_in_as(other, tenant: @tenant)
+    get "/ai-agents/#{persona_handle(persona)}/run"
+    assert_response :not_found
+
+    sign_in_as(@user, tenant: @tenant)
+    get "/ai-agents/#{persona_handle(persona)}/run"
+    assert_response :success
+  end
+
   test "admin with archived membership cannot view a collective-principaled agent's runs" do
     collective, persona, admin, _member = create_persona_collective_with_members
     create_persona_task_run(persona, initiated_by: admin)


### PR DESCRIPTION
## Summary

Admins and automators of a persona's principal collective could view, inspect, and cancel its task runs (shipped in the visibility bundle), but clicking **Run new task** returned a 404: `run_task` and `execute_task` still resolved the agent through the parent-only lookup, while the links on the runs and run-detail pages render unconditionally — so managers saw a link to a page they couldn't open.

## Changes

- `run_task` and `execute_task` now resolve the agent via `find_ai_agent_for_run_views`, the same admin-or-automator resolution the other run surfaces use.
- Comment on the lookup updated to name all five run surfaces and the rationale: rule authorship already lets these managers make the agent run on triggers, so manual dispatch grants nothing beyond what they hold. A manual run records the dispatching human as `initiated_by` at chain depth 0, so the audit trail names who did it.
- Workspace personas are unaffected — they resolve through the owner's parent-scoped lookup, and non-owners still 404.

## Tests

Five new controller tests (red-green): admin can open the run-new-task page; automator can dispatch (run records them as initiator at depth 0); pool-funded persona dispatch skips the individual billing gate; plain member still 404s on both GET and POST; workspace persona dispatch stays owner-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)