### PR TITLE
Emit and parse markdown frontmatter as standard YAML

### DIFF
--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "effect": "^3.21.0",
         "ioredis": "^5.4.0",
-        "undici": "^8.5.0"
+        "undici": "^8.5.0",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -1955,6 +1956,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "effect": "^3.21.0",
     "ioredis": "^5.4.0",
-    "undici": "^8.5.0"
+    "undici": "^8.5.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/agent-runner/src/core/MarkdownFrontmatter.ts
+++ b/agent-runner/src/core/MarkdownFrontmatter.ts
@@ -1,72 +1,73 @@
 /**
- * Parsers for YAML-flavored frontmatter that Rails' markdown layout wraps
- * every page response in. Used by McpClient to extract per-page action lists
- * and the server-resolved path from a `fetch_page` result.
+ * Parsers for the YAML frontmatter that Rails' markdown layout wraps every page
+ * response in. Used by McpClient to extract the per-page action list and the
+ * server-resolved path from a `fetch_page` result.
  *
- * These are deliberately small grep-and-slice parsers rather than a full YAML
- * implementation — the frontmatter shape we emit is fixed and predictable, so
- * a real parser would be over-engineered (and would force a runtime dep).
+ * Rails emits this frontmatter with a standard YAML emitter (Psych) and it is
+ * meant to be read by any standard YAML client, so we parse it with a real YAML
+ * parser. An earlier version grep-and-sliced the text, which coupled us to the
+ * exact whitespace/quoting Rails happened to produce; a real parser reads
+ * whatever valid YAML the server emits (quoted paths, column-0 or indented
+ * sequences, block scalars) the same way an external client would.
  */
+import { parse as parseYaml } from "yaml";
+
+interface Frontmatter {
+  readonly path?: unknown;
+  readonly actions?: unknown;
+}
 
 /**
- * Parse available action names from the markdown response's YAML frontmatter.
- * Matches Ruby MarkdownUiService.parse_frontmatter + actions extraction.
- *
- * The Rails markdown layout wraps every response in frontmatter:
- *   ---
- *   actions:
- *     - name: create_note
- *       description: Create a note
- *       ...
- *   ---
+ * Extract and parse the YAML frontmatter block that opens a markdown response.
+ * The block is fenced by a leading `---\n` and the next `\n---\n` (matching Ruby
+ * MarkdownUiService#parse_frontmatter). Returns the parsed mapping, or null when
+ * there is no frontmatter block, it is not valid YAML, or it is not a mapping.
+ */
+function parseFrontmatter(content: string): Frontmatter | null {
+  if (!content.startsWith("---\n")) return null;
+  const endIndex = content.indexOf("\n---\n", 4);
+  if (endIndex === -1) return null;
+
+  const block = content.slice(4, endIndex);
+  try {
+    const parsed: unknown = parseYaml(block);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Frontmatter;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse the available action names from a markdown response's frontmatter.
+ * Returns the ordered list of `actions[].name` values, skipping entries without
+ * a usable name. Empty when there is no frontmatter or no actions.
  */
 export function parseAvailableActions(content: string): readonly string[] {
-  // Must start with "---\n" (matches Ruby: content.start_with?("---\n"))
-  if (!content.startsWith("---\n")) return [];
+  const frontmatter = parseFrontmatter(content);
+  if (frontmatter === null || !Array.isArray(frontmatter.actions)) return [];
 
-  // Find closing "---\n" after position 4 (matches Ruby: content.index("\n---\n", 4))
-  const endIndex = content.indexOf("\n---\n", 4);
-  if (endIndex === -1) return [];
-
-  const frontmatter = content.slice(4, endIndex);
-
-  // Parse action names from the YAML frontmatter.
-  // We don't use a full YAML parser — just extract "- name: <value>" lines
-  // within the "actions:" block.
-  const actionsMatch = /^actions:\s*$/m.exec(frontmatter);
-  if (actionsMatch === null) return [];
-
-  const actionsBlock = frontmatter.slice(actionsMatch.index + actionsMatch[0].length);
   const names: string[] = [];
-
-  for (const line of actionsBlock.split("\n")) {
-    // Stop if we hit a non-indented line (next top-level YAML key)
-    if (line.length > 0 && !line.startsWith(" ") && !line.startsWith("\t")) break;
-
-    // Match only top-level action items (2-space indent: "  - name: value")
-    // Skip deeper nested "name:" like params (6+ spaces)
-    const nameMatch = /^  - name:\s*(.+)$/.exec(line);
-    if (nameMatch?.[1] !== undefined) {
-      const name = nameMatch[1].trim();
-      if (name !== "") names.push(name);
+  for (const action of frontmatter.actions) {
+    if (action === null || typeof action !== "object") continue;
+    const name: unknown = (action as { name?: unknown }).name;
+    if (typeof name === "string" && name.trim() !== "") {
+      names.push(name.trim());
     }
   }
-
   return names;
 }
 
 /**
- * Extract a `path: …` value from a markdown response's YAML frontmatter.
- * Used to resolve the path the server actually landed on (the server follows
- * redirects internally; we don't see hop-by-hop).
- *
- * Returns null if there's no frontmatter or no `path:` line in it.
+ * Extract the server-resolved `path` from a markdown response's frontmatter.
+ * The server follows redirects internally; this is the path it actually landed
+ * on. Returns null when there is no frontmatter or no string `path`.
  */
 export function parseResolvedPath(content: string): string | null {
-  if (!content.startsWith("---\n")) return null;
-  const endIndex = content.indexOf("\n---\n", 4);
-  if (endIndex === -1) return null;
-  const frontmatter = content.slice(4, endIndex);
-  const match = /^path:\s*(.+)$/m.exec(frontmatter);
-  return match?.[1]?.trim() ?? null;
+  const frontmatter = parseFrontmatter(content);
+  if (frontmatter === null) return null;
+  const path: unknown = frontmatter.path;
+  return typeof path === "string" && path.trim() !== "" ? path : null;
 }

--- a/agent-runner/test/core/MarkdownFrontmatter.test.ts
+++ b/agent-runner/test/core/MarkdownFrontmatter.test.ts
@@ -95,6 +95,62 @@ More content after rule
 `;
     expect(parseAvailableActions(content)).toEqual([]);
   });
+
+  // Rails emits this frontmatter with Psych (standard YAML): the sequence dash
+  // sits at column 0 (not indented), scalars are quoted only when needed, and a
+  // block scalar carries a multi-line title. A real YAML parser reads all of it;
+  // the old grep-and-slice parser required an exact 2-space `  - name:` indent
+  // and would have seen zero actions here.
+  it("parses Psych's canonical column-0 sequence output", () => {
+    const content = `---
+app: Harmonic
+host: t.example.com
+path: "/collectives/team"
+title: Home
+timestamp: 2026-07-23 12:00:00.000000000 Z
+actions:
+- name: create_note
+  visibility: public
+  description: 'Create a note: quickly'
+  params:
+  - name: body
+    type: string
+    required: true
+- name: vote
+  visibility: shared
+  description: Cast a vote
+---
+nav: | [Home](/) |
+`;
+    expect(parseAvailableActions(content)).toEqual(["create_note", "vote"]);
+  });
+
+  it("is not fooled by a nested params 'name' key", () => {
+    // params[].name must not be collected as an action name.
+    const content = `---
+actions:
+- name: create_note
+  params:
+  - name: body
+    type: string
+---
+# Page
+`;
+    expect(parseAvailableActions(content)).toEqual(["create_note"]);
+  });
+
+  it("reads a title block scalar without treating its lines as keys", () => {
+    const content = `---
+title: |-
+  pwned
+  actions: []
+actions:
+- name: real_action
+---
+# Page
+`;
+    expect(parseAvailableActions(content)).toEqual(["real_action"]);
+  });
 });
 
 describe("parseResolvedPath", () => {
@@ -108,5 +164,18 @@ describe("parseResolvedPath", () => {
 
   it("returns null when frontmatter has no path line", () => {
     expect(parseResolvedPath("---\napp: Harmonic\n---\n# Body")).toBeNull();
+  });
+
+  it("strips the quotes Psych adds around a path", () => {
+    // Psych quotes paths (leading slash), e.g. `path: "/collectives/team/n/abc"`.
+    // A real parser returns the unquoted value; the old bare-trim parser would
+    // have kept the surrounding quotes.
+    const content = `---
+app: Harmonic
+path: "/collectives/team/n/abc123"
+---
+# Body
+`;
+    expect(parseResolvedPath(content)).toBe("/collectives/team/n/abc123");
   });
 });

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -36,44 +36,41 @@ module MarkdownHelper
     end
   end
 
-  # Escape a value for emission as an inline YAML scalar in a markdown page's
-  # frontmatter block. That frontmatter is a wire protocol the agent-runner / MCP
-  # `fetch_page` consumer parses, so a user-controlled value (note title, decision
-  # question, scope/query, action description) must not be able to break out of
-  # its scalar, inject or corrupt keys, or be silently retyped. When quoting we
-  # escape control characters into YAML double-quoted escape sequences so the
-  # scalar stays on one physical line and round-trips exactly. Returns an
-  # html_safe string for direct <%= %>.
-  def yaml_escape(value)
-    str = value.to_s
-    return str.html_safe unless yaml_scalar_needs_quoting?(str)
-
-    escaped = str.gsub(/["\\\x00-\x1F\x7F]/) do |ch|
-      case ch
-      when '"' then '\\"'
-      when "\\" then "\\\\"
-      when "\n" then '\\n'
-      when "\t" then '\\t'
-      when "\r" then '\\r'
-      else format('\\x%02X', ch.ord)
-      end
-    end
-    ('"' + escaped + '"').html_safe
+  # Render the YAML frontmatter block that opens every markdown page response,
+  # reading the page state set by the controller. Delegates to
+  # markdown_frontmatter_block, which does the serialization.
+  def page_frontmatter
+    markdown_frontmatter_block(
+      app: "Harmonic",
+      host: "#{@current_tenant.subdomain}.#{ENV['HOSTNAME']}",
+      path: @current_path,
+      scope: @page_scope,
+      query: @page_query,
+      title: @page_title,
+      timestamp: Time.now.utc,
+      actions: available_actions_for_current_route,
+    )
   end
 
-  # A plain (unquoted) YAML scalar is safe to emit only if it parses back as the
-  # identical string. Let Psych be the oracle rather than enumerating YAML's
-  # quoting rules by hand: this catches structural indicators (a leading `- `,
-  # `#`, `@`; an embedded `: ` or ` #`; surrounding whitespace) AND values YAML
-  # resolves to a non-string (`true`, `123`, `null`, `~`, `.inf`, sexagesimal
-  # times) in one rule. Control characters always force quoting — we never hand
-  # them to the parser — and unparseable input fails closed to quoted.
-  def yaml_scalar_needs_quoting?(str)
-    return true if str.match?(/[\x00-\x1F\x7F]/)
+  # Serialize the page frontmatter to a YAML block, fences included.
+  #
+  # This frontmatter is a wire protocol: MarkdownUiService, the agent-runner, and
+  # any external client parse it with a standard YAML parser, so we EMIT it with a
+  # standard YAML emitter (Psych) rather than hand-templating. Psych owns every
+  # quoting/escaping decision, which makes scalar injection and silent retyping
+  # (a note titled "true" arriving as a boolean) impossible by construction —
+  # there is no hand-rolled escaper to get wrong. Returns an html_safe string
+  # (the response is text/markdown, not HTML, so YAML's `<`/`>`/`&` must pass
+  # through unescaped).
+  def markdown_frontmatter_block(app:, host:, path:, title:, timestamp:, scope: nil, query: nil, actions: [])
+    data = { "app" => app, "host" => host, "path" => path }
+    data["scope"] = scope if scope.present?
+    data["query"] = query if query.present?
+    data["title"] = title
+    data["timestamp"] = timestamp
+    data["actions"] = actions.map { |action| frontmatter_action_entry(action) } if actions.any?
 
-    YAML.safe_load(str) != str
-  rescue Psych::Exception
-    true
+    (YAML.dump(data) + "---").html_safe
   end
 
   MARKDOWN_CONTENT_TRUNCATION_LIMIT = 2_000
@@ -99,6 +96,30 @@ module MarkdownHelper
   end
 
   private
+
+  # Shape one action descriptor (symbol keys, from build_action_descriptor) into
+  # the string-keyed hash we emit in frontmatter. `params` and a param's
+  # `description` are omitted when absent to keep the block lean.
+  def frontmatter_action_entry(action)
+    entry = {
+      "name" => action[:name],
+      "visibility" => action[:visibility],
+      "description" => action[:description],
+    }
+    params = Array(action[:params]).map { |param| frontmatter_param_entry(param) }
+    entry["params"] = params if params.any?
+    entry
+  end
+
+  def frontmatter_param_entry(param)
+    entry = {
+      "name" => param[:name],
+      "type" => param[:type],
+      "required" => param[:required],
+    }
+    entry["description"] = param[:description] unless param[:description].nil?
+    entry
+  end
 
   def action_allowed_at_this_route?(action, current_user, context)
     decision = context[:resource]

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -36,6 +36,46 @@ module MarkdownHelper
     end
   end
 
+  # Escape a value for emission as an inline YAML scalar in a markdown page's
+  # frontmatter block. That frontmatter is a wire protocol the agent-runner / MCP
+  # `fetch_page` consumer parses, so a user-controlled value (note title, decision
+  # question, scope/query, action description) must not be able to break out of
+  # its scalar, inject or corrupt keys, or be silently retyped. When quoting we
+  # escape control characters into YAML double-quoted escape sequences so the
+  # scalar stays on one physical line and round-trips exactly. Returns an
+  # html_safe string for direct <%= %>.
+  def yaml_escape(value)
+    str = value.to_s
+    return str.html_safe unless yaml_scalar_needs_quoting?(str)
+
+    escaped = str.gsub(/["\\\x00-\x1F\x7F]/) do |ch|
+      case ch
+      when '"' then '\\"'
+      when "\\" then "\\\\"
+      when "\n" then '\\n'
+      when "\t" then '\\t'
+      when "\r" then '\\r'
+      else format('\\x%02X', ch.ord)
+      end
+    end
+    ('"' + escaped + '"').html_safe
+  end
+
+  # A plain (unquoted) YAML scalar is safe to emit only if it parses back as the
+  # identical string. Let Psych be the oracle rather than enumerating YAML's
+  # quoting rules by hand: this catches structural indicators (a leading `- `,
+  # `#`, `@`; an embedded `: ` or ` #`; surrounding whitespace) AND values YAML
+  # resolves to a non-string (`true`, `123`, `null`, `~`, `.inf`, sexagesimal
+  # times) in one rule. Control characters always force quoting — we never hand
+  # them to the parser — and unparseable input fails closed to quoted.
+  def yaml_scalar_needs_quoting?(str)
+    return true if str.match?(/[\x00-\x1F\x7F]/)
+
+    YAML.safe_load(str) != str
+  rescue Psych::Exception
+    true
+  end
+
   MARKDOWN_CONTENT_TRUNCATION_LIMIT = 2_000
 
   # Truncates content at a line boundary to reduce agent token usage.

--- a/app/views/layouts/application.md.erb
+++ b/app/views/layouts/application.md.erb
@@ -1,15 +1,3 @@
-<%
-# Helper to escape YAML values that contain special characters
-def yaml_escape(value)
-  str = value.to_s
-  needs_quoting = str.match?(/\A[@#*&!|>%\[\]{}'":\s-]/) ||
-                  str.include?(": ") ||
-                  str.include?(" #") ||
-                  str.match?(/\s\z/)
-  result = needs_quoting ? '"' + str.gsub('\\', '\\\\').gsub('"', '\\"') + '"' : str
-  result.html_safe
-end
--%>
 ---
 app: Harmonic
 host: <%= "#{@current_tenant.subdomain}.#{ENV['HOSTNAME']}" %>

--- a/app/views/layouts/application.md.erb
+++ b/app/views/layouts/application.md.erb
@@ -1,36 +1,4 @@
----
-app: Harmonic
-host: <%= "#{@current_tenant.subdomain}.#{ENV['HOSTNAME']}" %>
-path: <%= @current_path %>
-<% if @page_scope.present? -%>
-scope: <%= yaml_escape(@page_scope) %>
-<% end -%>
-<% if @page_query.present? -%>
-query: <%= yaml_escape(@page_query) %>
-<% end -%>
-title: <%= yaml_escape(@page_title) %>
-timestamp: <%= Time.now.utc %>
-<% actions = available_actions_for_current_route -%>
-<% if actions.any? -%>
-actions:
-<% actions.each do |action| -%>
-  - name: <%= action[:name] %>
-    visibility: <%= action[:visibility] %>
-    description: <%= yaml_escape(action[:description]) %>
-<% if action[:params]&.any? -%>
-    params:
-<% action[:params].each do |param| -%>
-      - name: <%= param[:name] %>
-        type: <%= param[:type] %>
-        required: <%= param[:required] %>
-<% if param[:description] -%>
-        description: <%= yaml_escape(param[:description]) %>
-<% end -%>
-<% end -%>
-<% end -%>
-<% end -%>
-<% end -%>
----
+<%= page_frontmatter %>
 nav: | [Home](/) <% if @current_collective && @current_collective != @current_tenant.main_collective -%>| <%= @current_collective.private_workspace? ? "Workspace" : "Collective" %>: [<%= @current_collective.name %>](<%= @current_collective.path %>)<% end -%><% if @current_user -%>| Logged in as [<%= @current_user.display_name %>](<%= @current_user.path %>)<% end -%><% if @current_representation_session -%> | acting on behalf of <%= @current_representation_session.representation_label %><% end -%> | [🔍](/search) | [<%= @unread_notification_count %>](/notifications) |
 <% if unattached_rep_sessions.any? -%>
 

--- a/test/controllers/pulse_controller_test.rb
+++ b/test/controllers/pulse_controller_test.rb
@@ -252,7 +252,7 @@ class PulseControllerTest < ActionDispatch::IntegrationTest
     get "#{@collective.path}", headers: { "Accept" => "text/markdown" }
     assert_response :success
     assert_includes response.body, "scope: collective:#{@collective.handle}"
-    # yaml_escape quotes a value starting with "-" so it doesn't parse as a YAML list item.
+    # The YAML emitter quotes a value starting with "-" so it doesn't parse as a YAML list item.
     assert_includes response.body, "query: \"-subtype:comment\""
   end
 

--- a/test/helpers/markdown_helper_test.rb
+++ b/test/helpers/markdown_helper_test.rb
@@ -74,4 +74,79 @@ class MarkdownHelperTest < ActionView::TestCase
     assert_includes notice, "showing 1990 of 3000 characters"
     assert_includes notice, "/n/abc?full_text=true"
   end
+
+  # yaml_escape
+  #
+  # The frontmatter block in application.md.erb is a wire protocol the
+  # agent-runner / MCP `fetch_page` consumer parses. yaml_escape is the sole
+  # chokepoint that keeps user-controlled values (note title, decision question,
+  # scope/query, descriptions) from breaking out of their scalar. Round-trip
+  # every escaped value through a real YAML parser: whatever went in must come
+  # back out unchanged, as a single scalar, injecting no keys.
+  def assert_yaml_roundtrip(input)
+    emitted = "title: #{yaml_escape(input)}\n"
+    parsed = YAML.safe_load(emitted)
+    assert_equal({ "title" => input }, parsed,
+                 "#{input.inspect} did not round-trip through frontmatter")
+  end
+
+  test "yaml_escape leaves a plain value unquoted" do
+    assert_equal "hello world", yaml_escape("hello world")
+  end
+
+  test "yaml_escape returns an html_safe string" do
+    assert_predicate yaml_escape("plain"), :html_safe?
+    assert_predicate yaml_escape("a: b"), :html_safe?
+  end
+
+  test "yaml_escape round-trips an interior newline as a single scalar" do
+    # The core injection: unquoted, this newline would start new frontmatter keys.
+    assert_yaml_roundtrip("pwned\ninjected_key: gotcha\nactions: []")
+  end
+
+  test "yaml_escape round-trips a value with a colon-space that would otherwise fold" do
+    # Quoted but with a literal newline, YAML folds the newline into a space.
+    assert_yaml_roundtrip("Ship it?\nactions: []")
+  end
+
+  test "yaml_escape round-trips tab and carriage-return control characters" do
+    assert_yaml_roundtrip("a\tb\r\nc")
+  end
+
+  test "yaml_escape round-trips other control characters via \\xNN escapes" do
+    assert_yaml_roundtrip("bell\aend")
+    assert_yaml_roundtrip("esc\e[31mred")
+    assert_yaml_roundtrip("null\x00byte")
+    assert_yaml_roundtrip("del\x7Fchar")
+  end
+
+  test "yaml_escape round-trips embedded quotes and backslashes" do
+    assert_yaml_roundtrip('quote " and \\ backslash')
+  end
+
+  test "yaml_escape round-trips YAML-significant leading characters and structure" do
+    ["- leading dash", "@ at sign", "#comment", "*anchor", "key: value",
+     "trailing space ", " leading space", "[list]", "{map}", ""].each do |input|
+      assert_yaml_roundtrip(input)
+    end
+  end
+
+  test "yaml_escape round-trips scalars YAML would otherwise retype to non-strings" do
+    # Bare, these emit `title: true` / `title: 123` etc. and parse back as a
+    # boolean / integer / null — a note literally titled "true" or "123" must
+    # survive as a string through the machine-parsed frontmatter.
+    ["true", "false", "yes", "no", "on", "off", "null", "~",
+     "123", "-5", "1.5", ".inf", ".nan", "12:30:00"].each do |input|
+      assert_yaml_roundtrip(input)
+    end
+  end
+
+  test "yaml_escape leaves search-syntax scope/query values unquoted" do
+    # These flow through yaml_escape as page scope/query; they parse back as
+    # plain strings, so quoting them would be noise the frontmatter tests reject.
+    ["visibility:public", "type:note", "list:tuned_in -subtype:comment",
+     "visibility:public creator:@alice"].each do |input|
+      assert_equal input, yaml_escape(input), "#{input.inspect} should stay unquoted"
+    end
+  end
 end

--- a/test/helpers/markdown_helper_test.rb
+++ b/test/helpers/markdown_helper_test.rb
@@ -75,78 +75,113 @@ class MarkdownHelperTest < ActionView::TestCase
     assert_includes notice, "/n/abc?full_text=true"
   end
 
-  # yaml_escape
+  # markdown_frontmatter_block
   #
-  # The frontmatter block in application.md.erb is a wire protocol the
-  # agent-runner / MCP `fetch_page` consumer parses. yaml_escape is the sole
-  # chokepoint that keeps user-controlled values (note title, decision question,
-  # scope/query, descriptions) from breaking out of their scalar. Round-trip
-  # every escaped value through a real YAML parser: whatever went in must come
-  # back out unchanged, as a single scalar, injecting no keys.
-  def assert_yaml_roundtrip(input)
-    emitted = "title: #{yaml_escape(input)}\n"
-    parsed = YAML.safe_load(emitted)
-    assert_equal({ "title" => input }, parsed,
-                 "#{input.inspect} did not round-trip through frontmatter")
+  # The frontmatter is a wire protocol MarkdownUiService, the agent-runner, and
+  # external clients parse with a standard YAML parser, so it is emitted with a
+  # standard YAML emitter (Psych). The property that matters: whatever value goes
+  # in — including adversarial titles/queries — parses back out as the identical
+  # string, injecting no keys and never silently retyped. Parse the emitted block
+  # the same way the consumer does (strip the fences, YAML.safe_load the body).
+  def frontmatter_of(block)
+    body = block.delete_prefix("---\n").delete_suffix("\n---")
+    YAML.safe_load(body, permitted_classes: [Time, Symbol])
   end
 
-  test "yaml_escape leaves a plain value unquoted" do
-    assert_equal "hello world", yaml_escape("hello world")
+  def build_block(**overrides)
+    markdown_frontmatter_block(**{
+      app: "Harmonic", host: "t.example.com", path: "/x",
+      title: "Hello", timestamp: Time.utc(2026, 7, 23, 12, 0, 0)
+    }.merge(overrides))
   end
 
-  test "yaml_escape returns an html_safe string" do
-    assert_predicate yaml_escape("plain"), :html_safe?
-    assert_predicate yaml_escape("a: b"), :html_safe?
+  test "markdown_frontmatter_block emits a fenced, html_safe block that parses" do
+    block = build_block
+    assert_predicate block, :html_safe?
+    assert block.start_with?("---\n"), "must open with a --- fence"
+    assert block.end_with?("\n---"), "must close with a --- fence"
+    fm = frontmatter_of(block)
+    assert_equal "Harmonic", fm["app"]
+    assert_equal "t.example.com", fm["host"]
+    assert_equal "/x", fm["path"]
+    assert_equal "Hello", fm["title"]
   end
 
-  test "yaml_escape round-trips an interior newline as a single scalar" do
-    # The core injection: unquoted, this newline would start new frontmatter keys.
-    assert_yaml_roundtrip("pwned\ninjected_key: gotcha\nactions: []")
+  test "markdown_frontmatter_block omits scope/query/actions when blank" do
+    fm = frontmatter_of(build_block(scope: nil, query: "", actions: []))
+    assert_not fm.key?("scope")
+    assert_not fm.key?("query")
+    assert_not fm.key?("actions")
   end
 
-  test "yaml_escape round-trips a value with a colon-space that would otherwise fold" do
-    # Quoted but with a literal newline, YAML folds the newline into a space.
-    assert_yaml_roundtrip("Ship it?\nactions: []")
+  test "markdown_frontmatter_block includes scope and query when present" do
+    fm = frontmatter_of(build_block(scope: "visibility:public", query: "type:note"))
+    assert_equal "visibility:public", fm["scope"]
+    assert_equal "type:note", fm["query"]
   end
 
-  test "yaml_escape round-trips tab and carriage-return control characters" do
-    assert_yaml_roundtrip("a\tb\r\nc")
-  end
-
-  test "yaml_escape round-trips other control characters via \\xNN escapes" do
-    assert_yaml_roundtrip("bell\aend")
-    assert_yaml_roundtrip("esc\e[31mred")
-    assert_yaml_roundtrip("null\x00byte")
-    assert_yaml_roundtrip("del\x7Fchar")
-  end
-
-  test "yaml_escape round-trips embedded quotes and backslashes" do
-    assert_yaml_roundtrip('quote " and \\ backslash')
-  end
-
-  test "yaml_escape round-trips YAML-significant leading characters and structure" do
-    ["- leading dash", "@ at sign", "#comment", "*anchor", "key: value",
-     "trailing space ", " leading space", "[list]", "{map}", ""].each do |input|
-      assert_yaml_roundtrip(input)
+  # A title/query containing a newline, control chars, quotes, or YAML structure
+  # must round-trip as one scalar and never inject a key — the injection the whole
+  # refactor removes. Psych is the escaper now, so this exercises the contract end
+  # to end rather than a hand-rolled helper.
+  [
+    "pwned\ninjected_key: gotcha\nactions: []",
+    "Ship it?\nactions: []",
+    "a\tb\r\nc",
+    "bell\aend",
+    "esc\e[31mred",
+    "null\x00byte",
+    "del\x7Fchar",
+    'quote " and \\ backslash',
+    "- leading dash",
+    "@ at sign",
+    "#comment",
+    "key: value",
+    " leading space",
+    "trailing space ",
+    "",
+  ].each do |payload|
+    test "markdown_frontmatter_block round-trips title #{payload.inspect} as a string" do
+      fm = frontmatter_of(build_block(title: payload))
+      assert_equal payload, fm["title"]
+      assert_equal ["app", "host", "path", "title", "timestamp"], fm.keys,
+                   "payload must not inject or reorder keys"
     end
   end
 
-  test "yaml_escape round-trips scalars YAML would otherwise retype to non-strings" do
-    # Bare, these emit `title: true` / `title: 123` etc. and parse back as a
-    # boolean / integer / null — a note literally titled "true" or "123" must
-    # survive as a string through the machine-parsed frontmatter.
-    ["true", "false", "yes", "no", "on", "off", "null", "~",
-     "123", "-5", "1.5", ".inf", ".nan", "12:30:00"].each do |input|
-      assert_yaml_roundtrip(input)
+  # Bare true/123/null etc. must survive as strings, not be retyped to
+  # boolean/integer/null by the parser.
+  ["true", "false", "yes", "no", "null", "~", "123", "-5", "1.5", "12:30:00"].each do |payload|
+    test "markdown_frontmatter_block keeps title #{payload.inspect} a string, not retyped" do
+      fm = frontmatter_of(build_block(title: payload))
+      assert_equal payload, fm["title"]
+      assert_kind_of String, fm["title"]
     end
   end
 
-  test "yaml_escape leaves search-syntax scope/query values unquoted" do
-    # These flow through yaml_escape as page scope/query; they parse back as
-    # plain strings, so quoting them would be noise the frontmatter tests reject.
-    ["visibility:public", "type:note", "list:tuned_in -subtype:comment",
-     "visibility:public creator:@alice"].each do |input|
-      assert_equal input, yaml_escape(input), "#{input.inspect} should stay unquoted"
-    end
+  test "markdown_frontmatter_block shapes actions and omits empty params/description" do
+    actions = [
+      { name: "create_note", visibility: "public", description: "Create a note",
+        params: [{ name: "body", type: "string", required: true, description: "the text" },
+                 { name: "title", type: "string", required: false, description: nil }] },
+      { name: "vote", visibility: "shared", description: "Cast a vote", params: [] },
+    ]
+    fm = frontmatter_of(build_block(actions: actions))
+
+    assert_equal %w[create_note vote], fm["actions"].map { |a| a["name"] }
+    create = fm["actions"][0]
+    assert_equal "public", create["visibility"]
+    assert_equal({ "name" => "body", "type" => "string", "required" => true, "description" => "the text" },
+                 create["params"][0])
+    # nil param description is omitted, not emitted as null.
+    assert_not create["params"][1].key?("description")
+    # An action with no params omits the key entirely.
+    assert_not fm["actions"][1].key?("params")
+  end
+
+  test "markdown_frontmatter_block round-trips an action description with YAML structure" do
+    actions = [{ name: "x", visibility: "public", description: "Do this: then #that", params: [] }]
+    fm = frontmatter_of(build_block(actions: actions))
+    assert_equal "Do this: then #that", fm["actions"][0]["description"]
   end
 end

--- a/test/integration/markdown_action_authorization_test.rb
+++ b/test/integration/markdown_action_authorization_test.rb
@@ -12,6 +12,19 @@ class MarkdownActionAuthorizationTest < ActionDispatch::IntegrationTest
     host! "#{@tenant.subdomain}.#{ENV['HOSTNAME']}"
   end
 
+  # Action names listed in the page's YAML frontmatter, parsed as the real
+  # consumers do. Precise where a bare `/vote/` body match would be ambiguous
+  # (the word also appears in page copy).
+  def frontmatter_action_names(body)
+    return [] unless body.start_with?("---\n")
+
+    end_index = body.index("\n---\n", 4)
+    return [] unless end_index
+
+    parsed = YAML.safe_load(body[4...end_index], permitted_classes: [Time, Symbol]) || {}
+    Array(parsed["actions"]).map { |action| action["name"] }
+  end
+
   # ==========================================
   # Note actions filtered by block
   # ==========================================
@@ -51,8 +64,9 @@ class MarkdownActionAuthorizationTest < ActionDispatch::IntegrationTest
     get decision.path, headers: { "Accept" => "text/markdown" }
 
     assert_response :success
-    assert_no_match(/^ {2}- name: vote$/m, response.body)
-    assert_no_match(/^ {2}- name: add_options$/m, response.body)
+    names = frontmatter_action_names(response.body)
+    assert_not_includes names, "vote"
+    assert_not_includes names, "add_options"
   end
 
   test "decision markdown frontmatter includes vote and add_options when no block" do

--- a/test/integration/markdown_frontmatter_injection_test.rb
+++ b/test/integration/markdown_frontmatter_injection_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+# End-to-end guard that the frontmatter escaper (MarkdownHelper#yaml_escape,
+# unit-tested in test/helpers/markdown_helper_test.rb) is actually wired into
+# the rendered `.md` page: a note title containing a newline — length-validated
+# only, so it survives verbatim into @page_title — must not break out of its
+# YAML scalar and corrupt the frontmatter the agent-runner / MCP `fetch_page`
+# consumer parses.
+class MarkdownFrontmatterInjectionTest < ActionDispatch::IntegrationTest
+  def setup
+    @tenant = @global_tenant
+    @tenant.enable_api!
+    @collective = @global_collective
+    @collective.enable_api!
+    @user = @global_user
+    Collective.scope_thread_to_collective(subdomain: @tenant.subdomain, handle: @collective.handle)
+    host! "#{@tenant.subdomain}.#{ENV.fetch("HOSTNAME", nil)}"
+  end
+
+  test "a newline in a note title cannot inject or corrupt page frontmatter" do
+    injected = "pwned\ninjected_key: gotcha\nactions: []"
+    note = create_note(title: injected, text: "body", created_by: @user)
+    sign_in_as(@user, tenant: @tenant)
+
+    get note.path, headers: { "Accept" => "text/markdown" }
+    assert_response :success
+
+    raw = response.body[/\A.*?^---$(.*?)^---$/m, 1]
+    fm = YAML.safe_load(raw, permitted_classes: [Time])
+
+    assert_equal injected, fm["title"], "title must round-trip as a single scalar"
+    assert_not fm.key?("injected_key"), "title newline must not inject a top-level key"
+    assert_kind_of Array, fm["actions"]
+    assert fm["actions"].any? { |a| a["name"] == "confirm_read" },
+           "the page's real actions must survive intact"
+  end
+end

--- a/test/integration/markdown_frontmatter_injection_test.rb
+++ b/test/integration/markdown_frontmatter_injection_test.rb
@@ -1,11 +1,11 @@
 require "test_helper"
 
-# End-to-end guard that the frontmatter escaper (MarkdownHelper#yaml_escape,
-# unit-tested in test/helpers/markdown_helper_test.rb) is actually wired into
-# the rendered `.md` page: a note title containing a newline — length-validated
-# only, so it survives verbatim into @page_title — must not break out of its
-# YAML scalar and corrupt the frontmatter the agent-runner / MCP `fetch_page`
-# consumer parses.
+# End-to-end guard that the frontmatter serializer (MarkdownHelper's
+# markdown_frontmatter_block, unit-tested in test/helpers/markdown_helper_test.rb)
+# is actually wired into the rendered `.md` page: a note title containing a
+# newline — length-validated only, so it survives verbatim into @page_title —
+# must not break out of its YAML scalar and corrupt the frontmatter the
+# agent-runner / MCP `fetch_page` consumer parses.
 class MarkdownFrontmatterInjectionTest < ActionDispatch::IntegrationTest
   def setup
     @tenant = @global_tenant

--- a/test/integration/markdown_ui_test.rb
+++ b/test/integration/markdown_ui_test.rb
@@ -50,19 +50,29 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
     response.body.include?("# Actions") || response.body.include?("# [Actions]")
   end
 
+  # Parse the YAML frontmatter block the same way the real consumers do
+  # (MarkdownUiService, the agent-runner), rather than regexing the raw body —
+  # the frontmatter is standard YAML, so values may be quoted or block-scalared.
+  def parsed_frontmatter
+    body = response.body
+    return {} unless body.start_with?("---\n")
+
+    end_index = body.index("\n---\n", 4)
+    return {} unless end_index
+
+    YAML.safe_load(body[4...end_index], permitted_classes: [Time, Symbol]) || {}
+  end
+
   def has_action_in_frontmatter?(action_name)
-    # Actions are now in YAML frontmatter, e.g., "- name: confirm_read"
-    response.body.include?("- name: #{action_name}")
+    Array(parsed_frontmatter["actions"]).any? { |action| action["name"] == action_name }
   end
 
   def page_title
-    m = response.body.match(/title: (.+)/)
-    m ? m[1] : nil
+    parsed_frontmatter["title"]
   end
 
   def page_path
-    m = response.body.match(/path: (.+)/)
-    m ? m[1] : nil
+    parsed_frontmatter["path"]
   end
 
   def assert_200_markdown_response(title, path, params: nil)
@@ -2591,8 +2601,8 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
       "Should not mark unrelated comments")
 
     # Frontmatter `path:` preserves comment_id so agents see the canonical URL
-    assert_match(/^path: \/collectives\/#{@collective.handle}\/d\/#{decision.truncated_id}\?comment_id=#{target.truncated_id}$/,
-      response.body, "Frontmatter path should retain comment_id")
+    assert_equal "/collectives/#{@collective.handle}/d/#{decision.truncated_id}?comment_id=#{target.truncated_id}",
+      page_path, "Frontmatter path should retain comment_id"
   end
 
   test "GET decision without ?comment_id= shows no inline marker and bare path in frontmatter" do
@@ -2603,8 +2613,8 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
     assert_equal 200, response.status
 
     assert_no_match(/📌/, response.body, "Should not render any marker without comment_id")
-    assert_match(/^path: \/collectives\/#{@collective.handle}\/d\/#{decision.truncated_id}$/, response.body,
-      "Frontmatter path should be the bare path when no comment_id")
+    assert_equal "/collectives/#{@collective.handle}/d/#{decision.truncated_id}", page_path,
+      "Frontmatter path should be the bare path when no comment_id"
   end
 
   test "GET decision with ?comment_id= matching a nested reply marks the nested reply" do
@@ -2622,8 +2632,8 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
   test "GET search with ?q= preserves the query in the frontmatter path" do
     get "/search?q=hello", headers: @headers
     assert_equal 200, response.status
-    assert_match(/^path: \/search\?q=hello$/, response.body,
-      "Frontmatter path should preserve ?q= for search")
+    assert_equal "/search?q=hello", page_path,
+      "Frontmatter path should preserve ?q= for search"
   end
 
   test "frontmatter path drops query params not on the preserved whitelist" do
@@ -2633,8 +2643,8 @@ class MarkdownUiTest < ActionDispatch::IntegrationTest
     assert_equal 200, response.status
 
     # Unknown params are stripped from the frontmatter path
-    assert_match(/^path: \/collectives\/#{@collective.handle}\/d\/#{decision.truncated_id}$/, response.body,
-      "Whitelisted-only: unknown query params shouldn't appear in the canonical path")
+    assert_equal "/collectives/#{@collective.handle}/d/#{decision.truncated_id}", page_path,
+      "Whitelisted-only: unknown query params shouldn't appear in the canonical path"
   end
 
   test "GET ai_agent task run markdown surfaces tool_calls and reasoning on think steps" do

--- a/test/integration/markdown_visibility_frontmatter_test.rb
+++ b/test/integration/markdown_visibility_frontmatter_test.rb
@@ -18,14 +18,22 @@ class MarkdownVisibilityFrontmatterTest < ActionDispatch::IntegrationTest
     host! "#{@tenant.subdomain}.#{ENV.fetch("HOSTNAME", nil)}"
   end
 
-  def visibility_for(body, action_name)
-    # Grab the `visibility:` line within the action block keyed by name.
-    # Block ends at the next `- name:` or the end of the actions list.
-    match = body.match(/^\s*- name: #{Regexp.escape(action_name)}\b.*?(?=^\s*- name:|^---)/m)
-    return nil unless match
+  # Parse the frontmatter as standard YAML (as the real consumers do) rather than
+  # matching indentation — Psych emits actions at column 0 and their params at a
+  # deeper indent, so an indent-based scan can't tell them apart.
+  def frontmatter_actions(body)
+    return [] unless body.start_with?("---\n")
 
-    vis = match[0].match(/^\s*visibility: (public|private|shared)\b/)
-    vis && vis[1]
+    end_index = body.index("\n---\n", 4)
+    return [] unless end_index
+
+    parsed = YAML.safe_load(body[4...end_index], permitted_classes: [Time, Symbol]) || {}
+    Array(parsed["actions"])
+  end
+
+  def visibility_for(body, action_name)
+    action = frontmatter_actions(body).find { |a| a["name"] == action_name }
+    action && action["visibility"]
   end
 
   test "agent-private actions carry visibility: private in /whoami frontmatter" do
@@ -67,10 +75,8 @@ class MarkdownVisibilityFrontmatterTest < ActionDispatch::IntegrationTest
     get "/notifications", headers: { "Accept" => "text/markdown" }
     assert_response :success
 
-    # Parse every action listed in the frontmatter and assert each is private.
-    # Match only top-level action entries (exactly 2-space indent) — deeper
-    # `- name:` lines inside `params:` blocks don't count.
-    listed = response.body.scan(/^  - name: ([a-z_]+)\b/).flatten
+    # Assert every listed action resolves to private (path-based rule).
+    listed = frontmatter_actions(response.body).map { |a| a["name"] }
     assert listed.any?, "expected notifications frontmatter to list at least one action"
 
     listed.each do |action_name|

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -209,8 +209,10 @@ class SearchTest < ActionDispatch::IntegrationTest
   test "GET search markdown includes path with query in frontmatter" do
     get search_path, params: { q: "test query" }, headers: @headers.merge("Accept" => "text/markdown")
     assert_response :success
-    # The frontmatter should include path with the query
-    assert_match "path: /search?q=", response.body
+    # The frontmatter path (standard YAML, so parse it) carries the query.
+    frontmatter = YAML.safe_load(response.body[/\A---\n(.*?)\n---\n/m, 1], permitted_classes: [Time, Symbol])
+    assert frontmatter["path"].start_with?("/search?q="),
+      "Frontmatter path should preserve ?q= for search, got #{frontmatter["path"].inspect}"
   end
 
   # People search — Phase 1 of discoverability


### PR DESCRIPTION
## Summary

The `.md` page frontmatter is a wire protocol: Rails, the agent-runner, and external clients all read it. Both ends were hand-rolling YAML — Rails hand-templated the block with a bespoke scalar escaper, and the agent-runner grep-and-sliced it with a parser hard-coded to the exact whitespace Rails happened to produce. That coupling is what made the original scalar-injection bug possible (a note title with an interior newline could break out of its scalar and corrupt/inject frontmatter keys) and would break the instant either side's formatting drifted.

This replaces both with the standard tools.

**Commit 1 — harden the escaper** (the original finding): a note title with an interior newline (or control char) slipped through `yaml_escape` unquoted and corrupted the frontmatter, or was silently folded/retyped.

**Commit 2 — rip the pattern out on both sides:**
- **Rails (emit):** builds an ordered Hash and serializes it with Psych (`YAML.dump`). There is no hand-rolled escaper left to get wrong, so scalar injection and silent retyping (a note titled `true` arriving as a boolean) are impossible by construction. `markdown_frontmatter_block` is a pure, unit-testable serializer; the 33-line hand-templated block collapses to `<%= page_frontmatter %>`.
- **agent-runner (parse):** replaces the grep-and-slice parser with a real parse of the fenced block via the `yaml` package, reading `actions[].name` and `path` from parsed data — format-agnostic, exactly as any external client would.

## Deploy sequencing (cross-package)

The agent-runner ships independently of Rails. A real YAML parser accepts **both** the current hand-emitted format and Psych's canonical output, so the safe order is **runner first**, then the Rails format change. No flag-day.

## Test changes

Several test helpers did the same naive parsing we removed — converted to parse the frontmatter as YAML:
- `page_path` / `page_title` extraction and inline `path:` regexes (Psych quotes paths: `path: "/..."`).
- An indent-coupled action scan that Psych's column-0 sequences had quietly turned into a **vacuous pass** — now asserts action exclusion against parsed data.

## Verification

- Rails: all touched suites green (351 combined), Sorbet + RuboCop clean.
- agent-runner: 299 tests (incl. new fixtures for column-0 sequences, quoted paths, nested-param `name`, block-scalar titles), typecheck + build clean.

## Follow-up (not in this PR)

Two signup `.md.erb` templates (`invite_required`, `confirm_invite`) still hand-emit frontmatter (they render `layout: false`). Safe today — all values are static — but the last instances of the reversed pattern; worth migrating when next touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)