### PR TITLE
Settings re-arch Phases 3+4: agent-setup pointer, checkout copy, settings slim-down

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -290,7 +290,22 @@ class ApplicationController < ActionController::Base
                     end
   end
 
+  # dismissed_notices key for the post-creation agent-setup pointer.
+  AGENT_SETUP_NOTICE_ID = "agent-setup-pointer"
+
   private
+
+  # The agent-setup funnel step to surface on the collective's landing pages,
+  # or nil to show nothing. Gated on admin standing and prior dismissal before
+  # touching the collective's pool/enrollment state, so the common member path
+  # stays cheap.
+  def agent_setup_pointer_step
+    member = @current_user&.collective_member
+    return nil unless member&.is_admin?
+    return nil if member.dismissed_notices.include?(AGENT_SETUP_NOTICE_ID)
+
+    @current_collective.agent_setup_step
+  end
 
   # Resolves user identity for API token-authenticated requests.
   #

--- a/app/controllers/collective_agents_controller.rb
+++ b/app/controllers/collective_agents_controller.rb
@@ -74,13 +74,13 @@ class CollectiveAgentsController < ApplicationController
                        pool = @current_collective.funding_pool
                        pool_open = pool.present? && !pool.archived?
                        if @current_tenant.feature_enabled?("stripe_billing") && !pool_open
-                         "Trio is enabled — its personas have joined #{@current_collective.name}. " \
-                           "They can't run until the funding pool is open: [open it on the pool page](#{@current_collective.path}/pool)."
+                         "One step left to turn on Trio: it needs an open funding pool before it can run. " \
+                           "[Open one on the pool page](#{@current_collective.path}/pool) to finish."
                        else
-                         "Trio is enabled — its personas have joined #{@current_collective.name}."
+                         "Trio is on — its personas have joined #{@current_collective.name}."
                        end
                      else
-                       "Trio is disabled — its personas have been deactivated."
+                       "Trio is off — its personas have been deactivated."
                      end
     redirect_to agents_page_path
   end
@@ -118,10 +118,16 @@ class CollectiveAgentsController < ApplicationController
     @current_collective.set_feature_flag!("trio", enabled)
     PersonaActivator.reconcile!(@current_collective)
     result = if enabled
-               "Trio is enabled in #{@current_collective.name}: its personas are members now. " \
-                 "On billing accounts they need an open funding pool to run."
+               pool = @current_collective.funding_pool
+               pool_open = pool.present? && !pool.archived?
+               if @current_tenant.feature_enabled?("stripe_billing") && !pool_open
+                 "Trio's personas are members of #{@current_collective.name} now, but Trio can't run until an open " \
+                   "funding pool exists. Open one at #{@current_collective.path}/pool to finish turning it on."
+               else
+                 "Trio is on in #{@current_collective.name}: its personas are members now."
+               end
              else
-               "Trio is disabled in #{@current_collective.name}; its personas have been deactivated."
+               "Trio is off in #{@current_collective.name}; its personas have been deactivated."
              end
     render_action_success({ action_name: "set_trio_enabled", resource: @current_collective, result: result })
   end

--- a/app/controllers/collectives_controller.rb
+++ b/app/controllers/collectives_controller.rb
@@ -70,6 +70,10 @@ class CollectivesController < ApplicationController
     @prev_commitments = @previous_cycle.commitments_closed_within_cycle
     @team = @current_collective.team
     @heartbeats = Heartbeat.where_in_cycle(@cycle) - [current_heartbeat]
+    # Steer admins toward finishing agent setup while the funnel is
+    # incomplete. Computed only for admins who haven't dismissed it, so the
+    # pool/enrollment lookups stay off the common member path.
+    @agent_setup_step = agent_setup_pointer_step
     unless @current_user.collective_member.dismissed_notices.include?('collective-welcome')
       @current_user.collective_member.dismiss_notice!('collective-welcome')
       if @current_collective.created_by == @current_user
@@ -78,6 +82,14 @@ class CollectivesController < ApplicationController
         flash[:notice] = "Welcome to #{@current_collective.name}! You can start creating notes, decisions, and commitments by clicking the plus icon to the right of the page header."
       end
     end
+  end
+
+  # Permanently dismiss the post-creation agent-setup pointer for this
+  # admin in this collective. Once dismissed it stays gone even if the funnel
+  # later regresses — the Agents page remains the resting-state checklist.
+  def dismiss_agent_setup
+    @current_user.collective_member&.dismiss_notice!(ApplicationController::AGENT_SETUP_NOTICE_ID)
+    redirect_to @current_collective.path
   end
 
   def new
@@ -172,14 +184,6 @@ class CollectivesController < ApplicationController
     if can_manage_own_collective_settings?
       @page_title = 'Collective Settings'
 
-      # Proration preview no longer needed here — reactivation is managed on /billing
-
-      # Pool state is only needed to decide whether to point at the pool
-      # page — the pool itself is managed there.
-      if @current_collective.standard? && @current_tenant.feature_enabled?("stripe_billing")
-        @funding_pools_enabled = @current_collective.funding_pools_available?
-        @funding_pool = @current_collective.funding_pool
-      end
       # Automation counts for display
       @enabled_automations_count = @current_collective.automation_rules.where(enabled: true).count
       # If the owner started a Stripe Checkout for this collective and

--- a/app/controllers/pulse_controller.rb
+++ b/app/controllers/pulse_controller.rb
@@ -101,6 +101,8 @@ class PulseController < ApplicationController
     @team = @current_collective.team
     @heartbeats = Heartbeat.where_in_cycle(@cycle)
     @pinned_items = @current_collective.pinned_items
+    # Steer admins toward finishing agent setup while the funnel is incomplete.
+    @agent_setup_step = agent_setup_pointer_step
   end
 
   def cycle_from_param

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -354,9 +354,13 @@ module ApplicationHelper
   # (lowercase for common nouns; product names stay cased) so callers can
   # splice them into prose. Combine with `to_sentence` for natural-language
   # output.
-  def paid_feature_labels(tenant)
+  # `trio_label` overrides how the built-in-agents item reads. The default
+  # descriptive form suits newcomer-facing surfaces (settings, upgrade preview)
+  # where "Trio" would be opaque; callers whose surrounding context already
+  # names Trio (the Agents page) can pass "Trio" for a shorter, parallel list.
+  def paid_feature_labels(tenant, trio_label: nil)
     labels = ["automations"]
-    labels << "the built-in agents (#{Personas.all.map(&:name).to_sentence})" if tenant.trio_enabled?
+    labels << (trio_label || "the built-in agents (#{Personas.all.map(&:name).to_sentence})") if tenant.trio_enabled?
     labels << "file attachments" if tenant.file_attachments_enabled?
     labels
   end

--- a/app/models/collective.rb
+++ b/app/models/collective.rb
@@ -572,6 +572,28 @@ class Collective < ApplicationRecord
     funding_pools_available? || funding_pool.present?
   end
 
+  # The next incomplete step in the built-in-agent setup funnel, or nil when
+  # the funnel is complete or doesn't apply. Drives the post-creation pointer
+  # that steers admins toward the Agents page. Only meaningful on billing
+  # tenants that offer Trio; the funnel begins once paid features are unlocked
+  # (a free collective hasn't entered it, so it gets no pointer).
+  sig { returns(T.nilable(Symbol)) }
+  def agent_setup_step
+    return nil unless standard?
+
+    tenant_record = T.must(tenant)
+    return nil unless tenant_record.feature_enabled?("stripe_billing")
+    return nil unless FeatureFlagService.tenant_enabled?(tenant_record, "trio")
+    return nil unless tier_unlocks_paid_features?
+    return :enable_trio unless trio_enabled?
+
+    pool = funding_pool
+    return :open_pool unless pool.present? && !pool.archived?
+    return :enroll_members if pool.enrollments.active.none?
+
+    nil
+  end
+
   sig { params(value: T.nilable(String)).void }
   def timezone=(value)
     return unless value.present?

--- a/app/views/billing/_credits_section.html.erb
+++ b/app/views/billing/_credits_section.html.erb
@@ -4,7 +4,7 @@
     power internal agents. See BillingController#topup / #load_credit_balance. %>
 <section class="pulse-section" style="margin-bottom: 24px;">
   <h2 class="pulse-section-title">AI Agent Credits</h2>
-  <p class="pulse-muted" style="margin-bottom: 12px;">Prepaid credits for AI agent LLM usage. Agents draw down from this balance as they run.</p>
+  <p class="pulse-muted" style="margin-bottom: 12px;">Prepaid credits for AI agent LLM usage. Agents draw down from this balance as they run. Separate from the $3/month collective plan — the plan turns paid features on; these credits pay for usage.</p>
 
   <div style="margin-bottom: 16px;">
     <% if @credit_balance_cents.nil? %>

--- a/app/views/collective_agents/show.html.erb
+++ b/app/views/collective_agents/show.html.erb
@@ -16,16 +16,11 @@
   </header>
 
   <div class="pulse-resource-body">
-    <% if flash[:notice] %>
-      <div class="pulse-notice pulse-notice-success" style="margin-bottom: 20px;"><%= flash[:notice] %></div>
-    <% end %>
-    <% if flash[:alert] %>
-      <div class="pulse-notice pulse-notice-danger" style="margin-bottom: 20px;"><%= flash[:alert] %></div>
-    <% end %>
-
+    <%# Flash is rendered once, by the layout, with markdown_inline — so link
+        pointers in a notice (e.g. the pool page) render as links. %>
     <% if @plan_gated %>
       <div class="pulse-notice" style="margin-bottom: 20px;">
-        This collective is on the free plan. The paid plan unlocks Trio, automations, file attachments, and more.
+        This collective is on the free plan. The paid plan unlocks <%= paid_feature_labels(@current_tenant, trio_label: "Trio").to_sentence %> on this collective.
         <% if @current_user&.id == @current_collective.created_by_id %>
           <a href="<%= @current_collective.path %>/upgrade" class="pulse-action-btn pulse-action-btn-sm">Upgrade</a>
         <% else %>
@@ -37,19 +32,22 @@
     <% if @trio_offered %>
       <section class="pulse-settings-section" id="trio-card">
         <h2 class="pulse-section-title">Trio</h2>
-        <% if @trio_enabled %>
+        <% if @trio_enabled && @trio_cannot_run %>
           <p>
-            Trio is enabled<% if @personas.any? %> —
+            Trio's personas have joined<% if @personas.any? %> —
+              <%= safe_join(@personas.map { |agent| link_to(agent.name, agent.path) }, " · ") %><% end %>, but Trio isn't running yet.
+          </p>
+          <div class="pulse-notice pulse-notice-warning">
+            One step left: Trio needs an open funding pool before it can run.
+            <a href="<%= @current_collective.path %>/pool">Open one on the pool page</a> to finish enabling it.
+          </div>
+        <% elsif @trio_enabled %>
+          <p>
+            Trio is on<% if @personas.any? %> —
               <%= safe_join(@personas.map { |agent| link_to(agent.name, agent.path) }, " · ") %><% end %>.
           </p>
-          <% if @trio_cannot_run %>
-            <div class="pulse-notice pulse-notice-danger">
-              Trio can't run: this collective has no open funding pool.
-              <a href="<%= @current_collective.path %>/pool">Open one on the pool page</a>.
-            </div>
-          <% end %>
         <% else %>
-          <p>Trio is not enabled.</p>
+          <p>Trio is off.</p>
         <% end %>
         <% if @is_agents_admin && !@plan_gated %>
           <% if @trio_enabled %>
@@ -70,9 +68,7 @@
         <p>
           <% if @pool_open %>
             The <a href="<%= @current_collective.path %>/pool">funding pool</a> is open —
-            <%= pluralize(@pool_enrolled_count, "member") %> enrolled,
-            ceiling <%= number_to_currency(@funding_pool.member_draw_cap_cents / 100.0) %>
-            per member per <%= @funding_pool.member_draw_cap_period %>.
+            <%= pluralize(@pool_enrolled_count, "member") %> enrolled.
           <% elsif @funding_pool %>
             The <a href="<%= @current_collective.path %>/pool">funding pool</a> is closed, so agents on its payroll cannot run.
           <% else %>

--- a/app/views/collective_agents/show.md.erb
+++ b/app/views/collective_agents/show.md.erb
@@ -3,20 +3,20 @@
 Agents in <%= @current_collective.name %>: what runs here and who pays for it.
 <% if @plan_gated %>
 
-This collective is on the free plan. The paid plan unlocks Trio, automations, file attachments, and more. The collective owner can upgrade at `<%= @current_collective.path %>/upgrade`.
+This collective is on the free plan. The paid plan unlocks <%= paid_feature_labels(@current_tenant, trio_label: "Trio").to_sentence %> on this collective. The collective owner can upgrade at `<%= @current_collective.path %>/upgrade`.
 <% end %>
 <% if @trio_offered %>
 
 ## Trio
 
-<% if @trio_enabled -%>
-Trio is enabled<% if @personas.any? %> — <%= @personas.map { |agent| "[#{agent.name}](#{agent.path})" }.join(" · ") %><% end %>.
-<% if @trio_cannot_run -%>
+<% if @trio_enabled && @trio_cannot_run -%>
+Trio's personas have joined<% if @personas.any? %> — <%= @personas.map { |agent| "[#{agent.name}](#{agent.path})" }.join(" · ") %><% end %>, but Trio isn't running yet.
 
-**Trio can't run: this collective has no open funding pool.** A collective admin can open one on the [pool page](<%= @current_collective.path %>/pool).
-<% end -%>
+**One step left: Trio needs an open funding pool before it can run.** A collective admin can open one on the [pool page](<%= @current_collective.path %>/pool) to finish enabling it.
+<% elsif @trio_enabled -%>
+Trio is on<% if @personas.any? %> — <%= @personas.map { |agent| "[#{agent.name}](#{agent.path})" }.join(" · ") %><% end %>.
 <% else -%>
-Trio is not enabled.
+Trio is off.
 <% end -%>
 <% end %>
 <% if @pool_page_available %>
@@ -24,7 +24,7 @@ Trio is not enabled.
 ## Funding
 
 <% if @pool_open -%>
-The [funding pool](<%= @current_collective.path %>/pool) is open — <%= pluralize(@pool_enrolled_count, "member") %> enrolled, ceiling <%= number_to_currency(@funding_pool.member_draw_cap_cents / 100.0) %> per member per <%= @funding_pool.member_draw_cap_period %>.
+The [funding pool](<%= @current_collective.path %>/pool) is open — <%= pluralize(@pool_enrolled_count, "member") %> enrolled.
 <% elsif @funding_pool -%>
 The [funding pool](<%= @current_collective.path %>/pool) is closed, so agents on its payroll cannot run.
 <% else -%>

--- a/app/views/collectives/_agent_setup_pointer.html.erb
+++ b/app/views/collectives/_agent_setup_pointer.html.erb
@@ -1,0 +1,32 @@
+<%# Post-creation funnel pointer: steers an admin toward finishing built-in
+    agent setup while it's incomplete. Rendered only when
+    @agent_setup_step is set (see CollectivesController#agent_setup_pointer_step),
+    which already gates on admin standing and prior dismissal. Every step
+    links the Agents page — the resting-state checklist — rather than jumping
+    straight to the pool, so there's one place to see what's left. %>
+<%
+  headline, detail = case @agent_setup_step
+    when :enable_trio
+      ["Finish setting up your agents",
+       "This collective is on the paid plan. Turn on the built-in agents to get started."]
+    when :open_pool
+      ["One step left to turn on your agents",
+       "The built-in agents need an open funding pool before they can run. Open one to finish."]
+    when :enroll_members
+      ["Your agents can't run yet",
+       "The funding pool is open — members need to enroll before the agents can run."]
+    end
+%>
+<div class="pulse-notice" id="agent-setup-pointer"
+     style="border: 1px solid var(--color-border-default); border-radius: 6px; margin-bottom: 16px; gap: 12px; align-items: flex-start;">
+  <div style="flex: 1;">
+    <strong><%= octicon 'command-palette', height: 14 %> <%= headline %></strong>
+    <div class="pulse-form-hint" style="margin-top: 2px;"><%= detail %></div>
+  </div>
+  <a href="<%= @current_collective.path %>/agents" class="pulse-action-btn">Set up agents</a>
+  <%= button_to "×", "#{@current_collective.path}/dismiss-agent-setup",
+        method: :post,
+        class: "pulse-dismiss-btn",
+        "aria-label": "Dismiss",
+        title: "Dismiss" %>
+</div>

--- a/app/views/collectives/settings.html.erb
+++ b/app/views/collectives/settings.html.erb
@@ -169,10 +169,9 @@
             FeatureFlagService.flag_metadata(f).fetch("collective_level", false) &&
             !FeatureFlagService.operator_managed?(f)
         }
-        # Trio is managed on the Agents page, not by a checkbox here — settings
-        # only points there. (The update endpoint still accepts the flag, so
-        # saving this form never silently disables Trio.)
-        trio_available = available_flags.include?("trio")
+        # Trio is managed on the Agents page (reachable from the sidebar menu),
+        # not by a checkbox here. The update endpoint still accepts the flag, so
+        # saving this form never silently disables Trio.
         available_flags -= ["trio"]
         tier_in_effect = @current_tenant.feature_enabled?("stripe_billing")
         if tier_in_effect
@@ -206,20 +205,6 @@
         </div>
       <% } %>
 
-      <% render_trio_pointer = -> {
-        %>
-        <div class="pulse-feature-flag-item">
-          <strong>Trio</strong>
-          <p class="pulse-muted" style="margin: 4px 0 6px 0; font-size: 13px;">
-            <%= @current_collective.feature_flag_enabled_locally?("trio") ? "Enabled" : "Not enabled" %> —
-            the built-in agents are managed on the Agents page.
-          </p>
-          <a href="<%= @current_collective.path %>/agents" class="pulse-action-btn pulse-action-btn-sm">
-            <%= octicon 'command-palette', height: 12 %> Manage agents
-          </a>
-        </div>
-      <% } %>
-
       <% render_automations_item = -> {
         %>
         <div class="pulse-feature-flag-item">
@@ -236,67 +221,29 @@
 
       <% show_paid_section = tier_in_effect && !@current_collective.is_main_collective? %>
       <% automations_available = @current_tenant.automations_enabled? %>
+      <%# Paid-feature toggles only render on the paid tier — the plan
+          lifecycle (upgrade, downgrade, billing) is the Plan section's job. %>
+      <% show_paid_features = show_paid_section && @current_collective.paid_tier? %>
       <%# Automations group with the paid features. Where there is no paid
           section (non-billing tenants, main collectives), they group with the
           plain features instead — never a standalone section of their own. %>
       <% automations_with_free = automations_available && !show_paid_section %>
-      <% trio_with_free = trio_available && !show_paid_section %>
-      <% if free_flags.any? || show_paid_section || automations_with_free || trio_with_free %>
+      <% if free_flags.any? || show_paid_features || automations_with_free %>
         <%# Suppress border-bottom; the sticky Save Settings form-actions below %>
         <%# has its own border-top, so keeping both produces two visible lines. %>
         <section class="pulse-settings-section" style="border-bottom: none;">
-          <% if free_flags.any? || automations_with_free || trio_with_free %>
+          <% if free_flags.any? || automations_with_free %>
             <h2 class="pulse-section-title"><%= tier_in_effect ? "Features" : "Features Enabled" %></h2>
             <% free_flags.each { |f| render_flag_item.call(f) } %>
             <% render_automations_item.call if automations_with_free %>
-            <% render_trio_pointer.call if trio_with_free %>
           <% end %>
 
-          <% if show_paid_section %>
+          <% if show_paid_features %>
             <h3 class="pulse-section-title" style="<%= free_flags.any? ? 'margin-top: 24px;' : '' %> font-size: 16px;">
               Paid Plan Features
             </h3>
-
-            <% if @current_collective.paid_tier? %>
-              <p class="pulse-muted" style="margin-bottom: 12px; font-size: 13px;">
-                <%= octicon 'credit-card', height: 12 %>
-                This collective is on the paid plan ($3/month).
-              </p>
-
-              <% render_automations_item.call if automations_available %>
-              <% paid_flags.each { |f| render_flag_item.call(f) } %>
-              <% render_trio_pointer.call if trio_available %>
-            <% elsif @current_collective.requires_stripe_billing? %>
-              <p class="pulse-muted" style="margin-bottom: 12px; font-size: 13px;">
-                <%= octicon 'alert', height: 12 %>
-                Billing lapsed — paid features are paused. Restore your subscription to resume.
-              </p>
-              <%= button_to "Resume billing", "/billing", method: :get,
-                            class: "pulse-action-btn",
-                            form: { style: "display: inline;" } %>
-            <% else %>
-              <p class="pulse-muted" style="margin-bottom: 12px; font-size: 13px;">
-                <%= octicon 'credit-card', height: 12 %>
-                Upgrade to the paid plan ($3/month) to unlock <%= paid_feature_labels(@current_tenant).to_sentence %> on this collective.
-              </p>
-              <% if @current_user.id == @current_collective.created_by_id %>
-                <%# Links go to the GET upgrade preview, which shows the %>
-                <%# prorated charge (for owners with billing) or the Stripe %>
-                <%# Checkout next step (without) before any charge happens. %>
-                <% if @pending_collective_upgrade_in_session %>
-                  <p class="pulse-muted" style="margin-bottom: 8px; font-size: 13px;">
-                    <em>You started checkout for this collective. Resume to finish.</em>
-                  </p>
-                  <a href="<%= @current_collective.path %>/upgrade" class="pulse-action-btn">Resume checkout</a>
-                <% else %>
-                  <a href="<%= @current_collective.path %>/upgrade" class="pulse-action-btn">Upgrade to Paid ($3/month)</a>
-                <% end %>
-              <% else %>
-                <p class="pulse-muted" style="font-size: 13px;">
-                  <em>Only the collective owner can upgrade.</em>
-                </p>
-              <% end %>
-            <% end %>
+            <% render_automations_item.call if automations_available %>
+            <% paid_flags.each { |f| render_flag_item.call(f) } %>
           <% end %>
         </section>
       <% end %>
@@ -306,65 +253,90 @@
       </div>
     <% end %>
 
-    <% if @current_tenant.feature_enabled?("stripe_billing") && !@current_collective.is_main_collective? && @current_collective.paid_tier? && @current_user.id == @current_collective.created_by_id %>
-      <%
-        downgrade_disables = paid_features_to_disable_on_downgrade(@current_collective)
-        n_auto = @enabled_automations_count.to_i
-        # Build two parallel sentences for the section copy and the confirm dialog.
-        # Phrases are conditional so we don't promise to turn off features the
-        # tenant doesn't support.
-        section_phrases = []
-        section_phrases << "disable #{pluralize(n_auto, 'enabled automation')}" if n_auto > 0
-        section_phrases << "turn off #{downgrade_disables.to_sentence}" if downgrade_disables.any?
-
-        confirm_phrases = []
-        confirm_phrases << "#{pluralize(n_auto, 'enabled automation')} will be disabled" if n_auto > 0
-        confirm_phrases << "#{downgrade_disables.to_sentence} will be turned off" if downgrade_disables.any?
-
-        confirm_text = "Downgrade #{@current_collective.name} to the free plan?"
-        confirm_text += " #{sentence_case(confirm_phrases.to_sentence)}." if confirm_phrases.any?
-      %>
+    <%# Plan: the permanent home of the collective's tier lifecycle. Tier
+        status shows to every admin; the upgrade/downgrade controls are the
+        owner's alone. Agents, pool, and members each have their own page
+        (reachable from the sidebar menu), so settings no longer points at them. %>
+    <% if @current_tenant.feature_enabled?("stripe_billing") && !@current_collective.is_main_collective? %>
+      <% is_owner = @current_user.id == @current_collective.created_by_id %>
       <section class="pulse-settings-section">
-        <h2 class="pulse-section-title">Downgrade to Free</h2>
-        <p class="pulse-section-description">
-          Move this collective back to the free plan.
-          <% if section_phrases.any? %>
-            This will <%= section_phrases.to_sentence %>.
+        <h2 class="pulse-section-title">Plan</h2>
+
+        <% if @current_collective.paid_tier? %>
+          <p class="pulse-section-description">
+            This collective is on the <strong>paid plan ($3/month)</strong>, billed to the owner's account.
+            The plan turns paid features on; prepaid usage credits — topped up per member — pay for agent activity separately.
+          </p>
+          <p class="pulse-muted" style="margin-bottom: 12px;">
+            <%= octicon 'credit-card', height: 14 %>
+            <% if @current_collective.billing_exempt? %>
+              Billing-exempt by an admin. <%= link_to "View billing", "/billing", class: "pulse-link" %>
+            <% else %>
+              <%= link_to "Manage billing", "/billing", class: "pulse-link" %>
+            <% end %>
+          </p>
+          <% if is_owner %>
+            <%
+              downgrade_disables = paid_features_to_disable_on_downgrade(@current_collective)
+              n_auto = @enabled_automations_count.to_i
+              # Build two parallel sentences for the section copy and the confirm dialog.
+              # Phrases are conditional so we don't promise to turn off features the
+              # tenant doesn't support.
+              section_phrases = []
+              section_phrases << "disable #{pluralize(n_auto, 'enabled automation')}" if n_auto > 0
+              section_phrases << "turn off #{downgrade_disables.to_sentence}" if downgrade_disables.any?
+
+              confirm_phrases = []
+              confirm_phrases << "#{pluralize(n_auto, 'enabled automation')} will be disabled" if n_auto > 0
+              confirm_phrases << "#{downgrade_disables.to_sentence} will be turned off" if downgrade_disables.any?
+
+              confirm_text = "Downgrade #{@current_collective.name} to the free plan?"
+              confirm_text += " #{sentence_case(confirm_phrases.to_sentence)}." if confirm_phrases.any?
+            %>
+            <p class="pulse-section-description">
+              Move this collective back to the free plan.
+              <% if section_phrases.any? %>This will <%= section_phrases.to_sentence %>.<% end %>
+            </p>
+            <%= button_to "Downgrade to Free",
+                          "#{@current_collective.path}/downgrade",
+                          method: :post,
+                          class: "pulse-action-btn-danger",
+                          form: { style: "display: inline;" },
+                          data: { turbo_confirm: confirm_text } %>
           <% end %>
-        </p>
-        <%= button_to "Downgrade to Free",
-                      "#{@current_collective.path}/downgrade",
-                      method: :post,
-                      class: "pulse-action-btn-danger",
-                      form: { style: "display: inline;" },
-                      data: { turbo_confirm: confirm_text } %>
+
+        <% elsif @current_collective.requires_stripe_billing? %>
+          <p class="pulse-section-description">
+            <%= octicon 'alert', height: 14 %>
+            Billing lapsed — paid features are paused. Restore your subscription to resume.
+          </p>
+          <%= button_to "Resume billing", "/billing", method: :get,
+                        class: "pulse-action-btn",
+                        form: { style: "display: inline;" } %>
+
+        <% else %>
+          <p class="pulse-section-description">
+            This collective is on the <strong>free plan</strong>. Upgrade to <strong>$3/month</strong> to unlock <%= paid_feature_labels(@current_tenant).to_sentence %>.
+            The plan is separate from prepaid usage credits, which fund agent activity.
+          </p>
+          <% if is_owner %>
+            <%# Links go to the GET upgrade preview, which shows the prorated %>
+            <%# charge (for owners with billing) or the Stripe Checkout next %>
+            <%# step (without) before any charge happens. %>
+            <% if @pending_collective_upgrade_in_session %>
+              <p class="pulse-muted" style="margin-bottom: 8px; font-size: 13px;">
+                <em>You started checkout for this collective. Resume to finish.</em>
+              </p>
+              <a href="<%= @current_collective.path %>/upgrade" class="pulse-action-btn">Resume checkout</a>
+            <% else %>
+              <a href="<%= @current_collective.path %>/upgrade" class="pulse-action-btn">Upgrade to Paid ($3/month)</a>
+            <% end %>
+          <% else %>
+            <p class="pulse-muted" style="font-size: 13px;"><em>Only the collective owner can upgrade.</em></p>
+          <% end %>
+        <% end %>
       </section>
     <% end %>
-
-    <% if @current_collective.standard? && @current_tenant.feature_enabled?("stripe_billing") && (@funding_pools_enabled || @funding_pool) %>
-      <section class="pulse-settings-section">
-        <h2 class="pulse-section-title">Agent Funding Pool</h2>
-        <p class="pulse-section-description">
-          A funding pool lets members fund this collective's agents together: each
-          LLM call an attached agent makes is billed to one enrolled member's own
-          prepaid balance. The pool is managed on the
-          <a href="<%= @current_collective.path %>/pool" class="pulse-link">pool page</a><%= @funding_pool ? "." : ", where an admin can open one." %>
-        </p>
-      </section>
-    <% end %>
-
-    <% unless @current_collective.private_workspace? %>
-      <section class="pulse-settings-section">
-        <h2 class="pulse-section-title">Agent Members</h2>
-        <p class="pulse-section-description">
-          Agents are members. See who runs here on the
-          <a href="<%= @current_collective.path %>/agents" class="pulse-link">Agents page</a>;
-          add or remove agents on the
-          <a href="<%= @current_collective.path %>/members" class="pulse-link">Members page</a>.
-        </p>
-      </section>
-    <% end %>
-
 
       <% if @current_tenant.feature_enabled?("collective_export") %>
         <section class="pulse-settings-section">
@@ -375,19 +347,6 @@
           <a href="<%= @current_collective.path %>/exports" class="pulse-action-btn">
             <%= octicon 'download', height: 14 %> Export Data
           </a>
-        </section>
-      <% end %>
-
-      <% if @current_tenant.feature_enabled?("stripe_billing") && !@current_collective.is_main_collective? && @current_collective.paid_tier? %>
-        <section class="pulse-settings-section">
-          <p class="pulse-muted">
-            <%= octicon 'credit-card', height: 14 %>
-            <% if @current_collective.billing_exempt? %>
-              Billing-exempt by an admin. <%= link_to "View billing", "/billing", class: "pulse-link" %>
-            <% else %>
-              <%= link_to "Manage billing", "/billing", class: "pulse-link" %>
-            <% end %>
-          </p>
         </section>
       <% end %>
 

--- a/app/views/collectives/settings.md.erb
+++ b/app/views/collectives/settings.md.erb
@@ -30,7 +30,6 @@ Current settings for **<%= @current_collective.name %>**:
       FeatureFlagService.flag_metadata(f).fetch("collective_level", false)
   }
   # Trio is managed on the Agents page, not through settings.
-  trio_available = available_flags.include?("trio")
   available_flags -= ["trio"]
   tier_in_effect = @current_tenant.feature_enabled?("stripe_billing")
   if tier_in_effect
@@ -38,9 +37,9 @@ Current settings for **<%= @current_collective.name %>**:
   else
     paid_flags, free_flags = [], available_flags
   end
-  trio_pointer_row = "| Trio | #{@current_collective.feature_flag_enabled_locally?('trio') ? 'Enabled' : 'Not enabled'} — managed on the [Agents page](#{@current_collective.path}/agents) |"
+  show_paid_features = tier_in_effect && !@current_collective.is_main_collective? && @current_collective.paid_tier?
 %>
-<% if free_flags.any? || (trio_available && !tier_in_effect) %>
+<% if free_flags.any? %>
 
 ## <%= tier_in_effect ? "Features" : "Features Enabled" %>
 
@@ -50,16 +49,10 @@ Current settings for **<%= @current_collective.name %>**:
 <% metadata = FeatureFlagService.flag_metadata(flag_name) %>
 | <%= metadata['name'] %> | <%= @current_collective.feature_flag_enabled_locally?(flag_name) ? 'Yes' : 'No' %> |
 <% end %>
-<% if trio_available && !tier_in_effect -%>
-<%= trio_pointer_row %>
-<% end -%>
 <% end %>
-<% if tier_in_effect && !@current_collective.is_main_collective? %>
+<% if show_paid_features %>
 
 ## Paid Plan Features
-
-<% if @current_collective.paid_tier? %>
-This collective is on the paid plan ($3/month).
 
 | Feature | Enabled |
 |---------|---------|
@@ -70,39 +63,29 @@ This collective is on the paid plan ($3/month).
 <% metadata = FeatureFlagService.flag_metadata(flag_name) %>
 | <%= metadata['name'] %> | <%= @current_collective.feature_flag_enabled_locally?(flag_name) ? 'Yes' : 'No' %> |
 <% end %>
-<% if trio_available -%>
-<%= trio_pointer_row %>
-<% end -%>
+<% end %>
+<% if tier_in_effect && !@current_collective.is_main_collective? %>
 
+## Plan
+
+<% if @current_collective.paid_tier? %>
+On the **paid plan ($3/month)**, billed to the owner's account. The plan turns paid features on; prepaid usage credits — topped up per member — pay for agent activity separately.
+
+<% if @current_collective.billing_exempt? %>
+Billing-exempt by an admin. [View billing](/billing)
+<% else %>
+[Manage billing](/billing)
+<% end %>
 <%
   md_downgrade_disables = paid_features_to_disable_on_downgrade(@current_collective)
   md_clauses = ["enabled automations will be disabled"]
   md_clauses << "#{md_downgrade_disables.to_sentence} will be turned off" if md_downgrade_disables.any?
 %>
-To move this collective back to the free plan, POST to `<%= @current_collective.path %>/downgrade`. <%= sentence_case(md_clauses.to_sentence) %>.
+To move this collective back to the free plan, POST to `<%= @current_collective.path %>/downgrade` (owner only). <%= sentence_case(md_clauses.to_sentence) %>.
 <% elsif @current_collective.requires_stripe_billing? %>
 **Billing lapsed** — paid features are paused. Restore your subscription at [/billing](/billing) to resume.
 <% else %>
-Upgrade to the paid plan ($3/month) to unlock <%= paid_feature_labels(@current_tenant).to_sentence %> on this collective. POST to `<%= @current_collective.path %>/upgrade` (owner only).
-<% end %>
-<% end %>
-<% unless @current_collective.private_workspace? %>
-
-Agents are members. The roster of agent members is on the [Agents page](<%= @current_collective.path %>/agents); add or remove agents on the [Members page](<%= @current_collective.path %>/members).
-<% end %>
-
-<% if @current_collective.standard? && @current_tenant.feature_enabled?("stripe_billing") && (@funding_pools_enabled || @funding_pool) %>
-
-## Funding Pool
-
-A funding pool lets members fund this collective's agents together: each LLM call an attached agent makes is billed to one enrolled member's own prepaid balance. The pool — its state, enrollment, and admin management — lives on the [pool page](<%= @current_collective.path %>/pool)<%= @funding_pool ? "." : ", where an admin can open one." %>
-<% end %>
-
-<% if @current_tenant.feature_enabled?("stripe_billing") && !@current_collective.is_main_collective? && @current_collective.paid_tier? %>
-<% if @current_collective.billing_exempt? %>
-Billing-exempt by an admin. [View billing](/billing)
-<% else %>
-[Manage billing](/billing)
+On the **free plan**. Upgrade to $3/month to unlock <%= paid_feature_labels(@current_tenant).to_sentence %> on this collective. POST to `<%= @current_collective.path %>/upgrade` (owner only). The plan is separate from prepaid usage credits, which fund agent activity.
 <% end %>
 <% end %>
 

--- a/app/views/collectives/show.html.erb
+++ b/app/views/collectives/show.html.erb
@@ -1,5 +1,9 @@
 <%= render 'collective_title' %>
 
+<% if @agent_setup_step %>
+  <%= render 'agent_setup_pointer' %>
+<% end %>
+
 <%= render 'heartbeat_section' %>
 
 <div class="blur-if-no-heartbeat <%= @current_heartbeat.nil? ? 'no-heartbeat' : 'has-heartbeat' %>">

--- a/app/views/collectives/upgrade_preview.html.erb
+++ b/app/views/collectives/upgrade_preview.html.erb
@@ -16,6 +16,11 @@
   <div class="pulse-resource-body">
     <p>The paid plan unlocks <%= paid_feature_labels(@current_tenant).to_sentence %> on this collective. <strong>$3/month</strong>, billed to your account.</p>
 
+    <p class="pulse-muted" style="font-size: 13px;">
+      <%= octicon 'info', height: 12 %>
+      This is the collective's monthly plan — separate from the prepaid usage credits that fund agent activity, which members top up as needed.
+    </p>
+
     <% if @has_active_billing %>
       <section class="pulse-settings-section">
         <div class="pulse-notice pulse-notice-warning" style="margin-bottom: 16px;">

--- a/app/views/funding_pools/show.html.erb
+++ b/app/views/funding_pools/show.html.erb
@@ -30,6 +30,11 @@
       never holds money.
     </p>
 
+    <p class="pulse-muted" style="font-size: 13px;">
+      <%= octicon 'info', height: 12 %>
+      These balances are prepaid usage credits — separate from the collective's $3/month plan. The plan turns paid features on; credits pay for what the agents actually run.
+    </p>
+
     <% if @funding_pool.nil? %>
       <p class="pulse-body-text">
         This collective has no funding pool open yet. Opening a pool puts the

--- a/app/views/pulse/feed.html.erb
+++ b/app/views/pulse/feed.html.erb
@@ -1,4 +1,7 @@
 <%= render 'pulse/heartbeat_banner' %>
+<% if @agent_setup_step %>
+  <%= render 'collectives/agent_setup_pointer' %>
+<% end %>
 <article class="pulse-resource-detail">
   <%# Same heartbeat blur ritual as the dashboard: presence before content.
       The blur wraps the whole content column — filter bar and feed chrome

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -583,6 +583,7 @@ Rails.application.routes.draw do
     post "#{prefix}/downgrade" => 'collectives#downgrade'
     post "#{prefix}/archive" => 'collectives#archive'
     post "#{prefix}/unarchive" => 'collectives#unarchive'
+    post "#{prefix}/dismiss-agent-setup" => 'collectives#dismiss_agent_setup'
     # The pool page owns every pool operation — page, form endpoints, and
     # described actions all live under the pool prefix.
     get "#{prefix}/pool" => 'funding_pools#show'

--- a/test/controllers/billing_controller_test.rb
+++ b/test/controllers/billing_controller_test.rb
@@ -260,6 +260,8 @@ class BillingControllerTest < ActionDispatch::IntegrationTest
     # Free account: nothing to pay, but the credits section is still offered.
     assert_match(/nothing to pay/i, response.body)
     assert_match(/AI Agent Credits/, response.body)
+    # The credits section distinguishes prepaid usage credits from the $3/month plan.
+    assert_match(/separate from the \$3\/month collective plan/i, response.body)
     assert_select "form[action=?]", "/billing/topup"
   end
 

--- a/test/controllers/collective_agents_controller_test.rb
+++ b/test/controllers/collective_agents_controller_test.rb
@@ -174,6 +174,12 @@ class CollectiveAgentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, "#{collective.path}/upgrade"
     assert_not_includes response.body, "Enable Trio"
+    # The plan-gate copy lists the actual paid features (from paid_feature_labels),
+    # not a hardcoded "…and more". On the Agents page the built-in agents are
+    # named "Trio" — the page's own Trio section makes the name self-evident.
+    assert_includes response.body, "unlocks automations and Trio on this collective"
+    assert_not_includes response.body, "the built-in agents (Melody"
+    assert_not_includes response.body, "and more"
   end
 
   test "the paid tier on a billing tenant gets the full page" do
@@ -202,8 +208,10 @@ class CollectiveAgentsControllerTest < ActionDispatch::IntegrationTest
     get "#{collective.path}/agents"
 
     assert_response :success
-    assert_includes response.body, "no open funding pool"
+    # Enabled-without-a-pool is framed as unfinished setup, not "enabled but broken".
+    assert_includes response.body, "needs an open funding pool"
     assert_includes response.body, "#{collective.path}/pool"
+    assert_not_includes response.body, "Trio is on"
   end
 
   test "the cannot-run warning clears once a pool is open" do
@@ -217,10 +225,11 @@ class CollectiveAgentsControllerTest < ActionDispatch::IntegrationTest
     get "#{collective.path}/agents"
 
     assert_response :success
-    assert_not_includes response.body, "no open funding pool"
+    assert_not_includes response.body, "needs an open funding pool"
+    assert_includes response.body, "Trio is on"
   end
 
-  test "the pool summary shows state, enrollment count, and ceiling" do
+  test "the pool summary shows state and enrollment count, without the ceiling detail" do
     collective = create_test_collective
     enable_self_serve_pools!(collective)
     pool = create_pool!(collective)
@@ -231,8 +240,9 @@ class CollectiveAgentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, "1 member enrolled"
-    assert_includes response.body, "$5.00"
     assert_includes response.body, "#{collective.path}/pool"
+    # Ceiling detail lives on the pool page, not the agents summary.
+    assert_not_includes response.body, "per member per"
   end
 
   test "agent members list personas and member-added agents alike, with their principals" do

--- a/test/controllers/collectives_controller_test.rb
+++ b/test/controllers/collectives_controller_test.rb
@@ -434,10 +434,11 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
     get "/collectives/#{test_collective.handle}/settings"
 
     assert_response :success
-    assert_includes response.body, "Upgrade to the paid plan"
-    # Banner lists paid features mid-sentence (lowercase common nouns); when the
-    # tenant has only Automations available, the copy says "unlock automations".
-    assert_includes response.body, "unlock automations on this collective"
+    assert_match(%r{Upgrade to .*\$3/month}, response.body)
+    # The Plan section lists paid features mid-sentence (lowercase common
+    # nouns); when the tenant has only Automations available, it reads
+    # "unlock automations".
+    assert_includes response.body, "unlock automations"
     assert_not_includes response.body, "built-in agents"
     assert_not_includes response.body, "file attachments"
   end
@@ -661,26 +662,27 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes response.body, "Paid plan"
   end
 
-  test "settings page shows Upgrade button on free collective" do
+  test "settings page shows the Plan section with an Upgrade button on a free collective" do
     enable_stripe_billing_flag!(@tenant)
     @tenant.enable_feature_flag!("trio")
     sign_in_as(@user, tenant: @tenant)
     get "/collectives/#{@collective.handle}/settings"
     assert_response :success
-    assert_includes response.body, "Paid Plan Features"
+    assert_select "h2.pulse-section-title", text: "Plan"
     assert_match(/Upgrade to Paid/i, response.body)
+    # Paid-feature toggles never render on a free collective — the plan
+    # lifecycle lives in the Plan section, not a "Paid Plan Features" panel.
+    assert_not_includes response.body, "Paid Plan Features"
   end
 
-  test "settings page shows Paid Plan Features even when personas/file_attachments off at tenant level" do
+  test "settings Plan section offers upgrade even when personas/file_attachments off at tenant level" do
     enable_stripe_billing_flag!(@tenant)
     @tenant.set_feature_flag!("trio", false)
     @tenant.set_feature_flag!("file_attachments", false)
     sign_in_as(@user, tenant: @tenant)
     get "/collectives/#{@collective.handle}/settings"
     assert_response :success
-    assert_includes response.body, "Paid Plan Features"
-    # On a free collective the section shows the explainer + Upgrade button,
-    # not the Automations panel (that's paid-only).
+    assert_select "h2.pulse-section-title", text: "Plan"
     assert_match(/Upgrade to Paid/i, response.body)
   end
 
@@ -809,6 +811,8 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_match(%r{\$3/month}, response.body)
+    # The plan vs. prepaid-credits distinction is stated where the two payments meet.
+    assert_match(/separate from the prepaid usage credits/i, response.body)
     # Confirmation form must POST to /upgrade with Turbo opted out
     # (controller may redirect cross-origin to Stripe Checkout).
     assert_match %r{<form[^>]*action="[^"]*#{Regexp.escape(@collective.handle)}/upgrade"[^>]*method="post"[^>]*>}, response.body
@@ -1935,7 +1939,7 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
     assert_not cm.has_role?("representative"), "a non-admin agent must not grant roles"
   end
 
-  test "the markdown settings page points at the pool page without pool state" do
+  test "the markdown settings page no longer carries a pool section" do
     collective = create_test_collective
     enable_stripe_billing_flag!(@tenant)
     FeatureFlagService.config["funding_pools"] ||= {}
@@ -1950,10 +1954,9 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
     get "#{collective.path}/settings", headers: { "Accept" => "text/markdown" }
 
     assert_response :success
-    assert_match(/## Funding Pool/, response.body)
-    assert_includes response.body, "[pool page](#{collective.path}/pool)"
-    assert_no_match(/Pool draw ceiling/, response.body)
-    assert_no_match(/Funded agents/, response.body)
+    # The pool has its own page (linked from the sidebar menu); settings only
+    # keeps the collective's own configuration and plan.
+    assert_no_match(/## Funding Pool/, response.body)
   end
 
   test "internal-only collective types cannot be created through the public path" do
@@ -2001,21 +2004,22 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
     @collective.save!
   end
 
-  test "settings page has no trio checkbox and points at the agents page instead" do
+  test "settings page has no trio checkbox" do
     offer_trio!
     sign_in_as(@user, tenant: @tenant)
     get "/collectives/#{@collective.handle}/settings"
     assert_response :success
+    # Trio is managed on the Agents page (reached from the sidebar menu); the
+    # settings save form carries no trio toggle.
     assert_select "input#feature_trio", count: 0
-    assert_select "a[href=?]", "#{@collective.path}/agents", minimum: 1
   end
 
-  test "settings markdown points trio at the agents page" do
+  test "settings markdown carries no trio row" do
     offer_trio!
     sign_in_as(@user, tenant: @tenant)
     get "/collectives/#{@collective.handle}/settings", headers: { "Accept" => "text/markdown" }
     assert_response :success
-    assert_includes response.body, "#{@collective.path}/agents"
+    assert_no_match(/^\| Trio \|/, response.body)
   end
 
   test "settings page no longer renders the agent membership section" do
@@ -2173,6 +2177,99 @@ class CollectivesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, "Markdown Member"
     assert_includes response.body, agent.name
+  end
+
+  # === Phase 3: post-creation agent-setup pointer ===
+
+  def make_collective_paid!
+    enable_stripe_billing_flag!(@tenant)
+    StripeCustomer.create!(billable: @user, stripe_id: "cus_#{SecureRandom.hex(4)}", active: true)
+    @collective.update!(tier: Collective::TIER_PAID)
+  end
+
+  def enable_trio_here!
+    offer_trio!
+    @collective.set_feature_flag!("trio", true)
+  end
+
+  def open_pool!
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    FundingPool.create!(tenant: @tenant, collective: @collective, created_by: @user, member_draw_cap_cents: 500)
+  ensure
+    Tenant.clear_thread_scope
+  end
+
+  test "homepage shows the agent-setup pointer to an admin whose paid collective has Trio off" do
+    make_collective_paid!
+    offer_trio!
+    sign_in_as(@user, tenant: @tenant)
+    get "/collectives/#{@collective.handle}"
+    assert_response :success
+    assert_select "#agent-setup-pointer"
+    assert_select "#agent-setup-pointer a[href=?]", "#{@collective.path}/agents"
+  end
+
+  test "homepage shows the agent-setup pointer when Trio is on but no pool is open" do
+    make_collective_paid!
+    enable_trio_here!
+    sign_in_as(@user, tenant: @tenant)
+    get "/collectives/#{@collective.handle}"
+    assert_response :success
+    assert_select "#agent-setup-pointer"
+  end
+
+  test "homepage shows the agent-setup pointer when a pool is open but no one is enrolled" do
+    make_collective_paid!
+    enable_trio_here!
+    open_pool!
+    sign_in_as(@user, tenant: @tenant)
+    get "/collectives/#{@collective.handle}"
+    assert_response :success
+    assert_select "#agent-setup-pointer"
+  end
+
+  test "homepage hides the agent-setup pointer once the funnel is complete" do
+    make_collective_paid!
+    enable_trio_here!
+    @user.stripe_customer.update!(pricing_plan_subscription_id: "bpps_#{SecureRandom.hex(4)}")
+    pool = open_pool!
+    pool.enroll!(@user, draw_cap_cents: 500)
+    sign_in_as(@user, tenant: @tenant)
+    get "/collectives/#{@collective.handle}"
+    assert_response :success
+    assert_select "#agent-setup-pointer", count: 0
+  end
+
+  test "homepage hides the agent-setup pointer from non-admins" do
+    make_collective_paid!
+    offer_trio!
+    member = add_member(name: "Plain Member")
+    sign_in_as(member, tenant: @tenant)
+    get "/collectives/#{@collective.handle}"
+    assert_response :success
+    assert_select "#agent-setup-pointer", count: 0
+  end
+
+  test "homepage hides the agent-setup pointer on a free collective" do
+    enable_stripe_billing_flag!(@tenant)
+    offer_trio!
+    sign_in_as(@user, tenant: @tenant)
+    get "/collectives/#{@collective.handle}"
+    assert_response :success
+    assert_select "#agent-setup-pointer", count: 0
+  end
+
+  test "homepage hides the agent-setup pointer after it is dismissed" do
+    make_collective_paid!
+    offer_trio!
+    sign_in_as(@user, tenant: @tenant)
+
+    post "/collectives/#{@collective.handle}/dismiss-agent-setup"
+    assert_redirected_to @collective.path
+
+    get "/collectives/#{@collective.handle}"
+    assert_response :success
+    assert_select "#agent-setup-pointer", count: 0
   end
 
   private

--- a/test/controllers/funding_pools_controller_test.rb
+++ b/test/controllers/funding_pools_controller_test.rb
@@ -321,6 +321,8 @@ class FundingPoolsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "a[href^=?]", "/billing?return_to=", count: 0
+    # The pool page distinguishes prepaid usage credits from the $3/month plan.
+    assert_match(/separate from the collective's \$3\/month plan/i, response.body)
   end
 
   # === The pool page without a pool ===
@@ -409,7 +411,7 @@ class FundingPoolsControllerTest < ActionDispatch::IntegrationTest
 
   # === Settings page hands the pool off ===
 
-  test "the settings page points at the pool page instead of hosting pool controls" do
+  test "the settings page hosts no pool controls" do
     collective = create_test_collective
     enable_funding_pools!(collective)
     create_pool!(collective)
@@ -418,7 +420,8 @@ class FundingPoolsControllerTest < ActionDispatch::IntegrationTest
     get "#{collective.path}/settings"
 
     assert_response :success
-    assert_select "a[href=?]", "#{collective.path}/pool"
+    # The pool has its own page (linked from the sidebar menu); settings hosts
+    # neither its controls nor a pointer to it.
     assert_select "form[action=?]", "#{collective.path}/pool/create_funding_pool", count: 0
     assert_select "form[action=?]", "#{collective.path}/pool/update_ceiling", count: 0
     assert_select "form[action=?]", "#{collective.path}/pool/close_funding_pool", count: 0


### PR DESCRIPTION
Completes the collective-settings re-architecture plan (`.claude/plans/collective-settings-rearchitecture-and-setup-flow.md`). Phases 1+2a+2b shipped in #518; this is Phases 3+4 plus review follow-ups.

## Phase 3 — funnel feedback
- **Post-creation agent-setup pointer** on the collective homepage. Shown to admins while the built-in-agent funnel is incomplete (paid-with-Trio-off → Trio-on-without-a-pool → pool-open-without-enrollments); links the Agents page and dismisses permanently per admin. Funnel state is a new `Collective#agent_setup_step`; the admin/dismissal gate lives in `ApplicationController` so the feed and the classic collective view share it. New route `POST {collective}/dismiss-agent-setup`.
- **Checkout-distinction copy** where the two payments meet (upgrade preview, pool page, billing credits): the $3/month plan turns paid features on; prepaid usage credits pay for agent activity, separately.

## Phase 4 — settings slim-down
- **New owner-facing Plan section** — the single home of the tier lifecycle: upgrade, downgrade, resume-billing, manage-billing, with the plan-vs-credits distinction. Tier status shows to every admin; the controls are the owner's alone. The save form now carries configuration and feature toggles only.
- Removed the interim pool, agent-membership, and Trio pointers from settings (HTML + markdown); each destination has its own page reached from the sidebar menu. The `settings` action no longer loads pool state it doesn't render.

## Review follow-ups (same branch)
- `paid_feature_labels` drops the hardcoded "…and more" on the Agents page and gains a `trio_label` override, so that page says "Trio" while newcomer-facing surfaces keep the descriptive "the built-in agents (Melody, Counterpoint, and Cadence)".
- **Reframed enabled-but-unfunded Trio as unfinished setup** rather than "enabled but can't run", across the enable flash, executor result, Agents card, and the setup pointer. "on"/"off" now describes the toggle; funding is the remaining step to finish. Card notice downgraded danger → warning.
- Fixed the Agents-page flash rendering markdown links raw: dropped the redundant in-body flash so the layout renders it once via `markdown_inline`.
- Dropped the ceiling detail from the Agents-page funding summary (it lives on the pool page).

## Testing
Red-green throughout. New/updated tests across `collectives_controller_test`, `collective_agents_controller_test`, `funding_pools_controller_test`, `billing_controller_test`. Affected suites green locally; Sorbet + TypeScript clean.

## Deploy notes
No migrations, env vars, or backfills. Post-merge: CHANGELOG entry.

A known-but-deferred bug surfaced during review (not in scope here): the run-task page shows a false "Billing inactive" banner for pool-funded personas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)