### PR TITLE
Harden login/signup front gates

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1259,6 +1259,24 @@ class ApplicationController < ActionController::Base
       return
     end
 
+    # Enforce the absolute device-trust cap (RefreshToken::MAX_TRUST_LIFETIME,
+    # 1 year — matching the API-token max lifetime). A device trusted longer than
+    # that must re-authenticate rather than be silently re-authenticated forever:
+    # the user falls through to the normal unauthenticated redirect and re-does
+    # the full login (including 2FA). Revoking, not just declining, kills a stolen
+    # copy of the same cookie.
+    if token.trust_expired?
+      SecurityAuditLog.log_refresh_ineligible(
+        token_id: token.id,
+        user_id: token.user_id,
+        ip: request.remote_ip,
+        reason: "trust_expired",
+      )
+      token.revoke!(reason: "trust_expired")
+      delete_refresh_cookie
+      return
+    end
+
     if token.rotated_at.present?
       if token.rotated_at > RefreshToken::REPLAY_GRACE_WINDOW.ago
         # In-flight race: a sibling request already rotated this token.

--- a/app/controllers/two_factor_auth_controller.rb
+++ b/app/controllers/two_factor_auth_controller.rb
@@ -27,7 +27,7 @@ class TwoFactorAuthController < ApplicationController
   # POST /login/verify-2fa
   def verify_submit
     @identity = pending_identity
-    code = params[:code]&.strip
+    code = submitted_code
 
     if @identity.otp_locked?
       SecurityAuditLog.log_2fa_lockout(identity: @identity, ip: request.remote_ip)
@@ -93,7 +93,7 @@ class TwoFactorAuthController < ApplicationController
   # POST /settings/two-factor/confirm
   def confirm_setup
     identity = current_identity
-    code = params[:code]&.strip
+    code = submitted_code
 
     if identity.verify_otp(code || "")
       identity.enable_otp!
@@ -148,7 +148,7 @@ class TwoFactorAuthController < ApplicationController
     end
 
     identity = current_identity
-    code = params[:code]&.strip
+    code = submitted_code
 
     # Verify code before disabling
     is_recovery_code = code.present? && code.gsub(/\s/, "").length > 6
@@ -173,7 +173,7 @@ class TwoFactorAuthController < ApplicationController
   # POST /settings/two-factor/regenerate-codes
   def regenerate_codes
     identity = current_identity
-    code = params[:code]&.strip
+    code = submitted_code
 
     # Verify code before regenerating
     if identity.verify_otp(code || "")
@@ -195,6 +195,15 @@ class TwoFactorAuthController < ApplicationController
 
   def is_auth_controller?
     true
+  end
+
+  # Submitted OTP / recovery code as a stripped string. params[:code] can arrive
+  # as an Array (`code[]=x`) or be absent; treat anything non-String as no code
+  # rather than calling String methods on it (NoMethodError -> 500). An empty
+  # result flows through as an invalid code, which every caller already handles.
+  def submitted_code
+    raw = params[:code]
+    raw.is_a?(String) ? raw.strip : nil
   end
 
   def require_pending_2fa

--- a/app/models/oauth_identity.rb
+++ b/app/models/oauth_identity.rb
@@ -13,9 +13,13 @@ class OauthIdentity < ApplicationRecord
       uid: auth.uid
     )
 
-    # If identity isn't linked to a user, check for an existing user with the same email
+    # If identity isn't linked to a user, check for an existing HUMAN with the
+    # same email. Scoped to humans so an OAuth login can never attach to (or
+    # take over) a non-human account — agents and collective identities never
+    # log in. Email is globally unique, so a non-human squatting the address
+    # surfaces as a create failure below rather than a silent mis-link.
     if identity.user_id.nil? && auth.info.email
-      user = User.find_by(email: auth.info.email)
+      user = User.find_by(email: auth.info.email, user_type: "human")
     end
 
     # Local + explicit signup flag: more durable than later asking the user

--- a/app/models/refresh_token.rb
+++ b/app/models/refresh_token.rb
@@ -24,9 +24,13 @@ class RefreshToken < ApplicationRecord
   # benign in-flight race (e.g. two tabs refreshing concurrently).
   REPLAY_GRACE_WINDOW = 30.seconds
 
-  # How recently the user must have passed 2FA on this device for silent
-  # refresh to skip the 2FA re-prompt.
-  TWO_FACTOR_TRUST_WINDOW = 30.days
+  # Absolute cap on how long a device stays silently trusted, matching the
+  # 1-year maximum lifetime of an API token. Anchored to `two_factor_at` (the
+  # establishing 2FA login), which is preserved across rotation — so unlike the
+  # sliding LIFETIME above, ordinary use does NOT extend it. Once exceeded, the
+  # user must complete a fresh full login (re-entering 2FA) rather than being
+  # silently re-authenticated forever.
+  MAX_TRUST_LIFETIME = 1.year
 
   # How stale `last_used_at` must be before ordinary request activity refreshes
   # it. Rotation stamps `last_used_at` exactly, but a live session never
@@ -43,6 +47,7 @@ class RefreshToken < ApplicationRecord
     "admin",
     "password_change",
     "two_factor_disabled",
+    "trust_expired",
   ].freeze
 
   class AlreadyRotated < StandardError; end
@@ -138,6 +143,19 @@ class RefreshToken < ApplicationRecord
   sig { returns(T::Boolean) }
   def expired?
     expires_at < Time.current
+  end
+
+  # True when the device's trust has outlived MAX_TRUST_LIFETIME. `two_factor_at`
+  # marks the establishing 2FA login and is preserved across rotation, so this is
+  # a true absolute cap: ordinary use doesn't extend it, and only a fresh full
+  # login resets it. Tokens with no recorded 2FA (not issued by the current login
+  # paths) are not aged out here; the eligibility checks upstream govern them.
+  sig { returns(T::Boolean) }
+  def trust_expired?
+    established_at = two_factor_at
+    return false if established_at.nil?
+
+    established_at < MAX_TRUST_LIFETIME.ago
   end
 
   sig { returns(T::Boolean) }

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -211,7 +211,14 @@ class Tenant < ApplicationRecord
 
   sig { params(provider: String).returns(T::Boolean) }
   def valid_auth_provider?(provider)
-    settings["auth_providers"].include?(provider)
+    # auth_providers is written at creation (set_defaults), so a nil here is a
+    # data-integrity bug, not a legitimate default. This gates the OAuth
+    # callback, so fail loudly with a clear message rather than guessing a
+    # provider set that could admit the wrong provider.
+    providers = settings["auth_providers"]
+    raise "Tenant #{subdomain.inspect} has no auth_providers configured (data integrity error)" if providers.nil?
+
+    providers.include?(provider)
   end
 
   # Categories of attachment content types this tenant accepts.

--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -19,7 +19,7 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 # Files/patterns to exclude from scanning (dev configs, tests, this script)
-EXCLUDE_FILES=".env.example|check-secrets.sh|stripe-setup.sh|secrets.*test|fixtures|database.yml|importmap.rb|randomness_provider/drand.rb|verify-audit-chain.py|audit_verify_controller.ts|audit_chain_verifier.test.ts|omni_auth_identity_test\.rb|email_confirmations_controller_test\.rb|activation_gate_test\.rb|email_confirmation_mailer_test\.rb|two_factor_auth_controller_test\.rb|password_resets_controller_test\.rb|omni_auth_bot_protection_test\.rb|refresh_token_revocation_test\.rb"
+EXCLUDE_FILES=".env.example|check-secrets.sh|stripe-setup.sh|secrets.*test|fixtures|database.yml|importmap.rb|randomness_provider/drand.rb|verify-audit-chain.py|audit_verify_controller.ts|audit_chain_verifier.test.ts|omni_auth_identity_test\.rb|email_confirmations_controller_test\.rb|activation_gate_test\.rb|email_confirmation_mailer_test\.rb|two_factor_auth_controller_test\.rb|password_resets_controller_test\.rb|omni_auth_bot_protection_test\.rb|refresh_token_revocation_test\.rb|authentication_security_test\.rb"
 
 # Patterns that suggest secrets (high confidence)
 # These patterns look for actual values, not just variable names

--- a/test/controllers/two_factor_auth_controller_test.rb
+++ b/test/controllers/two_factor_auth_controller_test.rb
@@ -182,6 +182,25 @@ class TwoFactorAuthControllerTest < ActionDispatch::IntegrationTest
            "expected 2FA to remain enabled — the tenant requires it"
   end
 
+  test "POST disable with an array-valued code param is rejected cleanly, not a 500" do
+    @tenant.update!(main_collective_id: @collective.id)
+    @tenant.settings["require_2fa"] = "false"
+    @tenant.save!
+    user = create_user(email: "arraycode-#{SecureRandom.hex(4)}@example.com", name: "Array Code")
+    identity = user.find_or_create_omni_auth_identity!
+    identity.generate_otp_secret!
+    identity.enable_otp!
+    sign_in_as(user, tenant: @tenant)
+
+    # Rails turns code[]=x into an Array; params[:code]&.strip would raise
+    # NoMethodError (500). It must be treated as an invalid code instead.
+    post two_factor_disable_path, params: { code: ["x"] }
+
+    assert_redirected_to two_factor_settings_path
+    assert_match(/invalid/i, flash[:alert].to_s)
+    assert identity.reload.otp_enabled, "2FA must remain enabled after an invalid disable attempt"
+  end
+
   test "post-setup Continue button defaults to the user's settings page" do
     # The shared setup uses create_tenant_collective_user, which doesn't set
     # main_collective_id — sign_in_as needs it to resolve current_collective.

--- a/test/integration/api_auth_test.rb
+++ b/test/integration/api_auth_test.rb
@@ -360,6 +360,15 @@ class ApiTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "a malformed X-Representation-Session-ID fails closed as forbidden" do
+    # The header is external and free-form. Rails casts a non-UUID value to nil
+    # for the uuid `id` column, so the lookup misses and representation is
+    # rejected (:not_found -> 403) rather than erroring — a guard that this
+    # fail-closed behavior survives any future change to the resolver.
+    get v1_api_endpoint, headers: @headers.merge("X-Representation-Session-ID" => "not-a-valid-session-id")
+    assert_response :forbidden
+  end
+
   private
 
   def enable_stripe_billing_flag!(tenant)

--- a/test/integration/authentication_security_test.rb
+++ b/test/integration/authentication_security_test.rb
@@ -695,4 +695,38 @@ class AuthenticationSecurityTest < ActionDispatch::IntegrationTest
     assert_redirected_to "/login"
     assert_match(/revoked/i, flash[:alert])
   end
+
+  # ==========================================
+  # Non-human account tests
+  # ==========================================
+  # Only human users may hold a browser session (load_session_user filters
+  # user_type: "human"). Agents and collective identities act via API tokens,
+  # never the browser session, so a non-human id must never resolve to a
+  # logged-in current_user even if it lands in session[:user_id].
+
+  test "a non-human user id in a valid login token never yields an authenticated session" do
+    host! "#{@tenant.subdomain}.#{ENV.fetch("HOSTNAME", nil)}"
+
+    # An AI agent, even one made a member of the tenant.
+    agent = User.create!(
+      email: "agent-#{SecureRandom.hex(4)}@example.com",
+      name: "Redteam Agent",
+      user_type: "ai_agent",
+      parent_id: @user.id,
+    )
+    @tenant.add_user!(agent)
+
+    # Forge a cross-subdomain login token for the agent (same construction as
+    # the real auth-domain handoff) and drive the tenant login callback.
+    derived_key = ActiveSupport::KeyGenerator.new(Rails.application.secret_key_base)
+                    .generate_key("cross_subdomain_token", 32)
+    crypt = ActiveSupport::MessageEncryptor.new(derived_key)
+    cookies[:token] = crypt.encrypt_and_sign("#{@tenant.id}:#{agent.id}:#{Time.current.to_i}")
+    get "/login/callback"
+
+    # No matter what the callback stashed, the next request must resolve to no
+    # authenticated user — the agent id cannot become a browser session.
+    get "/"
+    assert_redirected_to "/login"
+  end
 end

--- a/test/integration/oauth_signup_flow_test.rb
+++ b/test/integration/oauth_signup_flow_test.rb
@@ -207,4 +207,27 @@ class OauthSignupFlowTest < ActionDispatch::IntegrationTest
     assert_redirected_to "/login/return"
     assert_not_nil session[:user_id]
   end
+
+  test "a pending-2FA login cannot reach protected content by skipping the challenge" do
+    # Redteam: after the provider callback but before the TOTP code, the user
+    # is in the pending-2FA state (pending_2fa_identity_id set, user_id NOT).
+    # Navigating away from /login/verify-2fa to a protected tenant page must
+    # not serve it — the second factor cannot be skipped.
+    user = create_user(email: "ghskip-#{SecureRandom.hex(4)}@example.com", name: "GH Skip")
+    @tenant.add_user!(user)
+    @tenant.create_main_collective!(created_by: user)
+    omni = user.find_or_create_omni_auth_identity!
+    omni.generate_otp_secret!
+    omni.enable_otp!
+    github_callback(github_auth(email: user.email))
+    assert_equal omni.id, session[:pending_2fa_identity_id]
+    assert_nil session[:user_id], "no session yet — the challenge is unanswered"
+
+    # Skip the challenge and hit a protected tenant page.
+    host! "#{@tenant.subdomain}.#{ENV.fetch("HOSTNAME", nil)}"
+    get "/"
+
+    assert_nil session[:user_id], "the second factor was never completed — still no session"
+    assert_redirected_to "/login"
+  end
 end

--- a/test/integration/refresh_token_two_factor_trust_test.rb
+++ b/test/integration/refresh_token_two_factor_trust_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+# The absolute device-trust cap. Silent refresh silently re-authenticates a
+# device from its refresh token, but a device trusted longer than
+# RefreshToken::MAX_TRUST_LIFETIME (1 year, matching the API-token max lifetime)
+# must re-authenticate rather than be re-authed indefinitely. `two_factor_at`
+# marks the establishing 2FA login and is preserved verbatim across every
+# rotation, so it anchors a true absolute cap — ordinary use does not extend it,
+# only a fresh full login resets it.
+#
+# Redteam framing: a stolen refresh cookie must not grant unbounded access to an
+# account — the cap bounds how long the theft stays useful even as the token
+# rotates, and a legitimately long-lived session is periodically forced through
+# a full re-login.
+class RefreshTokenTwoFactorTrustTest < ActionDispatch::IntegrationTest
+  REFRESH_COOKIE = ApplicationController::REFRESH_COOKIE_NAME
+
+  setup do
+    @tenant = create_tenant(subdomain: "rt2fa-#{SecureRandom.hex(4)}")
+    @user = create_user(email: "rt2fa-#{SecureRandom.hex(4)}@example.com", name: "RT2FA User")
+    @tenant.add_user!(@user)
+    @tenant.create_main_collective!(created_by: @user)
+    host! "#{@tenant.subdomain}.#{ENV.fetch("HOSTNAME", nil)}"
+  end
+
+  # Stage a live refresh token whose establishing 2FA login is `established_at`,
+  # and present its cookie with NO browser session so a request must silent-refresh.
+  def stage_token(established_at:)
+    token = RefreshToken.issue!(user: @user, two_factor_at: Time.current)
+    token.update_column(:two_factor_at, established_at)
+    cookies[REFRESH_COOKIE] = T.must(token.plaintext_token)
+    token
+  end
+
+  test "a token within the trust lifetime silently re-authenticates" do
+    token = stage_token(established_at: 6.months.ago)
+
+    get "/"
+
+    assert token.reload.rotated?, "an in-lifetime token must silent-refresh (rotate) into a live session"
+    refute token.revoked?, "an in-lifetime token must not be revoked"
+    assert_not_nil cookies[REFRESH_COOKIE].presence, "the successor cookie must be set"
+  end
+
+  test "a token past the trust lifetime is revoked instead of silently re-authenticating" do
+    token = stage_token(established_at: (RefreshToken::MAX_TRUST_LIFETIME + 1.day).ago)
+
+    get "/"
+
+    assert token.reload.revoked?, "a token past the trust lifetime must be revoked"
+    assert_equal "trust_expired", token.revoked_reason
+    refute token.rotated?, "an expired-trust token must NOT rotate into a session"
+    assert_predicate cookies[REFRESH_COOKIE].to_s, :empty?, "the refresh cookie must be cleared"
+  end
+
+  test "a token just past the trust-lifetime boundary is treated as expired" do
+    token = stage_token(established_at: (RefreshToken::MAX_TRUST_LIFETIME + 1.second).ago)
+
+    get "/"
+
+    assert token.reload.revoked?, "just past the lifetime must be treated as expired"
+    assert_equal "trust_expired", token.revoked_reason
+  end
+end

--- a/test/models/oauth_identity_test.rb
+++ b/test/models/oauth_identity_test.rb
@@ -104,4 +104,42 @@ class OauthIdentityTest < ActiveSupport::TestCase
       OauthIdentity.find_or_create_from_auth(auth)
     end
   end
+
+  # === Redteam: OAuth must resolve only to human accounts ===
+
+  test "an OAuth login never links to or takes over a non-human account sharing the email" do
+    # Non-human users (agents, collective identities) never log in and never
+    # hold a browser session. Today their emails are synthetic and can't
+    # collide with a real OAuth email, but that invariant lives in the creation
+    # sites — the lookup must not depend on it. Email is globally unique, so the
+    # only safe outcomes are "link a HUMAN with this email" or "fail"; never
+    # "attach the login to the agent's account".
+    shared_email = "shared-#{SecureRandom.hex(6)}@example.com"
+    non_human = User.create!(email: shared_email, name: "Collective Identity", user_type: "collective_identity")
+
+    begin
+      OauthIdentity.find_or_create_from_auth(fake_auth(provider: "github", email: shared_email))
+    rescue ActiveRecord::RecordNotUnique
+      # Expected once the lookup is human-scoped: no human owns the email, and
+      # a new human can't be minted because the address is globally taken.
+    end
+
+    non_human.reload
+    assert_equal "collective_identity", non_human.user_type, "the non-human account's type must be untouched"
+    assert_nil OauthIdentity.find_by(user_id: non_human.id),
+               "an OAuth identity must never be attached to a non-human account"
+    assert_nil non_human.omni_auth_identity,
+               "an email/password identity must never be attached to a non-human account"
+  end
+
+  test "an OAuth login still links to an existing HUMAN account sharing the email" do
+    # Regression guard: human-scoping the lookup must not break the normal
+    # account-linking path.
+    human_email = "human-#{SecureRandom.hex(6)}@example.com"
+    human = User.create!(email: human_email, name: "Real Person", user_type: "human")
+
+    identity = OauthIdentity.find_or_create_from_auth(fake_auth(provider: "github", email: human_email))
+
+    assert_equal human.id, identity.user_id, "the OAuth identity must link to the existing human account"
+  end
 end

--- a/test/models/tenant_test.rb
+++ b/test/models/tenant_test.rb
@@ -217,6 +217,20 @@ class TenantTest < ActiveSupport::TestCase
     assert_not tenant.valid_auth_provider?("invalid")
   end
 
+  test "Tenant.valid_auth_provider? fails loudly on a corrupted (unset) auth_providers" do
+    # Every tenant gets auth_providers written at creation (set_defaults), so a
+    # nil here is a data-integrity bug, not a legitimate default. This gates the
+    # OAuth callback, so it must fail loudly rather than silently fall back to a
+    # provider set that could admit the wrong provider. The raise carries a
+    # meaningful message instead of a bare nil dereference.
+    tenant = create_tenant
+    tenant.settings.delete("auth_providers")
+    tenant.save!
+
+    error = assert_raises(RuntimeError) { tenant.valid_auth_provider?("github") }
+    assert_match(/auth_providers/, error.message)
+  end
+
   # === Thread Scope Tests ===
 
   test "Tenant.scope_thread_to_tenant sets thread variables" do


### PR DESCRIPTION
Security audit of the login/signup front gates, followed by a second pass hunting unconventional, codebase-specific vulnerabilities. Each fix is red-green TDD; the audit itself was verified against source (two agent-rated-HIGH findings turned out to be false positives on inspection — see below).

## Fixes (this PR)

1. **1-year absolute device-trust cap on silent refresh** — a refresh token's `expires_at` slides forward on every rotation, so an actively-used device was silently re-authenticated indefinitely and its human never re-authenticated. The stored `two_factor_at` (the establishing-login anchor, preserved across rotation) was the only fixed point but nothing read it. Silent refresh now enforces `MAX_TRUST_LIFETIME = 1.year` (matching the API-token max lifetime): past a year the token is revoked and a full re-login is required. Revoking rather than declining also kills a stolen copy of the cookie.
2. **OAuth email-linking scoped to humans** — `find_or_create_from_auth` could attach a login to a non-human account (agent / collective identity) sharing an email. Now human-scoped; a non-human squatting an address fails closed at create instead of mis-linking.
3. **`valid_auth_provider?` fails loud on corrupted config** — `auth_providers` is written at tenant creation, so a nil is a data-integrity bug, not a default. Replaced a bare `NoMethodError` with a deliberate, message-bearing raise (fail loud, never silently substitute a provider set).
4. **Malformed 2FA `code` param handled** — an array-valued `code[]=x` made `params[:code]&.strip` raise `NoMethodError` → 500 on every 2FA verify/confirm/disable/regenerate action. Coerced through a helper that treats any non-String as no code.

## Redteam guards (regression locks on previously-uncovered fail-closed behavior)

- A non-human user id, even in a valid cross-subdomain login token, never resolves to a browser session.
- A pending-2FA login can't reach protected content by skipping the challenge.
- A malformed `X-Representation-Session-ID` header fails closed as 403 (Rails' uuid cast → nil → not-found), locked against future resolver changes.

Also added `authentication_security_test.rb` to `check-secrets.sh` exclusions, alongside the sibling auth test files already there (intentional test-password fixtures).

## Verified and dismissed during the audit

- **Malformed representation session-id → 500**: false positive. Rails' `uuid` type casts garbage to `nil`; the lookup fails closed. No 500, no fix needed.
- **X-Forwarded-For throttle evasion**: not exploitable under the repo Caddyfile — bare `reverse_proxy` appends the real client IP, which Rails picks as the rightmost untrusted address.
- **Collective representation acting across collectives**: intended behavior (a collective participates in other collectives), bounded by `Collective#accessible_by?`.

## Deferred to their own branches (not in this PR)

- **Trustee grant per-action permissions unenforced on HTML/REST (MED–HIGH)** — a restricted trustee can exceed granted actions via the human UI/REST; the per-action check runs only on the markdown/MCP `/actions/` surface. Its own subsystem, deserves isolated treatment + tests.
- **YAML frontmatter newline injection via note title (MED)** — corrupts the agent-runner frontmatter wire protocol; harden `yaml_escape`.

All tests green; RuboCop / Sorbet / TypeScript clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)