### PR TITLE
Always show comments on the note show page

### DIFF
--- a/app/javascript/controllers/note_controller.test.ts
+++ b/app/javascript/controllers/note_controller.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import NoteController from "./note_controller"
+import { waitForController } from "../test/setup"
+
+describe("NoteController", () => {
+  let application: Application
+
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    application = Application.start()
+    application.register("note", NoteController)
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+  })
+
+  function renderConfirmSection() {
+    document.body.innerHTML = `
+      <span data-controller="note">
+        <div data-note-target="confirmSection">
+          <button
+            data-action="click->note#confirm mouseenter->note#confirmButtonMouseEnter mouseleave->note#confirmButtonMouseLeave"
+            data-note-target="confirmButton"
+            data-url="/n/abc123/confirm.html">
+            <span data-note-target="confirmButtonMessage">Confirm Read</span>
+          </button>
+        </div>
+      </span>
+    `
+  }
+
+  function captureErrors(): Error[] {
+    const errors: Error[] = []
+    application.handleError = (error: Error) => {
+      errors.push(error)
+    }
+    return errors
+  }
+
+  it("underlines the button message on hover", async () => {
+    renderConfirmSection()
+    await waitForController()
+
+    const button = document.querySelector("[data-note-target='confirmButton']") as HTMLElement
+    const message = document.querySelector("[data-note-target='confirmButtonMessage']") as HTMLElement
+
+    button.dispatchEvent(new MouseEvent("mouseenter"))
+    expect(message.style.textDecoration).toBe("underline")
+
+    button.dispatchEvent(new MouseEvent("mouseleave"))
+    expect(message.style.textDecoration).toBe("")
+  })
+
+  it("tolerates hover after the button message is replaced mid-confirm", async () => {
+    renderConfirmSection()
+    await waitForController()
+    const errors = captureErrors()
+
+    // confirm() swaps the button's innerHTML for a pending message, dropping the
+    // message span while the button and its hover bindings are still live.
+    const button = document.querySelector("[data-note-target='confirmButton']") as HTMLElement
+    button.innerHTML = "Confirming..."
+
+    button.dispatchEvent(new MouseEvent("mouseenter"))
+    button.dispatchEvent(new MouseEvent("mouseleave"))
+
+    expect(errors).toEqual([])
+  })
+})

--- a/app/javascript/controllers/note_controller.ts
+++ b/app/javascript/controllers/note_controller.ts
@@ -6,6 +6,7 @@ export default class NoteController extends Controller {
 
   declare readonly confirmButtonTarget: HTMLElement
   declare readonly confirmButtonMessageTarget: HTMLElement
+  declare readonly hasConfirmButtonMessageTarget: boolean
   declare readonly confirmSectionTarget: HTMLElement
   declare readonly historyLogTarget: HTMLElement
 
@@ -47,12 +48,16 @@ export default class NoteController extends Controller {
     }
   }
 
+  // The message span is gone between confirm()'s pending-message swap and the
+  // button's removal, while these bindings are still live.
   confirmButtonMouseEnter(_event: Event): void {
     if (this.editingName) return
+    if (!this.hasConfirmButtonMessageTarget) return
     this.confirmButtonMessageTarget.style.textDecoration = "underline"
   }
 
   confirmButtonMouseLeave(_event: Event): void {
+    if (!this.hasConfirmButtonMessageTarget) return
     this.confirmButtonMessageTarget.style.textDecoration = ""
   }
 

--- a/app/views/notes/_confirm.html.erb
+++ b/app/views/notes/_confirm.html.erb
@@ -15,8 +15,6 @@
       <% end %>
     <% end %>
   </p>
-  <%= render 'shared/pulse_comments', commentable: @note %>
-  <%= render 'shared/pulse_backlinks', resource: @note %>
 <% elsif @current_user %>
   <% if @note.is_reminder? && @note.reminder_delivered? %>
     <%# Delivered reminder: show acknowledge UI instead of confirm read %>
@@ -90,7 +88,7 @@
       Confirm Read
     </div>
     <p class="pulse-confirm-message">
-      Confirm that you have read this note to access comments and backlinks.
+      Confirm that you have read this note so others know you have seen it.
     </p>
     <div class="pulse-confirm-action">
       <button

--- a/app/views/notes/_history_log.html.erb
+++ b/app/views/notes/_history_log.html.erb
@@ -13,6 +13,3 @@
     <% end %>
   </div>
 <% end %>
-
-<%= render 'shared/pulse_comments', commentable: @note %>
-<%= render 'shared/pulse_backlinks', resource: @note %>

--- a/app/views/shared/_note_main.html.erb
+++ b/app/views/shared/_note_main.html.erb
@@ -189,5 +189,8 @@
   <div class="pulse-confirmed-section" data-note-target="confirmSection">
     <%= render 'notes/confirm' %>
   </div>
+
+  <%= render 'shared/pulse_comments', commentable: note %>
+  <%= render 'shared/pulse_backlinks', resource: note %>
 </article>
 <% end %>

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -1917,20 +1917,74 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes response.body, "View task run"
 
-    # Comments render only after the viewer confirms reading the note (the
-    # author counts as read), so non-author viewers confirm first.
     sign_in_as(automator, tenant: @tenant)
-    post "#{note_path}/actions/confirm_read"
     get note_path
     assert_response :success
     assert_includes response.body, "A persona reply.", "persona comment should render"
     assert_includes response.body, "View task run"
 
     sign_in_as(member, tenant: @tenant)
-    post "#{note_path}/actions/confirm_read"
     get note_path
     assert_response :success
     assert_includes response.body, "A persona reply.", "persona comment should render"
     assert_not_includes response.body, "View task run"
+  end
+
+  # === Comment Visibility Tests ===
+
+  test "note show renders comments for a viewer who has not confirmed read" do
+    other_user = create_user(name: "Unconfirmed Viewer")
+    @tenant.add_user!(other_user)
+    @collective.add_user!(other_user)
+    Tenant.current_id = @tenant.id
+
+    note = create_note(text: "Note body")
+    create_note(title: nil, text: "A comment on the note.", commentable: note)
+
+    sign_in_as(other_user, tenant: @tenant)
+    get "/collectives/#{@collective.handle}/n/#{note.truncated_id}"
+
+    assert_response :success
+    assert_not Note.find(note.id).user_has_read?(other_user), "viewer should not have confirmed read"
+    assert_includes response.body, "A comment on the note.", "comment should render without confirming read"
+    assert_includes response.body, "Add Comment", "comment form should render without confirming read"
+    assert_includes response.body, "Confirm Read", "confirm read button should still be offered"
+  end
+
+  test "note show keeps comments visible after the note is updated since the last confirm" do
+    other_user = create_user(name: "Stale Confirmer")
+    @tenant.add_user!(other_user)
+    @collective.add_user!(other_user)
+    Tenant.current_id = @tenant.id
+
+    note = create_note(text: "Note body")
+    create_note(title: nil, text: "A comment on the note.", commentable: note)
+    note.confirm_read!(other_user)
+    note.update!(text: "Note body, edited", updated_by: @user)
+
+    sign_in_as(other_user, tenant: @tenant)
+    get "/collectives/#{@collective.handle}/n/#{note.truncated_id}"
+
+    assert_response :success
+    assert_includes response.body, "Reconfirm to acknowledge the changes", "reconfirm prompt should still show"
+    assert_includes response.body, "A comment on the note.", "comment should stay visible pending reconfirmation"
+  end
+
+  test "note show renders a single comments section for a blocked viewer" do
+    other_user = create_user(name: "Blocked Viewer")
+    @tenant.add_user!(other_user)
+    @collective.add_user!(other_user)
+    Tenant.current_id = @tenant.id
+
+    note = create_note(text: "Note body")
+    UserBlock.create!(blocker: other_user, blocked: @user, tenant: @tenant)
+
+    sign_in_as(other_user, tenant: @tenant)
+    get "/collectives/#{@collective.handle}/n/#{note.truncated_id}"
+
+    assert_response :success
+    assert_equal 1, response.body.scan("pulse-comments-section").size, "comments section should render exactly once"
+    assert_includes response.body, "Commenting is unavailable because you have blocked the author"
+    assert_not_includes response.body, "Add Comment"
   end
 end

--- a/test/integration/anonymous_read_access_views_test.rb
+++ b/test/integration/anonymous_read_access_views_test.rb
@@ -42,10 +42,16 @@ class AnonymousReadAccessViewsTest < ActionDispatch::IntegrationTest
 
   # ---- Anon sees "Log in to comment" CTA on commentable show pages ----
   #
-  # Note: /n/:id does NOT render the comments section inline — it fetches it
-  # async from /n/:id/comments.html, which is not declared `allows_anonymous`.
-  # So anon viewers don't see comments on note pages, consistent with the
-  # scope of this feature (the three item show URLs only).
+  # The comment list is server-rendered inline on all three show pages. Live
+  # updates are the only thing anon viewers miss: the cable connection rejects
+  # anonymous users, so the refresh fetch to /comments.html never fires.
+
+  test "anon GET /n/:id shows a Log in to comment CTA" do
+    host! "#{PUBLIC_SUBDOMAIN}.#{ENV.fetch("HOSTNAME", nil)}"
+    get @note.path
+    assert_response :success
+    assert_match(/Log in.*to comment/m, response.body)
+  end
 
   test "anon GET /d/:id shows a Log in to comment CTA" do
     host! "#{PUBLIC_SUBDOMAIN}.#{ENV.fetch("HOSTNAME", nil)}"


### PR DESCRIPTION
## What

Comments on a note were hidden until the viewer confirmed reading it. This removes that gate — comments (and backlinks) now render for everyone, including anonymous viewers on public tenants.

## Why it was awkward to remove

The comments section wasn't rendered where you'd expect. It sat three partials deep inside the confirm-read branch:

`shared/_note_main` → `notes/_confirm` → `notes/_history` → `notes/_history_log`

So a single conditional was hiding three unrelated things: the comment thread and composer, the backlinks section, and the Confirmed Readers roster. Two side effects fell out of that:

- Comments vanished again on **every edit** to the note, until the viewer re-confirmed (the `confirmed_read_but_note_updated?` branch).
- Anonymous viewers never saw comments on notes at all, even though decisions and commitments show them, and the markdown surface has always rendered them unconditionally.

Worth noting the gate was never a real access control: `GET /n/:id/comments.html` returns the full list with no read check, the markdown/agent surface is ungated, and `CommentsChannel` only requires collective membership. The gate just stopped the page from rendering the section.

## What changed

Moved `shared/pulse_comments` and `shared/pulse_backlinks` up to `shared/_note_main`, where they render unconditionally — matching what decisions, commitments, and the markdown surface already do.

The **Confirmed Readers accordion stays inside the confirm section**, still behind `confirmed_read?`. It's read-state UI rather than content, and it has to stay within the `confirmSection` target that `note_controller` swaps on confirm, or the roster would stop updating when you click the button.

The confirm-read button remains, reworded from "Confirm that you have read this note to access comments and backlinks" to describe what it signals rather than what it unlocks — consistent with the awareness-not-endorsement framing in PHILOSOPHY.md.

Notes are now the last resource whose comments behave like every other one.

## Anonymous viewers

No controller changes needed. `_pulse_comments` already falls back to the "Log in to comment" CTA for a nil user, the list is server-rendered inline, and the Stimulus controller only re-fetches on a cable push — which anonymous connections never receive (they're rejected at the connection level). So anon viewers get a static list, exactly as on decisions and commitments. There's no point marking `comments_partial` as `allows_anonymous`, since the cable message that would trigger it can't reach them.

## Drive-by fix

Clicking Confirm Read logged `Missing target element "confirmButtonMessage"` to the console. `confirm()` replaces the button's `innerHTML` with a pending message, destroying the message span while the button and its hover bindings are still on the page — so any pointer movement during the request threw. Both handlers are now guarded on the target's presence. Unrelated to the gate and pre-dating it, but adjacent enough to fix here; it's a separate commit.

## Testing

Behavioral tests written red-first:

- Unconfirmed viewer sees the comment thread and composer
- Comments stay visible after an edit invalidates a prior confirmation
- Anonymous `GET /n/:id` shows the "Log in to comment" CTA
- Blocked viewer gets exactly one comments section (regression guard for the double-render risk in the refactor)
- New `note_controller.test.ts` — the controller's first test file — covering the hover affordance and the mid-confirm window that produced the console error

Also removed a confirm-read workaround in `notes_controller_test.rb` that existed only to get past this gate, and replaced a stale comment block in `anonymous_read_access_views_test.rb` claiming notes fetched comments asynchronously and that anon viewers never saw them — both halves were wrong.

Green: `notes_controller_test.rb` (89), `anonymous_read_access_views_test.rb` (8), `comments_list_component_test.rb`, `note_test.rb`, `note_history_event_test.rb`, `anonymous_read_access_user_profiles_test.rb`, and the full frontend suite (396). Sorbet, TypeScript, and the static-analysis scripts pass.

Also verified in the browser, since the comments section moved out from under `.pulse-confirmed-section`: renders correctly unconfirmed, and clicking Confirm Read swaps in the readers accordion with comments intact and not duplicated.

CHANGELOG entry to follow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)