### PR TITLE
Enforce trustee grant per-action permissions on HTML/REST routes

### DIFF
--- a/app/controllers/concerns/action_authorization_check.rb
+++ b/app/controllers/concerns/action_authorization_check.rb
@@ -37,6 +37,7 @@ module ActionAuthorizationCheck
 
   included do
     append_before_action :check_action_authorization
+    append_before_action :enforce_representation_action_grant
   end
 
   private
@@ -64,6 +65,41 @@ module ActionAuthorizationCheck
     return if ActionAuthorization.authorized?(action_name, @current_user, authorization_context)
 
     render_authorization_denied(action_name)
+  end
+
+  # Enforce the active user-representation grant's per-action permissions on the
+  # direct controller routes (the HTML forms and REST api/v1 endpoints mapped via
+  # CONTROLLER_ACTION_MAP). check_action_authorization runs the full
+  # ActionAuthorization.authorized? (which consults the grant) only on
+  # /actions/<name> POSTs; the mapped routes are gated by ActionCapabilityCheck
+  # alone, which — under user representation, where @current_user is the granting
+  # human — never consults the grant. A grant scoped to a subset of actions was
+  # therefore silently bypassable through the human UI and REST. This applies the
+  # SAME trustee check (ActionAuthorization.trustee_authorized?) to those mapped
+  # writes, and only under a user-representation session, so ordinary traffic is
+  # untouched.
+  def enforce_representation_action_grant
+    session = @current_representation_session
+    return unless session&.user_representation?
+    return unless write_request?
+    # /actions/<name> POSTs are already gated by check_action_authorization.
+    return if request.path.match?(%r{/actions/[^/]+/?$})
+
+    mapped_action = ActionCapabilityCheck::CONTROLLER_ACTION_MAP["#{controller_path}##{action_name}"]
+    # Unmapped routes carry no action name to check the grant against; they keep
+    # their controller guards (mirrors ActionCapabilityCheck deferring on
+    # unmapped writes for non-restricted users).
+    return if mapped_action.blank?
+    return if SESSION_MANAGEMENT_ACTIONS.include?(mapped_action)
+
+    # trustee_authorized? for a user-representation session reads only these two
+    # context keys; pass them directly rather than the full authorization_context
+    # so this gate does no incidental resource/handle lookups on every mapped
+    # controller.
+    context = { representation_session: session, collective: @current_collective }
+    return if ActionAuthorization.trustee_authorized?(@current_user, mapped_action, context)
+
+    render_authorization_denied(mapped_action)
   end
 
   # Context passed to ActionAuthorization.authorized? at execute time.

--- a/test/integration/api_representation_test.rb
+++ b/test/integration/api_representation_test.rb
@@ -176,6 +176,36 @@ class ApiRepresentationTest < ActionDispatch::IntegrationTest
                  "but was attributed to #{note.created_by.name} (#{note.created_by.user_type})"
   end
 
+  test "a scoped trustee grant is enforced on the direct (non-/actions/) routes too" do
+    # Alice grants Bob permission to create notes ONLY. The grant's per-action
+    # permissions were enforced only on the markdown /actions/ surface; on the
+    # direct HTML/REST routes the representative could exceed the grant. Lock it.
+    grant = create_trustee_authorization(
+      tenant: @tenant, granting_user: @alice, trustee_user: @bob,
+      permissions: { "create_note" => true }, accepted: true,
+    )
+    session_id = start_representation_session_via_api(grant: grant)
+    rep_headers = @headers.merge(
+      "X-Representation-Session-ID" => session_id,
+      "X-Representing-User" => @alice.handle,
+    )
+
+    # Granted action on the legacy route still works (no regression).
+    post "/collectives/#{@collective.handle}/note",
+         params: { title: "Permitted", text: "created as Alice, permitted" }, headers: rep_headers
+    assert Note.tenant_scoped_only(@tenant.id).exists?(title: "Permitted"),
+           "the granted create_note action must still succeed under representation"
+
+    # Ungranted action on the legacy route: Bob may only create_note, so creating
+    # a decision as Alice must be denied — not silently allowed as it was when
+    # only the /actions/ surface enforced the grant.
+    post "/collectives/#{@collective.handle}/decide",
+         params: { question: "Sneaky decision?", description: "should be blocked" }, headers: rep_headers
+    assert_response :forbidden
+    assert_not Decision.tenant_scoped_only(@tenant.id).exists?(question: "Sneaky decision?"),
+               "the ungranted create_decision action must be blocked on the legacy surface"
+  end
+
   test "API rejects representation with invalid session ID" do
     fake_session_id = SecureRandom.uuid
 


### PR DESCRIPTION
Closes the deferred MED–HIGH finding from the login/signup security audit (#521): a trustee grant's per-action `permissions` were enforceable only on the markdown/MCP `/actions/` surface, and silently bypassable through the direct HTML forms and REST `api/v1` routes.

## The bug

A trustee grant can be scoped to a subset of actions (e.g. `permissions: {"add_comment" => true}`). That restriction is enforced by `ActionAuthorization.trustee_authorized?` → `grant.has_action_permission?`, which runs at execute time only via `check_action_authorization` — and that gate early-returns on any path that isn't `/actions/<name>`.

The direct controller routes (the HTML forms and REST `api/v1` endpoints mapped via `CONTROLLER_ACTION_MAP`) are gated by `ActionCapabilityCheck` alone, which calls `CapabilityCheck.allowed?(@current_user, …)`. Under user representation `@current_user` is the **granting** human, for whom `allowed?` returns `true` unconditionally — so the grant was never consulted. A representative restricted to, say, commenting could create a decision (or note, commitment, vote, settings change…) as the grantor by using the human UI or REST instead of the markdown action.

The per-request **collective-scope** dimension of the grant was already enforced everywhere (`validate_authenticated_access`); only the per-action dimension leaked.

## The fix

`enforce_representation_action_grant` — a before_action that, **only under an active user-representation session**, applies the same `trustee_authorized?` check to the mapped `CONTROLLER_ACTION_MAP` writes. It reuses the exact `/actions/` logic so the two surfaces can't diverge, does no incidental resource/handle lookups (passes just the `representation_session` + `collective` context that check reads), and defers on unmapped routes so their controller guards stand. Ordinary (non-representation) traffic is untouched.

The gate keys on `@current_representation_session`, which both transports set — the API resolver (header) and the browser resolver (cookie) — so the human-UI path is closed by the same code.

## Test

Red-green: a grant scoped to `create_note` lets the representative create a note but is now **403'd** when creating a decision as the grantor via the direct `/decide` route (before the fix: 302 → decision created). No regressions across 148 representation/authorization tests; Sorbet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)