### PR TITLE
Sprite setup fixes, per-agent sprites, and automation-rule soft delete

### DIFF
--- a/app/controllers/agent_automations_controller.rb
+++ b/app/controllers/agent_automations_controller.rb
@@ -23,6 +23,7 @@ class AgentAutomationsController < ApplicationController
   def index
     @page_title = "Automations - #{@ai_agent.display_name}"
     @automation_rules = AutomationRule.tenant_scoped_only
+      .not_deleted
       .where(ai_agent_id: @ai_agent.id)
       .excluding_notification_webhooks
       .order(created_at: :desc)
@@ -201,7 +202,7 @@ class AgentAutomationsController < ApplicationController
 
   def execute_delete
     name = @automation_rule.name
-    @automation_rule.destroy!
+    @automation_rule.soft_delete!(by: @current_user)
 
     render_action_success({
       action_name: "delete_automation_rule",
@@ -303,6 +304,7 @@ class AgentAutomationsController < ApplicationController
 
   def set_automation_rule
     @automation_rule = AutomationRule.tenant_scoped_only
+      .not_deleted
       .where(ai_agent_id: @ai_agent.id)
       .find_by!(truncated_id: params[:automation_id])
   end

--- a/app/controllers/ai_agent_bridge_setups_controller.rb
+++ b/app/controllers/ai_agent_bridge_setups_controller.rb
@@ -33,8 +33,9 @@ class AiAgentBridgeSetupsController < ApplicationController
     @bridge_add_command = "harmonic-bridge add --from #{@public_setup_url}"
     # Each agent gets its own sprite — its own environment/workspace — so the
     # command names the sprite after the agent. Lowercased and hyphenated:
-    # sprite names become DNS subdomains (<name>-<suffix>.sprites.app).
-    sprite_name = "harmonic-#{params[:handle]}".downcase.gsub(/[^a-z0-9-]+/, "-")
+    # sprite names become DNS subdomains (<name>-<suffix>.sprites.app). Built
+    # from the canonical stored handle, not params (Brakeman taint).
+    sprite_name = "harmonic-#{@ai_agent_handle}".downcase.gsub(/[^a-z0-9-]+/, "-")
     @sprite_setup_command =
       "npx @ibis-coordination/harmonic-bridge setup-sprite --from #{@public_setup_url} --sprite-name #{sprite_name} --harness claude-code"
   end
@@ -129,6 +130,7 @@ class AiAgentBridgeSetupsController < ApplicationController
     return render(status: :not_found, plain: "404 Not Found") if tu.nil?
 
     @ai_agent = tu.user
+    @ai_agent_handle = tu.handle
     render(status: :not_found, plain: "404 Not Found") unless @ai_agent.external_ai_agent?
   end
 

--- a/app/controllers/ai_agent_bridge_setups_controller.rb
+++ b/app/controllers/ai_agent_bridge_setups_controller.rb
@@ -31,7 +31,12 @@ class AiAgentBridgeSetupsController < ApplicationController
     @page_title = "harmonic-bridge setup — #{@ai_agent.display_name}"
     @public_setup_url = harmonic_bridge_setup_url(public_id: @setup.public_id)
     @bridge_add_command = "harmonic-bridge add --from #{@public_setup_url}"
-    @sprite_setup_command = "npx @ibis-coordination/harmonic-bridge setup-sprite --from #{@public_setup_url} --harness claude-code"
+    # Each agent gets its own sprite — its own environment/workspace — so the
+    # command names the sprite after the agent. Lowercased and hyphenated:
+    # sprite names become DNS subdomains (<name>-<suffix>.sprites.app).
+    sprite_name = "harmonic-#{params[:handle]}".downcase.gsub(/[^a-z0-9-]+/, "-")
+    @sprite_setup_command =
+      "npx @ibis-coordination/harmonic-bridge setup-sprite --from #{@public_setup_url} --sprite-name #{sprite_name} --harness claude-code"
   end
 
   # GET /ai-agents/:handle/bridge-setup

--- a/app/controllers/collective_automations_controller.rb
+++ b/app/controllers/collective_automations_controller.rb
@@ -28,6 +28,7 @@ class CollectiveAutomationsController < ApplicationController
   def index
     @page_title = "Automations - #{@current_collective.name}"
     @automation_rules = AutomationRule.tenant_scoped_only
+      .not_deleted
       .where(collective_id: @current_collective.id)
       .where(ai_agent_id: nil)
       .order(created_at: :desc)
@@ -239,13 +240,13 @@ class CollectiveAutomationsController < ApplicationController
     render_action_description({
                                 action_name: "delete_automation_rule",
                                 resource: @automation_rule,
-                                description: "Permanently delete the automation rule",
+                                description: "Delete the automation rule",
                                 params: [],
                               })
   end
 
   def execute_delete
-    @automation_rule.destroy!
+    @automation_rule.soft_delete!(by: @current_user)
     render_action_success({
                             action_name: "delete_automation_rule",
                             resource: nil,
@@ -498,6 +499,7 @@ class CollectiveAutomationsController < ApplicationController
 
   def set_automation_rule
     @automation_rule = AutomationRule.tenant_scoped_only
+      .not_deleted
       .where(collective_id: @current_collective.id)
       .where(ai_agent_id: nil)
       .find_by!(truncated_id: params[:automation_id])

--- a/app/controllers/incoming_webhooks_controller.rb
+++ b/app/controllers/incoming_webhooks_controller.rb
@@ -52,6 +52,7 @@ class IncomingWebhooksController < ActionController::Base
   def find_automation_rule
     # Find within the current tenant's automation rules
     AutomationRule.tenant_scoped_only(@current_tenant.id)
+      .not_deleted
       .where(trigger_type: "webhook")
       .find_by(webhook_path: params[:webhook_path])
   end

--- a/app/controllers/notification_webhooks_controller.rb
+++ b/app/controllers/notification_webhooks_controller.rb
@@ -55,10 +55,17 @@ class NotificationWebhooksController < ApplicationController
   end
 
   # DELETE /(u|ai-agents)/:handle/webhook
-  # After destroy the webhook page would show the "create new" form, which
-  # is confusing right after a delete. Redirect to settings instead.
+  # Soft delete: hard destroy would cascade into run history and is
+  # blocked by FKs from bridge setups anyway. After delete the webhook
+  # page would show the "create new" form, which is confusing right
+  # after a delete. Redirect to settings instead.
   def destroy
-    @webhook_rule&.destroy!
+    if @webhook_rule
+      @webhook_rule.soft_delete!(by: @current_user)
+      # Mirror of the create-side sync: removing the webhook can drop the
+      # human's billable_quantity by one; push that to Stripe immediately.
+      sync_billable_quantity!
+    end
     redirect_to settings_path_for_target, notice: "Webhook deleted."
   end
 
@@ -116,7 +123,7 @@ class NotificationWebhooksController < ApplicationController
     # right after a successful billing flow.
     set_webhook_rule
     if @webhook_rule
-      sync_subscription_for_new_billable!
+      sync_billable_quantity!
       return redirect_to show_path_for_target, notice: "Billing set up — your webhook is ready."
     end
 
@@ -178,7 +185,7 @@ class NotificationWebhooksController < ApplicationController
       enabled: true
     )
     if @webhook_rule.save
-      sync_subscription_for_new_billable!
+      sync_billable_quantity!
       # Redirect so the URL bar lands on the canonical show URL — refresh-safe.
       # Secret rides through one flash round-trip in the encrypted session.
       redirect_to show_path_for_target, flash: { reveal_secret: secret }
@@ -259,11 +266,11 @@ class NotificationWebhooksController < ApplicationController
     redirect_to checkout_url, allow_other_host: true
   end
 
-  # After saving the webhook, push the updated billable_quantity to Stripe so
-  # the human is charged proration immediately. No-op for agents (skipped by
-  # the human? gate) and for humans without an active subscription (the
+  # After adding or removing a webhook, push the updated billable_quantity
+  # to Stripe so the human's proration adjusts immediately. No-op for agents
+  # (billed separately) and for humans without an active subscription (the
   # Stripe-Checkout-first path handles charging before save).
-  def sync_subscription_for_new_billable!
+  def sync_billable_quantity!
     return unless @target_user.human?
     return unless @target_user.stripe_customer&.active?
 

--- a/app/jobs/automation_scheduler_job.rb
+++ b/app/jobs/automation_scheduler_job.rb
@@ -28,7 +28,7 @@ class AutomationSchedulerJob < SystemJob
   def scheduled_rules
     AutomationRule.unscoped_for_system_job
       .where(trigger_type: "schedule")
-      .where(enabled: true)
+      .where(enabled: true, deleted_at: nil)
   end
 
   sig { params(rule: AutomationRule).void }

--- a/app/jobs/cleanup_abandoned_bridge_setups_job.rb
+++ b/app/jobs/cleanup_abandoned_bridge_setups_job.rb
@@ -31,6 +31,9 @@ class CleanupAbandonedBridgeSetupsJob < SystemJob
         rule = AutomationRule.unscoped_for_system_job.find_by(id: setup.automation_rule_id)
         token = ApiToken.unscoped_for_system_job.find_by(id: setup.api_token_id)
         setup.destroy!
+        # Hard destroy is sanctioned here, as in revert_completion!: the
+        # rule was minted by an unfinished redeem and never registered.
+        rule&.allow_hard_destroy = true
         rule&.destroy!
         token&.destroy!
       end

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -2,6 +2,7 @@
 
 class ApiToken < ApplicationRecord
   extend T::Sig
+  include HasDeletedAt
 
   self.implicit_order_column = "created_at"
   belongs_to :tenant
@@ -155,11 +156,6 @@ class ApiToken < ApplicationRecord
   end
 
   sig { returns(T::Boolean) }
-  def deleted?
-    !deleted_at.nil?
-  end
-
-  sig { returns(T::Boolean) }
   def sys_admin?
     sys_admin == true
   end
@@ -240,10 +236,11 @@ class ApiToken < ApplicationRecord
     token
   end
 
+  # Token revocation is the HasDeletedAt soft delete under its historical
+  # name; no actor column exists on api_tokens, so nothing records `by`.
   sig { void }
   def delete!
-    self.deleted_at ||= T.cast(Time.current, ActiveSupport::TimeWithZone)
-    save!
+    soft_delete!
   end
 
   sig { void }

--- a/app/models/automation_rule.rb
+++ b/app/models/automation_rule.rb
@@ -4,6 +4,7 @@ class AutomationRule < ApplicationRecord
   extend T::Sig
   include HasTruncatedId
   include MightNotBelongToCollective
+  include HasDeletedAt
 
   TRIGGER_TYPES = ["event", "schedule", "webhook", "manual"].freeze
 
@@ -27,7 +28,17 @@ class AutomationRule < ApplicationRecord
   before_validation :generate_webhook_secret, on: :create
   before_validation :generate_webhook_path, on: :create
 
-  scope :enabled, -> { where(enabled: true) }
+  # "Delete" on a rule soft-deletes it (HasDeletedAt#soft_delete!) so run
+  # history, task-run attribution, and bridge-setup references survive.
+  # Hard destroy cascades through automation_rule_runs (dependent:
+  # :destroy) and is reserved for data-retention tooling via
+  # `allow_hard_destroy`.
+  before_destroy :block_unsanctioned_hard_destroy, prepend: true
+  attr_accessor :allow_hard_destroy
+
+  # A soft-deleted rule must never fire regardless of its enabled flag —
+  # every dispatch path composes from this scope.
+  scope :enabled, -> { where(enabled: true, deleted_at: nil) }
   # Matches both the singular `event_type` (legacy) and `event_types` array forms.
   # Uses jsonb's `@>` containment operator (no `?` to escape) — array form must
   # be a JSON array of strings; the bind is a one-element JSON array literal.
@@ -50,7 +61,8 @@ class AutomationRule < ApplicationRecord
   # on (tenant_id, COALESCE(ai_agent_id, user_id)) — at most one row.
   scope :notification_webhook_for, lambda { |owner|
     column = owner.ai_agent? ? :ai_agent_id : :user_id
-    where(trigger_type: "event")
+    not_deleted
+      .where(trigger_type: "event")
       .where(column => owner.id)
       .where("(actions->>'webhook_url') IS NOT NULL")
   }
@@ -255,7 +267,7 @@ class AutomationRule < ApplicationRecord
     recipient_id = ai_agent_id || user_id
     return if recipient_id.nil?
 
-    scope = AutomationRule.tenant_scoped_only(tenant_id).where(
+    scope = AutomationRule.tenant_scoped_only(tenant_id).not_deleted.where(
       "(ai_agent_id = :rid OR user_id = :rid) AND (actions->>'webhook_url') IS NOT NULL",
       rid: recipient_id
     )
@@ -263,6 +275,23 @@ class AutomationRule < ApplicationRecord
     return unless scope.exists?
 
     errors.add(:base, "This user already has a notification webhook. Edit or delete the existing one first.")
+  end
+
+  sig { void }
+  def block_unsanctioned_hard_destroy
+    return if allow_hard_destroy
+
+    errors.add(:base, "Automation rules are soft-deleted (soft_delete!), not destroyed — destroying would cascade into run history.")
+    throw :abort
+  end
+
+  # Soft-deleting a rule also disables it and records who did it. The
+  # rule stops dispatching, disappears from listings, and stops counting
+  # for uniqueness and billing, while its row — and every run, task run,
+  # and bridge-setup row referencing it — survives.
+  sig { params(by: T.nilable(User)).returns(T::Hash[Symbol, T.untyped]) }
+  def soft_delete_updates(by)
+    { enabled: false, updated_by: by }
   end
 
   sig { void }

--- a/app/models/concerns/has_deleted_at.rb
+++ b/app/models/concerns/has_deleted_at.rb
@@ -1,0 +1,50 @@
+# typed: false
+
+# The base soft-delete contract: "delete" sets deleted_at and keeps the
+# row (for audit history and FK integrity). There is no restore — models
+# that need one build it on top (see SoftDeletable, which extends this
+# with a grace-period undo and content behaviors). Not to be confused
+# with the archived_at family (CollectiveMember, FundingPool, ...),
+# which is reversible deactivation, not deletion.
+#
+# Deliberately no default_scope here: deleted rows must stay reachable
+# through belongs_to associations (e.g. run history pages load the
+# deleted rule that produced a run), and tenancy scoping already
+# composes in ApplicationRecord. Filter with `.not_deleted` at query
+# sites instead. (SoftDeletable layers its own default_scope on top —
+# content should vanish everywhere; config and credentials should not.)
+module HasDeletedAt
+  extend ActiveSupport::Concern
+
+  included do
+    scope :not_deleted, -> { where(deleted_at: nil) }
+  end
+
+  def deleted?
+    deleted_at.present?
+  end
+
+  # Idempotent: soft-deleting a deleted row is a no-op.
+  def soft_delete!(by: nil)
+    return if deleted?
+
+    transaction do
+      update!({ deleted_at: Time.current }.merge(soft_delete_updates(by)))
+      after_soft_delete(by)
+    end
+  end
+
+  private
+
+  # Override to fold model-specific columns into the delete update —
+  # attribution (updated_by, deleted_by_id) or side effects (enabled:
+  # false). Attribution columns differ per model, which is why `by` is
+  # threaded through rather than written to a fixed column here.
+  def soft_delete_updates(_by)
+    {}
+  end
+
+  # Override for non-column side effects (search index, pins, ...).
+  # Runs inside the soft_delete! transaction.
+  def after_soft_delete(_by); end
+end

--- a/app/models/concerns/soft_deletable.rb
+++ b/app/models/concerns/soft_deletable.rb
@@ -1,12 +1,15 @@
 # typed: false
 
-# Grace-period soft delete.
+# Grace-period soft delete for content (notes, decisions, commitments,
+# user lists). Extends HasDeletedAt — the base "delete keeps the row"
+# contract — with what makes content deletion different: a restore
+# window (undo_delete!), deleted_by attribution, removal from the search
+# index and collective pins, and a default_scope (content should vanish
+# everywhere; HasDeletedAt models deliberately have no default scope).
 #
-# soft_delete! is metadata-only — sets deleted_at, deleted_by_id, and
-# hard_delete_after — and removes the row from the search index and any
-# collective pins. It does NOT touch column values; defense-in-depth comes
-# from accessor masking on each model (Note#title etc. return "[deleted]"
-# when deleted? is true).
+# soft_delete! is metadata-only — it does NOT touch column values;
+# defense-in-depth comes from accessor masking on each model
+# (Note#title etc. return "[deleted]" when deleted? is true).
 #
 # Attachments are preserved during the grace period and purged by the
 # HardDeleteExpiredRecordsJob when the row is destroyed.
@@ -16,13 +19,13 @@
 # has passed (the row should already be gone by then).
 module SoftDeletable
   extend ActiveSupport::Concern
+  include HasDeletedAt
 
   DEFAULT_GRACE_PERIOD = 30.days
 
   class GracePeriodExpired < StandardError; end
 
   included do
-    scope :not_deleted, -> { where(deleted_at: nil) }
     scope :with_deleted, -> { unscope(where: :deleted_at) }
     default_scope { not_deleted }
 
@@ -43,23 +46,12 @@ module SoftDeletable
     end
   end
 
-  def soft_delete!(by:)
-    transaction do
-      now = Time.current
-      updates = { deleted_at: now, deleted_by_id: by.id }
-      updates[:hard_delete_after] = now + DEFAULT_GRACE_PERIOD if self.class.participates_in_hard_delete?
-      update!(updates)
-      SearchIndexer.delete(self) if respond_to?(:delete_from_search_index, true)
-      collective.unpin_item!(self) if respond_to?(:collective) && collective.respond_to?(:has_pinned?) && collective.has_pinned?(self)
-      on_soft_delete if respond_to?(:on_soft_delete, true)
-    end
-  end
-
   def undo_delete!(by:)
     return unless deleted?
     if self.class.participates_in_hard_delete? && hard_delete_after.present? && hard_delete_after <= Time.current
       raise GracePeriodExpired, "#{self.class.name}##{id} grace period has expired"
     end
+
     transaction do
       updates = { deleted_at: nil, deleted_by_id: nil }
       updates[:hard_delete_after] = nil if self.class.column_names.include?("hard_delete_after")
@@ -68,14 +60,11 @@ module SoftDeletable
     end
   end
 
-  def deleted?
-    deleted_at.present?
-  end
-
   # True once the row has been finalized (content nulled, row preserved).
   # Only meaningful for models with a tombstoned_at column.
   def tombstoned?
     return false unless self.class.column_names.include?("tombstoned_at")
+
     self[:tombstoned_at].present?
   end
 
@@ -84,5 +73,19 @@ module SoftDeletable
   # content even when called on a soft-deleted record.
   def content_snapshot
     raise NotImplementedError, "#{self.class.name} must implement #content_snapshot"
+  end
+
+  private
+
+  def soft_delete_updates(by)
+    updates = { deleted_by_id: by.id }
+    updates[:hard_delete_after] = Time.current + DEFAULT_GRACE_PERIOD if self.class.participates_in_hard_delete?
+    updates
+  end
+
+  def after_soft_delete(_by)
+    SearchIndexer.delete(self) if respond_to?(:delete_from_search_index, true)
+    collective.unpin_item!(self) if respond_to?(:collective) && collective.respond_to?(:has_pinned?) && collective.has_pinned?(self)
+    on_soft_delete if respond_to?(:on_soft_delete, true)
   end
 end

--- a/app/models/harmonic_bridge_setup.rb
+++ b/app/models/harmonic_bridge_setup.rb
@@ -111,6 +111,7 @@ class HarmonicBridgeSetup < ApplicationRecord
       # that hasn't been staged yet. Other rule shapes (scheduled tasks,
       # collective-wide rules) are unrelated and stay out of scope.
       conflicting = AutomationRule.tenant_scoped_only(tenant_id)
+        .not_deleted
         .where(ai_agent_id: ai_agent_user_id)
         .where("(actions->>'webhook_url') IS NOT NULL OR name = ?", PENDING_RULE_NAME)
       raise ConflictingSetup if conflicting.exists?
@@ -190,6 +191,9 @@ class HarmonicBridgeSetup < ApplicationRecord
       rule = automation_rule
       token = api_token
       update!(api_token: nil, automation_rule: nil, webhook_registered_at: nil)
+      # Hard destroy is sanctioned here: the rule was minted moments ago by
+      # this setup's redeem! and never registered, so it has no history.
+      rule&.allow_hard_destroy = true
       rule&.destroy!
       token&.destroy!
     end
@@ -274,7 +278,7 @@ class HarmonicBridgeSetup < ApplicationRecord
   def no_existing_notification_webhook_for_agent
     return if ai_agent_user_id.blank? || tenant_id.blank?
 
-    existing = AutomationRule.tenant_scoped_only(tenant_id).where(
+    existing = AutomationRule.tenant_scoped_only(tenant_id).not_deleted.where(
       "ai_agent_id = :id AND (actions->>'webhook_url') IS NOT NULL",
       id: ai_agent_user_id
     )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -943,7 +943,7 @@ class User < ApplicationRecord
     return false if tenant_ids.empty?
 
     AutomationRule.for_user_across_tenants(self)
-      .where(tenant_id: tenant_ids)
+      .where(tenant_id: tenant_ids, deleted_at: nil)
       .where("(actions->>'webhook_url') IS NOT NULL")
       .exists?
   end

--- a/app/views/help/self_hosting_agents.md.erb
+++ b/app/views/help/self_hosting_agents.md.erb
@@ -28,10 +28,10 @@ The host must be reachable from the public internet over HTTPS — a cloud VM wi
 If the host is a [Fly.io Sprite](https://sprites.dev) — a micro-VM that hibernates when idle, wakes on incoming requests, and comes with a public HTTPS URL — `setup-sprite` automates the bridge setup. With the Sprites CLI installed and authenticated (see the [Sprites documentation](https://docs.sprites.dev)), run:
 
 ```
-npx @ibis-coordination/harmonic-bridge setup-sprite --from <URL> --harness claude-code
+npx @ibis-coordination/harmonic-bridge setup-sprite --from <URL> --sprite-name <name> --harness claude-code
 ```
 
-The `<URL>` comes from the agent's settings page — see [Connect an agent](#connect-an-agent) below. The `setup-sprite` command creates the sprite, installs `harmonic-bridge` inside it, configures hibernation-safe wake handling, and redeems the setup URL from inside the sprite. The Sprites account belongs to the operator; Harmonic never controls the machine.
+The `<URL>` comes from the agent's settings page — see [Connect an agent](#connect-an-agent) below; the command shown there fills in both the URL and a sprite name derived from the agent's handle. Each agent gets its own sprite — its own environment and workspace. The `setup-sprite` command creates the sprite, installs `harmonic-bridge` inside it, configures hibernation-safe wake handling, and redeems the setup URL from inside the sprite. The Sprites account belongs to the operator; Harmonic never controls the machine.
 
 The `--harness` flag is explicit opt-in: `--harness claude-code` writes a ready-to-use Claude Code wake command and hands off to `claude login`. Without the flag, no harness is assumed — the setup finishes with a stub `wake_command` for the operator to replace, and the daemon config's `timeout_seconds` should be set so a hung wake can't hold the sprite awake (and billed) indefinitely.
 

--- a/db/migrate/20260723120000_add_deleted_at_to_automation_rules.rb
+++ b/db/migrate/20260723120000_add_deleted_at_to_automation_rules.rb
@@ -1,0 +1,31 @@
+# "Delete" on an automation rule becomes archive: the rule row stays so
+# run history, task-run attribution, and bridge-setup references survive
+# (hard destroy cascades through automation_rule_runs and is blocked by
+# FKs from harmonic_bridge_setups and ai_agent_task_runs anyway).
+#
+# The one-notification-webhook-per-recipient unique index must ignore
+# archived rows, or a recipient could never create a replacement webhook
+# after deleting one.
+class AddDeletedAtToAutomationRules < ActiveRecord::Migration[7.2]
+  def up
+    add_column :automation_rules, :deleted_at, :datetime
+
+    execute "DROP INDEX IF EXISTS uniq_notification_webhook_per_user"
+    execute <<~SQL.squish
+      CREATE UNIQUE INDEX uniq_notification_webhook_per_user
+      ON automation_rules (tenant_id, COALESCE(ai_agent_id, user_id))
+      WHERE (actions->>'webhook_url') IS NOT NULL AND deleted_at IS NULL
+    SQL
+  end
+
+  def down
+    execute "DROP INDEX IF EXISTS uniq_notification_webhook_per_user"
+    execute <<~SQL.squish
+      CREATE UNIQUE INDEX uniq_notification_webhook_per_user
+      ON automation_rules (tenant_id, COALESCE(ai_agent_id, user_id))
+      WHERE (actions->>'webhook_url') IS NOT NULL
+    SQL
+
+    remove_column :automation_rules, :deleted_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -353,7 +353,8 @@ CREATE TABLE public.automation_rules (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     truncated_id character varying GENERATED ALWAYS AS ("left"((id)::text, 8)) STORED NOT NULL,
-    updated_by_id uuid
+    updated_by_id uuid,
+    deleted_at timestamp(6) without time zone
 );
 
 
@@ -6612,7 +6613,7 @@ CREATE INDEX search_index_p9_tenant_id_replying_to_id_idx ON public.search_index
 -- Name: uniq_notification_webhook_per_user; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX uniq_notification_webhook_per_user ON public.automation_rules USING btree (tenant_id, COALESCE(ai_agent_id, user_id)) WHERE ((actions ->> 'webhook_url'::text) IS NOT NULL);
+CREATE UNIQUE INDEX uniq_notification_webhook_per_user ON public.automation_rules USING btree (tenant_id, COALESCE(ai_agent_id, user_id)) WHERE (((actions ->> 'webhook_url'::text) IS NOT NULL) AND (deleted_at IS NULL));
 
 
 --
@@ -10628,6 +10629,7 @@ ALTER TABLE ONLY public.decision_audit_entries
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260723120000'),
 ('20260719130000'),
 ('20260719120000'),
 ('20260719090000'),

--- a/harmonic-bridge/package-lock.json
+++ b/harmonic-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ibis-coordination/harmonic-bridge",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ibis-coordination/harmonic-bridge",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.6.0"

--- a/harmonic-bridge/package.json
+++ b/harmonic-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibis-coordination/harmonic-bridge",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Webhook bridge daemon for running Harmonic AI agents on your own hardware.",
   "type": "module",
   "main": "dist/index.js",

--- a/harmonic-bridge/src/setup-sprite.test.ts
+++ b/harmonic-bridge/src/setup-sprite.test.ts
@@ -51,8 +51,13 @@ function makeFakeExec(overrides?: {
       if (script.includes("npm install")) return { code: 0, stdout: "added 1 package\n", stderr: "" };
       if (script.includes("harmonic-bridge init")) return { code: 0, stdout: "", stderr: "" };
       if (script.includes("base64 -d")) return { code: 0, stdout: "", stderr: "" };
-      if (script.includes("test -d /home/sprite/.claude")) {
+      if (script.includes("test -f /home/sprite/.claude/.credentials.json")) {
         return { code: overrides?.claudeAuthed ? 0 : 1, stdout: "", stderr: "" };
+      }
+      if (script.includes("test -d /home/sprite/.claude")) {
+        // The Sprites base image ships ~/.claude (settings, hooks, skills)
+        // without credentials, so a bare directory check always passes.
+        return { code: 0, stdout: "", stderr: "" };
       }
       if (script.includes("services list")) return { code: 0, stdout: "[]", stderr: "" };
       if (script.includes("services create") || script.includes("services restart")) {
@@ -173,7 +178,8 @@ test("setup-sprite: --harness claude-code opts into the claude after_add steps a
   assert.match(config, /claude-code-harness/);
 
   assert.equal(interactive.calls.length, 1, "claude login handoff expected when not authed");
-  assert.ok(interactive.calls[0]!.join(" ").includes("claude login"), `got: ${interactive.calls[0]!.join(" ")}`);
+  // `claude login` is not a subcommand; /login is the CLI's login flow.
+  assert.ok(interactive.calls[0]!.join(" ").includes("claude /login"), `got: ${interactive.calls[0]!.join(" ")}`);
 });
 
 test("setup-sprite: skips the login handoff when claude is already authed in the sprite", async () => {

--- a/harmonic-bridge/src/setup-sprite.ts
+++ b/harmonic-bridge/src/setup-sprite.ts
@@ -54,10 +54,14 @@ interface HarnessDefinition {
 const HARNESSES: Readonly<Record<string, HarnessDefinition>> = Object.freeze({
   "claude-code": {
     afterAdd: ["claude-code-per-agent-mcp-config", "claude-code-harness"],
-    authCheckScript: "test -d /home/sprite/.claude",
-    authCommand: (spriteName) => ["sprite", "exec", "-s", spriteName, "--", "claude", "login"],
+    // The Sprites base image ships ~/.claude (settings, hooks) with no
+    // credentials — only the credentials file proves a completed login.
+    authCheckScript: "test -f /home/sprite/.claude/.credentials.json",
+    authCommand: (spriteName) => ["sprite", "exec", "-s", spriteName, "--", "claude", "/login"],
     authInstructions:
-      "Claude Code needs a one-time login inside the sprite. A browser URL will be\nprinted — open it, authorize, and paste the code back.",
+      "Claude Code needs a one-time login inside the sprite. In the Claude session\n" +
+      "that opens, complete the login (open the printed URL, authorize, paste the\n" +
+      "code back), then exit Claude (/exit) to continue.",
   },
 });
 

--- a/sorbet/rbi/dsl/api_token.rbi
+++ b/sorbet/rbi/dsl/api_token.rbi
@@ -514,6 +514,9 @@ class ApiToken
     def none(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+    def not_deleted(*args, &blk); end
+
+    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
     def null_relation?(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
@@ -1862,6 +1865,9 @@ class ApiToken
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
     def none(*args, &blk); end
+
+    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+    def not_deleted(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
     def null_relation?(*args, &blk); end

--- a/sorbet/rbi/dsl/automation_rule.rbi
+++ b/sorbet/rbi/dsl/automation_rule.rbi
@@ -181,6 +181,7 @@ class AutomationRule
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         block: T.proc.params(object: ::AutomationRule).void
       ).void
@@ -191,10 +192,11 @@ class AutomationRule
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol
       ).returns(T::Enumerator[::AutomationRule])
     end
-    def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
+    def find_each(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
 
     sig do
       params(
@@ -202,6 +204,7 @@ class AutomationRule
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         block: T.proc.params(object: T::Array[::AutomationRule]).void
       ).void
@@ -212,10 +215,11 @@ class AutomationRule
         finish: T.untyped,
         batch_size: Integer,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol
       ).returns(T::Enumerator[T::Enumerator[::AutomationRule]])
     end
-    def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, order: :asc, &block); end
+    def find_in_batches(start: nil, finish: nil, batch_size: 1000, error_on_ignore: nil, cursor: primary_key, order: :asc, &block); end
 
     sig do
       params(
@@ -297,6 +301,7 @@ class AutomationRule
         finish: T.untyped,
         load: T.untyped,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         use_ranges: T.untyped,
         block: T.proc.params(object: PrivateRelation).void
@@ -309,11 +314,12 @@ class AutomationRule
         finish: T.untyped,
         load: T.untyped,
         error_on_ignore: T.untyped,
+        cursor: T.untyped,
         order: Symbol,
         use_ranges: T.untyped
       ).returns(::ActiveRecord::Batches::BatchEnumerator)
     end
-    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, order: :asc, use_ranges: nil, &block); end
+    def in_batches(of: 1000, start: nil, finish: nil, load: false, error_on_ignore: nil, cursor: primary_key, order: :asc, use_ranges: nil, &block); end
 
     sig { params(record: T.untyped).returns(T::Boolean) }
     def include?(record); end
@@ -673,6 +679,9 @@ class AutomationRule
     def none(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
+    def not_deleted(*args, &blk); end
+
+    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
     def notification_webhook_for(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateAssociationRelation) }
@@ -1025,6 +1034,51 @@ class AutomationRule
     sig { void }
     def created_by_id_will_change!; end
 
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deleted_at; end
+
+    sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deleted_at=(value); end
+
+    sig { returns(T::Boolean) }
+    def deleted_at?; end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deleted_at_before_last_save; end
+
+    sig { returns(T.untyped) }
+    def deleted_at_before_type_cast; end
+
+    sig { returns(T::Boolean) }
+    def deleted_at_came_from_user?; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def deleted_at_change; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def deleted_at_change_to_be_saved; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def deleted_at_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deleted_at_in_database; end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def deleted_at_previous_change; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def deleted_at_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deleted_at_previously_was; end
+
+    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
+    def deleted_at_was; end
+
+    sig { void }
+    def deleted_at_will_change!; end
+
     sig { returns(T.nilable(::String)) }
     def description; end
 
@@ -1359,6 +1413,9 @@ class AutomationRule
     def restore_created_by_id!; end
 
     sig { void }
+    def restore_deleted_at!; end
+
+    sig { void }
     def restore_description!; end
 
     sig { void }
@@ -1444,6 +1501,12 @@ class AutomationRule
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def saved_change_to_created_by_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
+    def saved_change_to_deleted_at; end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def saved_change_to_deleted_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
     def saved_change_to_description; end
@@ -1971,6 +2034,9 @@ class AutomationRule
     def will_save_change_to_created_by_id?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
+    def will_save_change_to_deleted_at?(from: T.unsafe(nil), to: T.unsafe(nil)); end
+
+    sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
     def will_save_change_to_description?(from: T.unsafe(nil), to: T.unsafe(nil)); end
 
     sig { params(from: T.untyped, to: T.untyped).returns(T::Boolean) }
@@ -2151,6 +2217,9 @@ class AutomationRule
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
     def none(*args, &blk); end
+
+    sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
+    def not_deleted(*args, &blk); end
 
     sig { params(args: T.untyped, blk: T.untyped).returns(PrivateRelation) }
     def notification_webhook_for(*args, &blk); end

--- a/sorbet/rbi/shims/has_deleted_at.rbi
+++ b/sorbet/rbi/shims/has_deleted_at.rbi
@@ -1,0 +1,11 @@
+# typed: true
+
+# Types for the HasDeletedAt concern (the concern itself is typed: false
+# because it reads the including model's deleted_at column).
+module HasDeletedAt
+  sig { returns(T::Boolean) }
+  def deleted?; end
+
+  sig { params(by: T.nilable(User)).void }
+  def soft_delete!(by: nil); end
+end

--- a/test/controllers/agent_automations_controller_test.rb
+++ b/test/controllers/agent_automations_controller_test.rb
@@ -243,13 +243,49 @@ class AgentAutomationsControllerTest < ActionDispatch::IntegrationTest
   test "parent can delete automation" do
     rule = create_automation_rule(name: "To Delete")
 
-    assert_difference "AutomationRule.unscoped.count", -1 do
+    assert_no_difference "AutomationRule.unscoped.count" do
       post "/ai-agents/#{@ai_agent.handle}/automations/#{rule.truncated_id}/actions/delete_automation_rule",
            headers: @headers
     end
 
     assert_response :success
     assert_includes response.body, "deleted"
+    rule.reload
+    assert_not_nil rule.deleted_at
+
+    # Soft-deleted rules disappear from the automations index.
+    get "/ai-agents/#{@ai_agent.handle}/automations", headers: @headers
+    assert_not_includes response.body, "To Delete"
+  end
+
+  test "delete succeeds for a rule with dispatch history and keeps that history" do
+    rule = create_automation_rule(name: "Ran Tasks")
+    task_run = AiAgentTaskRun.unscoped.create!(
+      tenant: @tenant,
+      ai_agent: @ai_agent,
+      initiated_by: @user,
+      automation_rule: rule,
+      task: "Do the thing",
+      max_steps: 10,
+      status: "completed",
+      success: true
+    )
+    rule_run = AutomationRuleRun.unscoped.create!(
+      tenant: @tenant,
+      automation_rule: rule,
+      ai_agent_task_run: task_run,
+      status: "completed"
+    )
+
+    post "/ai-agents/#{@ai_agent.handle}/automations/#{rule.truncated_id}/actions/delete_automation_rule",
+         headers: @headers
+
+    assert_response :success
+    rule.reload
+    assert_not_nil rule.deleted_at
+    # Attribution survives: the task run and rule run still reference the rule.
+    assert_equal rule.id, task_run.reload.automation_rule_id
+    assert_equal rule.id, rule_run.reload.automation_rule_id
   end
 
   # === Toggle Tests ===

--- a/test/controllers/ai_agent_bridge_setups_controller_test.rb
+++ b/test/controllers/ai_agent_bridge_setups_controller_test.rb
@@ -40,6 +40,17 @@ class AiAgentBridgeSetupsControllerTest < ActionDispatch::IntegrationTest
     s
   end
 
+  # Each agent gets its own sprite: the command names the sprite after the
+  # agent (lowercased — sprite names become DNS subdomains).
+  def sprite_command_re(setup)
+    Regexp.new(
+      "npx @ibis-coordination/harmonic-bridge setup-sprite " \
+      "--from \\S+/bridge-setups/#{Regexp.escape(setup.public_id)} " \
+      "--sprite-name harmonic-#{Regexp.escape(@agent_handle.downcase)} " \
+      "--harness claude-code"
+    )
+  end
+
   # === POST execute_connect_harmonic_bridge ===
 
   test "POST execute_connect_harmonic_bridge: mints a setup and redirects to its show page" do
@@ -100,14 +111,12 @@ class AiAgentBridgeSetupsControllerTest < ActionDispatch::IntegrationTest
     get show_path(setup.public_id)
     assert_response :ok
 
-    sprite_command_re =
-      %r{npx @ibis-coordination/harmonic-bridge setup-sprite --from \S+/bridge-setups/#{Regexp.escape(setup.public_id)} --harness claude-code}
     add_command_re = %r{harmonic-bridge add --from \S+/bridge-setups/#{Regexp.escape(setup.public_id)}}
 
-    assert_match(sprite_command_re, response.body)
+    assert_match(sprite_command_re(setup), response.body)
     assert_match(add_command_re, response.body)
     # Sprites is one option among others, listed after the generic host path.
-    assert_operator response.body.index(add_command_re), :<, response.body.index(sprite_command_re)
+    assert_operator response.body.index(add_command_re), :<, response.body.index(sprite_command_re(setup))
     assert_no_match(/recommended/i, response.body)
     # Sprites setup itself is Fly's product — link to their docs, don't inline them.
     assert_match(/docs\.sprites\.dev/, response.body)
@@ -118,10 +127,7 @@ class AiAgentBridgeSetupsControllerTest < ActionDispatch::IntegrationTest
     setup = make_setup
     get show_path(setup.public_id), headers: { "Accept" => "text/markdown" }
     assert_response :ok
-    assert_match(
-      %r{npx @ibis-coordination/harmonic-bridge setup-sprite --from \S+/bridge-setups/#{Regexp.escape(setup.public_id)} --harness claude-code},
-      response.body
-    )
+    assert_match(sprite_command_re(setup), response.body)
     assert_match(%r{harmonic-bridge add --from \S+/bridge-setups/#{Regexp.escape(setup.public_id)}}, response.body)
   end
 

--- a/test/controllers/collective_automations_controller_test.rb
+++ b/test/controllers/collective_automations_controller_test.rb
@@ -247,13 +247,19 @@ class CollectiveAutomationsControllerTest < ActionDispatch::IntegrationTest
   test "collective admin can delete automation" do
     rule = create_collective_automation_rule(name: "To Delete")
 
-    assert_difference "AutomationRule.unscoped.count", -1 do
+    assert_no_difference "AutomationRule.unscoped.count" do
       post "/collectives/#{@collective.handle}/settings/automations/#{rule.truncated_id}/actions/delete_automation_rule",
         headers: @headers
     end
 
     assert_response :success
     assert_includes response.body, "deleted"
+    rule.reload
+    assert_not_nil rule.deleted_at
+
+    # Soft-deleted rules disappear from the automations index.
+    get "/collectives/#{@collective.handle}/settings/automations", headers: @headers
+    assert_not_includes response.body, "To Delete"
   end
 
   # === Toggle Tests ===

--- a/test/controllers/incoming_webhooks_controller_test.rb
+++ b/test/controllers/incoming_webhooks_controller_test.rb
@@ -178,6 +178,17 @@ class IncomingWebhooksControllerTest < ActionDispatch::IntegrationTest
 
   # === Not Found Tests ===
 
+  test "soft-deleted rule returns 404" do
+    @automation_rule.update!(deleted_at: Time.current) # enabled flag stays true
+    payload = { "event" => "test" }.to_json
+
+    post "/hooks/#{@webhook_path}",
+      params: payload,
+      headers: valid_webhook_headers(payload)
+
+    assert_response :not_found
+  end
+
   test "unknown webhook_path returns 404" do
     payload = { "event" => "test" }.to_json
 

--- a/test/controllers/notification_webhooks_controller_test.rb
+++ b/test/controllers/notification_webhooks_controller_test.rb
@@ -195,13 +195,67 @@ class NotificationWebhooksControllerTest < ActionDispatch::IntegrationTest
 
   # === DELETE ===
 
-  test "delete removes the rule" do
-    create_webhook_for(@user)
+  test "delete soft-deletes the rule and keeps its row" do
+    rule = create_webhook_for(@user)
 
-    assert_difference "AutomationRule.count", -1 do
+    assert_no_difference "AutomationRule.unscoped.count" do
       delete "/u/#{@user_handle}/webhook"
     end
     assert_response :redirect
+
+    rule.reload
+    assert_not_nil rule.deleted_at
+    assert_not rule.enabled?
+
+    # The webhook page treats the soft-deleted rule as gone: create form again.
+    get "/u/#{@user_handle}/webhook"
+    assert_select 'form input[name="webhook_url"]'
+  end
+
+  test "delete succeeds for a bridge-connected webhook and keeps the bridge setup row" do
+    Tenant.scope_thread_to_tenant(subdomain: @tenant.subdomain)
+    bridge_setup = HarmonicBridgeSetup.create!(tenant: @tenant, ai_agent_user: @external_agent, created_by_user: @user)
+    Tenant.clear_thread_scope
+    rule = create_webhook_for(@external_agent)
+    bridge_setup.update!(automation_rule: rule, redeemed_at: Time.current, webhook_registered_at: Time.current)
+
+    delete "/ai-agents/#{@external_agent_handle}/webhook"
+    assert_response :redirect
+
+    rule.reload
+    assert_not_nil rule.deleted_at
+    bridge_setup.reload
+    assert_equal rule.id, bridge_setup.automation_rule_id
+  end
+
+  test "a replacement webhook can be created after deleting the previous one" do
+    create_webhook_for(@user)
+    delete "/u/#{@user_handle}/webhook"
+
+    patch "/u/#{@user_handle}/webhook", params: { webhook_url: "https://replacement.example.com/hook" }
+    assert_redirected_to "/u/#{@user_handle}/webhook"
+
+    assert AutomationRule.unscoped.where(user_id: @user.id)
+      .exists?(["actions->>'webhook_url' = ?", "https://replacement.example.com/hook"])
+  end
+
+  test "a soft-deleted webhook no longer counts toward has_notification_webhook?" do
+    create_webhook_for(@user)
+    assert @user.has_notification_webhook?([@tenant.id])
+
+    delete "/u/#{@user_handle}/webhook"
+    assert_not @user.has_notification_webhook?([@tenant.id])
+  end
+
+  test "delete syncs the subscription quantity down for billable humans" do
+    create_webhook_for(@user)
+    StripeCustomer.create!(billable: @user, stripe_id: "cus_#{SecureRandom.hex(4)}", active: true)
+
+    synced = []
+    StripeService.stub :sync_subscription_quantity!, ->(user) { synced << user.id } do
+      delete "/u/#{@user_handle}/webhook"
+    end
+    assert_equal [@user.id], synced
   end
 
   # === Rotate ===

--- a/test/jobs/automation_scheduler_job_test.rb
+++ b/test/jobs/automation_scheduler_job_test.rb
@@ -68,6 +68,15 @@ class AutomationSchedulerJobTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not process soft-deleted rules" do
+    rule = create_scheduled_rule(cron: "* * * * *")
+    rule.update!(deleted_at: Time.current) # enabled flag stays true
+
+    assert_no_difference "AutomationRuleRun.count" do
+      AutomationSchedulerJob.perform_now
+    end
+  end
+
   # === Cron Expression Matching (Time-Frozen Tests) ===
 
   test "fires rule at exact cron time" do

--- a/test/models/automation_rule_test.rb
+++ b/test/models/automation_rule_test.rb
@@ -610,4 +610,75 @@ class AutomationRuleTest < ActiveSupport::TestCase
     rule.actions = rule.actions.merge("webhook_url" => "https://example.com/updated")
     assert rule.valid?, rule.errors.full_messages.to_s
   end
+
+  # === Soft delete ===
+
+  def create_simple_rule(**attrs)
+    AutomationRule.create!({
+      tenant: @tenant,
+      ai_agent: @ai_agent,
+      created_by: @user,
+      name: "Archivable",
+      trigger_type: "event",
+      trigger_config: { "event_type" => "note.created" },
+      actions: { "task" => "Respond" },
+      enabled: true,
+    }.merge(attrs))
+  end
+
+  def create_webhook_rule_for(owner, url: "https://example.com/hook")
+    owner_attrs = owner.ai_agent? ? { ai_agent: owner } : { user: owner }
+    AutomationRule.create!({
+      tenant: @tenant,
+      created_by: @user,
+      name: "Webhook",
+      trigger_type: "event",
+      trigger_config: { "event_types" => ["notifications.delivered"] },
+      actions: { "webhook_url" => url },
+    }.merge(owner_attrs))
+  end
+
+  test "soft_delete! soft-deletes the rule, disables it, and records who" do
+    rule = create_simple_rule
+    rule.soft_delete!(by: @user)
+
+    rule.reload
+    assert_not_nil rule.deleted_at
+    assert_not rule.enabled?
+    assert_equal @user.id, rule.updated_by_id
+  end
+
+  test "enabled scope excludes soft-deleted rules even when the enabled flag is true" do
+    rule = create_simple_rule
+    rule.update!(deleted_at: Time.current) # enabled flag stays true
+
+    assert_not_includes AutomationRule.enabled, rule
+  end
+
+  test "notification_webhook_for excludes soft-deleted rules" do
+    rule = create_webhook_rule_for(@user)
+    assert_includes AutomationRule.notification_webhook_for(@user), rule
+
+    rule.soft_delete!(by: @user)
+    assert_empty AutomationRule.notification_webhook_for(@user)
+  end
+
+  test "a replacement webhook passes validation after the old one is soft-deleted" do
+    create_webhook_rule_for(@user).soft_delete!(by: @user)
+
+    replacement = create_webhook_rule_for(@user, url: "https://example.com/replacement")
+    assert replacement.persisted?
+  end
+
+  test "hard destroy is blocked unless explicitly allowed" do
+    rule = create_simple_rule
+    run = AutomationRuleRun.create!(tenant: @tenant, automation_rule: rule, status: "completed")
+
+    assert_raises(ActiveRecord::RecordNotDestroyed) { rule.destroy! }
+    assert AutomationRuleRun.exists?(run.id), "blocked destroy must not cascade into run history"
+
+    rule.allow_hard_destroy = true
+    rule.destroy!
+    assert_not AutomationRule.exists?(rule.id)
+  end
 end


### PR DESCRIPTION
Four commits in two threads that met in the middle: finishing the sprite-hosted bridge-agent rollout, and fixing the webhook-deletion 500 it surfaced.

## Sprite setup fixes (harmonic-bridge 0.2.2)

- **Fix the Claude Code auth check and login handoff in `setup-sprite`.** The Sprites base image ships `~/.claude` (settings, hooks, skills) with no credentials, so the bare directory check always passed and the login step was silently skipped — the first real setup produced an agent that couldn't run Claude. The check now requires `~/.claude/.credentials.json`. Also `claude login` is not a CLI subcommand; the handoff now runs `claude /login` and tells the operator to exit afterward.
- **Each agent gets its own sprite.** The bridge-setup page command previously omitted `--sprite-name`, funneling every agent an operator connects into one shared sprite named `harmonic-agent`. The page now embeds `--sprite-name harmonic-<handle>` (lowercased — sprite names become DNS subdomains), so each agent gets its own environment by default. `/help/self-hosting-agents` updated to match.

After merge: tag the merge commit `bridge-v0.2.2` to publish to npm.

## Automation-rule soft delete

Deleting a bridge-connected notification webhook 500ed: `harmonic_bridge_setups.automation_rule_id` holds an FK to the rule with no inverse association, so Postgres refused the destroy (same latent shape on `ai_agent_task_runs`). Those FK violations were accidental audit guards — a hard destroy cascades through `automation_rule_runs` (NOT NULL rule FK), wiping run status, trigger provenance, and chain metadata for exactly the rules with the richest history.

- **New `HasDeletedAt` concern** — the base soft-delete contract (delete keeps the row, no restore, deliberately no default_scope so deleted rows stay reachable through `belongs_to` for run-history pages). `SoftDeletable` now includes it and implements its hooks (side effect: re-deleting already-deleted content no longer re-extends the 30-day grace period); `ApiToken` includes it with `delete!` as a compatibility wrapper. Not to be confused with the `archived_at` family, which is reversible deactivation.
- **Rule delete is now soft delete** on all three surfaces (notification webhooks, agent automations, collective automations): the rule stops dispatching (`enabled` scope, scheduler job, inbound webhook lookup → 404), disappears from listings, stops counting for the one-webhook-per-recipient unique index and validation (both rebuilt to ignore deleted rows, so a replacement webhook can be created), and stops counting as billable. The webhook delete path now also syncs the Stripe subscription quantity down — a pre-existing gap where users kept paying for a deleted webhook.
- **Hard destroy is guarded** (`before_destroy` + `allow_hard_destroy` escape hatch, used only by the bridge-setup revert path for its just-minted, never-registered rule).

## Testing

Red-green throughout. New coverage: the bridge-connected-webhook regression itself, rule-with-task-run-history deletion keeping attribution, replacement webhook after delete, deleted rules excluded from dispatch/scheduler/inbound-webhooks/billing, Stripe sync-down on delete, hard-destroy guard, sprite-command shape (per-agent name, ordering, no vendor endorsement). Full batteries green: content-deletion/SoftDeletable/ApiToken suites (349 runs), automation controllers + dispatcher + executor + bridge-setup + billing (~570 runs), harmonic-bridge npm tests (186). Sorbet, rubocop, and all static checks pass.

Deploy: web only; one additive migration (`deleted_at` column + partial-unique-index rebuild on `automation_rules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)