### PR TITLE
Scope notification-delivered events to the recipient's own rules

### DIFF
--- a/app/services/automation_dispatcher.rb
+++ b/app/services/automation_dispatcher.rb
@@ -38,30 +38,31 @@ class AutomationDispatcher
     collective_id = event.collective_id
     return [] if collective_id.nil?
 
-    # Fast path: notification-forwarding events fire per-recipient and can be
-    # high-volume. Short-circuit when the recipient (event.actor) has no
-    # notification-webhook rule. Hits the partial unique index on
-    # `(tenant_id, COALESCE(ai_agent_id, user_id))` filtered by webhook_url.
+    # Notification-delivered events fire per-recipient (event.actor is the
+    # recipient) and their content is private to that recipient: ONLY rules
+    # owned by the recipient may fire. Matching by collective membership
+    # here would deliver one member's notification payloads to every other
+    # member's webhook, and collective rules have no owner, so they never
+    # match per-recipient events. The event's collective is provenance
+    # (every Event row is collective-scoped), not a routing input — no
+    # membership check and no tier gate: the webhook forwards the
+    # notification system the recipient already has, not a paid automation.
     if NOTIFICATION_DELIVERED_EVENTS.include?(event.event_type)
       recipient_id = event.actor_id
       return [] if recipient_id.nil?
-      return [] unless AutomationRule
+
+      return AutomationRule
         .tenant_scoped_only(event.tenant_id)
         .enabled
-        .where("(actions->>'webhook_url') IS NOT NULL")
+        .for_event_type(event.event_type)
         .where("ai_agent_id = :rid OR user_id = :rid", rid: recipient_id)
-        .exists?
+        .select { |rule| matches_rule?(event, rule) }
     end
 
     collective = Collective.tenant_scoped_only(event.tenant_id).find_by(id: collective_id)
     return [] if collective.nil?
-    # Notification-forwarding events bypass the tier gate — the webhook is a
-    # forwarder for the notification system the user already has, not a paid
-    # automation. Chat collectives are free-tier; without this bypass, chat
-    # message webhooks would never fire on stripe-billing tenants.
-    unless NOTIFICATION_DELIVERED_EVENTS.include?(event.event_type)
-      return [] unless collective.tier_unlocks_paid_features?
-    end
+    # Automations are a paid feature (see method comment).
+    return [] unless collective.tier_unlocks_paid_features?
 
     # Find rules with collective access in a single query
     rules = AutomationRule
@@ -83,8 +84,13 @@ class AutomationDispatcher
   sig { params(event: Event, rule: AutomationRule).returns(T::Boolean) }
   def self.matches_rule?(event, rule)
     # Collective access check (redundant safety net — also enforced at
-    # the query level in find_matching_rules)
-    return false unless rule_has_collective_access?(rule, event)
+    # the query level in find_matching_rules). Skipped for per-recipient
+    # notification events: those match on rule ownership, and the
+    # recipient's own notification forwards regardless of their current
+    # membership state in the event's collective.
+    unless NOTIFICATION_DELIVERED_EVENTS.include?(event.event_type)
+      return false unless rule_has_collective_access?(rule, event)
+    end
 
     # Check mention filter for agent rules
     if rule.agent_rule? && rule.mention_filter.present?

--- a/test/services/automation_dispatcher_test.rb
+++ b/test/services/automation_dispatcher_test.rb
@@ -882,6 +882,105 @@ class AutomationDispatcherTest < ActiveSupport::TestCase
     assert_includes AutomationDispatcher.find_matching_rules(event), rule
   end
 
+  # === Recipient scoping for notification-delivered events ===
+
+  test "notification-delivered event fires only the recipient's rules, not other members' rules" do
+    recipient = create_ai_agent(parent: @user, name: "Recip #{SecureRandom.hex(2)}", agent_configuration: { "mode" => "external" })
+    bystander = create_ai_agent(parent: @user, name: "Bystander #{SecureRandom.hex(2)}", agent_configuration: { "mode" => "external" })
+    [recipient, bystander].each do |agent|
+      @tenant.add_user!(agent)
+      @collective.add_user!(agent)
+    end
+
+    webhook_rule = lambda do |owner_attrs, name|
+      AutomationRule.create!(
+        {
+          tenant: @tenant,
+          created_by: @user,
+          name: name,
+          trigger_type: "event",
+          trigger_config: { "event_types" => ["notifications.delivered", "reminders.delivered"] },
+          actions: { "webhook_url" => "https://example.com/#{name}" },
+          enabled: true,
+        }.merge(owner_attrs)
+      )
+    end
+    recipient_rule = webhook_rule.call({ ai_agent: recipient }, "recipient-hook")
+    bystander_rule = webhook_rule.call({ ai_agent: bystander }, "bystander-hook")
+    human_rule = webhook_rule.call({ user: @user }, "human-hook")
+
+    event = Event.create!(
+      tenant: @tenant, collective: @collective,
+      event_type: "notifications.delivered", actor: recipient, subject: @collective,
+    )
+
+    matching = AutomationDispatcher.find_matching_rules(event)
+    assert_includes matching, recipient_rule
+    # A notification is private to its recipient: another member's webhook
+    # must never receive it.
+    assert_not_includes matching, bystander_rule
+    assert_not_includes matching, human_rule
+  end
+
+  test "notification-delivered event fires the recipient's rule regardless of collective membership state" do
+    # The event's collective is provenance (every Event row is
+    # collective-scoped), not a routing input: the recipient's own
+    # notification forwards to their own endpoint, period.
+    recipient = create_ai_agent(parent: @user, name: "RecipM #{SecureRandom.hex(2)}", agent_configuration: { "mode" => "external" })
+    @tenant.add_user!(recipient)
+    @collective.add_user!(recipient)
+    rule = AutomationRule.create!(
+      tenant: @tenant,
+      ai_agent: recipient,
+      created_by: @user,
+      name: "Recipient hook",
+      trigger_type: "event",
+      trigger_config: { "event_types" => ["notifications.delivered"] },
+      actions: { "webhook_url" => "https://example.com/hook" },
+      enabled: true
+    )
+    event = Event.create!(
+      tenant: @tenant, collective: @collective,
+      event_type: "notifications.delivered", actor: recipient, subject: @collective,
+    )
+
+    @collective.collective_members.find_by(user: recipient).archive!
+    assert_includes AutomationDispatcher.find_matching_rules(event), rule
+  end
+
+  test "notification-delivered event does not fire collective rules" do
+    recipient = create_ai_agent(parent: @user, name: "RecipC #{SecureRandom.hex(2)}", agent_configuration: { "mode" => "external" })
+    @tenant.add_user!(recipient)
+    @collective.add_user!(recipient)
+    AutomationRule.create!(
+      tenant: @tenant,
+      ai_agent: recipient,
+      created_by: @user,
+      name: "Recipient hook",
+      trigger_type: "event",
+      trigger_config: { "event_types" => ["notifications.delivered"] },
+      actions: { "webhook_url" => "https://example.com/hook" },
+      enabled: true
+    )
+    collective_rule = AutomationRule.create!(
+      tenant: @tenant,
+      collective: @collective,
+      created_by: @user,
+      name: "Collective notification listener",
+      trigger_type: "event",
+      trigger_config: { "event_types" => ["notifications.delivered"] },
+      actions: [{ "type" => "internal_action", "action" => "create_note", "params" => { "text" => "seen" } }],
+      enabled: true
+    )
+
+    event = Event.create!(
+      tenant: @tenant, collective: @collective,
+      event_type: "notifications.delivered", actor: recipient, subject: @collective,
+    )
+
+    assert_not_includes AutomationDispatcher.find_matching_rules(event), collective_rule
+  end
+
   # === Self-trigger carve-out for notification-delivered events ===
 
   test "notification-delivered event fires agent rule even when actor is the agent" do


### PR DESCRIPTION
`notifications.delivered` and `reminders.delivered` fire per-recipient — `event.actor` is the recipient — but `find_matching_rules` only used the recipient for a fast-path existence check. The actual matching query was the content-event one: every enabled rule owned by any member of the event's collective. With two webhook-bearing members in one collective, each member's webhook received the other's notification payloads — private notification content (titles, bodies, URLs) delivered to another principal's endpoint. Surfaced live when an agent reported waking on a payload addressed to a different agent.

Reminders were arguably worse: for standalone reminders the delivery job picks an arbitrary collective the user belongs to just to satisfy the event system, so reminder payloads fanned out to that collective's webhook-bearing members.

## The fix

The event's collective is provenance (every Event row is collective-scoped), not a routing input for a recipient-addressed event. Notification-delivered events now match **purely on rule ownership**:

- Only rules owned by the recipient (`ai_agent_id` / `user_id`) are considered — never other members' rules.
- Collective rules, having no owner, never match per-recipient events.
- The collective-access check in `matches_rule?` is skipped for these events — an archived membership no longer silently stops a recipient's own notifications from forwarding to their own endpoint.
- The tier-gate carve-out collapses to a plain gate, since notification events no longer reach the content-event path at all.

Content events (`note.created` etc.) keep collective-membership matching byte-for-byte unchanged.

## Behavior-change caveat

Any rule that relied on firing for *other* members' notification events stops doing so. Nothing in the codebase or docs offers that as a feature — it's the vulnerability restated — but a prod scan for rules subscribed to these events that aren't recipient-style webhook/wake rules would confirm zero collateral before deploy.

## Testing

Red-green: three new tests pin the semantics (bystander agent and human member rules excluded; collective rules excluded; recipient's own rule fires even with archived membership). Full dispatcher suite (50 runs) plus the delivery blast radius (notification/reminder delivery jobs, notification webhooks controller, automation executor — 90 runs) green. Sorbet clean.

Deploy: web only, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)