### PR TITLE
harmonic-bridge 0.2.3: fix the sprite harness login path

### DIFF
--- a/harmonic-bridge/package-lock.json
+++ b/harmonic-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ibis-coordination/harmonic-bridge",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ibis-coordination/harmonic-bridge",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.6.0"

--- a/harmonic-bridge/package.json
+++ b/harmonic-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibis-coordination/harmonic-bridge",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Webhook bridge daemon for running Harmonic AI agents on your own hardware.",
   "type": "module",
   "main": "dist/index.js",

--- a/harmonic-bridge/src/add.test.ts
+++ b/harmonic-bridge/src/add.test.ts
@@ -191,6 +191,27 @@ test("add: runs after_add steps when configured", async () => {
   }
 });
 
+test("add: after_add steps are followed by a second SIGHUP so the daemon picks up their config edits", async () => {
+  // The first SIGHUP (before registration) loads the agent with the STUB
+  // wake_command; harness after_add steps rewrite it on disk. Without a
+  // reload the daemon keeps executing the stub — webhooks 204 but every
+  // wake fails with "wake_command not configured".
+  const f = makeFixture({ afterAdd: `after_add:\n  - command: 'printf STEP-RAN > $HARMONIC_BRIDGE_AGENT_DIR/probe.txt'\n` });
+  try {
+    const { fetch: fakeFetch } = recordingFetch([() => makeMetadataResponse(), () => makeOkResponse()]);
+    const signals: Array<[number, NodeJS.Signals]> = [];
+    const code = await runAdd(["--from", SETUP_URL], {
+      configDir: f.configDir,
+      fetch: fakeFetch,
+      kill: (pid, sig) => { signals.push([pid, sig]); },
+    });
+    assert.equal(code, 0);
+    assert.deepEqual(signals.map((s) => s[1]), ["SIGHUP", "SIGHUP"]);
+  } finally {
+    f.cleanup();
+  }
+});
+
 // ---------- argument + config-side errors ----------
 
 test("add: missing --from returns 64 with usage", async () => {

--- a/harmonic-bridge/src/add.ts
+++ b/harmonic-bridge/src/add.ts
@@ -213,6 +213,18 @@ export async function runAdd(args: readonly string[], opts: AddOpts): Promise<nu
         else stderr.write(`  FAIL ${tag} — ${result.error}\n`);
       },
     });
+
+    // The SIGHUP in step 5 loaded the agent with the stub wake_command;
+    // steps like the claude-code harness rewrite it on disk. Reload again
+    // or the daemon keeps executing the stub — webhooks ack with 204 but
+    // every wake fails with "wake_command not configured".
+    const reload = await sendSighup(opts.configDir, doKill);
+    if (!reload.ok) {
+      stderr.write(
+        `harmonic-bridge add: warning — daemon reload after after_add steps failed (${reload.error}).\n` +
+        `Run 'harmonic-bridge reload' to pick up their config changes.\n`,
+      );
+    }
   }
 
   // 8. Done.

--- a/harmonic-bridge/src/setup-sprite.test.ts
+++ b/harmonic-bridge/src/setup-sprite.test.ts
@@ -73,11 +73,12 @@ function makeFakeExec(overrides?: {
   return { exec, calls };
 }
 
-function makeFakeInteractive(): { execInteractive: ExecInteractive; calls: string[][] } {
+function makeFakeInteractive(onCall?: () => void): { execInteractive: ExecInteractive; calls: string[][] } {
   const calls: string[][] = [];
   return {
     execInteractive: async (argv) => {
       calls.push([...argv]);
+      onCall?.();
       return 0;
     },
     calls,
@@ -165,8 +166,11 @@ test("setup-sprite: without --harness, no harness assumptions are made", async (
 });
 
 test("setup-sprite: --harness claude-code opts into the claude after_add steps and login flow", async () => {
-  const fake = makeFakeExec();
-  const interactive = makeFakeInteractive();
+  // The login handoff succeeds: the credentials check passes once the
+  // interactive command has run.
+  const overrides = { claudeAuthed: false };
+  const fake = makeFakeExec(overrides);
+  const interactive = makeFakeInteractive(() => { overrides.claudeAuthed = true; });
   const r = await run(["--from", FROM_URL, "--sprite-name", "my-agent", "--harness", "claude-code"], {
     exec: fake.exec,
     execInteractive: interactive.execInteractive,
@@ -178,8 +182,44 @@ test("setup-sprite: --harness claude-code opts into the claude after_add steps a
   assert.match(config, /claude-code-harness/);
 
   assert.equal(interactive.calls.length, 1, "claude login handoff expected when not authed");
+  const handoff = interactive.calls[0]!.join(" ");
   // `claude login` is not a subcommand; /login is the CLI's login flow.
-  assert.ok(interactive.calls[0]!.join(" ").includes("claude /login"), `got: ${interactive.calls[0]!.join(" ")}`);
+  assert.ok(handoff.includes("claude /login"), `got: ${handoff}`);
+  // Without a pseudo-TTY, claude runs in print mode where /login is
+  // unavailable (and exits 0 anyway).
+  assert.ok(handoff.includes("--tty"), `got: ${handoff}`);
+
+  // The time-limited single-use URL is redeemed BEFORE the human-paced
+  // login: the connection is the product, harness auth is the final
+  // additive step, and a login failure must not strand an expired URL.
+  const addIndex = fake.calls.findIndex((c) => c.script?.includes("harmonic-bridge add"));
+  assert.ok(addIndex >= 0, "expected the add step to run");
+  const authCheckIndex = fake.calls.findIndex((c) => c.script?.includes(".credentials.json"));
+  assert.ok(authCheckIndex > addIndex, "harness auth must follow the bridge connection");
+
+  // The harness just wrote a working wake command — the generic "edit
+  // wake_command" next-steps hint must not contradict it.
+  assert.doesNotMatch(r.out, /Edit wake_command/);
+});
+
+test("setup-sprite: a failed login leaves the agent connected and names the one remaining step", async () => {
+  // claude exits 0 even when /login is unavailable (print mode), so the
+  // exit code proves nothing — only the credentials check does.
+  const fake = makeFakeExec({ claudeAuthed: false });
+  const interactive = makeFakeInteractive(); // exits 0, auth stays absent
+  const r = await run(["--from", FROM_URL, "--sprite-name", "my-agent", "--harness", "claude-code"], {
+    exec: fake.exec,
+    execInteractive: interactive.execInteractive,
+  });
+
+  assert.notEqual(r.code, 0, "must fail when auth did not take");
+  // The connection already succeeded — the URL was redeemed before login.
+  const allScripts = fake.calls.map((c) => c.script ?? "").join("\n");
+  assert.match(allScripts, /harmonic-bridge add/);
+  // The fix is one manual command, not a re-run (the URL is consumed).
+  assert.match(r.err, /connected/);
+  assert.match(r.err, /sprite exec --tty/, "must show the manual login command");
+  assert.doesNotMatch(r.err, /re-run/i);
 });
 
 test("setup-sprite: skips the login handoff when claude is already authed in the sprite", async () => {

--- a/harmonic-bridge/src/setup-sprite.ts
+++ b/harmonic-bridge/src/setup-sprite.ts
@@ -57,7 +57,9 @@ const HARNESSES: Readonly<Record<string, HarnessDefinition>> = Object.freeze({
     // The Sprites base image ships ~/.claude (settings, hooks) with no
     // credentials — only the credentials file proves a completed login.
     authCheckScript: "test -f /home/sprite/.claude/.credentials.json",
-    authCommand: (spriteName) => ["sprite", "exec", "-s", spriteName, "--", "claude", "/login"],
+    // --tty is required: without a pseudo-TTY claude runs in print mode,
+    // where /login is unavailable (and exits 0 anyway).
+    authCommand: (spriteName) => ["sprite", "exec", "--tty", "-s", spriteName, "--", "claude", "/login"],
     authInstructions:
       "Claude Code needs a one-time login inside the sprite. In the Claude session\n" +
       "that opens, complete the login (open the printed URL, authorize, paste the\n" +
@@ -154,23 +156,9 @@ export async function runSetupSprite(args: readonly string[], opts: SetupSpriteO
     if (create.code !== 0) return fail(stderr, "create service", create);
   }
 
-  // 7. Harness auth (only with an explicit --harness).
-  if (harness && harnessName) {
-    const check = await inSprite(harness.authCheckScript);
-    if (check.code !== 0) {
-      stdout.write(`\n${harness.authInstructions}\n\n`);
-      const authCode = await execInteractive(harness.authCommand(spriteName));
-      if (authCode !== 0) {
-        stderr.write(`harmonic-bridge setup-sprite: ${harnessName} auth did not complete. Re-run to retry.\n`);
-        return 1;
-      }
-    } else {
-      stdout.write(`${harnessName} already authenticated in the sprite.\n`);
-    }
-  }
-
-  // 8. Redeem the setup URL in-sprite. Single-use: this is the only place
-  //    it is ever used, and only once.
+  // 7. Redeem the setup URL in-sprite. Single-use AND time-limited: this
+  //    runs before any human-paced step so the URL can't expire mid-setup,
+  //    and it is the only place the URL is ever used, only once.
   stdout.write("Connecting the agent to Harmonic…\n");
   const add = await inSprite(`${BRIDGE_BIN} add --from ${shellQuote(fromUrl)}`);
   if (add.code !== 0) {
@@ -181,9 +169,15 @@ export async function runSetupSprite(args: readonly string[], opts: SetupSpriteO
     );
     return 1;
   }
-  stdout.write(indent(add.stdout.trim()) + "\n");
+  // With a harness, its after_add step just wrote a working wake command —
+  // drop the generic "edit wake_command" next-steps hint, which would
+  // contradict it.
+  const addOutput = harness
+    ? add.stdout.split(/\n\s*Next steps:[\s\S]*/)[0]!.trim()
+    : add.stdout.trim();
+  stdout.write(indent(addOutput) + "\n");
 
-  // 9. Smoke probe: a GET must reach the daemon and be rejected with 405.
+  // 8. Smoke probe: a GET must reach the daemon and be rejected with 405.
   let probeNote = "";
   try {
     const probe = await doFetch(`${publicUrl}/webhook/probe`, { method: "GET" });
@@ -194,6 +188,31 @@ export async function runSetupSprite(args: readonly string[], opts: SetupSpriteO
     probeNote = `Probe WARNING: could not reach ${publicUrl}/webhook/probe — ${e instanceof Error ? e.message : String(e)}\n`;
   }
   stdout.write(probeNote);
+
+  // 9. Harness auth, last (only with an explicit --harness): it is the one
+  //    human-paced step, so everything time-sensitive already happened. If
+  //    it fails, the agent is fully connected and exactly one manual
+  //    command remains — no re-run, the URL is already consumed.
+  if (harness && harnessName) {
+    const check = await inSprite(harness.authCheckScript);
+    if (check.code !== 0) {
+      stdout.write(`\n${harness.authInstructions}\n\n`);
+      const authCode = await execInteractive(harness.authCommand(spriteName));
+      // The exit code proves nothing (claude exits 0 even when /login is
+      // unavailable) — only the credentials check does.
+      const verify = await inSprite(harness.authCheckScript);
+      if (authCode !== 0 || verify.code !== 0) {
+        stderr.write(
+          `harmonic-bridge setup-sprite: ${harnessName} auth did not complete.\n` +
+          `The agent is connected to Harmonic, but wakes will fail until the login is done.\n` +
+          `Finish it with:\n  ${harness.authCommand(spriteName).join(" ")}\n`,
+        );
+        return 1;
+      }
+    } else {
+      stdout.write(`${harnessName} already authenticated in the sprite.\n`);
+    }
+  }
 
   stdout.write("\nDone.\n");
   if (harness) {


### PR DESCRIPTION
Four fixes from the first true end-to-end run of `setup-sprite --harness claude-code` (the 0.2.2 auth-check fix exposed a path that had never executed before):

- **TTY for the login handoff** — `sprite exec` allocates no pseudo-TTY by default, so `claude /login` landed in print mode where `/login` is unavailable. Pass `--tty`; verified live that Claude then enters its interactive login flow.
- **Auth is verified, not assumed** — Claude exits 0 even in that failure mode, so the exit-code check waved it through and setup finished "Done" with an unauthenticated agent. The credentials check now re-runs after the handoff.
- **Connect first, log in last** — the login ran before the redeem step, parking the human-paced OAuth round-trip inside the setup URL's 15-minute window. Now the agent connects to Harmonic immediately and harness auth is the final step: a failed login leaves a fully connected agent and exactly one printed command to finish — no re-run, no expired URL. The generic "edit wake_command" next-steps hint is suppressed when a harness just wrote a working wake command.
- **Reload after `after_add` steps** — `add` SIGHUPs the daemon before registration (required so the verification POST finds the agent) while the config still holds the stub wake command; harness `after_add` steps rewrite it on disk, but nothing reloaded the daemon. Webhooks acked 204 while every wake executed the stale stub, printing "wake_command not configured". A second SIGHUP now follows the steps.

## Testing

Red-green throughout; 188 bridge tests green, typecheck + build clean. Verified end to end on a live sprite: fresh setup URL, reordered flow, browser login, then a Harmonic chat message woke the agent and it replied.

After merge: tag the merge commit `bridge-v0.2.3` to publish. Bridge-only — no Rails changes, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)