### PR TITLE
harmonic-admin CLI v1 + fix latently broken /metrics endpoint

### DIFF
--- a/.claude/plans/harmonic-admin-cli.md
+++ b/.claude/plans/harmonic-admin-cli.md
@@ -1,0 +1,65 @@
+# harmonic-admin CLI
+
+**Status: settled direction, compressed 2026-07-31. One well-documented CLI
+for instance operations — `dev` (local dev + GitHub) and `prod` (deploy /
+monitoring / admin / comms) contexts. v1 is the basics below; everything
+else is listed as later work, one line each.**
+
+## Settled decisions
+
+- **TypeScript, in-repo `harmonic-admin/`, bridge conventions** — npm
+  `@ibis-coordination/harmonic-admin`, published by tagging `admin-vX.Y.Z`,
+  installable on sprites like the bridge.
+- **Capability lives in credentials, not the binary.** Same CLI everywhere;
+  a command works iff its credential is present. Deploy needs server
+  presence/SSH (Dan-only, deliberately). Status needs read-only tokens.
+- **Credentials home**: `~/.config/harmonic-admin/env` (chmod 600, env vars
+  override) on laptops and the prod host; bridge secrets backend on sprites.
+  That file holds **read-only, individually-revocable tokens only** — agents
+  share the OS user, so this tier is readable by them; the dangerous tier
+  (SSH/deploy) stays password-gated and in no file. The CLI never prints
+  token values.
+- **Every command's help states where it acts** (local / GitHub /
+  prod-over-HTTPS / prod-server-side) and whether it mutates.
+- **Wraps existing scripts, doesn't rewrite them.**
+
+## v1 — the basics
+
+```
+harmonic-admin prod status            # healthcheck + metrics + Sentry digest
+harmonic-admin prod sentry issues     # unresolved issues, frequency
+harmonic-admin prod sentry show <id>  # one issue in detail
+harmonic-admin doctor                 # which credentials/sources are configured (values masked)
+```
+
+`prod status` degrades gracefully per source (missing credential → "no
+access to X").
+
+*Acceptance:* from a laptop, no SSH, "how's prod doing?" gets a grounded
+answer covering availability, error state, and job backlog in one command.
+
+**Prod facts (2026-07-31):** Sentry, Slack security alerts, and UptimeRobot
+are live. `METRICS_AUTH_TOKEN` is not set — `/metrics` 503s until Dan sets
+one (`openssl rand -hex 32`, prod `.env`, restart web); not blocking, status
+runs on healthcheck + Sentry meanwhile.
+
+**Dan-side setup:** mint a read-only Sentry API token (`project:read`,
+`event:read`, `org:read`) → `~/.config/harmonic-admin/env`; set the metrics
+token when convenient.
+
+## Later (each one line, in rough order)
+
+- `prod report` — post the digest as a note + notification (the steward's
+  comms primitive).
+- Steward wakes: sprite agent + scheduled rule + Sentry-alert → inbound
+  automation webhook; runs the same commands, reports to Dan.
+- `prod deploy|rollback|maintenance|caddyfile` — wrap the server-side
+  scripts; prod host installs the CLI from npm instead of copied scripts.
+- `dev start|stop|test|console|checks` — wrap local scripts.
+- `--target staging|admin` once those instances exist.
+- UptimeRobot API in the digest; log aggregation (trigger: first
+  investigation that dead-ends without request logs); metrics history
+  (trigger: first trend question a snapshot can't answer).
+- Into-Harmonic migration (Harmonic holds vendor tokens server-side; agents
+  use their own scoped tokens) — the eventual "agents use secrets without
+  reading them" answer; trigger: cross-instance work begins.

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -8,9 +8,11 @@ class MetricsController < ActionController::Base # rubocop:disable Rails/Applica
   before_action :authenticate_metrics_token
 
   def show
-    # Skip standard application callbacks for metrics endpoint
-    exporter = Yabeda::Prometheus::Exporter.new
-    render plain: exporter.call({})&.last&.first || "", content_type: "text/plain"
+    # Yabeda gauges (e.g. sidekiq queue sizes) are populated by collect
+    # blocks that only run when a scrape asks for them.
+    Yabeda.collect!
+    render plain: Prometheus::Client::Formats::Text.marshal(Prometheus::Client.registry),
+           content_type: "text/plain"
   end
 
   private

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -23,6 +23,10 @@ services:
       - RAILS_ENV=production
       - RAILS_LOG_TO_STDOUT=true
       - RAILS_SERVE_STATIC_FILES=true
+      # The web process serves /metrics, so it must collect the cluster-wide
+      # sidekiq gauges (queue sizes, retry/dead counts) that yabeda-sidekiq
+      # otherwise only collects inside Sidekiq server processes.
+      - YABEDA_SIDEKIQ_COLLECT_CLUSTER_METRICS=true
     env_file:
       - .env
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     user: "1000:1000"
+    environment:
+      # The web process serves /metrics, so it must collect the cluster-wide
+      # sidekiq gauges (queue sizes, retry/dead counts) that yabeda-sidekiq
+      # otherwise only collects inside Sidekiq server processes.
+      - YABEDA_SIDEKIQ_COLLECT_CLUSTER_METRICS=true
     volumes:
       - .:/app
       - node_modules:/app/node_modules

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -202,16 +202,29 @@ Expose application metrics for scraping by Prometheus or compatible services.
 - `rails_db_runtime_seconds` - Database query time
 
 **Sidekiq (via yabeda-sidekiq):**
-- `sidekiq_jobs_executed_total` - Total jobs executed
-- `sidekiq_jobs_failed_total` - Total failed jobs
-- `sidekiq_job_runtime_seconds` - Job execution time
-- `sidekiq_queue_size` - Current queue depth
+- `sidekiq_jobs_enqueued_total` - Total jobs enqueued
+- `sidekiq_jobs_waiting_count` - Current queue depth, per queue
+- `sidekiq_jobs_retry_count` - Failed jobs waiting to be retried
+- `sidekiq_jobs_dead_count` - Jobs that exceeded their retry count
+- `sidekiq_jobs_scheduled_count` - Jobs scheduled for later execution
+- `sidekiq_active_workers_count` / `sidekiq_active_processes` - Busy workers / worker processes
+- `sidekiq_queue_latency` - Seconds since the oldest waiting job was enqueued, per queue
+
+The cluster-wide gauges above require `YABEDA_SIDEKIQ_COLLECT_CLUSTER_METRICS=true`
+on the web service (set in the compose files), because `/metrics` is served by the
+web process, not a Sidekiq server process. Per-job execution metrics
+(`sidekiq_jobs_executed_total`, `sidekiq_jobs_failed_total`, runtime histograms)
+are collected only inside Sidekiq server processes and do not appear on `/metrics`.
 
 **Custom Application Metrics:**
-- `harmonic_auth_login_attempts_total` - Login attempts by result
-- `harmonic_content_notes_created_total` - Notes created
-- `harmonic_security_rate_limited_total` - Rate limited requests
-- `harmonic_security_ip_blocked_total` - Blocked IPs
+- `auth_login_attempts_total` - Login attempts by result
+- `content_notes_created_total` - Notes created (also decisions, commitments, votes)
+- `security_rate_limited_total` - Rate limited requests
+- `security_ip_blocked_total` - Blocked IPs
+- `api_requests_total` / `api_request_duration_seconds` - API traffic and latency
+- `automations_runs_total` (+ rate-limit/chain-block/recurrence counters) - Automation activity
+- `deadline_events_fired_total` / `deadline_events_errors_total` - Deadline processing
+- `users_active_users` - Users active in the last 15 minutes
 
 ---
 

--- a/harmonic-admin/.gitignore
+++ b/harmonic-admin/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+.env
+.env.local

--- a/harmonic-admin/LICENSE
+++ b/harmonic-admin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dan Allison
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/harmonic-admin/README.md
+++ b/harmonic-admin/README.md
@@ -1,0 +1,64 @@
+# harmonic-admin
+
+Admin CLI for operating Harmonic instances: monitoring today, deployment and
+broader sysadmin tasks over time. One well-documented CLI covers everything an
+admin (human or agent) needs; capability lives in credentials, not the binary —
+a command works iff its credential is present.
+
+## Install
+
+```bash
+npm install -g @ibis-coordination/harmonic-admin
+```
+
+Or run from the repo:
+
+```bash
+cd harmonic-admin && npm install && npm run dev -- doctor
+```
+
+## Commands
+
+Every command states where it acts and whether it mutates. Nothing in this
+version mutates anything.
+
+| Command | Acts | Description |
+|---------|------|-------------|
+| `harmonic-admin prod status` | prod over HTTPS + Sentry API | Availability (healthcheck), job backlog (/metrics), and error digest (Sentry) in one view |
+| `harmonic-admin prod sentry issues` | Sentry API | Unresolved issues, most recent first |
+| `harmonic-admin prod sentry show <id>` | Sentry API | One issue in detail, including the latest event |
+| `harmonic-admin doctor` | local only | Which credentials/sources are configured; never prints secret values |
+
+`prod status` degrades gracefully per source: a missing credential produces a
+"no access" line for that section, and the rest of the digest still renders.
+
+## Configuration
+
+Credentials live in `~/.config/harmonic-admin/env` (create it with `chmod 600`).
+`KEY=VALUE` lines; `#` comments; real environment variables override the file;
+`HARMONIC_ADMIN_CONFIG` overrides the file path.
+
+That file holds **read-only, individually-revocable tokens only.** Anything
+dangerous (SSH, deploy access) deliberately has no home here.
+
+| Key | Secret | Purpose |
+|-----|--------|---------|
+| `HARMONIC_PROD_URL` | no | Prod base URL (default `https://www.harmonic.social`; must be the canonical host — a redirect would strip the metrics bearer header) |
+| `HARMONIC_METRICS_TOKEN` | yes | Bearer token for the `/metrics` endpoint |
+| `SENTRY_API_TOKEN` | yes | Read-only Sentry token (scopes: `project:read`, `event:read`, `org:read`) |
+| `SENTRY_ORG` | no | Sentry organization slug |
+| `SENTRY_PROJECT` | no | Sentry project slug |
+| `SENTRY_BASE_URL` | no | Sentry API base (default `https://sentry.io`) |
+
+The CLI never prints token values — `doctor` reports `set (file)` / `set (env)`
+/ `not set` for secret keys.
+
+## Development
+
+```bash
+npm test           # node:test via tsx
+npm run typecheck  # tsc --noEmit
+npm run build      # compile to dist/
+```
+
+Releases are published from the monorepo by tagging `admin-vX.Y.Z`.

--- a/harmonic-admin/package-lock.json
+++ b/harmonic-admin/package-lock.json
@@ -1,0 +1,573 @@
+{
+  "name": "@ibis-coordination/harmonic-admin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@ibis-coordination/harmonic-admin",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "harmonic-admin": "dist/bin.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/harmonic-admin/package.json
+++ b/harmonic-admin/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@ibis-coordination/harmonic-admin",
+  "version": "0.1.0",
+  "description": "Admin CLI for operating Harmonic instances: deployment, monitoring, and sysadmin tasks.",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "harmonic-admin": "dist/bin.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test $(find src -name '*.test.ts' -type f)",
+    "dev": "tsx src/bin.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ibis-coordination/Harmonic.git",
+    "directory": "harmonic-admin"
+  },
+  "homepage": "https://github.com/ibis-coordination/Harmonic/tree/main/harmonic-admin#readme",
+  "bugs": {
+    "url": "https://github.com/ibis-coordination/Harmonic/issues"
+  },
+  "keywords": [
+    "harmonic",
+    "admin",
+    "monitoring",
+    "cli"
+  ]
+}

--- a/harmonic-admin/src/bin.ts
+++ b/harmonic-admin/src/bin.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// Binary entry point. The actual dispatch lives in `runCommand` in ./cli
+// so it stays importable and side-effect-free for tests. This file is what
+// `package.json` `bin.harmonic-admin` points at.
+
+import { runCommand } from "./cli.js";
+
+runCommand(process.argv.slice(2)).then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(`harmonic-admin: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  },
+);

--- a/harmonic-admin/src/cli.test.ts
+++ b/harmonic-admin/src/cli.test.ts
@@ -1,0 +1,193 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import { runCommand } from "./cli.js";
+
+function collect(stream: PassThrough): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    stream.on("data", (c: Buffer) => chunks.push(c));
+    stream.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    stream.on("error", reject);
+  });
+}
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+async function run(
+  args: string[],
+  opts: { configPath?: string; env?: Record<string, string>; fetchImpl?: typeof fetch } = {},
+): Promise<RunResult> {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdoutPromise = collect(stdout);
+  const stderrPromise = collect(stderr);
+  const code = await runCommand(args, {
+    configPath: opts.configPath ?? "/nonexistent/harmonic-admin/env",
+    env: opts.env ?? {},
+    fetchImpl: opts.fetchImpl,
+    stdout,
+    stderr,
+  });
+  stdout.end();
+  stderr.end();
+  return { code, stdout: await stdoutPromise, stderr: await stderrPromise };
+}
+
+async function withTempConfig<T>(contents: string, fn: (configPath: string) => Promise<T>): Promise<T> {
+  const dir = mkdtempSync(path.join(tmpdir(), "harmonic-admin-cli-"));
+  try {
+    const configPath = path.join(dir, "env");
+    writeFileSync(configPath, contents);
+    return await fn(configPath);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const SENTRY_CONFIG = [
+  "SENTRY_API_TOKEN=tok-secret-value",
+  "SENTRY_ORG=ibis",
+  "SENTRY_PROJECT=harmonic",
+  "SENTRY_BASE_URL=https://sentry.example",
+  "HARMONIC_PROD_URL=https://prod.example",
+].join("\n");
+
+const ISSUE = {
+  id: "123456",
+  shortId: "HARMONIC-42",
+  title: "NoMethodError in notes",
+  count: "17",
+  userCount: 3,
+  level: "error",
+  lastSeen: "2026-07-31T09:08:07Z",
+  permalink: "https://sentry.example/organizations/ibis/issues/123456/",
+};
+
+function fakeFetch(routes: Record<string, { status: number; body: string }>): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = String(input);
+    const urlPath = url.split("?")[0] ?? url;
+    const route = routes[urlPath];
+    if (!route) return new Response("not found", { status: 404 });
+    return new Response(route.body, { status: route.status });
+  }) as typeof fetch;
+}
+
+test("help: prints usage with execution locus and mutation note", async () => {
+  const result = await run(["help"]);
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /Usage: harmonic-admin/);
+  assert.match(result.stdout, /prod status/);
+  assert.match(result.stdout, /doctor/);
+  assert.match(result.stdout, /Read-only/);
+  assert.match(result.stdout, /HTTPS/);
+});
+
+test("no args: prints usage", async () => {
+  const result = await run([]);
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /Usage: harmonic-admin/);
+});
+
+test("unknown command: exit 64 with message on stderr", async () => {
+  const result = await run(["bogus"]);
+  assert.equal(result.code, 64);
+  assert.match(result.stderr, /unknown command "bogus"/);
+});
+
+test("doctor: reports set/not-set per key without printing secret values", async () => {
+  await withTempConfig(SENTRY_CONFIG, async (configPath) => {
+    const result = await run(["doctor"], { configPath });
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /SENTRY_API_TOKEN\s+set \(file\)/);
+    assert.match(result.stdout, /HARMONIC_METRICS_TOKEN\s+not set/);
+    assert.ok(!result.stdout.includes("tok-secret-value"));
+    assert.match(result.stdout, /SENTRY_ORG\s+ibis \(file\)/);
+    assert.match(result.stdout, /HARMONIC_PROD_URL\s+https:\/\/prod\.example \(file\)/);
+    assert.match(result.stdout, new RegExp(configPath.replace(/[/\\]/g, "[/\\\\]")));
+  });
+});
+
+test("doctor: notes when the config file does not exist", async () => {
+  const result = await run(["doctor"]);
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /does not exist/);
+});
+
+test("prod status: renders sections and exits 0 when healthy", async () => {
+  await withTempConfig(SENTRY_CONFIG, async (configPath) => {
+    const routes = {
+      "https://prod.example/healthcheck": {
+        status: 200,
+        body: JSON.stringify({ status: "ok", checks: { database: true, redis: true } }),
+      },
+      "https://sentry.example/api/0/projects/ibis/harmonic/issues/": {
+        status: 200,
+        body: JSON.stringify([ISSUE]),
+      },
+    };
+    const result = await run(["prod", "status"], { configPath, fetchImpl: fakeFetch(routes) });
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /Availability/);
+    assert.match(result.stdout, /database: ok/);
+    assert.match(result.stdout, /no access to metrics/);
+    assert.match(result.stdout, /HARMONIC-42/);
+  });
+});
+
+test("prod sentry issues: lists unresolved issues", async () => {
+  await withTempConfig(SENTRY_CONFIG, async (configPath) => {
+    const routes = {
+      "https://sentry.example/api/0/projects/ibis/harmonic/issues/": {
+        status: 200,
+        body: JSON.stringify([ISSUE]),
+      },
+    };
+    const result = await run(["prod", "sentry", "issues"], { configPath, fetchImpl: fakeFetch(routes) });
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /HARMONIC-42/);
+    assert.match(result.stdout, /17 events/);
+  });
+});
+
+test("prod sentry issues: missing credentials explains what to set and exits 1", async () => {
+  const result = await run(["prod", "sentry", "issues"]);
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /SENTRY_API_TOKEN/);
+});
+
+test("prod sentry show: renders issue detail with latest event tags", async () => {
+  await withTempConfig(SENTRY_CONFIG, async (configPath) => {
+    const routes = {
+      "https://sentry.example/api/0/issues/123456/": { status: 200, body: JSON.stringify(ISSUE) },
+      "https://sentry.example/api/0/issues/123456/events/latest/": {
+        status: 200,
+        body: JSON.stringify({
+          dateCreated: "2026-07-31T09:08:07Z",
+          message: "undefined method",
+          tags: [{ key: "release", value: "1.63.0" }],
+        }),
+      },
+    };
+    const result = await run(["prod", "sentry", "show", "123456"], { configPath, fetchImpl: fakeFetch(routes) });
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /HARMONIC-42/);
+    assert.match(result.stdout, /release: 1\.63\.0/);
+  });
+});
+
+test("prod sentry show: missing id is a usage error", async () => {
+  await withTempConfig(SENTRY_CONFIG, async (configPath) => {
+    const result = await run(["prod", "sentry", "show"], { configPath });
+    assert.equal(result.code, 64);
+    assert.match(result.stderr, /requires an issue id/);
+  });
+});

--- a/harmonic-admin/src/cli.ts
+++ b/harmonic-admin/src/cli.ts
@@ -1,0 +1,189 @@
+// CLI dispatch for harmonic-admin. Imported by ./bin.ts (the actual entry
+// point) and by tests. No side effects on import — runCommand must be
+// invoked explicitly.
+//
+// Every command here is read-only. Commands under `prod` act over HTTPS
+// against the production instance and the Sentry API; `doctor` acts
+// locally. Nothing in this CLI prints a credential value.
+
+import type { Writable } from "node:stream";
+import { loadConfig, type AdminConfig } from "./config.js";
+import { runDoctor } from "./doctor.js";
+import { runProdStatus, type StatusSection } from "./status.js";
+import { SentryClient } from "./sentry.js";
+
+export interface CliOpts {
+  /** Explicit config file path; wins over HARMONIC_ADMIN_CONFIG and the default. */
+  readonly configPath?: string;
+  /** Environment map. Defaults to process.env. */
+  readonly env?: Record<string, string | undefined>;
+  readonly fetchImpl?: typeof fetch;
+  readonly stdout?: Writable;
+  readonly stderr?: Writable;
+}
+
+export async function runCommand(args: readonly string[], opts: CliOpts = {}): Promise<number> {
+  const stdout = opts.stdout ?? process.stdout;
+  const stderr = opts.stderr ?? process.stderr;
+  const command = args[0];
+
+  if (command === undefined || command === "help" || command === "--help" || command === "-h") {
+    printUsage(stdout);
+    return 0;
+  }
+
+  const config = await loadConfig({ configPath: opts.configPath, env: opts.env });
+
+  if (command === "doctor") {
+    return runDoctor(config, stdout);
+  }
+
+  if (command === "prod") {
+    return await runProd(args.slice(1), config, opts, stdout, stderr);
+  }
+
+  stderr.write(`harmonic-admin: unknown command "${command}"\n`);
+  printUsage(stderr);
+  return 64;
+}
+
+async function runProd(
+  args: readonly string[],
+  config: AdminConfig,
+  opts: CliOpts,
+  stdout: Writable,
+  stderr: Writable,
+): Promise<number> {
+  const sub = args[0];
+
+  if (sub === "status") {
+    const result = await runProdStatus(config, { fetchImpl: opts.fetchImpl });
+    for (const section of result.sections) {
+      stdout.write(renderSection(section));
+    }
+    return result.exitCode;
+  }
+
+  if (sub === "sentry") {
+    return await runSentry(args.slice(1), config, opts, stdout, stderr);
+  }
+
+  stderr.write(`harmonic-admin: unknown command "prod ${sub ?? ""}"\n`);
+  printUsage(stderr);
+  return 64;
+}
+
+async function runSentry(
+  args: readonly string[],
+  config: AdminConfig,
+  opts: CliOpts,
+  stdout: Writable,
+  stderr: Writable,
+): Promise<number> {
+  const sub = args[0];
+  if (sub !== "issues" && sub !== "show") {
+    stderr.write(`harmonic-admin: unknown command "prod sentry ${sub ?? ""}"\n`);
+    printUsage(stderr);
+    return 64;
+  }
+
+  const missing = (["SENTRY_API_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT"] as const).filter(
+    (key) => config.values[key] === undefined,
+  );
+  if (missing.length > 0) {
+    stderr.write(
+      `harmonic-admin: no access to Sentry — set ${missing.join(", ")} in ${config.path} ` +
+        "(read-only token; scopes project:read, event:read, org:read)\n",
+    );
+    return 1;
+  }
+
+  const client = new SentryClient({
+    baseUrl: config.values.SENTRY_BASE_URL ?? "https://sentry.io",
+    org: config.values.SENTRY_ORG as string,
+    project: config.values.SENTRY_PROJECT as string,
+    apiToken: config.values.SENTRY_API_TOKEN as string,
+    fetchImpl: opts.fetchImpl,
+  });
+
+  if (sub === "issues") {
+    const issues = await client.listUnresolvedIssues();
+    if (issues.length === 0) {
+      stdout.write("No unresolved issues.\n");
+      return 0;
+    }
+    for (const issue of issues) {
+      stdout.write(
+        `${issue.shortId}  [${issue.level ?? "?"}]  ${issue.title}\n` +
+          `  ${issue.count} events` +
+          (issue.userCount !== undefined ? `, ${issue.userCount} users` : "") +
+          (issue.lastSeen ? `, last seen ${issue.lastSeen}` : "") +
+          `  (id: ${issue.id})\n`,
+      );
+    }
+    return 0;
+  }
+
+  const id = args[1];
+  if (id === undefined) {
+    stderr.write('harmonic-admin: "prod sentry show" requires an issue id\n');
+    return 64;
+  }
+  const detail = await client.getIssue(id);
+  const { issue, latestEvent } = detail;
+  stdout.write(`${issue.shortId}  [${issue.level ?? "?"}]  ${issue.title}\n`);
+  if (issue.culprit) stdout.write(`culprit:    ${issue.culprit}\n`);
+  stdout.write(`events:     ${issue.count}` + (issue.userCount !== undefined ? ` (${issue.userCount} users)` : "") + "\n");
+  if (issue.firstSeen) stdout.write(`first seen: ${issue.firstSeen}\n`);
+  if (issue.lastSeen) stdout.write(`last seen:  ${issue.lastSeen}\n`);
+  if (issue.permalink) stdout.write(`link:       ${issue.permalink}\n`);
+  if (latestEvent) {
+    stdout.write("\nLatest event:\n");
+    if (latestEvent.dateCreated) stdout.write(`  at:      ${latestEvent.dateCreated}\n`);
+    if (latestEvent.message) stdout.write(`  message: ${latestEvent.message}\n`);
+    for (const [key, value] of Object.entries(latestEvent.tags)) {
+      stdout.write(`  ${key}: ${value}\n`);
+    }
+  }
+  return 0;
+}
+
+const STATE_BADGES = {
+  ok: "[ok]",
+  warn: "[warn]",
+  down: "[DOWN]",
+  "no-access": "[no access]",
+} as const;
+
+function renderSection(section: StatusSection): string {
+  const lines = [`${STATE_BADGES[section.state]} ${section.title}`];
+  for (const line of section.lines) {
+    lines.push(`  ${line}`);
+  }
+  return lines.join("\n") + "\n\n";
+}
+
+function printUsage(out: Writable): void {
+  out.write(`Usage: harmonic-admin <command>
+
+Commands:
+  doctor                    Local: report which credentials/sources are configured.
+                            Never prints secret values.
+  prod status               HTTPS to prod + Sentry API: availability, job backlog,
+                            and error digest in one view. Read-only.
+  prod sentry issues        Sentry API: unresolved issues, most recent first. Read-only.
+  prod sentry show <id>     Sentry API: one issue in detail. Read-only.
+
+No command here mutates anything. Commands under \`prod\` act over HTTPS with
+read-only tokens; \`doctor\` acts locally only.
+
+Configuration (~/.config/harmonic-admin/env, chmod 600; KEY=VALUE lines;
+real environment variables override; HARMONIC_ADMIN_CONFIG overrides the path):
+  HARMONIC_PROD_URL         Prod base URL (default https://www.harmonic.social)
+  HARMONIC_METRICS_TOKEN    Bearer token for /metrics (secret)
+  SENTRY_API_TOKEN          Read-only Sentry token (secret; project:read, event:read, org:read)
+  SENTRY_ORG                Sentry organization slug
+  SENTRY_PROJECT            Sentry project slug
+  SENTRY_BASE_URL           Sentry API base (default https://sentry.io)
+`);
+}

--- a/harmonic-admin/src/config.test.ts
+++ b/harmonic-admin/src/config.test.ts
@@ -1,0 +1,102 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { loadConfig, CONFIG_KEYS, SECRET_KEYS, defaultConfigPath } from "./config.js";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = mkdtempSync(path.join(tmpdir(), "harmonic-admin-config-"));
+  try {
+    return await fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("loadConfig: reads KEY=VALUE lines from the env file", async () => {
+  await withTempDir(async (dir) => {
+    const configPath = path.join(dir, "env");
+    writeFileSync(configPath, "SENTRY_ORG=ibis\nSENTRY_PROJECT=harmonic\n");
+    const config = await loadConfig({ configPath, env: {} });
+    assert.equal(config.values.SENTRY_ORG, "ibis");
+    assert.equal(config.values.SENTRY_PROJECT, "harmonic");
+    assert.equal(config.sources.SENTRY_ORG, "file");
+  });
+});
+
+test("loadConfig: ignores comments, blank lines, and tolerates export prefix and quotes", async () => {
+  await withTempDir(async (dir) => {
+    const configPath = path.join(dir, "env");
+    writeFileSync(
+      configPath,
+      [
+        "# Sentry read-only token",
+        "",
+        'export SENTRY_API_TOKEN="abc123"',
+        "SENTRY_ORG='ibis'",
+      ].join("\n"),
+    );
+    const config = await loadConfig({ configPath, env: {} });
+    assert.equal(config.values.SENTRY_API_TOKEN, "abc123");
+    assert.equal(config.values.SENTRY_ORG, "ibis");
+  });
+});
+
+test("loadConfig: environment variables override file values", async () => {
+  await withTempDir(async (dir) => {
+    const configPath = path.join(dir, "env");
+    writeFileSync(configPath, "SENTRY_ORG=from-file\n");
+    const config = await loadConfig({ configPath, env: { SENTRY_ORG: "from-env" } });
+    assert.equal(config.values.SENTRY_ORG, "from-env");
+    assert.equal(config.sources.SENTRY_ORG, "env");
+  });
+});
+
+test("loadConfig: missing file yields defaults only, and fileExists false", async () => {
+  await withTempDir(async (dir) => {
+    const configPath = path.join(dir, "nope", "env");
+    const config = await loadConfig({ configPath, env: {} });
+    assert.equal(config.fileExists, false);
+    assert.equal(config.values.SENTRY_API_TOKEN, undefined);
+    assert.equal(config.values.HARMONIC_PROD_URL, "https://www.harmonic.social");
+    assert.equal(config.sources.HARMONIC_PROD_URL, "default");
+    assert.equal(config.values.SENTRY_BASE_URL, "https://sentry.io");
+  });
+});
+
+test("loadConfig: unknown keys in the file are ignored", async () => {
+  await withTempDir(async (dir) => {
+    const configPath = path.join(dir, "env");
+    writeFileSync(configPath, "SOME_RANDOM_KEY=x\nSENTRY_ORG=ibis\n");
+    const config = await loadConfig({ configPath, env: {} });
+    assert.equal(config.values.SENTRY_ORG, "ibis");
+    assert.ok(!("SOME_RANDOM_KEY" in config.values));
+  });
+});
+
+test("loadConfig: HARMONIC_ADMIN_CONFIG env var overrides the default path", async () => {
+  await withTempDir(async (dir) => {
+    const configPath = path.join(dir, "custom-env");
+    writeFileSync(configPath, "SENTRY_ORG=via-custom-path\n");
+    const config = await loadConfig({ env: { HARMONIC_ADMIN_CONFIG: configPath } });
+    assert.equal(config.values.SENTRY_ORG, "via-custom-path");
+    assert.equal(config.path, configPath);
+  });
+});
+
+test("CONFIG_KEYS covers the v1 sources and SECRET_KEYS is a subset", () => {
+  for (const key of ["HARMONIC_PROD_URL", "HARMONIC_METRICS_TOKEN", "SENTRY_API_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT", "SENTRY_BASE_URL"]) {
+    assert.ok((CONFIG_KEYS as readonly string[]).includes(key), `missing ${key}`);
+  }
+  for (const key of SECRET_KEYS) {
+    assert.ok((CONFIG_KEYS as readonly string[]).includes(key));
+  }
+  assert.ok(SECRET_KEYS.includes("SENTRY_API_TOKEN"));
+  assert.ok(SECRET_KEYS.includes("HARMONIC_METRICS_TOKEN"));
+  assert.ok(!SECRET_KEYS.includes("SENTRY_ORG"));
+});
+
+test("defaultConfigPath: lives under ~/.config/harmonic-admin", () => {
+  assert.match(defaultConfigPath(), /\.config\/harmonic-admin\/env$/);
+});

--- a/harmonic-admin/src/config.ts
+++ b/harmonic-admin/src/config.ts
@@ -1,0 +1,117 @@
+// Credential/config loading for harmonic-admin.
+//
+// Configuration lives in an env-format file (default:
+// ~/.config/harmonic-admin/env, chmod 600), overridable per-key by real
+// environment variables and wholesale by HARMONIC_ADMIN_CONFIG. The file
+// holds read-only, individually-revocable tokens only; nothing in this
+// module (or the CLI at large) ever prints a token value.
+
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+export const CONFIG_KEYS = [
+  "HARMONIC_PROD_URL",
+  "HARMONIC_METRICS_TOKEN",
+  "SENTRY_API_TOKEN",
+  "SENTRY_ORG",
+  "SENTRY_PROJECT",
+  "SENTRY_BASE_URL",
+] as const;
+
+export type ConfigKey = (typeof CONFIG_KEYS)[number];
+
+/** Keys whose values must never be written to any output stream. */
+export const SECRET_KEYS: readonly ConfigKey[] = ["HARMONIC_METRICS_TOKEN", "SENTRY_API_TOKEN"];
+
+const DEFAULTS: Partial<Record<ConfigKey, string>> = {
+  // The www host, not the apex: the apex 301s to www, and fetch strips
+  // Authorization headers on cross-origin redirects, which would break the
+  // authenticated /metrics call.
+  HARMONIC_PROD_URL: "https://www.harmonic.social",
+  SENTRY_BASE_URL: "https://sentry.io",
+};
+
+export type ConfigSource = "env" | "file" | "default";
+
+export interface AdminConfig {
+  readonly values: Partial<Record<ConfigKey, string>>;
+  readonly sources: Partial<Record<ConfigKey, ConfigSource>>;
+  /** Resolved path of the env file (whether or not it exists). */
+  readonly path: string;
+  readonly fileExists: boolean;
+}
+
+export interface LoadConfigOpts {
+  /** Explicit env file path; wins over HARMONIC_ADMIN_CONFIG and the default. */
+  readonly configPath?: string;
+  /** Environment map. Defaults to process.env. */
+  readonly env?: Record<string, string | undefined>;
+}
+
+export function defaultConfigPath(): string {
+  return path.join(homedir(), ".config", "harmonic-admin", "env");
+}
+
+export async function loadConfig(opts: LoadConfigOpts = {}): Promise<AdminConfig> {
+  const env = opts.env ?? process.env;
+  const configPath = opts.configPath ?? env.HARMONIC_ADMIN_CONFIG ?? defaultConfigPath();
+
+  let fileValues: Record<string, string> = {};
+  let fileExists = false;
+  try {
+    const raw = await fs.readFile(configPath, "utf8");
+    fileExists = true;
+    fileValues = parseEnvFile(raw);
+  } catch (e) {
+    if (!isNodeError(e) || e.code !== "ENOENT") throw e;
+  }
+
+  const values: Partial<Record<ConfigKey, string>> = {};
+  const sources: Partial<Record<ConfigKey, ConfigSource>> = {};
+  for (const key of CONFIG_KEYS) {
+    const fromEnv = env[key];
+    const fromFile = fileValues[key];
+    const fromDefault = DEFAULTS[key];
+    if (fromEnv !== undefined && fromEnv !== "") {
+      values[key] = fromEnv;
+      sources[key] = "env";
+    } else if (fromFile !== undefined && fromFile !== "") {
+      values[key] = fromFile;
+      sources[key] = "file";
+    } else if (fromDefault !== undefined) {
+      values[key] = fromDefault;
+      sources[key] = "default";
+    }
+  }
+
+  return { values, sources, path: configPath, fileExists };
+}
+
+function parseEnvFile(raw: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    const withoutExport = trimmed.startsWith("export ") ? trimmed.slice("export ".length).trim() : trimmed;
+    const eq = withoutExport.indexOf("=");
+    if (eq <= 0) continue;
+    const key = withoutExport.slice(0, eq).trim();
+    out[key] = unquote(withoutExport.slice(eq + 1).trim());
+  }
+  return out;
+}
+
+function unquote(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0];
+    if ((first === '"' || first === "'") && value.endsWith(first)) {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}
+
+function isNodeError(e: unknown): e is NodeJS.ErrnoException {
+  return e instanceof Error && "code" in e;
+}

--- a/harmonic-admin/src/doctor.ts
+++ b/harmonic-admin/src/doctor.ts
@@ -1,0 +1,38 @@
+// `doctor` — acts locally only. Reports which credentials/sources are
+// configured and where each value came from. Secret values are never
+// written to output; non-secret values (URLs, org/project slugs) are shown.
+
+import type { Writable } from "node:stream";
+import { CONFIG_KEYS, SECRET_KEYS, type AdminConfig } from "./config.js";
+
+export function runDoctor(config: AdminConfig, stdout: Writable): number {
+  stdout.write(`Config file: ${config.path}${config.fileExists ? "" : " (does not exist)"}\n\n`);
+
+  for (const key of CONFIG_KEYS) {
+    const value = config.values[key];
+    const source = config.sources[key];
+    let display: string;
+    if (value === undefined) {
+      display = "not set";
+    } else if (SECRET_KEYS.includes(key)) {
+      display = `set (${source})`;
+    } else {
+      display = `${value} (${source})`;
+    }
+    stdout.write(`${key.padEnd(24)} ${display}\n`);
+  }
+
+  stdout.write("\n");
+  stdout.write(readiness("prod status", missingFor(config, [])) + " (availability always; metrics and Sentry sections need their keys)\n");
+  stdout.write(readiness("prod sentry", missingFor(config, ["SENTRY_API_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT"])) + "\n");
+  return 0;
+}
+
+function missingFor(config: AdminConfig, keys: readonly (typeof CONFIG_KEYS)[number][]): string[] {
+  return keys.filter((key) => config.values[key] === undefined);
+}
+
+function readiness(command: string, missing: string[]): string {
+  if (missing.length === 0) return `${command.padEnd(24)} ready`;
+  return `${command.padEnd(24)} missing ${missing.join(", ")}`;
+}

--- a/harmonic-admin/src/index.ts
+++ b/harmonic-admin/src/index.ts
@@ -1,0 +1,9 @@
+export { runCommand, type CliOpts } from "./cli.js";
+export { loadConfig, defaultConfigPath, CONFIG_KEYS, SECRET_KEYS } from "./config.js";
+export type { AdminConfig, ConfigKey, ConfigSource, LoadConfigOpts } from "./config.js";
+export { runProdStatus } from "./status.js";
+export type { ProdStatusResult, StatusSection, SectionState } from "./status.js";
+export { SentryClient } from "./sentry.js";
+export type { SentryIssue, SentryIssueDetail, SentryEvent } from "./sentry.js";
+export { parsePrometheusText, summarizeSidekiq } from "./prom.js";
+export type { PromSample, SidekiqSummary } from "./prom.js";

--- a/harmonic-admin/src/prom.test.ts
+++ b/harmonic-admin/src/prom.test.ts
@@ -1,0 +1,57 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parsePrometheusText, summarizeSidekiq } from "./prom.js";
+
+const SAMPLE = `# HELP sidekiq_jobs_waiting_count The number of jobs waiting to process in all queues.
+# TYPE sidekiq_jobs_waiting_count gauge
+sidekiq_jobs_waiting_count{queue="default"} 3
+sidekiq_jobs_waiting_count{queue="mailers"} 0
+# TYPE sidekiq_jobs_retry_count gauge
+sidekiq_jobs_retry_count 2
+# TYPE sidekiq_jobs_dead_count gauge
+sidekiq_jobs_dead_count 7
+# TYPE sidekiq_active_workers_count gauge
+sidekiq_active_workers_count 1
+# TYPE rails_requests_total counter
+rails_requests_total{controller="notes",action="index",status="200"} 1500
+`;
+
+test("parsePrometheusText: parses names, labels, and values, skipping comments", () => {
+  const samples = parsePrometheusText(SAMPLE);
+  const waiting = samples.filter((s) => s.name === "sidekiq_jobs_waiting_count");
+  assert.equal(waiting.length, 2);
+  assert.deepEqual(waiting[0]?.labels, { queue: "default" });
+  assert.equal(waiting[0]?.value, 3);
+  const retry = samples.find((s) => s.name === "sidekiq_jobs_retry_count");
+  assert.deepEqual(retry?.labels, {});
+  assert.equal(retry?.value, 2);
+});
+
+test("parsePrometheusText: tolerates label values containing commas and escaped quotes", () => {
+  const samples = parsePrometheusText('m{a="x,y",b="q\\"z"} 1\n');
+  assert.deepEqual(samples[0]?.labels, { a: "x,y", b: 'q"z' });
+});
+
+test("parsePrometheusText: skips malformed lines rather than throwing", () => {
+  const samples = parsePrometheusText("not a metric line at all\nm 5\n");
+  assert.equal(samples.length, 1);
+  assert.equal(samples[0]?.name, "m");
+});
+
+test("summarizeSidekiq: totals waiting per queue plus retry/dead/workers", () => {
+  const summary = summarizeSidekiq(parsePrometheusText(SAMPLE));
+  assert.equal(summary.waitingTotal, 3);
+  assert.deepEqual(summary.waitingByQueue, { default: 3, mailers: 0 });
+  assert.equal(summary.retry, 2);
+  assert.equal(summary.dead, 7);
+  assert.equal(summary.activeWorkers, 1);
+});
+
+test("summarizeSidekiq: absent families come back undefined, not zero", () => {
+  const summary = summarizeSidekiq(parsePrometheusText("rails_requests_total 5\n"));
+  assert.equal(summary.waitingTotal, undefined);
+  assert.equal(summary.retry, undefined);
+  assert.equal(summary.dead, undefined);
+  assert.equal(summary.activeWorkers, undefined);
+  assert.deepEqual(summary.waitingByQueue, {});
+});

--- a/harmonic-admin/src/prom.ts
+++ b/harmonic-admin/src/prom.ts
@@ -1,0 +1,76 @@
+// Minimal Prometheus text-format parsing, enough to summarize the gauges
+// that yabeda-sidekiq exports from /metrics. Malformed lines are skipped:
+// a partial digest beats a crashed status command.
+
+export interface PromSample {
+  readonly name: string;
+  readonly labels: Record<string, string>;
+  readonly value: number;
+}
+
+export function parsePrometheusText(text: string): PromSample[] {
+  const samples: PromSample[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    const sample = parseSampleLine(trimmed);
+    if (sample) samples.push(sample);
+  }
+  return samples;
+}
+
+function parseSampleLine(line: string): PromSample | undefined {
+  const match = /^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{.*\})?\s+(\S+)/.exec(line);
+  if (!match) return undefined;
+  const [, name, labelBlock, rawValue] = match;
+  if (name === undefined || rawValue === undefined) return undefined;
+  const value = Number(rawValue);
+  if (Number.isNaN(value)) return undefined;
+  return { name, labels: labelBlock ? parseLabels(labelBlock) : {}, value };
+}
+
+function parseLabels(block: string): Record<string, string> {
+  // block is `{key="value",...}`; values may contain escaped quotes.
+  const labels: Record<string, string> = {};
+  const re = /([a-zA-Z_][a-zA-Z0-9_]*)="((?:\\.|[^"\\])*)"/g;
+  for (const match of block.matchAll(re)) {
+    const [, key, raw] = match;
+    if (key === undefined || raw === undefined) continue;
+    labels[key] = raw.replace(/\\(.)/g, "$1");
+  }
+  return labels;
+}
+
+export interface SidekiqSummary {
+  readonly waitingTotal: number | undefined;
+  readonly waitingByQueue: Record<string, number>;
+  readonly retry: number | undefined;
+  readonly dead: number | undefined;
+  readonly activeWorkers: number | undefined;
+}
+
+export function summarizeSidekiq(samples: readonly PromSample[]): SidekiqSummary {
+  const waitingByQueue: Record<string, number> = {};
+  let waitingTotal: number | undefined;
+  for (const s of samples) {
+    if (s.name !== "sidekiq_jobs_waiting_count") continue;
+    waitingTotal = (waitingTotal ?? 0) + s.value;
+    const queue = s.labels.queue;
+    if (queue !== undefined) waitingByQueue[queue] = (waitingByQueue[queue] ?? 0) + s.value;
+  }
+  return {
+    waitingTotal,
+    waitingByQueue,
+    retry: sumFamily(samples, "sidekiq_jobs_retry_count"),
+    dead: sumFamily(samples, "sidekiq_jobs_dead_count"),
+    activeWorkers: sumFamily(samples, "sidekiq_active_workers_count"),
+  };
+}
+
+function sumFamily(samples: readonly PromSample[], name: string): number | undefined {
+  let total: number | undefined;
+  for (const s of samples) {
+    if (s.name === name) total = (total ?? 0) + s.value;
+  }
+  return total;
+}

--- a/harmonic-admin/src/sentry.test.ts
+++ b/harmonic-admin/src/sentry.test.ts
@@ -1,0 +1,131 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { SentryClient } from "./sentry.js";
+
+const ISSUE_FIXTURE = {
+  id: "123456",
+  shortId: "HARMONIC-42",
+  title: "NoMethodError: undefined method `foo' for nil",
+  culprit: "NotesController#create",
+  level: "error",
+  count: "17",
+  userCount: 3,
+  firstSeen: "2026-07-30T01:02:03Z",
+  lastSeen: "2026-07-31T09:08:07Z",
+  permalink: "https://sentry.io/organizations/ibis/issues/123456/",
+};
+
+const EVENT_FIXTURE = {
+  dateCreated: "2026-07-31T09:08:07Z",
+  message: "undefined method `foo' for nil",
+  tags: [
+    { key: "environment", value: "production" },
+    { key: "release", value: "1.63.0" },
+  ],
+};
+
+interface RecordedRequest {
+  url: string;
+  headers: Record<string, string>;
+}
+
+function fakeFetch(routes: Record<string, unknown>, recorded: RecordedRequest[]): typeof fetch {
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    recorded.push({ url, headers: (init?.headers ?? {}) as Record<string, string> });
+    const path = url.split("?")[0] ?? url;
+    for (const [route, body] of Object.entries(routes)) {
+      if (path === route) {
+        return new Response(JSON.stringify(body), { status: 200 });
+      }
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+}
+
+function client(routes: Record<string, unknown>, recorded: RecordedRequest[]): SentryClient {
+  return new SentryClient({
+    baseUrl: "https://sentry.io",
+    org: "ibis",
+    project: "harmonic",
+    apiToken: "tok-secret",
+    fetchImpl: fakeFetch(routes, recorded),
+  });
+}
+
+test("listUnresolvedIssues: hits the project issues endpoint with bearer auth", async () => {
+  const recorded: RecordedRequest[] = [];
+  const c = client({ "https://sentry.io/api/0/projects/ibis/harmonic/issues/": [ISSUE_FIXTURE] }, recorded);
+  const issues = await c.listUnresolvedIssues();
+  assert.equal(issues.length, 1);
+  assert.equal(issues[0]?.shortId, "HARMONIC-42");
+  assert.equal(issues[0]?.count, 17);
+  const request = recorded[0];
+  assert.ok(request);
+  assert.match(request.url, /query=is%3Aunresolved/);
+  assert.equal(request.headers["Authorization"], "Bearer tok-secret");
+});
+
+test("getIssue: fetches issue detail plus latest event", async () => {
+  const recorded: RecordedRequest[] = [];
+  const c = client(
+    {
+      "https://sentry.io/api/0/issues/123456/events/latest/": EVENT_FIXTURE,
+      "https://sentry.io/api/0/issues/123456/": ISSUE_FIXTURE,
+    },
+    recorded,
+  );
+  const detail = await c.getIssue("123456");
+  assert.equal(detail.issue.title, ISSUE_FIXTURE.title);
+  assert.equal(detail.latestEvent?.message, EVENT_FIXTURE.message);
+  assert.deepEqual(detail.latestEvent?.tags, { environment: "production", release: "1.63.0" });
+});
+
+test("getIssue: missing latest event degrades to issue detail alone", async () => {
+  const recorded: RecordedRequest[] = [];
+  const c = client({ "https://sentry.io/api/0/issues/123456/": ISSUE_FIXTURE }, recorded);
+  const detail = await c.getIssue("123456");
+  assert.equal(detail.issue.shortId, "HARMONIC-42");
+  assert.equal(detail.latestEvent, undefined);
+});
+
+test("getIssue: resolves a short id via the org shortids endpoint", async () => {
+  const recorded: RecordedRequest[] = [];
+  const c = client(
+    {
+      "https://sentry.io/api/0/organizations/ibis/shortids/HARMONIC-42/": { groupId: "123456" },
+      "https://sentry.io/api/0/issues/123456/": ISSUE_FIXTURE,
+      "https://sentry.io/api/0/issues/123456/events/latest/": EVENT_FIXTURE,
+    },
+    recorded,
+  );
+  const detail = await c.getIssue("HARMONIC-42");
+  assert.equal(detail.issue.id, "123456");
+  assert.equal(detail.latestEvent?.message, EVENT_FIXTURE.message);
+});
+
+test("getIssue: numeric ids skip shortid resolution", async () => {
+  const recorded: RecordedRequest[] = [];
+  const c = client({ "https://sentry.io/api/0/issues/123456/": ISSUE_FIXTURE }, recorded);
+  await c.getIssue("123456");
+  assert.ok(!recorded.some((r) => r.url.includes("/shortids/")));
+});
+
+test("errors: 401 explains the token was rejected without echoing it", async () => {
+  const failFetch = (async () => new Response("unauthorized", { status: 401 })) as typeof fetch;
+  const c = new SentryClient({
+    baseUrl: "https://sentry.io",
+    org: "ibis",
+    project: "harmonic",
+    apiToken: "tok-secret",
+    fetchImpl: failFetch,
+  });
+  await assert.rejects(
+    () => c.listUnresolvedIssues(),
+    (e: Error) => {
+      assert.match(e.message, /Sentry rejected the API token/);
+      assert.ok(!e.message.includes("tok-secret"));
+      return true;
+    },
+  );
+});

--- a/harmonic-admin/src/sentry.ts
+++ b/harmonic-admin/src/sentry.ts
@@ -1,0 +1,132 @@
+// Read-only Sentry API client. Acts over HTTPS against the Sentry API;
+// needs a token with project:read / event:read / org:read only. Token
+// values never appear in output or error messages.
+
+export interface SentryClientOpts {
+  readonly baseUrl: string;
+  readonly org: string;
+  readonly project: string;
+  readonly apiToken: string;
+  readonly fetchImpl?: typeof fetch;
+}
+
+export interface SentryIssue {
+  readonly id: string;
+  readonly shortId: string;
+  readonly title: string;
+  readonly culprit: string | undefined;
+  readonly level: string | undefined;
+  readonly count: number;
+  readonly userCount: number | undefined;
+  readonly firstSeen: string | undefined;
+  readonly lastSeen: string | undefined;
+  readonly permalink: string | undefined;
+}
+
+export interface SentryEvent {
+  readonly dateCreated: string | undefined;
+  readonly message: string | undefined;
+  readonly tags: Record<string, string>;
+}
+
+export interface SentryIssueDetail {
+  readonly issue: SentryIssue;
+  readonly latestEvent: SentryEvent | undefined;
+}
+
+export class SentryClient {
+  private readonly opts: SentryClientOpts;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: SentryClientOpts) {
+    this.opts = opts;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async listUnresolvedIssues(limit = 25): Promise<SentryIssue[]> {
+    const { baseUrl, org, project } = this.opts;
+    const url =
+      `${baseUrl}/api/0/projects/${org}/${project}/issues/` +
+      `?query=${encodeURIComponent("is:unresolved")}&limit=${limit}`;
+    const raw = await this.getJson(url);
+    if (!Array.isArray(raw)) throw new Error("Sentry returned an unexpected issue list shape");
+    return raw.map((item) => toIssue(item as Record<string, unknown>));
+  }
+
+  async getIssue(idOrShortId: string): Promise<SentryIssueDetail> {
+    const { baseUrl } = this.opts;
+    const id = /^\d+$/.test(idOrShortId) ? idOrShortId : await this.resolveShortId(idOrShortId);
+    const issueRaw = await this.getJson(`${baseUrl}/api/0/issues/${encodeURIComponent(id)}/`);
+    const issue = toIssue(issueRaw as Record<string, unknown>);
+    let latestEvent: SentryEvent | undefined;
+    try {
+      const eventRaw = await this.getJson(`${baseUrl}/api/0/issues/${encodeURIComponent(id)}/events/latest/`);
+      latestEvent = toEvent(eventRaw as Record<string, unknown>);
+    } catch {
+      latestEvent = undefined;
+    }
+    return { issue, latestEvent };
+  }
+
+  private async resolveShortId(shortId: string): Promise<string> {
+    const { baseUrl, org } = this.opts;
+    const raw = await this.getJson(`${baseUrl}/api/0/organizations/${org}/shortids/${encodeURIComponent(shortId)}/`);
+    const groupId = (raw as Record<string, unknown>).groupId;
+    if (typeof groupId !== "string" || groupId === "") {
+      throw new Error(`Sentry could not resolve short id "${shortId}" to an issue`);
+    }
+    return groupId;
+  }
+
+  private async getJson(url: string): Promise<unknown> {
+    const response = await this.fetchImpl(url, {
+      headers: { Authorization: `Bearer ${this.opts.apiToken}` },
+    });
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(
+        "Sentry rejected the API token (HTTP " +
+          response.status +
+          "). Check SENTRY_API_TOKEN and its scopes (project:read, event:read, org:read).",
+      );
+    }
+    if (!response.ok) {
+      throw new Error(`Sentry API request failed: HTTP ${response.status} for ${url}`);
+    }
+    return await response.json();
+  }
+}
+
+function toIssue(raw: Record<string, unknown>): SentryIssue {
+  return {
+    id: String(raw.id ?? ""),
+    shortId: String(raw.shortId ?? raw.id ?? ""),
+    title: String(raw.title ?? "(untitled)"),
+    culprit: optionalString(raw.culprit),
+    level: optionalString(raw.level),
+    count: Number(raw.count ?? 0),
+    userCount: typeof raw.userCount === "number" ? raw.userCount : undefined,
+    firstSeen: optionalString(raw.firstSeen),
+    lastSeen: optionalString(raw.lastSeen),
+    permalink: optionalString(raw.permalink),
+  };
+}
+
+function toEvent(raw: Record<string, unknown>): SentryEvent {
+  const tags: Record<string, string> = {};
+  if (Array.isArray(raw.tags)) {
+    for (const tag of raw.tags) {
+      if (tag && typeof tag === "object" && "key" in tag && "value" in tag) {
+        tags[String((tag as Record<string, unknown>).key)] = String((tag as Record<string, unknown>).value);
+      }
+    }
+  }
+  return {
+    dateCreated: optionalString(raw.dateCreated),
+    message: optionalString(raw.message),
+    tags,
+  };
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value !== "" ? value : undefined;
+}

--- a/harmonic-admin/src/status.test.ts
+++ b/harmonic-admin/src/status.test.ts
@@ -1,0 +1,163 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { AdminConfig } from "./config.js";
+import { runProdStatus } from "./status.js";
+
+const HEALTHY_BODY = JSON.stringify({ status: "ok", checks: { database: true, redis: true } });
+const UNHEALTHY_BODY = JSON.stringify({ status: "unhealthy", checks: { database: true, redis: false } });
+
+const METRICS_BODY = [
+  'sidekiq_jobs_waiting_count{queue="default"} 4',
+  "sidekiq_jobs_retry_count 1",
+  "sidekiq_jobs_dead_count 0",
+  "sidekiq_active_workers_count 2",
+].join("\n");
+
+const SENTRY_ISSUES = [
+  {
+    id: "1",
+    shortId: "HARMONIC-7",
+    title: "Timeout::Error in webhooks",
+    count: "12",
+    userCount: 2,
+    level: "error",
+    lastSeen: "2026-07-31T10:00:00Z",
+  },
+];
+
+function makeConfig(values: Record<string, string>): AdminConfig {
+  return {
+    values: values as AdminConfig["values"],
+    sources: {},
+    path: "/tmp/none",
+    fileExists: true,
+  };
+}
+
+type Route = { status: number; body: string };
+
+function fakeFetch(routes: Record<string, Route>): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = String(input);
+    const path = url.split("?")[0] ?? url;
+    const route = routes[path];
+    if (!route) return new Response("not found", { status: 404 });
+    return new Response(route.body, { status: route.status });
+  }) as typeof fetch;
+}
+
+const FULL_CONFIG = {
+  HARMONIC_PROD_URL: "https://prod.example",
+  HARMONIC_METRICS_TOKEN: "metrics-tok",
+  SENTRY_API_TOKEN: "sentry-tok",
+  SENTRY_ORG: "ibis",
+  SENTRY_PROJECT: "harmonic",
+  SENTRY_BASE_URL: "https://sentry.example",
+};
+
+const FULL_ROUTES: Record<string, Route> = {
+  "https://prod.example/healthcheck": { status: 200, body: HEALTHY_BODY },
+  "https://prod.example/metrics": { status: 200, body: METRICS_BODY },
+  "https://sentry.example/api/0/projects/ibis/harmonic/issues/": {
+    status: 200,
+    body: JSON.stringify(SENTRY_ISSUES),
+  },
+};
+
+test("runProdStatus: all sources configured and healthy", async () => {
+  const result = await runProdStatus(makeConfig(FULL_CONFIG), { fetchImpl: fakeFetch(FULL_ROUTES) });
+  assert.equal(result.exitCode, 0);
+  const text = result.sections.map((s) => `${s.title}\n${s.lines.join("\n")}`).join("\n\n");
+  assert.match(text, /database: ok/);
+  assert.match(text, /redis: ok/);
+  assert.match(text, /waiting: 4/);
+  assert.match(text, /dead: 0/);
+  assert.match(text, /HARMONIC-7/);
+  assert.match(text, /12 events/);
+});
+
+test("runProdStatus: unhealthy healthcheck sets exit code 1 and names the failing check", async () => {
+  const routes = {
+    ...FULL_ROUTES,
+    "https://prod.example/healthcheck": { status: 503, body: UNHEALTHY_BODY },
+  };
+  const result = await runProdStatus(makeConfig(FULL_CONFIG), { fetchImpl: fakeFetch(routes) });
+  assert.equal(result.exitCode, 1);
+  const availability = result.sections.find((s) => s.title.toLowerCase().includes("availability"));
+  assert.ok(availability);
+  assert.equal(availability.state, "down");
+  assert.match(availability.lines.join("\n"), /redis: FAILING/);
+});
+
+test("runProdStatus: unreachable host reports down, other sections still render", async () => {
+  const failFetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.startsWith("https://prod.example")) throw new Error("getaddrinfo ENOTFOUND prod.example");
+    const path = url.split("?")[0] ?? url;
+    const route = FULL_ROUTES[path];
+    if (!route) return new Response("not found", { status: 404 });
+    return new Response(route.body, { status: route.status });
+  }) as typeof fetch;
+  const result = await runProdStatus(makeConfig(FULL_CONFIG), { fetchImpl: failFetch });
+  assert.equal(result.exitCode, 1);
+  const text = result.sections.map((s) => s.lines.join("\n")).join("\n");
+  assert.match(text, /unreachable/i);
+  assert.match(text, /HARMONIC-7/);
+});
+
+test("runProdStatus: missing metrics token degrades to a no-access line", async () => {
+  const { HARMONIC_METRICS_TOKEN: _omitted, ...withoutMetricsToken } = FULL_CONFIG;
+  const result = await runProdStatus(makeConfig(withoutMetricsToken), { fetchImpl: fakeFetch(FULL_ROUTES) });
+  assert.equal(result.exitCode, 0);
+  const jobs = result.sections.find((s) => s.title.toLowerCase().includes("jobs"));
+  assert.ok(jobs);
+  assert.equal(jobs.state, "no-access");
+  assert.match(jobs.lines.join("\n"), /HARMONIC_METRICS_TOKEN/);
+});
+
+test("runProdStatus: missing Sentry credentials degrade to a no-access line naming the missing keys", async () => {
+  const { SENTRY_API_TOKEN: _a, SENTRY_ORG: _b, ...rest } = FULL_CONFIG;
+  const result = await runProdStatus(makeConfig(rest), { fetchImpl: fakeFetch(FULL_ROUTES) });
+  const errors = result.sections.find((s) => s.title.toLowerCase().includes("error"));
+  assert.ok(errors);
+  assert.equal(errors.state, "no-access");
+  assert.match(errors.lines.join("\n"), /SENTRY_API_TOKEN/);
+  assert.match(errors.lines.join("\n"), /SENTRY_ORG/);
+});
+
+test("runProdStatus: metrics endpoint 503 (token unset server-side) explains rather than crashes", async () => {
+  const routes = {
+    ...FULL_ROUTES,
+    "https://prod.example/metrics": { status: 503, body: "Metrics unavailable" },
+  };
+  const result = await runProdStatus(makeConfig(FULL_CONFIG), { fetchImpl: fakeFetch(routes) });
+  assert.equal(result.exitCode, 0);
+  const jobs = result.sections.find((s) => s.title.toLowerCase().includes("jobs"));
+  assert.ok(jobs);
+  assert.equal(jobs.state, "no-access");
+  assert.match(jobs.lines.join("\n"), /503/);
+});
+
+test("runProdStatus: dead jobs present flips the jobs section to warn", async () => {
+  const routes = {
+    ...FULL_ROUTES,
+    "https://prod.example/metrics": {
+      status: 200,
+      body: 'sidekiq_jobs_waiting_count{queue="default"} 0\nsidekiq_jobs_dead_count 9\n',
+    },
+  };
+  const result = await runProdStatus(makeConfig(FULL_CONFIG), { fetchImpl: fakeFetch(routes) });
+  const jobs = result.sections.find((s) => s.title.toLowerCase().includes("jobs"));
+  assert.equal(jobs?.state, "warn");
+});
+
+test("runProdStatus: no unresolved issues reads as ok", async () => {
+  const routes = {
+    ...FULL_ROUTES,
+    "https://sentry.example/api/0/projects/ibis/harmonic/issues/": { status: 200, body: "[]" },
+  };
+  const result = await runProdStatus(makeConfig(FULL_CONFIG), { fetchImpl: fakeFetch(routes) });
+  const errors = result.sections.find((s) => s.title.toLowerCase().includes("error"));
+  assert.equal(errors?.state, "ok");
+  assert.match(errors?.lines.join("\n") ?? "", /no unresolved issues/i);
+});

--- a/harmonic-admin/src/status.ts
+++ b/harmonic-admin/src/status.ts
@@ -1,0 +1,176 @@
+// `prod status` — one command answering "how's prod doing?" from a laptop,
+// no SSH. Acts over HTTPS against the prod instance (/healthcheck, /metrics)
+// and the Sentry API. Read-only. Each source degrades independently: a
+// missing credential yields a "no access" section, never a crash.
+
+import type { AdminConfig } from "./config.js";
+import { parsePrometheusText, summarizeSidekiq } from "./prom.js";
+import { SentryClient } from "./sentry.js";
+
+export type SectionState = "ok" | "warn" | "down" | "no-access";
+
+export interface StatusSection {
+  readonly title: string;
+  readonly state: SectionState;
+  readonly lines: readonly string[];
+}
+
+export interface ProdStatusResult {
+  readonly sections: readonly StatusSection[];
+  /** 0 when the app is up (regardless of missing optional sources), 1 when down/unreachable. */
+  readonly exitCode: number;
+}
+
+export interface RunProdStatusOpts {
+  readonly fetchImpl?: typeof fetch;
+}
+
+export async function runProdStatus(config: AdminConfig, opts: RunProdStatusOpts = {}): Promise<ProdStatusResult> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const prodUrl = (config.values.HARMONIC_PROD_URL ?? "https://www.harmonic.social").replace(/\/$/, "");
+
+  const [availability, jobs, errors] = await Promise.all([
+    checkAvailability(prodUrl, fetchImpl),
+    checkJobs(prodUrl, config, fetchImpl),
+    checkErrors(config, fetchImpl),
+  ]);
+
+  return {
+    sections: [availability, jobs, errors],
+    exitCode: availability.state === "down" ? 1 : 0,
+  };
+}
+
+async function checkAvailability(prodUrl: string, fetchImpl: typeof fetch): Promise<StatusSection> {
+  const title = `Availability (${prodUrl}/healthcheck)`;
+  let response: Response;
+  try {
+    response = await fetchImpl(`${prodUrl}/healthcheck`);
+  } catch (e) {
+    return {
+      title,
+      state: "down",
+      lines: [`unreachable: ${e instanceof Error ? e.message : String(e)}`],
+    };
+  }
+
+  let checks: Record<string, boolean> = {};
+  let overall: string | undefined;
+  try {
+    const body = (await response.json()) as { status?: string; checks?: Record<string, boolean> };
+    overall = body.status;
+    checks = body.checks ?? {};
+  } catch {
+    // Non-JSON body (e.g. an intermediary error page); the HTTP status still tells the story.
+  }
+
+  const lines: string[] = [];
+  for (const [name, ok] of Object.entries(checks)) {
+    lines.push(`${name}: ${ok ? "ok" : "FAILING"}`);
+  }
+  if (response.ok && overall === "ok") {
+    return { title, state: "ok", lines: lines.length > 0 ? lines : ["ok"] };
+  }
+  lines.unshift(`HTTP ${response.status}${overall ? ` (status: ${overall})` : ""}`);
+  return { title, state: "down", lines };
+}
+
+async function checkJobs(prodUrl: string, config: AdminConfig, fetchImpl: typeof fetch): Promise<StatusSection> {
+  const title = "Jobs & metrics (/metrics)";
+  const token = config.values.HARMONIC_METRICS_TOKEN;
+  if (token === undefined) {
+    return {
+      title,
+      state: "no-access",
+      lines: ["no access to metrics — HARMONIC_METRICS_TOKEN is not set"],
+    };
+  }
+
+  let response: Response;
+  try {
+    response = await fetchImpl(`${prodUrl}/metrics`, { headers: { Authorization: `Bearer ${token}` } });
+  } catch (e) {
+    return {
+      title,
+      state: "no-access",
+      lines: [`metrics unreachable: ${e instanceof Error ? e.message : String(e)}`],
+    };
+  }
+  if (!response.ok) {
+    return {
+      title,
+      state: "no-access",
+      lines: [
+        `no access to metrics — HTTP ${response.status}` +
+          (response.status === 503 ? " (METRICS_AUTH_TOKEN not set on the server?)" : ""),
+      ],
+    };
+  }
+
+  const summary = summarizeSidekiq(parsePrometheusText(await response.text()));
+  const lines: string[] = [];
+  if (summary.waitingTotal !== undefined) {
+    lines.push(`sidekiq waiting: ${summary.waitingTotal}${formatQueues(summary.waitingByQueue)}`);
+  }
+  if (summary.retry !== undefined) lines.push(`sidekiq retry: ${summary.retry}`);
+  if (summary.dead !== undefined) lines.push(`sidekiq dead: ${summary.dead}`);
+  if (summary.activeWorkers !== undefined) lines.push(`sidekiq active workers: ${summary.activeWorkers}`);
+  if (lines.length === 0) {
+    return { title, state: "warn", lines: ["metrics endpoint responded but exposed no sidekiq gauges"] };
+  }
+  const state: SectionState = (summary.dead ?? 0) > 0 ? "warn" : "ok";
+  return { title, state, lines };
+}
+
+function formatQueues(byQueue: Record<string, number>): string {
+  const parts = Object.entries(byQueue).map(([queue, count]) => `${queue}: ${count}`);
+  return parts.length > 0 ? ` (${parts.join(", ")})` : "";
+}
+
+async function checkErrors(config: AdminConfig, fetchImpl: typeof fetch): Promise<StatusSection> {
+  const title = "Errors (Sentry, unresolved)";
+  const missing = (["SENTRY_API_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT"] as const).filter(
+    (key) => config.values[key] === undefined,
+  );
+  if (missing.length > 0) {
+    return {
+      title,
+      state: "no-access",
+      lines: [`no access to Sentry — missing ${missing.join(", ")}`],
+    };
+  }
+
+  const client = new SentryClient({
+    baseUrl: config.values.SENTRY_BASE_URL ?? "https://sentry.io",
+    org: config.values.SENTRY_ORG as string,
+    project: config.values.SENTRY_PROJECT as string,
+    apiToken: config.values.SENTRY_API_TOKEN as string,
+    fetchImpl,
+  });
+
+  let issues;
+  try {
+    issues = await client.listUnresolvedIssues();
+  } catch (e) {
+    return {
+      title,
+      state: "no-access",
+      lines: [e instanceof Error ? e.message : String(e)],
+    };
+  }
+
+  if (issues.length === 0) {
+    return { title, state: "ok", lines: ["no unresolved issues"] };
+  }
+  const top = [...issues].sort((a, b) => b.count - a.count).slice(0, 5);
+  const lines = [
+    `${issues.length} unresolved issue${issues.length === 1 ? "" : "s"}`,
+    ...top.map(
+      (issue) =>
+        `${issue.shortId}  ${issue.title}  — ${issue.count} events` +
+        (issue.userCount !== undefined ? `, ${issue.userCount} users` : "") +
+        (issue.lastSeen ? `, last seen ${issue.lastSeen}` : ""),
+    ),
+  ];
+  return { title, state: "warn", lines };
+}

--- a/harmonic-admin/tsconfig.build.json
+++ b/harmonic-admin/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}

--- a/harmonic-admin/tsconfig.json
+++ b/harmonic-admin/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/test/controllers/metrics_controller_test.rb
+++ b/test/controllers/metrics_controller_test.rb
@@ -1,0 +1,31 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MetricsControllerTest < ActionDispatch::IntegrationTest
+  test "renders Prometheus text format" do
+    get "/metrics"
+    assert_response :success
+    assert_equal "text/plain", response.media_type
+    # Prometheus text format is comment lines (# HELP / # TYPE) and samples;
+    # with no auth token configured outside production, the endpoint is open.
+    assert_match(/\A(#|[a-zA-Z_:]|\z)/, response.body)
+  end
+
+  test "rejects a wrong token when one is configured" do
+    ENV["METRICS_AUTH_TOKEN"] = "expected-token"
+    get "/metrics", headers: { "Authorization" => "Bearer wrong-token" }
+    assert_response :unauthorized
+  ensure
+    ENV.delete("METRICS_AUTH_TOKEN")
+  end
+
+  test "accepts the configured token" do
+    ENV["METRICS_AUTH_TOKEN"] = "expected-token"
+    get "/metrics", headers: { "Authorization" => "Bearer expected-token" }
+    assert_response :success
+  ensure
+    ENV.delete("METRICS_AUTH_TOKEN")
+  end
+end


### PR DESCRIPTION
## Summary

Two related pieces: a new `harmonic-admin` CLI for operating prod without SSH, and a fix for the `/metrics` endpoint bug that building it uncovered.

### harmonic-admin CLI v1 (`harmonic-admin/`)

New in-repo TypeScript package (same conventions as `harmonic-bridge/`: npm `@ibis-coordination/harmonic-admin`, future publish by `admin-vX.Y.Z` tag). Read-only commands answering "how's prod doing?" from a laptop:

```
harmonic-admin prod status            # healthcheck + /metrics + Sentry digest
harmonic-admin prod sentry issues     # unresolved issues, most recent first
harmonic-admin prod sentry show <id>  # one issue in detail (short ids resolve)
harmonic-admin doctor                 # which credentials are configured (masked)
```

- Credentials live in `~/.config/harmonic-admin/env` (chmod 600; env vars override; `HARMONIC_ADMIN_CONFIG` overrides the path). Read-only, individually-revocable tokens only; the CLI never prints token values.
- Each `prod status` source degrades independently — a missing credential yields a "no access" line, never a crash.
- Default prod URL is the **www host**: the apex 301s to www, and fetch strips `Authorization` on cross-origin redirects, which would silently break the authenticated `/metrics` call.
- 37 tests (node:test via tsx), typecheck + build clean.

### /metrics endpoint fix

The endpoint was latently broken since it was written: `Yabeda::Prometheus::Exporter` is Rack middleware whose constructor takes `(app, options)`, so `Exporter.new` raised `ArgumentError` on every scrape. Nobody saw it because prod returned 503 before auth (`METRICS_AUTH_TOKEN` was unset until now). Fixed by rendering the registry via Prometheus text marshaling after `Yabeda.collect!`, with a new controller test covering render + both auth branches.

Also opts the web service into `YABEDA_SIDEKIQ_COLLECT_CLUSTER_METRICS=true` in both compose files — the cluster-wide sidekiq gauges (queue depth, retry/dead) are otherwise only collected inside Sidekiq server processes, and `/metrics` is served by web. Corrected `docs/MONITORING.md` metric names against a live scrape.

## Verification

- Live against prod: healthcheck section, all three Sentry commands (including short-id resolution, which the CLI itself surfaced as a 404 during testing).
- Live against dev: full `prod status` all-green including the sidekiq gauges after the compose change.
- Dogfooding note: the prod `/metrics` 500 was diagnosed via `harmonic-admin prod sentry issues` — the fresh `RUBY-RAILS-14` issue pointed straight at `MetricsController#show`.
- Prod's metrics section stays "no access — HTTP 500" until this deploys; healthcheck + Sentry sections are fully live now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)