### PR TITLE
Document the setup-sprite path and fix the npm Trusted Publishing workflow

### DIFF
--- a/.github/workflows/publish-harmonic-bridge.yml
+++ b/.github/workflows/publish-harmonic-bridge.yml
@@ -22,6 +22,12 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update npm for Trusted Publishing
+        # The OIDC credential exchange requires npm >= 11.5.1; Node 22
+        # bundles npm 10.x, which silently publishes unauthenticated and
+        # fails with a masked E404.
+        run: npm install -g npm@11
+
       - name: Install dependencies
         working-directory: harmonic-bridge
         run: npm ci

--- a/app/assets/stylesheets/pulse/_layout.css
+++ b/app/assets/stylesheets/pulse/_layout.css
@@ -111,7 +111,7 @@
 /* Center the logo relative to the window at every width. In-flow, space-between
    would center it between the left control and the right cluster, which reads
    as off-center against the full width. Absolute positioning lifts it out of
-   flow so the left slot (places toggle on desktop, back button on mobile #322)
+   flow so the left slot (places toggle on desktop, back button on mobile, issue 322)
    and the right cluster flank a truly centered logo. */
 .pulse-top-header .pulse-logo {
   position: absolute;

--- a/app/controllers/ai_agent_bridge_setups_controller.rb
+++ b/app/controllers/ai_agent_bridge_setups_controller.rb
@@ -26,6 +26,14 @@ class AiAgentBridgeSetupsController < ApplicationController
     :describe_cancel_harmonic_bridge_setup, :execute_cancel_harmonic_bridge_setup,
   ]
 
+  # GET /ai-agents/:handle/bridge-setup/:public_id
+  def show
+    @page_title = "harmonic-bridge setup — #{@ai_agent.display_name}"
+    @public_setup_url = harmonic_bridge_setup_url(public_id: @setup.public_id)
+    @bridge_add_command = "harmonic-bridge add --from #{@public_setup_url}"
+    @sprite_setup_command = "npx @ibis-coordination/harmonic-bridge setup-sprite --from #{@public_setup_url} --harness claude-code"
+  end
+
   # GET /ai-agents/:handle/bridge-setup
   def new
     @page_title = "Connect harmonic-bridge — #{@ai_agent.display_name}"
@@ -34,13 +42,6 @@ class AiAgentBridgeSetupsController < ApplicationController
     # bounce off HarmonicBridgeSetup's no_existing_notification_webhook_for_agent
     # validation. The model validation is still the real guard.
     @notification_webhook = AutomationRule.tenant_scoped_only.notification_webhook_for(@ai_agent).first
-  end
-
-  # GET /ai-agents/:handle/bridge-setup/:public_id
-  def show
-    @page_title = "harmonic-bridge setup — #{@ai_agent.display_name}"
-    @public_setup_url = harmonic_bridge_setup_url(public_id: @setup.public_id)
-    @bridge_add_command = "harmonic-bridge add --from #{@public_setup_url}"
   end
 
   # GET /ai-agents/:handle/bridge-setup/actions
@@ -74,18 +75,18 @@ class AiAgentBridgeSetupsController < ApplicationController
     )
     if setup.errors.any?
       return render_action_error({
-                                   action_name: "connect_harmonic_bridge",
-                                   resource: @ai_agent,
-                                   error: setup.errors.full_messages.to_sentence,
-                                 })
+        action_name: "connect_harmonic_bridge",
+        resource: @ai_agent,
+        error: setup.errors.full_messages.to_sentence,
+      })
     end
 
     render_action_success({
-                            action_name: "connect_harmonic_bridge",
-                            resource: @ai_agent,
-                            result: "Bridge setup URL minted. Paste the command on your bridge host.",
-                            redirect_to: ai_agent_bridge_setup_path(@ai_agent.handle, setup.public_id),
-                          })
+      action_name: "connect_harmonic_bridge",
+      resource: @ai_agent,
+      result: "Bridge setup URL minted. Paste the command on your bridge host.",
+      redirect_to: ai_agent_bridge_setup_path(@ai_agent.handle, setup.public_id),
+    })
   end
 
   # GET /ai-agents/:handle/bridge-setup/:public_id/actions/cancel_harmonic_bridge_setup
@@ -103,11 +104,11 @@ class AiAgentBridgeSetupsController < ApplicationController
     @setup.destroy!
 
     render_action_success({
-                            action_name: "cancel_harmonic_bridge_setup",
-                            resource: @setup,
-                            result: "Bridge setup cancelled.",
-                            redirect_to: ai_agent_settings_path(@ai_agent.handle),
-                          })
+      action_name: "cancel_harmonic_bridge_setup",
+      resource: @setup,
+      result: "Bridge setup cancelled.",
+      redirect_to: ai_agent_settings_path(@ai_agent.handle),
+    })
   end
 
   private
@@ -123,7 +124,7 @@ class AiAgentBridgeSetupsController < ApplicationController
     return render(status: :not_found, plain: "404 Not Found") if tu.nil?
 
     @ai_agent = tu.user
-    return render(status: :not_found, plain: "404 Not Found") unless @ai_agent.external_ai_agent?
+    render(status: :not_found, plain: "404 Not Found") unless @ai_agent.external_ai_agent?
   end
 
   def authorize_parent

--- a/app/views/ai_agent_bridge_setups/show.html.erb
+++ b/app/views/ai_agent_bridge_setups/show.html.erb
@@ -31,8 +31,9 @@
         </p>
       </section>
     <% else %>
-      <%# === Active setup: show the command to paste === %>
+      <%# === Active setup: show the commands to paste === %>
       <section class="pulse-settings-section">
+        <h2 class="pulse-section-title">On your own host</h2>
         <p>
           On the host where <code>harmonic-bridge</code> is running, paste the command below into a terminal.
           It exchanges this URL for an MCP token + a notification webhook subscription, then verifies the
@@ -47,6 +48,27 @@
         <p class="pulse-hint">
           Expires <%= time_ago_in_words(@setup.expires_at, include_seconds: true) %> from now
           (<%= l(@setup.expires_at, format: :short) %>).
+        </p>
+      </section>
+
+      <section class="pulse-settings-section">
+        <h2 class="pulse-section-title">On a Fly.io Sprite</h2>
+        <p>
+          If you use <a href="https://sprites.dev" target="_blank" rel="noopener">Fly.io Sprites</a>,
+          one command creates the sprite, installs <code>harmonic-bridge</code> on it, and connects
+          <%= @ai_agent.display_name %>. Install and authenticate the Sprites CLI first — see the
+          <a href="https://docs.sprites.dev" target="_blank" rel="noopener">Sprites documentation</a> —
+          then run this on your computer:
+        </p>
+
+        <div style="display:flex;gap:8px;align-items:flex-start;">
+          <pre class="pulse-form-input" style="flex:1;min-width:0;font-family:var(--font-family-mono);margin:0;white-space:pre-wrap;word-break:break-all;"><%= @sprite_setup_command %></pre>
+          <%= render 'shared/copy_button', text: @sprite_setup_command %>
+        </div>
+        <p class="pulse-hint">
+          <code>--harness claude-code</code> preconfigures a Claude Code wake command and hands off to
+          <code>claude login</code>. The flag is optional — omit it to wire up a different harness yourself.
+          See <a href="/help/self-hosting-agents">self-hosting agents</a> for details.
         </p>
       </section>
 

--- a/app/views/ai_agent_bridge_setups/show.md.erb
+++ b/app/views/ai_agent_bridge_setups/show.md.erb
@@ -5,13 +5,25 @@ This setup URL has expired. The operator must mint a fresh one from the agent's 
 
 * [Back to agent settings](<%= ai_agent_settings_path(@ai_agent.handle) %>)
 <% else %>
-On the host where `harmonic-bridge` is running, paste this command into a terminal:
+## On a host running `harmonic-bridge`
+
+Paste this command into a terminal on that host:
 
 ```
 harmonic-bridge add --from <%= @public_setup_url %>
 ```
 
 The command exchanges this URL for an MCP token plus a notification webhook subscription, then asks Harmonic to send a test delivery to confirm the bridge is reachable before enabling the webhook.
+
+## On a Fly.io Sprite
+
+For operators using [Fly.io Sprites](https://sprites.dev): with the Sprites CLI installed and authenticated (see the [Sprites documentation](https://docs.sprites.dev)), one command on the operator's computer creates the sprite, installs `harmonic-bridge` on it, and redeems this setup URL in-sprite:
+
+```
+<%= @sprite_setup_command %>
+```
+
+`--harness claude-code` preconfigures a Claude Code wake command and hands off to `claude login`. The flag is optional; omit it to wire up a different harness manually. See [self-hosting agents](/help/self-hosting-agents).
 
 | Property | Value |
 |----------|-------|

--- a/app/views/help/self_hosting_agents.md.erb
+++ b/app/views/help/self_hosting_agents.md.erb
@@ -23,13 +23,29 @@ npm install -g @ibis-coordination/harmonic-bridge
 
 The host must be reachable from the public internet over HTTPS — a cloud VM with a TLS certificate, a reverse proxy on a domain you own, or a tunnel like [cloudflared](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) or [ngrok](https://ngrok.com/).
 
+### Hosting on Fly.io Sprites
+
+If the host is a [Fly.io Sprite](https://sprites.dev) — a micro-VM that hibernates when idle, wakes on incoming requests, and comes with a public HTTPS URL — `setup-sprite` automates the bridge setup. With the Sprites CLI installed and authenticated (see the [Sprites documentation](https://docs.sprites.dev)), run:
+
+```
+npx @ibis-coordination/harmonic-bridge setup-sprite --from <URL> --harness claude-code
+```
+
+The `<URL>` comes from the agent's settings page — see [Connect an agent](#connect-an-agent) below. The `setup-sprite` command creates the sprite, installs `harmonic-bridge` inside it, configures hibernation-safe wake handling, and redeems the setup URL from inside the sprite. The Sprites account belongs to the operator; Harmonic never controls the machine.
+
+The `--harness` flag is explicit opt-in: `--harness claude-code` writes a ready-to-use Claude Code wake command and hands off to `claude login`. Without the flag, no harness is assumed — the setup finishes with a stub `wake_command` for the operator to replace, and the daemon config's `timeout_seconds` should be set so a hung wake can't hold the sprite awake (and billed) indefinitely.
+
+Re-running `setup-sprite` is safe: each step checks before acting, so it repairs a partial setup.
+
 ### Connect an agent
 
-On the agent's settings page in Harmonic, click **"Connect harmonic-bridge"** under "Connect a client". Harmonic shows a command for you to copy and execute on your host machine. The command follows the following format with a single-use URL that is valid for 15 minutes.
+On the agent's settings page in Harmonic, click **"Connect harmonic-bridge"** under "Connect a client". Harmonic shows setup commands embedding a single-use URL that is valid for 15 minutes. On the host where the bridge daemon is running:
 
 ```
 harmonic-bridge add --from <URL>
 ```
+
+(On a Sprite, `setup-sprite --from <URL>` runs this step in-sprite for you.)
 
 The command initiates a handshake with Harmonic that verifies the webhook endpoint is reachable and responding properly, then stores the received credentials in the secrets manager configured on the host. If the handshake fails, no credentials are issued — fix the cause, click "Connect harmonic-bridge" for a fresh URL, and try again.
 

--- a/test/controllers/ai_agent_bridge_setups_controller_test.rb
+++ b/test/controllers/ai_agent_bridge_setups_controller_test.rb
@@ -95,6 +95,36 @@ class AiAgentBridgeSetupsControllerTest < ActionDispatch::IntegrationTest
     assert_match(%r{harmonic-bridge add --from \S+/bridge-setups/#{Regexp.escape(setup.public_id)}}, response.body)
   end
 
+  test "GET show: offers the Sprites path with the setup-sprite command" do
+    setup = make_setup
+    get show_path(setup.public_id)
+    assert_response :ok
+
+    sprite_command_re =
+      %r{npx @ibis-coordination/harmonic-bridge setup-sprite --from \S+/bridge-setups/#{Regexp.escape(setup.public_id)} --harness claude-code}
+    add_command_re = %r{harmonic-bridge add --from \S+/bridge-setups/#{Regexp.escape(setup.public_id)}}
+
+    assert_match(sprite_command_re, response.body)
+    assert_match(add_command_re, response.body)
+    # Sprites is one option among others, listed after the generic host path.
+    assert_operator response.body.index(add_command_re), :<, response.body.index(sprite_command_re)
+    assert_no_match(/recommended/i, response.body)
+    # Sprites setup itself is Fly's product — link to their docs, don't inline them.
+    assert_match(/docs\.sprites\.dev/, response.body)
+    assert_no_match(/install\.sh/, response.body)
+  end
+
+  test "GET show: markdown view also offers the Sprites path" do
+    setup = make_setup
+    get show_path(setup.public_id), headers: { "Accept" => "text/markdown" }
+    assert_response :ok
+    assert_match(
+      %r{npx @ibis-coordination/harmonic-bridge setup-sprite --from \S+/bridge-setups/#{Regexp.escape(setup.public_id)} --harness claude-code},
+      response.body
+    )
+    assert_match(%r{harmonic-bridge add --from \S+/bridge-setups/#{Regexp.escape(setup.public_id)}}, response.body)
+  end
+
   test "GET show: also serves text/markdown for the fetch_page flow" do
     setup = make_setup
     get show_path(setup.public_id), headers: { "Accept" => "text/markdown" }
@@ -134,6 +164,7 @@ class AiAgentBridgeSetupsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_match(/expired/i, response.body)
     assert_no_match(/harmonic-bridge add --from \S*#{Regexp.escape(setup.public_id)}/, response.body)
+    assert_no_match(/setup-sprite --from \S*#{Regexp.escape(setup.public_id)}/, response.body)
   end
 
   # === POST execute_cancel_harmonic_bridge_setup ===
@@ -254,7 +285,7 @@ class AiAgentBridgeSetupsControllerTest < ActionDispatch::IntegrationTest
     # End-to-end check that the AI_AGENT_ALWAYS_BLOCKED list actually
     # routes through to a deny decision. If a future refactor changes the
     # restriction predicate or the deny path, this catches it.
-    refute CapabilityCheck.allowed?(@agent, "connect_harmonic_bridge")
-    refute CapabilityCheck.allowed?(@agent, "cancel_harmonic_bridge_setup")
+    assert_not CapabilityCheck.allowed?(@agent, "connect_harmonic_bridge")
+    assert_not CapabilityCheck.allowed?(@agent, "cancel_harmonic_bridge_setup")
   end
 end

--- a/test/controllers/help_controller_test.rb
+++ b/test/controllers/help_controller_test.rb
@@ -6,7 +6,7 @@ class HelpControllerTest < ActionDispatch::IntegrationTest
   setup do
     @tenant = @global_tenant
     @user = @global_user
-    host! "#{@tenant.subdomain}.#{ENV['HOSTNAME']}"
+    host! "#{@tenant.subdomain}.#{ENV.fetch("HOSTNAME", nil)}"
     @tenant.set_feature_flag!("api", true)
     @tenant.set_feature_flag!("external_ai_agents", true)
     sign_in_as(@user, tenant: @tenant)
@@ -88,6 +88,22 @@ class HelpControllerTest < ActionDispatch::IntegrationTest
     assert_match(/Connect harmonic-bridge/, response.body)
   end
 
+  test "/help/self-hosting-agents documents the Sprites path" do
+    get "/help/self-hosting-agents"
+    assert_response :success
+    # Sprites is one hosting option; setup-sprite automates the bridge side.
+    assert_match(/Sprites/, response.body)
+    assert_match(/setup-sprite --from/, response.body)
+    # Harness wiring is explicit opt-in via --harness; no harness is assumed.
+    assert_match(/--harness/, response.body)
+    # Sprites install/auth is Fly's product — link their docs, don't inline them.
+    assert_match(/docs\.sprites\.dev/, response.body)
+    assert_no_match(/install\.sh/, response.body)
+    assert_no_match(/recommended/i, response.body)
+    # The generic-host instructions must survive alongside the Sprites path.
+    assert_match(/cloudflared|reverse proxy/, response.body)
+  end
+
   test "/help/self-hosting-agents renders in markdown too" do
     get "/help/self-hosting-agents", headers: { "Accept" => "text/markdown" }
     assert_response :success
@@ -123,8 +139,8 @@ class HelpControllerTest < ActionDispatch::IntegrationTest
     get "/help/mcp/connect/cursor"
     assert_response :success
     # Breadcrumb should expose Home > Help > MCP > Connect <Harness>
-    assert_match(/href="\/help"[^>]*>Help/, response.body)
-    assert_match(/href="\/help\/mcp"[^>]*>MCP/, response.body)
+    assert_match(%r{href="/help"[^>]*>Help}, response.body)
+    assert_match(%r{href="/help/mcp"[^>]*>MCP}, response.body)
     assert_includes response.body, "Connect Cursor"
   end
 
@@ -164,7 +180,7 @@ class HelpControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "all harness slugs render successfully" do
-    slugs = %w[cursor claude-code claude-desktop codex codex-cloud cline continue goose hermes-agent openclaw]
+    slugs = ["cursor", "claude-code", "claude-desktop", "codex", "codex-cloud", "cline", "continue", "goose", "hermes-agent", "openclaw"]
     slugs.each do |slug|
       get "/help/mcp/connect/#{slug}"
       assert_response :success, "Expected /help/mcp/connect/#{slug} to render but got #{response.status}"
@@ -185,7 +201,7 @@ class HelpControllerTest < ActionDispatch::IntegrationTest
   test "/help/agents/getting-started breadcrumb links to /help/agents" do
     get "/help/agents/getting-started"
     assert_response :success
-    assert_match(/href="\/help\/agents"[^>]*>Agents/, response.body)
+    assert_match(%r{href="/help/agents"[^>]*>Agents}, response.body)
     assert_includes response.body, "Getting started"
   end
 


### PR DESCRIPTION
## Summary

Rails-side follow-up to #526 (harmonic-bridge 0.2.1: `setup-sprite` + `hold_awake_during_wake`), plus a fix for the failed 0.2.1 npm publish.

- **Bridge-setup show page** (HTML + markdown): now offers two hosting paths — the existing `harmonic-bridge add` command for a host the operator already runs, followed by the `setup-sprite` command for operators using Fly.io Sprites. Sprites is presented neutrally (one option, listed second, never "recommended"); Sprites CLI install/auth is deferred to the official docs at docs.sprites.dev rather than inlined. The worked example uses `--harness claude-code`; the flag is explicit opt-in, with no harness assumed without it.
- **`/help/self-hosting-agents`**: matching "Hosting on Fly.io Sprites" section — what `setup-sprite` automates, the `--harness` opt-in semantics, the `timeout_seconds` caveat (hold-awake without a wake timeout can hold a sprite awake and billed indefinitely), and that re-running `setup-sprite` repairs a partial setup.
- **Publish workflow**: the `bridge-v0.2.1` publish failed with a masked E404 because Trusted Publishing's OIDC exchange requires npm >= 11.5.1, while Node 22 bundles npm 10.x (which publishes unauthenticated). Added a pinned `npm install -g npm@11` step. 0.1.0 predated the switch to Trusted Publishing, so this path had never run. After merge, publish 0.2.1 via `workflow_dispatch` from main — re-running the tag run would use the workflow as of the tag's commit.
- Drive-by: reworded a CSS comment whose `#322` issue reference tripped `check-style-guide.sh`'s hex-color scan.

CHANGELOG intentionally untouched — one entry will bundle #526 + this PR post-merge so the versions line up.

## Test plan

- New controller tests assert both commands render with the setup's real single-use URL (HTML + markdown), the generic path is listed first, "recommended" appears nowhere, no Sprites install instructions are inlined (docs link instead), and neither command renders on an expired setup.
- New help test asserts the Sprites section, the `--harness` opt-in, the docs link, and that the generic-host instructions survived.
- 55 tests / 233 assertions green across both files; rubocop, Sorbet, and all static-check scripts pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)